### PR TITLE
Add timeout to the e2e command

### DIFF
--- a/internal/test/e2e/artifacts.go
+++ b/internal/test/e2e/artifacts.go
@@ -20,7 +20,7 @@ func (e *E2ESession) uploadGeneratedFilesFromInstance(testName string) {
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().String()
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		e.logger.Error(err, "error uploading log files from instance")
 	} else {
 		e.logger.V(1).Info("Successfully uploaded log files to S3")
@@ -34,7 +34,7 @@ func (e *E2ESession) uploadDiagnosticArchiveFromInstance(testName string) {
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().exclude("*").include(bundleNameFormat).String()
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		e.logger.Error(err, "error uploading diagnostic bundle from instance")
 	} else {
 		e.logger.V(1).Info("Successfully uploaded diagnostic bundle files to S3")
@@ -48,7 +48,7 @@ func (e *E2ESession) uploadJUnitReportFromInstance(testName string) {
 		e.generatedArtifactsBucketPath(), testName,
 	).recursive().exclude("*").include(junitFile).String()
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		e.logger.Error(err, "error uploading JUnit report from instance")
 	} else {
 		e.logger.V(1).Info("Successfully uploaded JUnit report files to S3")

--- a/internal/test/e2e/fluxGit.go
+++ b/internal/test/e2e/fluxGit.go
@@ -82,7 +82,7 @@ func (e *E2ESession) writeFileToInstance(file fileFromBytes) error {
 	e.logger.V(1).Info("Writing bytes to file in instance", "file", file.dstPath)
 
 	command := fmt.Sprintf("echo $'%s' >> %s && chmod %d %[2]s", file.contentString(), file.dstPath, file.permission)
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("writing file in instance: %v", err)
 	}
 	e.logger.V(1).Info("Successfully wrote file", "file", file.dstPath)
@@ -94,7 +94,7 @@ func (e *E2ESession) downloadFileInInstance(file s3Files) error {
 	e.logger.V(1).Info("Downloading from s3 in instance", "file", file.key)
 
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s %s && chmod %d %[3]s", e.storageBucket, file.key, file.dstPath, file.permission)
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("downloading file in instance: %v", err)
 	}
 	e.logger.V(1).Info("Successfully downloaded file", "file", file.key)
@@ -105,7 +105,7 @@ func (e *E2ESession) downloadFileInInstance(file s3Files) error {
 func (e *E2ESession) setUpSshAgent(privateKeyFile string) error {
 	command := fmt.Sprintf("eval $(ssh-agent -s) ssh-add %s", privateKeyFile)
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("starting SSH agent on instance: %v", err)
 	}
 	e.logger.V(1).Info("Successfully started SSH agent on instance")

--- a/internal/test/e2e/oidc.go
+++ b/internal/test/e2e/oidc.go
@@ -117,7 +117,7 @@ func (e *E2ESession) downloadSignerKeyInInstance(folder string) (pathInInstance 
 	e.logger.V(1).Info("Downloading from s3 in instance", "key", saSignerKey)
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s ./%s", e.storageBucket, saSignerKey, saSignerPath)
 
-	if err = ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err = ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return "", fmt.Errorf("downloading signer key in instance: %v", err)
 	}
 	e.logger.V(1).Info("Successfully downloaded signer key")

--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -77,7 +77,7 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 	command := fmt.Sprintf("sudo mkdir -p /etc/docker/certs.d/%s", endpoint)
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("creating directory in instance: %v", err)
 	}
 	decodedCert, err := base64.StdEncoding.DecodeString(cert)
@@ -86,7 +86,7 @@ func (e *E2ESession) mountRegistryCert(cert string, endpoint string) error {
 	}
 	command = fmt.Sprintf("sudo cat <<EOF>> /etc/docker/certs.d/%s/ca.crt\n%s\nEOF", endpoint, string(decodedCert))
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("mounting certificate in instance: %v", err)
 	}
 

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -74,7 +74,7 @@ func (e *E2ESession) setup(regex string) error {
 	}
 
 	e.logger.V(1).Info("Waiting until SSM is ready")
-	err = ssm.WaitForSSMReady(e.session, e.instanceId)
+	err = ssm.WaitForSSMReady(e.session, e.instanceId, ssmTimeout)
 	if err != nil {
 		return fmt.Errorf("waiting for ssm in new instance: %v", err)
 	}
@@ -184,7 +184,7 @@ func (e *E2ESession) setup(regex string) error {
 func (e *E2ESession) updateFSInotifyResources() error {
 	command := fmt.Sprintf("sudo sysctl fs.inotify.max_user_watches=%v && sudo sysctl fs.inotify.max_user_instances=%v", maxUserWatches, maxUserInstances)
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("updating fs inotify resources: %v", err)
 	}
 	e.logger.V(1).Info("Successfully updated the fs inotify user watches and instances")
@@ -230,7 +230,7 @@ func (e *E2ESession) downloadRequiredFileInInstance(file string) error {
 	e.logger.V(1).Info("Downloading from s3 in instance", "file", file)
 
 	command := fmt.Sprintf("aws s3 cp s3://%s/%s/%[3]s ./bin/ && chmod 645 ./bin/%[3]s", e.storageBucket, e.jobId, file)
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("downloading file in instance: %v", err)
 	}
 	e.logger.V(1).Info("Successfully downloaded file")
@@ -251,7 +251,7 @@ func (e *E2ESession) downloadRequiredFilesInInstance() error {
 func (e *E2ESession) createTestNameFile(testName string) error {
 	command := fmt.Sprintf("echo \"%s\" > %s", testName, testNameFile)
 
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("creating test name file in instance: %v", err)
 	}
 	e.logger.V(1).Info("Successfully created test name file")

--- a/internal/test/e2e/tinkerbell.go
+++ b/internal/test/e2e/tinkerbell.go
@@ -83,7 +83,7 @@ func (e *E2ESession) setTinkerbellBootstrapIPInInstance(tinkInterface string) er
 	e.logger.V(1).Info("Setting Tinkerbell Bootstrap IP in instance")
 
 	command := fmt.Sprintf("export T_TINKERBELL_BOOTSTRAP_IP=$(/sbin/ip -o -4 addr list %s | awk '{print $4}' | cut -d/ -f1) && echo T_TINKERBELL_BOOTSTRAP_IP=\"$T_TINKERBELL_BOOTSTRAP_IP\" | tee -a /etc/environment", tinkInterface)
-	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command); err != nil {
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
 		return fmt.Errorf("setting tinkerbell boostrap ip: %v", err)
 	}
 


### PR DESCRIPTION
*Description of changes:*
Add timeout to the e2e command. This makes sure that the e2e test command itself times out instead of the SSM command timing out. With this change, we will be able to get the results of the tests that finished even if the instance timed out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

