### PR TITLE
Add Nutanix to Compare EKS Anywhere and EKS page

### DIFF
--- a/docs/content/en/docs/concepts/eksafeatures.md
+++ b/docs/content/en/docs/concepts/eksafeatures.md
@@ -29,7 +29,7 @@ To learn more about Amazon EKS, see [Amazon Elastic Kubernetes Service](https://
 | Cluster updates        | Manual CLI updates for control plane. Flux supported rolling updates for data plane | Managed in-place updates for control plane and managed rolling updates for data plane.                       |
 ||||
 | **Compute** |||
-| Compute options | CloudStack, VMware vSphere, Bare Metal servers | Amazon EC2, AWS Fargate | 
+| Compute options | CloudStack, VMware vSphere, Nutanix, Bare Metal servers | Amazon EC2, AWS Fargate | 
 | Supported node operating systems   | Bottlerocket, Ubuntu, and RHEL         | Amazon Linux 2, Windows Server, Bottlerocket, Ubuntu |
 | Physical hardware (servers, network equipment, storage, etc.) | Managed by customer | Managed by AWS |
 | Serverless | Not supported | Amazon EKS on AWS Fargate |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Nutanix to the EKS-A and EKS comparison page. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

