### PR TITLE
Adding bundles-override to package cli commands

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -15,7 +15,8 @@ type applyPackageOptions struct {
 	fileName string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var apo = &applyPackageOptions{}
@@ -27,6 +28,8 @@ func init() {
 		"", "Filename that contains curated packages custom resources to apply")
 	applyPackagesCommand.Flags().StringVar(&apo.kubeConfig, "kubeconfig", "",
 		"Path to an optional kubeconfig file to use.")
+	applyPackagesCommand.Flags().StringVar(&apo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 
 	err := applyPackagesCommand.MarkFlagRequired("filename")
 	if err != nil {
@@ -55,7 +58,7 @@ func applyPackages(ctx context.Context) error {
 		return err
 	}
 
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithBundlesOverride(apo.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -38,6 +38,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 	config := New(opts...)
 	return dependencies.NewFactory().
 		WithExecutableMountDirs(config.mountPaths...).
+		WithCustomExecutableImage(config.bundlesOverride).
 		WithExecutableBuilder().
 		WithManifestReader().
 		WithKubectl().
@@ -50,11 +51,12 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 type PackageOpt func(*PackageConfig)
 
 type PackageConfig struct {
-	registryName string
-	kubeVersion  string
-	kubeConfig   string
-	mountPaths   []string
-	spec         *cluster.Spec
+	registryName    string
+	kubeVersion     string
+	kubeConfig      string
+	mountPaths      []string
+	spec            *cluster.Spec
+	bundlesOverride string
 }
 
 func New(options ...PackageOpt) *PackageConfig {
@@ -92,5 +94,12 @@ func WithClusterSpec(spec *cluster.Spec) func(config *PackageConfig) {
 func WithKubeConfig(kubeConfig string) func(*PackageConfig) {
 	return func(config *PackageConfig) {
 		config.kubeConfig = kubeConfig
+	}
+}
+
+// WithBundlesOverride sets bundlesOverride in the config with incoming value.
+func WithBundlesOverride(bundlesOverride string) func(*PackageConfig) {
+	return func(config *PackageConfig) {
+		config.bundlesOverride = bundlesOverride
 	}
 }

--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -38,7 +38,7 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 	config := New(opts...)
 	return dependencies.NewFactory().
 		WithExecutableMountDirs(config.mountPaths...).
-		WithCustomExecutableImage(config.bundlesOverride).
+		WithCustomBundles(config.bundlesOverride).
 		WithExecutableBuilder().
 		WithManifestReader().
 		WithKubectl().

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -15,7 +15,8 @@ type createPackageOptions struct {
 	fileName string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var cpo = &createPackageOptions{}
@@ -27,6 +28,8 @@ func init() {
 		"", "Filename that contains curated packages custom resources to create")
 	createPackagesCommand.Flags().StringVar(&cpo.kubeConfig, "kubeconfig", "",
 		"Path to an optional kubeconfig file to use.")
+	createPackagesCommand.Flags().StringVar(&cpo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 
 	err := createPackagesCommand.MarkFlagRequired("filename")
 	if err != nil {
@@ -54,7 +57,7 @@ func createPackages(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithBundlesOverride(cpo.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -14,8 +14,9 @@ import (
 type deletePackageOptions struct {
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig  string
-	clusterName string
+	kubeConfig      string
+	clusterName     string
+	bundlesOverride string
 }
 
 var delPkgOpts = deletePackageOptions{}
@@ -27,6 +28,8 @@ func init() {
 		"Path to an optional kubeconfig file to use.")
 	deletePackageCommand.Flags().StringVar(&delPkgOpts.clusterName, "cluster", "",
 		"Cluster for package deletion.")
+	deletePackageCommand.Flags().StringVar(&delPkgOpts.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 	if err := deletePackageCommand.MarkFlagRequired("cluster"); err != nil {
 		log.Fatalf("marking cluster flag as required: %s", err)
 	}
@@ -50,7 +53,7 @@ func deleteResources(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithBundlesOverride(delPkgOpts.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -14,8 +14,9 @@ import (
 type describePackagesOption struct {
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig  string
-	clusterName string
+	kubeConfig      string
+	clusterName     string
+	bundlesOverride string
 }
 
 var dpo = &describePackagesOption{}
@@ -27,6 +28,8 @@ func init() {
 		"Path to an optional kubeconfig file to use.")
 	describePackagesCommand.Flags().StringVar(&dpo.clusterName, "cluster", "",
 		"Cluster to describe packages.")
+	describePackagesCommand.Flags().StringVar(&dpo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 	if err := describePackagesCommand.MarkFlagRequired("cluster"); err != nil {
 		log.Fatalf("marking cluster flag as required: %s", err)
 	}
@@ -51,7 +54,7 @@ func describeResources(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithBundlesOverride(dpo.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/generatepackage.go
+++ b/cmd/eksctl-anywhere/cmd/generatepackage.go
@@ -17,7 +17,8 @@ type generatePackageOptions struct {
 	registry    string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var gpOptions = &generatePackageOptions{}
@@ -29,6 +30,7 @@ func init() {
 	generatePackageCommand.Flags().StringVar(&gpOptions.registry, "registry", "", "Used to specify an alternative registry for package generation")
 	generatePackageCommand.Flags().StringVar(&gpOptions.kubeConfig, "kubeconfig", "",
 		"Path to an optional kubeconfig file to use.")
+	generatePackageCommand.Flags().StringVar(&gpOptions.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	if err := generatePackageCommand.MarkFlagRequired("cluster"); err != nil {
 		log.Fatalf("marking cluster flag as required: %s", err)
 	}
@@ -68,7 +70,7 @@ func generatePackages(ctx context.Context, args []string) error {
 		return err
 	}
 
-	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(gpOptions.registry), WithKubeVersion(gpOptions.kubeVersion), WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(gpOptions.registry), WithKubeVersion(gpOptions.kubeVersion), WithMountPaths(kubeConfig), WithBundlesOverride(gpOptions.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/get.go
+++ b/cmd/eksctl-anywhere/cmd/get.go
@@ -31,8 +31,8 @@ func preRunPackages(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getResources(ctx context.Context, resourceType, output, kubeConfig, clusterName string, args []string) error {
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
+func getResources(ctx context.Context, resourceType, output, kubeConfig, clusterName, bundlesOverride string, args []string) error {
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithBundlesOverride(bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/getpackage.go
+++ b/cmd/eksctl-anywhere/cmd/getpackage.go
@@ -12,8 +12,9 @@ type getPackageOptions struct {
 	output string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig  string
-	clusterName string
+	kubeConfig      string
+	clusterName     string
+	bundlesOverride string
 }
 
 var gpo = &getPackageOptions{}
@@ -27,6 +28,8 @@ func init() {
 		"Path to an optional kubeconfig file.")
 	getPackageCommand.Flags().StringVar(&gpo.clusterName, "cluster", "",
 		"Cluster to get list of packages.")
+	getPackageCommand.Flags().StringVar(&gpo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 	if err := getPackageCommand.MarkFlagRequired("cluster"); err != nil {
 		log.Fatalf("marking cluster flag as required: %s", err)
 	}
@@ -44,6 +47,6 @@ var getPackageCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return getResources(cmd.Context(), "packages", gpo.output, kubeConfig, gpo.clusterName, args)
+		return getResources(cmd.Context(), "packages", gpo.output, kubeConfig, gpo.clusterName, gpo.bundlesOverride, args)
 	},
 }

--- a/cmd/eksctl-anywhere/cmd/getpackagebundle.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundle.go
@@ -10,7 +10,8 @@ type getPackageBundleOptions struct {
 	output string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var gpbo = &getPackageBundleOptions{}
@@ -22,6 +23,8 @@ func init() {
 		"Specifies the output format (valid option: json, yaml)")
 	getPackageBundleCommand.Flags().StringVar(&gpbo.kubeConfig, "kubeconfig", "",
 		"Path to an optional kubeconfig file.")
+	getPackageBundleCommand.Flags().StringVar(&gpbo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 }
 
 var getPackageBundleCommand = &cobra.Command{
@@ -36,6 +39,6 @@ var getPackageBundleCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return getResources(cmd.Context(), "packagebundles", gpbo.output, kubeConfig, "", args)
+		return getResources(cmd.Context(), "packagebundles", gpbo.output, kubeConfig, "", gpbo.bundlesOverride, args)
 	},
 }

--- a/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
@@ -10,7 +10,8 @@ type getPackageBundleControllerOptions struct {
 	output string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var gpbco = &getPackageBundleControllerOptions{}
@@ -22,6 +23,8 @@ func init() {
 		"o", "", "Specifies the output format (valid option: json, yaml)")
 	getPackageBundleControllerCommand.Flags().StringVar(&gpbco.kubeConfig,
 		"kubeconfig", "", "Path to an optional kubeconfig file.")
+	getPackageBundleControllerCommand.Flags().StringVar(&gpbco.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 }
 
 var getPackageBundleControllerCommand = &cobra.Command{
@@ -36,6 +39,6 @@ var getPackageBundleControllerCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return getResources(cmd.Context(), "packagebundlecontrollers", gpbco.output, kubeConfig, "", args)
+		return getResources(cmd.Context(), "packagebundlecontrollers", gpbco.output, kubeConfig, "", gpbco.bundlesOverride, args)
 	},
 }

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -15,8 +15,9 @@ import (
 )
 
 type installControllerOptions struct {
-	fileName   string
-	kubeConfig string
+	fileName        string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var ico = &installControllerOptions{}
@@ -25,6 +26,8 @@ func init() {
 	installCmd.AddCommand(installPackageControllerCommand)
 	installPackageControllerCommand.Flags().StringVarP(&ico.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
 	installPackageControllerCommand.Flags().StringVar(&ico.kubeConfig, "kubeConfig", "", "Management cluster kubeconfig file")
+	installPackageControllerCommand.Flags().StringVar(&ico.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 	if err := installPackageControllerCommand.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
@@ -56,7 +59,7 @@ func installPackageController(ctx context.Context) error {
 		return fmt.Errorf("the cluster config file provided is invalid: %v", err)
 	}
 
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithClusterSpec(clusterSpec), WithKubeConfig(ico.kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithClusterSpec(clusterSpec), WithKubeConfig(ico.kubeConfig), WithBundlesOverride(ico.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -19,7 +19,8 @@ type installPackageOptions struct {
 	customConfigs []string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var ipo = &installPackageOptions{}
@@ -39,6 +40,8 @@ func init() {
 		"Path to an optional kubeconfig file to use.")
 	installPackageCommand.Flags().StringVar(&ipo.clusterName, "cluster", "",
 		"Target cluster for installation.")
+	installPackageCommand.Flags().StringVar(&ipo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 
 	if err := installPackageCommand.MarkFlagRequired("package-name"); err != nil {
 		log.Fatalf("marking package-name flag as required: %s", err)
@@ -77,7 +80,7 @@ func installPackages(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(ipo.registry), WithKubeVersion(ipo.kubeVersion), WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(ipo.registry), WithKubeVersion(ipo.kubeVersion), WithMountPaths(kubeConfig), WithBundlesOverride(ipo.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/listpackages.go
+++ b/cmd/eksctl-anywhere/cmd/listpackages.go
@@ -17,7 +17,8 @@ type listPackagesOption struct {
 	registry    string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig string
+	kubeConfig      string
+	bundlesOverride string
 }
 
 var lpo = &listPackagesOption{}
@@ -33,6 +34,8 @@ func init() {
 		"Path to a kubeconfig file to use when source is a cluster.")
 	listPackagesCommand.Flags().StringVar(&lpo.clusterName, "cluster", "",
 		"Name of cluster for package list.")
+	listPackagesCommand.Flags().StringVar(&lpo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 }
 
 var listPackagesCommand = &cobra.Command{
@@ -57,7 +60,7 @@ func listPackages(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(lpo.registry), WithKubeVersion(lpo.kubeVersion), WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithRegistryName(lpo.registry), WithKubeVersion(lpo.kubeVersion), WithMountPaths(kubeConfig), WithBundlesOverride(lpo.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -15,8 +15,9 @@ type upgradePackageOptions struct {
 	bundleVersion string
 	// kubeConfig is an optional kubeconfig file to use when querying an
 	// existing cluster.
-	kubeConfig  string
-	clusterName string
+	kubeConfig      string
+	clusterName     string
+	bundlesOverride string
 }
 
 var upo = &upgradePackageOptions{}
@@ -30,6 +31,8 @@ func init() {
 		"", "Path to an optional kubeconfig file to use.")
 	upgradePackagesCommand.Flags().StringVar(&upo.clusterName, "cluster",
 		"", "Cluster to upgrade.")
+	upgradePackagesCommand.Flags().StringVar(&upo.bundlesOverride, "bundles-override", "",
+		"Override default Bundles manifest (not recommended)")
 
 	err := upgradePackagesCommand.MarkFlagRequired("bundle-version")
 	if err != nil {
@@ -60,7 +63,7 @@ func upgradePackages(ctx context.Context) error {
 		return err
 	}
 
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig))
+	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithBundlesOverride(upo.bundlesOverride))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -262,7 +262,7 @@ func (f *Factory) selectImageFromBundleOverride(bundlesOverride string) (string,
 	// Note: Currently using the first available version of the cli tools
 	// This is because the binaries bundled are all the same version hence no compatibility concerns
 	// In case, there is a change to this behavior, there might be a need to reassess this item
-	return releaseBundles.Spec.VersionsBundles[0].Eksa.CliTools.VersionedImage(), nil
+	return releaseBundles.DefaultEksAToolsImage().VersionedImage(), nil
 }
 
 // WithCustomBundles allows configuring a bundle override.

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -271,7 +271,6 @@ func (f *Factory) WithCustomBundles(bundlesOverride string) *Factory {
 		return f
 	}
 	f.config.bundlesOverride = bundlesOverride
-	f.WithExecutableImage()
 	return f
 }
 

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -271,6 +271,7 @@ func (f *Factory) WithCustomBundles(bundlesOverride string) *Factory {
 		return f
 	}
 	f.config.bundlesOverride = bundlesOverride
+	f.WithExecutableImage()
 	return f
 }
 

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -441,6 +441,42 @@ func TestFactoryBuildWithCuratedPackagesCustomManifestImage(t *testing.T) {
 	tt.Expect(deps.BundleRegistry).NotTo(BeNil())
 }
 
+func TestFactoryBuildWithCuratedPackagesCustomManifestImageNoOverrides(t *testing.T) {
+	tt := newTest(t, vsphere)
+	deps, err := dependencies.NewFactory().
+		WithCustomExecutableImage("").
+		WithManifestReader().
+		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.BundleRegistry).NotTo(BeNil())
+}
+
+func TestFactoryBuildWithCuratedPackagesCustomManifestImageMissingBundle(t *testing.T) {
+	tt := newTest(t, vsphere)
+	_, err := dependencies.NewFactory().
+		WithCustomExecutableImage("testdata/not_exist.yaml").
+		WithManifestReader().
+		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
+		Build(context.Background())
+
+	tt.Expect(err).NotTo(BeNil())
+}
+
+func TestFactoryBuildWithCuratedPackagesCustomManifestWithExistingExecConfig(t *testing.T) {
+	tt := newTest(t, vsphere)
+	deps, err := dependencies.NewFactory().
+		UseExecutableImage("test-exec-image").
+		WithCustomExecutableImage("testdata/not_exist.yaml").
+		WithManifestReader().
+		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.BundleRegistry).NotTo(BeNil())
+}
+
 func TestFactoryBuildWithExecutablesUsingDocker(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -432,7 +432,7 @@ func TestFactoryBuildWithCuratedPackagesDefaultRegistry(t *testing.T) {
 func TestFactoryBuildWithCuratedPackagesCustomManifestImage(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
-		WithCustomExecutableImage("testdata/cli_tools_bundle.yaml").
+		WithCustomBundles("testdata/cli_tools_bundle.yaml").
 		WithManifestReader().
 		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
 		Build(context.Background())
@@ -444,7 +444,7 @@ func TestFactoryBuildWithCuratedPackagesCustomManifestImage(t *testing.T) {
 func TestFactoryBuildWithCuratedPackagesCustomManifestImageNoOverrides(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
-		WithCustomExecutableImage("").
+		WithCustomBundles("").
 		WithManifestReader().
 		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
 		Build(context.Background())
@@ -456,7 +456,7 @@ func TestFactoryBuildWithCuratedPackagesCustomManifestImageNoOverrides(t *testin
 func TestFactoryBuildWithCuratedPackagesCustomManifestImageMissingBundle(t *testing.T) {
 	tt := newTest(t, vsphere)
 	_, err := dependencies.NewFactory().
-		WithCustomExecutableImage("testdata/not_exist.yaml").
+		WithCustomBundles("testdata/not_exist.yaml").
 		WithManifestReader().
 		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
 		Build(context.Background())
@@ -468,7 +468,7 @@ func TestFactoryBuildWithCuratedPackagesCustomManifestWithExistingExecConfig(t *
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		UseExecutableImage("test-exec-image").
-		WithCustomExecutableImage("testdata/not_exist.yaml").
+		WithCustomBundles("testdata/not_exist.yaml").
 		WithManifestReader().
 		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
 		Build(context.Background())

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -429,6 +429,18 @@ func TestFactoryBuildWithCuratedPackagesDefaultRegistry(t *testing.T) {
 	tt.Expect(deps.BundleRegistry).NotTo(BeNil())
 }
 
+func TestFactoryBuildWithCuratedPackagesCustomManifestImage(t *testing.T) {
+	tt := newTest(t, vsphere)
+	deps, err := dependencies.NewFactory().
+		WithCustomExecutableImage("testdata/cli_tools_bundle.yaml").
+		WithManifestReader().
+		WithCuratedPackagesRegistry("", "1.22", version.Info{GitVersion: "1.19"}).
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.BundleRegistry).NotTo(BeNil())
+}
+
 func TestFactoryBuildWithExecutablesUsingDocker(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().

--- a/pkg/dependencies/testdata/cli_tools_bundle.yaml
+++ b/pkg/dependencies/testdata/cli_tools_bundle.yaml
@@ -1,0 +1,12 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+spec:
+  cliMaxVersion: ""
+  cliMinVersion: ""
+  number: 0
+  versionsBundles:
+    - eksa:
+        cliTools:
+          uri: test.registry/eks-anywhere-cli-tools:v0.0.0
+        components:
+          uri: test.registry


### PR DESCRIPTION
Co-authored-by: a-cool-train <acool@amazon.com>

*Issue #5396 *

*Description of changes:*
Adds bundles-override to package cli commands for generate, apply, create, get, delete, describe, and list.

*Testing (if applicable):*
Without override-bundles flag example for get package
```
./eksctl-anywhere get packages --cluster mgmt -v 4
2023-04-13T20:39:57.565Z        V4      Reading bundles manifest        {"url": "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml"}
2023-04-13T20:39:57.590Z        V2      Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.15.1-eks-a-v0.0.0-dev-build.6720"}
2023-04-13T20:39:57.723Z        V3      Initializing long running container     {"name": "eksa_1681418397590899255", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.15.1-eks-a-v0.0.0-dev-build.6720"}
....
```
With override-bundles flag
```
./eksctl-anywhere get packages --cluster mgmt --bundles-override manifest.yaml -v 4
2023-04-13T20:39:09.473Z        V4      Reading bundles manifest        {"url": "manifest.yaml"}
2023-04-13T20:39:09.492Z        V2      Pulling docker image    {"image": "public.ecr.aws/w9m0f3l5/cli-tools:v0.15.0-eks-a-33"}
2023-04-13T20:39:09.698Z        V3      Initializing long running container     {"name": "eksa_1681418349492932435", "image": "public.ecr.aws/w9m0f3l5/cli-tools:v0.15.0-eks-a-33"}
...
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

