### PR TITLE
Simplify CloudStack template builder 

### DIFF
--- a/controllers/resource/template.go
+++ b/controllers/resource/template.go
@@ -179,7 +179,7 @@ func (r *CloudStackTemplate) TemplateResources(ctx context.Context, eksaCluster 
 	}
 	clusterSpec.CloudStackDatacenter = &csdc
 	// control plane and etcd updates are prohibited in controller so those specs should not change
-	templateBuilder := cloudstack.NewTemplateBuilder(&csdc.Spec, &cpCsmc.Spec, &etcdCsmc.Spec, workerNodeGroupMachineSpecs, r.now)
+	templateBuilder := cloudstack.NewTemplateBuilder(r.now)
 	clusterName := clusterSpec.Cluster.Name
 
 	oldCsdc, err := r.ExistingCloudStackDatacenterConfig(ctx, eksaCluster, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0])
@@ -211,8 +211,6 @@ func (r *CloudStackTemplate) TemplateResources(ctx context.Context, eksaCluster 
 
 	cpOpt := func(values map[string]interface{}) {
 		values["controlPlaneTemplateName"] = controlPlaneTemplateName
-		values["cloudstackControlPlaneSshAuthorizedKey"] = sshAuthorizedKey(cpCsmc.Spec.Users)
-		values["cloudstackEtcdSshAuthorizedKey"] = sshAuthorizedKey(etcdCsmc.Spec.Users)
 		values["etcdTemplateName"] = etcdTemplateName
 	}
 

--- a/controllers/resource/testdata/cloudstackEtcdadmcluster.yaml
+++ b/controllers/resource/testdata/cloudstackEtcdadmcluster.yaml
@@ -28,7 +28,7 @@ preEtcdadmCommands:
 users:
   - name: capc
     sshAuthorizedKeys:
-      - 'ssh-rsa ssh_key_value'
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8='
     sudo: ALL=(ALL) NOPASSWD:ALL
 infrastructureTemplate:
   apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/controllers/resource/testdata/cloudstackKubeadmconfigTemplateSpec.yaml
+++ b/controllers/resource/testdata/cloudstackKubeadmconfigTemplateSpec.yaml
@@ -44,5 +44,5 @@ spec:
       users:
         - name: capc
           sshAuthorizedKeys:
-            - 'ssh-rsa ssh_key_value'
+            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8=
           sudo: ALL=(ALL) NOPASSWD:ALL

--- a/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
+++ b/controllers/resource/testdata/cloudstackKubeadmcontrolplane.yaml
@@ -99,7 +99,7 @@ spec:
     users:
       - name: capc
         sshAuthorizedKeys:
-          - 'ssh-rsa ssh_key_value'
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8=
         sudo: ALL=(ALL) NOPASSWD:ALL
   replicas: 1
   version: v1.19.8-eks-1-19-4

--- a/controllers/resource/testdata/cloudstackMachineConfigSpec.yaml
+++ b/controllers/resource/testdata/cloudstackMachineConfigSpec.yaml
@@ -19,5 +19,5 @@ spec:
   users:
     - name: capc
       sshAuthorizedKeys:
-        - "ssh-rsa ssh_key_value"
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8=
 status: {}

--- a/controllers/resource/testdata/eksa-cluster-cloudstack-etcd.yaml
+++ b/controllers/resource/testdata/eksa-cluster-cloudstack-etcd.yaml
@@ -58,9 +58,9 @@ spec:
   computeOffering:
     name: "Large Instance"
   users:
-    - name: "cpac"
-      sshAuthorizedKeys:
-        - "ssh-rsa ssh-key-value"
+        - name: capc
+          sshAuthorizedKeys:
+            - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8="
   template:
     name: "rhel-8-kube-v1.21.5"
   diskOffering:

--- a/controllers/resource/testdata/eksa-cluster-cloudstack.yaml
+++ b/controllers/resource/testdata/eksa-cluster-cloudstack.yaml
@@ -53,9 +53,9 @@ spec:
   computeOffering:
     name: "Large Instance"
   users:
-    - name: "cpac"
+    - name: capc
       sshAuthorizedKeys:
-        - "ssh-rsa ssh-key-value"
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8="
   template:
     name: "rhel-8-kube-v1.21.5"
   diskOffering:

--- a/controllers/resource/testdata/eksa-cluster-cloudstack_no_changes.yaml
+++ b/controllers/resource/testdata/eksa-cluster-cloudstack_no_changes.yaml
@@ -49,7 +49,7 @@ spec:
   users:
     - name: capc
       sshAuthorizedKeys:
-        - "ssh-rsa ssh_key_value"
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8="
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: CloudStackDatacenterConfig

--- a/internal/pkg/api/cloudstackmachines.go
+++ b/internal/pkg/api/cloudstackmachines.go
@@ -1,12 +1,11 @@
 package api
 
 import (
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
 type CloudStackMachineConfigFiller func(m *anywherev1.CloudStackMachineConfig)
-
-const DefaultCloudstackUser = "capc"
 
 func FillCloudStackMachineConfig(m *anywherev1.CloudStackMachineConfig, fillers ...CloudStackMachineConfigFiller) {
 	for _, f := range fillers {
@@ -29,7 +28,7 @@ func WithCloudStackSSHKey(value string) CloudStackMachineConfigFiller {
 func setCloudStackSSHKeyForFirstUser(m *anywherev1.CloudStackMachineConfig, key string) {
 	if len(m.Spec.Users) == 0 {
 		m.Spec.Users = []anywherev1.UserConfiguration{{
-			Name: DefaultCloudstackUser,
+			Name: v1alpha1.DefaultCloudStackUser,
 		}}
 	}
 

--- a/pkg/api/v1alpha1/cloudstackmachineconfig.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig.go
@@ -9,6 +9,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// DefaultCloudStackUser is the default CloudStackMachingConfig username.
+const DefaultCloudStackUser = "capc"
+
+// CloudStackMachineConfigKind is the kind value for a CloudStackMachineConfig.
 const CloudStackMachineConfigKind = "CloudStackMachineConfig"
 
 // Taken from https://github.com/shapeblue/cloudstack/blob/08bb4ad9fea7e422c3d3ac6d52f4670b1e89eed7/api/src/main/java/com/cloud/vm/VmDetailConstants.java

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -418,10 +418,6 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				return fmt.Errorf("unable to get datacenter config from file %s: %v", clusterConfigFile, err)
 			}
 
-			machineConfigs, err := v1alpha1.GetCloudStackMachineConfigs(clusterConfigFile)
-			if err != nil {
-				return fmt.Errorf("unable to get machine config from file %s: %v", clusterConfigFile, err)
-			}
 			execConfig, err := decoder.ParseCloudStackCredsFromEnv()
 			if err != nil {
 				return fmt.Errorf("parsing CloudStack credentials: %v", err)
@@ -430,7 +426,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 			if err != nil {
 				return fmt.Errorf("building validator from exec config: %v", err)
 			}
-			f.dependencies.Provider = cloudstack.NewProvider(datacenterConfig, machineConfigs, clusterConfig, f.dependencies.Kubectl, validator, f.dependencies.Writer, time.Now, logger.Get())
+			f.dependencies.Provider = cloudstack.NewProvider(datacenterConfig, clusterConfig, f.dependencies.Kubectl, validator, f.dependencies.Writer, time.Now, logger.Get())
 
 		case v1alpha1.SnowDatacenterKind:
 			f.dependencies.Provider = snow.NewProvider(

--- a/pkg/providers/cloudstack/controlplane.go
+++ b/pkg/providers/cloudstack/controlplane.go
@@ -2,6 +2,7 @@ package cloudstack
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -31,7 +32,7 @@ func (p ControlPlane) Objects() []kubernetes.Object {
 
 // ControlPlaneSpec builds a CloudStack ControlPlane definition based on an eks-a cluster spec.
 func ControlPlaneSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, clusterSpec *cluster.Spec) (*ControlPlane, error) {
-	templateBuilder := generateTemplateBuilder(clusterSpec)
+	templateBuilder := NewTemplateBuilder(time.Now)
 	controlPlaneYaml, err := templateBuilder.GenerateCAPISpecControlPlane(
 		clusterSpec,
 		func(values map[string]interface{}) {

--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -576,7 +576,7 @@ rules:
 					{
 						Name:              "mySshUsername",
 						Sudo:              ptr.String("ALL=(ALL) NOPASSWD:ALL"),
-						SSHAuthorizedKeys: []string{"<no value>"},
+						SSHAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=="},
 					},
 				},
 				Format:                   "cloud-config",

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -457,7 +457,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		m.Spec.Users = append(m.Spec.Users,
 			anywherev1.UserConfiguration{
 				Name:              "user",
-				SshAuthorizedKeys: []string{""},
+				SshAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8= ubuntu@ip-10-2-0-6"},
 			})
 	})
 	machineConfigWN := machineConfig(func(m *anywherev1.CloudStackMachineConfig) {
@@ -465,7 +465,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		m.Spec.Users = append(m.Spec.Users,
 			anywherev1.UserConfiguration{
 				Name:              "user",
-				SshAuthorizedKeys: []string{""},
+				SshAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8ZEibIrz1AUBKDvmDiWLs9f5DnOerC4qPITiDtSOuPAsxgZbRMavBfVTxodMdAkYRYlXxK6PqNo0ve0qcOV2yvpxH1OogasMMetck6BlM/dIoo3vEY4ZoG9DuVRIf9Iry5gJKbpMDYWpx1IGZrDMOFcIM20ii2qLQQk5hfq9OqdqhToEJFixdgJt/y/zt6Koy3kix+XsnrVdAHgWAq4CZuwt1G6JUAqrpob3H8vPmL7aS+35ktf0pHBm6nYoxRhslnWMUb/7vpzWiq+fUBIm2LYqvrnm7t3fRqFx7p2sZqAm2jDNivyYXwRXkoQPR96zvGeMtuQ5BVGPpsDfVudSW21+pEXHI0GINtTbua7Ogz7wtpVywSvHraRgdFOeY9mkXPzvm2IhoqNrteck2GErwqSqb19mPz6LnHueK0u7i6WuQWJn0CUoCtyMGIrowXSviK8qgHXKrmfTWATmCkbtosnLskNdYuOw8bKxq5S4WgdQVhPps2TiMSZndjX5NTr8= ubuntu@ip-10-2-0-6"},
 			})
 	})
 

--- a/pkg/providers/cloudstack/spec.go
+++ b/pkg/providers/cloudstack/spec.go
@@ -5,36 +5,17 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
-type Spec struct {
-	*cluster.Spec
-	datacenterConfig     *anywherev1.CloudStackDatacenterConfig
-	machineConfigsLookup map[string]*anywherev1.CloudStackMachineConfig
-}
-
-func NewSpec(clusterSpec *cluster.Spec, machineConfigs map[string]*anywherev1.CloudStackMachineConfig, datacenterConfig *anywherev1.CloudStackDatacenterConfig) *Spec {
-	machineConfigsInCluster := map[string]*anywherev1.CloudStackMachineConfig{}
-	for _, m := range clusterSpec.Cluster.MachineConfigRefs() {
-		machineConfig, ok := machineConfigs[m.Name]
-		if !ok {
-			continue
-		}
-		machineConfigsInCluster[m.Name] = machineConfig
-	}
-
-	return &Spec{
-		Spec:                 clusterSpec,
-		datacenterConfig:     datacenterConfig,
-		machineConfigsLookup: machineConfigsInCluster,
-	}
-}
-
-func (s *Spec) controlPlaneMachineConfig() *anywherev1.CloudStackMachineConfig {
-	return s.machineConfigsLookup[s.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
-}
-
-func (s *Spec) etcdMachineConfig() *anywherev1.CloudStackMachineConfig {
+func etcdMachineConfig(s *cluster.Spec) *anywherev1.CloudStackMachineConfig {
 	if s.Cluster.Spec.ExternalEtcdConfiguration == nil || s.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef == nil {
 		return nil
 	}
-	return s.machineConfigsLookup[s.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
+	return s.CloudStackMachineConfigs[s.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
+}
+
+func controlPlaneMachineConfig(s *cluster.Spec) *anywherev1.CloudStackMachineConfig {
+	return s.CloudStackMachineConfigs[s.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name]
+}
+
+func workerMachineConfig(s *cluster.Spec, workers anywherev1.WorkerNodeGroupConfiguration) *anywherev1.CloudStackMachineConfig {
+	return s.CloudStackMachineConfigs[workers.MachineGroupRef.Name]
 }

--- a/pkg/providers/cloudstack/validator_mocks.go
+++ b/pkg/providers/cloudstack/validator_mocks.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	decoder "github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	gomock "github.com/golang/mock/gomock"
@@ -52,7 +53,7 @@ func (mr *MockProviderValidatorMockRecorder) ValidateCloudStackDatacenterConfig(
 }
 
 // ValidateClusterMachineConfigs mocks base method.
-func (m *MockProviderValidator) ValidateClusterMachineConfigs(arg0 context.Context, arg1 *Spec) error {
+func (m *MockProviderValidator) ValidateClusterMachineConfigs(arg0 context.Context, arg1 *cluster.Spec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateClusterMachineConfigs", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/pkg/providers/cloudstack/validator_registry.go
+++ b/pkg/providers/cloudstack/validator_registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/networkutils"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -31,7 +32,7 @@ type ValidatorFactory struct {
 // ProviderValidator exposes a common interface to avoid coupling on implementation details and to support mocking.
 type ProviderValidator interface {
 	ValidateCloudStackDatacenterConfig(ctx context.Context, datacenterConfig *anywherev1.CloudStackDatacenterConfig) error
-	ValidateClusterMachineConfigs(ctx context.Context, cloudStackClusterSpec *Spec) error
+	ValidateClusterMachineConfigs(ctx context.Context, clusterSpec *cluster.Spec) error
 	ValidateControlPlaneEndpointUniqueness(endpoint string) error
 	ValidateSecretsUnchanged(ctx context.Context, cluster *types.Cluster, execConfig *decoder.CloudStackExecConfig, client ProviderKubectlClient) error
 }

--- a/pkg/providers/cloudstack/workers.go
+++ b/pkg/providers/cloudstack/workers.go
@@ -2,6 +2,7 @@ package cloudstack
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -24,7 +25,7 @@ type (
 // It talks to the cluster with a client to detect changes in immutable objects and generates new
 // names for them.
 func WorkersSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*Workers, error) {
-	templateBuilder := generateTemplateBuilder(spec)
+	templateBuilder := NewTemplateBuilder(time.Now)
 	machineTemplateNames, kubeadmConfigTemplateNames := clusterapi.InitialTemplateNamesForWorkers(spec)
 	workersYaml, err := templateBuilder.GenerateCAPISpecWorkers(spec, machineTemplateNames, kubeadmConfigTemplateNames)
 	if err != nil {

--- a/pkg/providers/cloudstack/workers_test.go
+++ b/pkg/providers/cloudstack/workers_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
@@ -28,8 +27,8 @@ func TestWorkersSpecNewCluster(t *testing.T) {
 	ctx := context.Background()
 	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
 	client := test.NewFakeKubeClient()
-	format.MaxLength = 40000
 	workers, err := cloudstack.WorkersSpec(ctx, logger, client, spec)
+
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(workers).NotTo(BeNil())
 	g.Expect(workers.Groups).To(HaveLen(2))
@@ -97,7 +96,6 @@ func TestWorkersSpecUpgradeCluster(t *testing.T) {
 	// Like for example, the ResourceVersion
 	expectedGroup1 := oldGroup1.DeepCopy()
 	expectedGroup2 := oldGroup2.DeepCopy()
-
 	objs := make([]kubernetes.Object, 0, 6)
 	objs = append(objs, oldGroup1.Objects()...)
 	objs = append(objs, oldGroup2.Objects()...)
@@ -231,7 +229,7 @@ func TestWorkersSpecRegistryMirrorConfiguration(t *testing.T) {
 	ctx := context.Background()
 	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
 	client := test.NewFakeKubeClient()
-	format.MaxLength = 40000
+
 	tests := []struct {
 		name         string
 		mirrorConfig *anywherev1.RegistryMirrorConfiguration
@@ -251,8 +249,6 @@ func TestWorkersSpecRegistryMirrorConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			format.MaxLength = 40000
-
 			spec.Cluster.Spec.RegistryMirrorConfiguration = tt.mirrorConfig
 			workers, err := cloudstack.WorkersSpec(ctx, logger, client, spec)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -389,7 +385,7 @@ func kubeadmConfigTemplate(opts ...func(*bootstrapv1.KubeadmConfigTemplate)) *bo
 						{
 							Name:              "mySshUsername",
 							Sudo:              ptr.String("ALL=(ALL) NOPASSWD:ALL"),
-							SSHAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"},
+							SSHAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=="},
 						},
 					},
 					Format: bootstrapv1.Format("cloud-config"),

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -8,7 +8,6 @@ import (
 	etcdadmbootstrapv1 "github.com/aws/etcdadm-bootstrap-provider/api/v1beta1"
 	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
@@ -265,7 +264,6 @@ func TestControlPlaneSpecRegistryMirrorConfiguration(t *testing.T) {
 		},
 	}
 
-	format.MaxLength = 40000
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			spec.Cluster.Spec.RegistryMirrorConfiguration = tt.mirrorConfig

--- a/pkg/providers/vsphere/workers_test.go
+++ b/pkg/providers/vsphere/workers_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1beta1"
@@ -241,7 +240,6 @@ func TestWorkersSpecRegistryMirrorConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			format.MaxLength = 40000
 
 			spec.Cluster.Spec.RegistryMirrorConfiguration = tt.mirrorConfig
 			workers, err := vsphere.WorkersSpec(ctx, logger, client, spec)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The [CloudStackTemplateBuilder](https://github.com/aws/eks-anywhere/blob/2ca366517b41fede3256ec0e47e5de37b9f59a2a/pkg/providers/cloudstack/cloudstack.go#L633) has dependencies on `controlPlaneMachineSpec`, `WorkerNodeGroupMachineSpecs`, and `etcdMachineSpecs`. According to [here](https://github.com/aws/eks-anywhere/blob/50ee3e1e0705b769039fdff04d53e471e198dd50/controllers/resource/template.go#L181), it seems as though it was made prohibiting control plane and ETCD updates, and these provided arguments help to override what's in the provided spec. Given we are working on the new controller, we don't need this limitation anymore, it also makes the code made the code more complex. 

This PR does the following:
1. Removes dependencies from the CloudStackTemplateBuilder, simplifying it to make use the API structs in the provided cluster.Spec instead of maintaining it's own versions of the data.
2. It moves SSH key normalization to the template builder level as opposed to during defaulting. This way user comments in the SSH keys will be kept in the CloudStackMachineConfigs as entered by the user but removed from machine templates. Also, now it's only done in one place.
3. Adds logic to assign a default username for the CloudStackMachineConfig user. If there were no users specified, the logic here would default the SSH key for the default user but not the username and there would be an error late during the creation process. This adds defaulting logic for the username as well to avoid that.
4. Remove CloudStack provider dependency on API structs. Given the cluster spec is passed to most methods as an arguments, this is easier to track as the single source of truth. This avoids bugs where updates are only performed in one place but not the other.

*Testing (if applicable):*
- Unit tests
- Run create/upgrade e2e test manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

