### PR TITLE
Update inaccurate notes

### DIFF
--- a/docs/content/en/docs/getting-started/local-environment/_index.md
+++ b/docs/content/en/docs/getting-started/local-environment/_index.md
@@ -29,7 +29,7 @@ To install the EKS Anywhere binaries and see system requirements please follow t
       --provider docker > $CLUSTER_NAME.yaml
    ```
 
-   The command above creates a file named eksa-cluster.yaml with the contents below in the path where it is executed.
+   The command above creates a file named mgmt.yaml (if you used the provided example) with the contents below in the path where it is executed.
    The configuration specification is divided into two sections:
 
    * Cluster


### PR DESCRIPTION
*Issue #, if available:*
The notes describing the expected file name (eksa-cluster.yaml) is not accurate if the instructions were followed - it will be mgmt.yaml.  Also, the example yaml output shown indicates that the metadata:name = mgmt.

*Description of changes:*
I update the notes to indicate the filename will be "mgmt.yaml" (and added verbiage to say "if the instructions were followed)

*Testing (if applicable):*
NOTE:  there are a numerous references to "eksa-cluster.yaml" in other *.md files.  I have not proceeded far enough (yet) to know whether this matters.  Example:

```
docs//content/en/docs/tasks/cluster/cluster-iam-auth.md:    clusters/$CLUSTER_NAME/eksa-system/eksa-cluster.yaml
docs//content/en/docs/tasks/cluster/cluster-iam-auth.md:    git add eksa-cluster.yaml
```
Or
```
docs//content/en/docs/tasks/cluster/cluster-flux.md:    clusters/$CLUSTER_NAME/eksa-system/eksa-cluster.yaml
docs//content/en/docs/tasks/cluster/cluster-flux.md:    git add eksa-cluster.yaml
docs//content/en/docs/tasks/cluster/cluster-flux.md:      clusters/<management-cluster-name>/$CLUSTER_NAME/eksa-system/eksa-cluster.yaml
docs//content/en/docs/tasks/cluster/cluster-flux.md:         git add clusters/<management-cluster-name>/$CLUSTER_NAME/eksa-system/eksa-cluster.yaml
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

