### PR TITLE
fixes redaction test flappiness

### DIFF
--- a/pkg/executables/executables_test.go
+++ b/pkg/executables/executables_test.go
@@ -1,6 +1,7 @@
 package executables_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -10,6 +11,8 @@ import (
 func TestRedactCreds(t *testing.T) {
 	str := "My username is username123. My password is password456"
 	t.Setenv(constants.VSphereUsernameKey, "username123")
+	os.Unsetenv(constants.VSpherePasswordKey)
+	os.Unsetenv("var")
 	envMap := map[string]string{"var": "value", constants.VSpherePasswordKey: "password456"}
 
 	expected := "My username is *****. My password is *****"


### PR DESCRIPTION
The test was reliant on an env value not being set. Now that precondition is enforced.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

