### PR TITLE
Resolved e2e singlenode for skip power action

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1167,7 +1167,7 @@ func TestTinkerbellKubernetes126SingleNodeSkipPowerActions(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t, framework.WithUbuntu126Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		framework.WithClusterSingleNode(v1alpha1.Kube126),
 		framework.WithNoPowerActions(),
 		framework.WithControlPlaneHardware(1),
 	)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Resolved e2e singlenode skip power action issue for tinkerbell. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

