### PR TITLE
use --password-stdin to prevent process table leaking

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -101,11 +101,11 @@ func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
 	logger.Info("Logging in to helm registry", "registry", registry)
-	params := []string{"registry", "login", registry, "--username", username, "--password", password}
+	params := []string{"registry", "login", registry, "--username", username, "--password-stdin"}
 	if h.insecure {
 		params = append(params, "--insecure")
 	}
-	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()
+	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).WithStdIn([]byte(password)).Run()
 	return err
 }
 


### PR DESCRIPTION
Modifies the `helm registry login` command to use the `--password-stdin` flag which prevents leaking the password on the process table.

This might also be the cause of a bug: https://github.com/aws/eks-anywhere-packages/issues/923

Though as far as I can tell, the helm registry login command still accepts the `--password flag`, though it prints a warning.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

