### PR TITLE
renaming github e2e tests

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -279,7 +279,7 @@ func TestTinkerbellKubernetes126UbuntuWorkloadClusterWithAPI(t *testing.T) {
 	runWorkloadClusterWithAPIFlowForBareMetal(test)
 }
 
-func TestTinkerbellKubernetes126UbuntuWorkloadClusterGithubFluxAPI(t *testing.T) {
+func TestTinkerbellKubernetes126UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithUbuntu126Tinkerbell())
 	managementCluster := framework.NewClusterE2ETest(
 		t,
@@ -673,7 +673,7 @@ func TestTinkerbellKubernetes125UbuntuTo126Upgrade(t *testing.T) {
 	)
 }
 
-func TestTinkerbellUpgrade126MulticlusterWorkloadClusterWorkerScaleupWithFluxAPI(t *testing.T) {
+func TestTinkerbellUpgrade126MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
 	provider := framework.NewTinkerbell(t, framework.WithUbuntu126Tinkerbell())
 	managementCluster := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating Tinkerbell E2E test names to ensure Flux Github tests match the setupFluxEnv() and setupFluxGitEnv() regex patterns.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

