### PR TITLE
add a comment, and rename to make deprecation more obvious

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deprecated_importimages.go
+++ b/cmd/eksctl-anywhere/cmd/deprecated_importimages.go
@@ -1,5 +1,13 @@
 package cmd
 
+//////////////////////////////////////////////////////
+//
+// WARNING: The command defined in this file is DEPRECATED.
+//
+// See ./import_images.go for the newer command.
+//
+//////////////////////////////////////////////////////
+
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
Renames the file and adds a comment to make it clear this command is deprecated.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

