### PR TITLE
Tinkerbell skip power action e2e test for a singlenode cluster

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1163,6 +1163,26 @@ func TestTinkerbellKubernetes126SkipPowerActions(t *testing.T) {
 	test.ValidateHardwareDecommissioned()
 }
 
+func TestTinkerbellKubernetes126SingleNodeSkipPowerActions(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewTinkerbell(t, framework.WithUbuntu126Tinkerbell()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		framework.WithNoPowerActions(),
+		framework.WithControlPlaneHardware(1),
+	)
+
+	test.GenerateClusterConfig()
+	test.GenerateHardwareConfig()
+	test.PowerOffHardware()
+	test.PXEBootHardware()
+	test.PowerOnHardware()
+	test.CreateCluster(framework.WithForce(), framework.WithControlPlaneWaitTimeout("20m"))
+	test.DeleteCluster()
+	test.PowerOffHardware()
+	test.ValidateHardwareDecommissioned()
+}
+
 func TestTinkerbellKubernetes126UbuntuControlPlaneScaleUp(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithUbuntu126Tinkerbell())
 	test := framework.NewClusterE2ETest(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We cannot run skip power action e2e test because nodes timeout waiting for ipxe if we power it on before cluster creation starts. Thus, to test out skip power action, added a single node e2e test to test out functionality.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

