### PR TITLE
Security Improvement for binary install

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -53,7 +53,7 @@ The EKS Anywhere plugin requires `eksctl` version 0.66.0 or newer.
 curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
     --silent --location \
     | tar xz -C /tmp
-sudo install -o root -g root -m 0755 /tmp/eksctl /usr/local/bin/eksctl
+sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
 ```
 
 Install the `eksctl-anywhere` plugin.
@@ -64,7 +64,7 @@ EKS_ANYWHERE_TARBALL_URL=$(curl https://anywhere-assets.eks.amazonaws.com/releas
 curl $EKS_ANYWHERE_TARBALL_URL \
     --silent --location \
     | tar xz ./eksctl-anywhere
-sudo install -o root -g root -m 0755 ./eksctl-anywhere /usr/local/bin/eksctl-anywhere
+sudo install -m 0755 ./eksctl-anywhere /usr/local/bin/eksctl-anywhere
 ```
 
 Install the `kubectl` Kubernetes command line tool.
@@ -75,7 +75,7 @@ Or you can install the latest kubectl directly with the following.
 ```bash
 export OS="$(uname -s | tr A-Z a-z)" ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS}/${ARCH}/kubectl"
-sudo install -o root -g root -m 0755 ./kubectl /usr/local/bin/kubectl
+sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
 ```
 
 ### Upgrade eksctl-anywhere

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -53,7 +53,7 @@ The EKS Anywhere plugin requires `eksctl` version 0.66.0 or newer.
 curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
     --silent --location \
     | tar xz -C /tmp
-sudo mv /tmp/eksctl /usr/local/bin/
+sudo install -o root -g root -m 0755 /tmp/eksctl /usr/local/bin/eksctl
 ```
 
 Install the `eksctl-anywhere` plugin.
@@ -64,7 +64,7 @@ EKS_ANYWHERE_TARBALL_URL=$(curl https://anywhere-assets.eks.amazonaws.com/releas
 curl $EKS_ANYWHERE_TARBALL_URL \
     --silent --location \
     | tar xz ./eksctl-anywhere
-sudo mv ./eksctl-anywhere /usr/local/bin/
+sudo install -o root -g root -m 0755 ./eksctl-anywhere /usr/local/bin/eksctl-anywhere
 ```
 
 Install the `kubectl` Kubernetes command line tool.
@@ -75,8 +75,7 @@ Or you can install the latest kubectl directly with the following.
 ```bash
 export OS="$(uname -s | tr A-Z a-z)" ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS}/${ARCH}/kubectl"
-sudo mv ./kubectl /usr/local/bin
-sudo chmod +x /usr/local/bin/kubectl
+sudo install -o root -g root -m 0755 ./kubectl /usr/local/bin/kubectl
 ```
 
 ### Upgrade eksctl-anywhere


### PR DESCRIPTION
*Issue #, if available:*
The method for installing the eksctl and associated commands is not secure as it creates a file in a system-wide directory owned by a user (user = whoever the person is logged in as).  

*Description of changes:*
Instead of using mv (and chmod in some of the examples), use the "install" command with appropriate flags
ex - replace first line (mv) with the second (install)

```
sudo mv /tmp/eksctl /usr/local/bin/
sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
```

*Testing (if applicable):*

RHEL8
```
[jradtke@rhel8 ~]$ touch /tmp/test
[jradtke@rhel8 ~]$ ls -l /tmp/test
-rw-rw-r--. 1 jradtke jradtke 0 Apr 24 16:48 /tmp/test
[jradtke@rhel8 ~]$ sudo install -m 0755 /tmp/test /tmp/test1
[jradtke@rhel8 ~]$ ls -l /tmp | grep test
-rw-rw-r--. 1 jradtke jradtke  0 Apr 24 16:48 test
-rwxr-xr-x. 1 root    root     0 Apr 24 16:48 test1
```
macOS
```
macOS:~ jaradtke$ touch /tmp/test
macOS:~ jaradtke$ ls -l /tmp/test
-rw-r--r--  1 jaradtke  wheel  0 Apr 24 17:02 /tmp/test
macOS:~ jaradtke$ sudo install -m 0755 /tmp/test /tmp/test1
macOS:~ jaradtke$ ls -l /tmp/ | grep test
-rw-r--r--  1 jaradtke  wheel      0 Apr 24 17:02 test
-rwxr-xr-x  1 root      wheel      0 Apr 24 17:03 test1
macOS:~ jaradtke$ uname -s
Darwin
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

