### PR TITLE
Add Timeout to Delete Full Lifecycle API E2E

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -348,8 +348,12 @@ func (k *Kubectl) ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *type
 }
 
 // DeleteManifest uses client-side logic to delete objects defined in a yaml manifest.
-func (k *Kubectl) DeleteManifest(ctx context.Context, kubeconfigPath, manifestPath string, timeout string) error {
-	if _, err := k.Execute(ctx, "delete", "-f", manifestPath, "--kubeconfig", kubeconfigPath, "--timeout", timeout); err != nil {
+func (k *Kubectl) DeleteManifest(ctx context.Context, kubeconfigPath, manifestPath string, opts ...KubectlOpt) error {
+	params := []string{
+		"delete", "-f", manifestPath, "--kubeconfig", kubeconfigPath,
+	}
+	applyOpts(&params, opts...)
+	if _, err := k.Execute(ctx, params...); err != nil {
 		return fmt.Errorf("executing apply manifest: %v", err)
 	}
 	return nil

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -349,7 +349,7 @@ func (k *Kubectl) ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *type
 
 // DeleteManifest uses client-side logic to delete objects defined in a yaml manifest.
 func (k *Kubectl) DeleteManifest(ctx context.Context, kubeconfigPath, manifestPath string) error {
-	if _, err := k.Execute(ctx, "delete", "-f", manifestPath, "--kubeconfig", kubeconfigPath); err != nil {
+	if _, err := k.Execute(ctx, "delete", "-f", manifestPath, "--kubeconfig", kubeconfigPath, "--timeout", "20m"); err != nil {
 		return fmt.Errorf("executing apply manifest: %v", err)
 	}
 	return nil

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -348,8 +348,8 @@ func (k *Kubectl) ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *type
 }
 
 // DeleteManifest uses client-side logic to delete objects defined in a yaml manifest.
-func (k *Kubectl) DeleteManifest(ctx context.Context, kubeconfigPath, manifestPath string) error {
-	if _, err := k.Execute(ctx, "delete", "-f", manifestPath, "--kubeconfig", kubeconfigPath, "--timeout", "20m"); err != nil {
+func (k *Kubectl) DeleteManifest(ctx context.Context, kubeconfigPath, manifestPath string, timeout string) error {
+	if _, err := k.Execute(ctx, "delete", "-f", manifestPath, "--kubeconfig", kubeconfigPath, "--timeout", timeout); err != nil {
 		return fmt.Errorf("executing apply manifest: %v", err)
 	}
 	return nil

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -210,7 +210,7 @@ func TestKubectlDeleteManifestSuccess(t *testing.T) {
 	spec := "specfile"
 
 	k, ctx, cluster, e := newKubectl(t)
-	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile}
+	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", "20m"}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, nil)
 	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec); err != nil {
 		t.Errorf("Kubectl.DeleteManifest() error = %v, want nil", err)
@@ -222,7 +222,7 @@ func TestKubectlDeleteManifestError(t *testing.T) {
 	spec := "specfile"
 
 	k, ctx, cluster, e := newKubectl(t)
-	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile}
+	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", "20m"}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, errors.New("error from execute"))
 	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec); err == nil {
 		t.Errorf("Kubectl.DeleteManifest() error = nil, want not nil")

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -208,11 +208,12 @@ func TestKubectlApplyKubeSpecFromBytesError(t *testing.T) {
 func TestKubectlDeleteManifestSuccess(t *testing.T) {
 	t.Parallel()
 	spec := "specfile"
+	timeout := "20m"
 
 	k, ctx, cluster, e := newKubectl(t)
-	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", "20m"}
+	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", timeout}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, nil)
-	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec); err != nil {
+	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec, timeout); err != nil {
 		t.Errorf("Kubectl.DeleteManifest() error = %v, want nil", err)
 	}
 }
@@ -220,11 +221,12 @@ func TestKubectlDeleteManifestSuccess(t *testing.T) {
 func TestKubectlDeleteManifestError(t *testing.T) {
 	t.Parallel()
 	spec := "specfile"
+	timeout := "20m"
 
 	k, ctx, cluster, e := newKubectl(t)
-	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", "20m"}
+	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", timeout}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, errors.New("error from execute"))
-	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec); err == nil {
+	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec, timeout); err == nil {
 		t.Errorf("Kubectl.DeleteManifest() error = nil, want not nil")
 	}
 }

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -208,12 +208,11 @@ func TestKubectlApplyKubeSpecFromBytesError(t *testing.T) {
 func TestKubectlDeleteManifestSuccess(t *testing.T) {
 	t.Parallel()
 	spec := "specfile"
-	timeout := "20m"
 
 	k, ctx, cluster, e := newKubectl(t)
-	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", timeout}
+	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, nil)
-	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec, timeout); err != nil {
+	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec); err != nil {
 		t.Errorf("Kubectl.DeleteManifest() error = %v, want nil", err)
 	}
 }
@@ -221,12 +220,11 @@ func TestKubectlDeleteManifestSuccess(t *testing.T) {
 func TestKubectlDeleteManifestError(t *testing.T) {
 	t.Parallel()
 	spec := "specfile"
-	timeout := "20m"
 
 	k, ctx, cluster, e := newKubectl(t)
-	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile, "--timeout", timeout}
+	expectedParam := []string{"delete", "-f", spec, "--kubeconfig", cluster.KubeconfigFile}
 	e.EXPECT().Execute(ctx, gomock.Eq(expectedParam)).Return(bytes.Buffer{}, errors.New("error from execute"))
-	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec, timeout); err == nil {
+	if err := k.DeleteManifest(ctx, cluster.KubeconfigFile, spec); err == nil {
 		t.Errorf("Kubectl.DeleteManifest() error = nil, want not nil")
 	}
 }

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2320,7 +2320,7 @@ func TestVSphereMulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
 	test.DeleteManagementCluster()
 }
 
-func TestVSphereUpgradeKubernetesUbuntuAPI(t *testing.T) {
+func TestVSphereUpgradeKubernetes123to124UbuntuWorkloadClusterAPI(t *testing.T) {
 	vsphere := framework.NewVSphere(t)
 
 	managementCluster := framework.NewClusterE2ETest(
@@ -2350,22 +2350,9 @@ func TestVSphereUpgradeKubernetesUbuntuAPI(t *testing.T) {
 		),
 	)
 
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.UpdateClusterConfig(
-			vsphere.WithUbuntu124(),
-		)
-		wc.ApplyClusterManifest()
-		wc.DeleteWorkloadVsphereCSI()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
+	runWorkloadClusterUpgradeFlowAPI(test,
+		vsphere.WithUbuntu124(),
+	)
 }
 
 func TestVSphereCiliumDisableCSIUbuntuAPI(t *testing.T) {

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -53,7 +53,10 @@ func (w *WorkloadCluster) ApplyClusterManifest() {
 func (w *WorkloadCluster) DeleteClusterWithKubectl() {
 	ctx := context.Background()
 	w.T.Logf("Deleting workload cluster %s with kubectl", w.ClusterName)
-	if err := w.KubectlClient.DeleteManifest(ctx, w.ManagementClusterKubeconfigFile(), w.ClusterConfigLocation, kubectlDeleteTimeout); err != nil {
+	opts := func(params *[]string) {
+		*params = append(*params, "--timeout", kubectlDeleteTimeout)
+	}
+	if err := w.KubectlClient.DeleteManifest(ctx, w.ManagementClusterKubeconfigFile(), w.ClusterConfigLocation, opts); err != nil {
 		w.T.Fatalf("Failed to delete workload cluster config: %s", err)
 	}
 	w.StopIfFailed()

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -13,6 +13,10 @@ import (
 	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
+const (
+	kubectlDeleteTimeout = "20m"
+)
+
 type WorkloadCluster struct {
 	*ClusterE2ETest
 	ManagementClusterKubeconfigFile func() string
@@ -49,7 +53,7 @@ func (w *WorkloadCluster) ApplyClusterManifest() {
 func (w *WorkloadCluster) DeleteClusterWithKubectl() {
 	ctx := context.Background()
 	w.T.Logf("Deleting workload cluster %s with kubectl", w.ClusterName)
-	if err := w.KubectlClient.DeleteManifest(ctx, w.ManagementClusterKubeconfigFile(), w.ClusterConfigLocation); err != nil {
+	if err := w.KubectlClient.DeleteManifest(ctx, w.ManagementClusterKubeconfigFile(), w.ClusterConfigLocation, kubectlDeleteTimeout); err != nil {
 		w.T.Fatalf("Failed to delete workload cluster config: %s", err)
 	}
 	w.StopIfFailed()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a 20 minute timeout to calls that delete clusters with kubectl for full lifecycle api e2e tests

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

