### PR TITLE
Add IRSA & IAM Auth Support for Nutanix

### DIFF
--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -152,8 +152,9 @@ func buildTemplateMapCP(
 ) (map[string]interface{}, error) {
 	bundle := clusterSpec.VersionsBundle
 	format := "cloud-config"
-	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig)
-
+	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
+		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
+		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig))
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf)).
 		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration))
@@ -232,6 +233,10 @@ func buildTemplateMapCP(
 		values["projectIDType"] = controlPlaneMachineSpec.Project.Type
 		values["projectName"] = controlPlaneMachineSpec.Project.Name
 		values["projectUUID"] = controlPlaneMachineSpec.Project.UUID
+	}
+
+	if clusterSpec.AWSIamConfig != nil {
+		values["awsIamAuth"] = true
 	}
 
 	return values, nil

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -296,6 +296,46 @@ func TestNewNutanixTemplateBuilderNodeTaintsAndLabels(t *testing.T) {
 	assert.Equal(t, expectedWorkersSpec, workerSpec)
 }
 
+func TestNewNutanixTemplateBuilderIAMAuth(t *testing.T) {
+	dcConf, machineConf, workerConfs := minimalNutanixConfigSpec(t)
+
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-iamauth.yaml")
+
+	cpSpec, err := builder.GenerateCAPISpecControlPlane(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+
+	expectedControlPlaneSpec, err := os.ReadFile("testdata/expected_results_iamauth.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
+}
+
+func TestNewNutanixTemplateBuilderIRSA(t *testing.T) {
+	dcConf, machineConf, workerConfs := minimalNutanixConfigSpec(t)
+
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-irsa.yaml")
+
+	cpSpec, err := builder.GenerateCAPISpecControlPlane(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+
+	expectedControlPlaneSpec, err := os.ReadFile("testdata/expected_results_irsa.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
+}
+
 func minimalNutanixConfigSpec(t *testing.T) (*anywherev1.NutanixDatacenterConfig, *anywherev1.NutanixMachineConfig, map[string]anywherev1.NutanixMachineConfigSpec) {
 	dcConf := &anywherev1.NutanixDatacenterConfig{}
 	err := yaml.Unmarshal([]byte(nutanixDatacenterConfigSpec), dcConf)

--- a/pkg/providers/nutanix/testdata/eksa-cluster-iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-iamauth.yaml
@@ -1,0 +1,93 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  identityProviderRefs:
+    - kind: AWSIamConfig
+      name: aws-iam-auth-config
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: AWSIamConfig
+metadata:
+  name: aws-iam-auth-config
+spec:
+  awsRegion: "us-east-1"
+  backendMode:
+    - "EKSConfigMap"
+  mapUsers:
+    - userARN: arn:aws:iam::861212534935:user/eksaiamauth
+      username: eksaiamauth
+      groups:
+        - "system:masters"
+  partition: "aws"

--- a/pkg/providers/nutanix/testdata/eksa-cluster-irsa.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-irsa.yaml
@@ -1,0 +1,77 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  podIamConfig:
+    serviceAccountIssuer: https://keycloak.nutanix.com/auth/realms/test/
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -1,75 +1,66 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixCluster
 metadata:
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
 spec:
   prismCentral:
-{{- if .nutanixAdditionalTrustBundle }}
-    additionalTrustBundle:
-      kind: String
-      data: |
-{{ .nutanixAdditionalTrustBundle | indent 8 }}
-{{- end }}
-    address: "{{.nutanixEndpoint}}"
-    port: {{.nutanixPort}}
-    insecure: {{.nutanixInsecure}}
+    address: "prism.nutanix.com"
+    port: 9440
+    insecure: false
     credentialRef:
-      name: "{{.secretName}}"
+      name: "capx-eksa-unit-test"
       kind: Secret
   controlPlaneEndpoint:
-    host: "{{.controlPlaneEndpointIp}}"
+    host: "test-ip"
     port: 6443
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: "{{.clusterName}}"
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
 spec:
   clusterNetwork:
     services:
-      cidrBlocks: {{.serviceCidrs}}
+      cidrBlocks: [10.96.0.0/12]
     pods:
-      cidrBlocks: {{.podCidrs}}
+      cidrBlocks: [192.168.0.0/16]
     serviceDomain: "cluster.local"
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: "{{.clusterName}}"
+    name: "eksa-unit-test"
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: NutanixCluster
-    name: "{{.clusterName}}"
+    name: "eksa-unit-test"
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: "{{.clusterName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
 spec:
-  replicas: {{.controlPlaneReplicas}}
-  version: "{{.kubernetesVersion}}"
+  replicas: 3
+  version: "v1.19.8-eks-1-19-4"
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
-      name: "{{.controlPlaneTemplateName}}"
+      name: "<no value>"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: "{{.kubernetesRepository}}"
+      imageRepository: "public.ecr.aws/eks-distro/kubernetes"
       apiServer:
         certSANs:
           - localhost
           - 127.0.0.1
           - 0.0.0.0
-{{- if .apiServerExtraArgs }}
         extraArgs:
-{{ .apiServerExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if .awsIamAuth}}
+          authentication-token-webhook-config-file: /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
         extraVolumes:
           - hostPath: /var/lib/kubeadm/aws-iam-authenticator/
             mountPath: /etc/kubernetes/aws-iam-authenticator/
@@ -79,25 +70,18 @@ spec:
             mountPath: /var/aws-iam-authenticator/
             name: awsiamcert
             readOnly: false
-{{- end}}
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"
       dns:
-        imageRepository: {{.corednsRepository}}
-        imageTag: {{.corednsVersion}}
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
       etcd:
-{{- if .externalEtcd }}
         external:
           endpoints: []
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
-{{- else }}
-        local:
-          imageRepository: {{.etcdRepository}}
-          imageTag: {{.etcdImageTag}}
-{{- end }}
     files:
     - content: |
         apiVersion: v1
@@ -109,7 +93,7 @@ spec:
         spec:
           containers:
             - name: kube-vip
-              image: {{.kubeVipImage}}
+              image: 
               imagePullPolicy: IfNotPresent
               args:
                 - manager
@@ -117,7 +101,7 @@ spec:
                 - name: vip_arp
                   value: "true"
                 - name: address
-                  value: "{{.controlPlaneEndpointIp}}"
+                  value: "test-ip"
                 - name: port
                   value: "6443"
                 - name: vip_cidr
@@ -137,9 +121,9 @@ spec:
                 - name: vip_retryperiod
                   value: "2"
                 - name: svc_enable
-                  value: "{{.kubeVipSvcEnable}}"
+                  value: "false"
                 - name: lb_enable
-                  value: "{{.kubeVipLBEnable}}"
+                  value: "false"
               securityContext:
                 capabilities:
                   add:
@@ -159,37 +143,6 @@ spec:
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
-{{- if .registryCACert }}
-    - content: |
-{{ .registryCACert | indent 8 }}
-      owner: root:root
-      path: "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .registryMirrorMap }}
-    - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          {{- range $orig, $mirror := .registryMirrorMap }}
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-            endpoint = ["https://{{ $mirror }}"]
-          {{- end }}
-{{- if or .registryCACert .insecureSkip }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-{{- if .registryCACert }}
-            ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .insecureSkip }}
-            insecure_skip_verify = {{ .insecureSkip }}
-{{- end }}
-{{- end }}
-{{- if .registryAuth }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-            username = "{{.registryUsername}}"
-            password = "{{.registryPassword}}"
-{{- end }}
-      owner: root:root
-      path: "/etc/containerd/config_append.toml"
-{{- end }}
-{{- if .awsIamAuth}}
     - content: |
         # clusters refers to the remote service.
         clusters:
@@ -213,19 +166,18 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/kubeconfig.yaml
     - contentFrom:
         secret:
-          name: {{.clusterName}}-aws-iam-authenticator-ca
+          name: eksa-unit-test-aws-iam-authenticator-ca
           key: cert.pem
       permissions: "0640"
       owner: root:root
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/cert.pem
     - contentFrom:
         secret:
-          name: {{.clusterName}}-aws-iam-authenticator-ca
+          name: eksa-unit-test-aws-iam-authenticator-ca
           key: key.pem
       permissions: "0640"
       owner: root:root
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
-{{- end}}
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -233,20 +185,7 @@ spec:
           # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
           #cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -254,37 +193,19 @@ spec:
           cloud-provider: external
           read-only-port: "0"
           anonymous-auth: "false"
-{{- if .kubeletExtraArgs }}
-{{ .kubeletExtraArgs.ToYaml | indent 10 }}
-{{- end }}
-{{- if .controlPlaneTaints }}
-        taints:
-{{- range .controlPlaneTaints}}
-          - key: {{ .Key }}
-            value: {{ .Value }}
-            effect: {{ .Effect }}
-{{- if .TimeAdded }}
-            timeAdded: {{ .TimeAdded }}
-{{- end }}
-{{- end }}
-{{- end }}
-        name: "{{`{{ ds.meta_data.hostname }}`}}"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
     users:
-      - name: "{{.controlPlaneSshUsername }}"
+      - name: "mySshUsername"
         lockPassword: false
         sudo: ALL=(ALL) NOPASSWD:ALL
         sshAuthorizedKeys:
-          - "{{.controlPlaneSshAuthorizedKey}}"
+          - "mySshAuthorizedKey"
     preKubeadmCommands:
-{{- if and .registryMirrorMap }}
-      - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
-      - sudo systemctl daemon-reload
-      - sudo systemctl restart containerd
-{{- end }}
-      - hostnamectl set-hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
-      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >> /etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true
@@ -292,60 +213,24 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate
 metadata:
-  name: "{{.controlPlaneTemplateName}}"
-  namespace: "{{.eksaSystemNamespace}}"
+  name: "<no value>"
+  namespace: "eksa-system"
 spec:
   template:
     spec:
-      providerID: "nutanix://{{.clusterName}}-m1"
-      vcpusPerSocket: {{.vcpusPerSocket}}
-      vcpuSockets: {{.vcpuSockets}}
-      memorySize: {{.memorySize}}
-      systemDiskSize: {{.systemDiskSize}}
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
       image:
-{{- if (eq .imageIDType "name") }}
         type: name
-        name: "{{.imageName}}"
-{{ else if (eq .imageIDType "uuid") }}
-        type: uuid
-        uuid: "{{.imageUUID}}"
-{{- end }}
+        name: "prism-image"
+
       cluster:
-{{- if (eq .nutanixPEClusterIDType "name") }}
         type: name
-        name: "{{.nutanixPEClusterName}}"
-{{- else if (eq .nutanixPEClusterIDType "uuid") }}
-        type: uuid
-        uuid: "{{.nutanixPEClusterUUID}}"
-{{- end }}
+        name: "prism-cluster"
       subnet:
-{{- if (eq .subnetIDType "name") }}
         - type: name
-          name: "{{.subnetName}}"
-{{- else if (eq .subnetIDType "uuid") }}
-        - type: uuid
-          uuid: "{{.subnetUUID}}"
-{{ end }}
-{{- if .projectIDType}}
-      project:
-{{- if (eq .projectIDType "name") }}
-        type: name
-        name: "{{.projectName}}"
-{{- else if (eq .projectIDType "uuid") }}
-        type: uuid
-        uuid: "{{.projectUUID}}"
-{{ end }}
-{{ end }}
+          name: "prism-subnet"
 ---
-{{- if .registryAuth }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-credentials
-  namespace: {{.eksaSystemNamespace}}
-  labels:
-    clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.registryUsername}}"
-  password: "{{.registryPassword}}"
-{{- end }}

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -1,0 +1,192 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  prismCentral:
+    address: "prism.nutanix.com"
+    port: 9440
+    insecure: false
+    credentialRef:
+      name: "capx-eksa-unit-test"
+      kind: Secret
+  controlPlaneEndpoint:
+    host: "test-ip"
+    port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: [10.96.0.0/12]
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    serviceDomain: "cluster.local"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: "eksa-unit-test"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixCluster
+    name: "eksa-unit-test"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  replicas: 3
+  version: "v1.19.8-eks-1-19-4"
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: NutanixMachineTemplate
+      name: "<no value>"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: "public.ecr.aws/eks-distro/kubernetes"
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
+        extraArgs:
+          service-account-issuer: https://keycloak.nutanix.com/auth/realms/test/
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
+      etcd:
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+            - name: kube-vip
+              image: 
+              imagePullPolicy: IfNotPresent
+              args:
+                - manager
+              env:
+                - name: vip_arp
+                  value: "true"
+                - name: address
+                  value: "test-ip"
+                - name: port
+                  value: "6443"
+                - name: vip_cidr
+                  value: "32"
+                - name: cp_enable
+                  value: "true"
+                - name: cp_namespace
+                  value: kube-system
+                - name: vip_ddns
+                  value: "false"
+                - name: vip_leaderelection
+                  value: "true"
+                - name: vip_leaseduration
+                  value: "15"
+                - name: vip_renewdeadline
+                  value: "10"
+                - name: vip_retryperiod
+                  value: "2"
+                - name: svc_enable
+                  value: "false"
+                - name: lb_enable
+                  value: "false"
+              securityContext:
+                capabilities:
+                  add:
+                    - NET_ADMIN
+                    - SYS_TIME
+                    - NET_RAW
+              volumeMounts:
+                - mountPath: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              resources: {}
+          hostNetwork: true
+          volumes:
+            - name: kubeconfig
+              hostPath:
+                type: FileOrCreate
+                path: /etc/kubernetes/admin.conf
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+          #cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
+    users:
+      - name: "mySshUsername"
+        lockPassword: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        sshAuthorizedKeys:
+          - "mySshAuthorizedKey"
+    preKubeadmCommands:
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+    postKubeadmCommands:
+      - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    useExperimentalRetryJoin: true
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "<no value>"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---

--- a/test/e2e/nutanix_test.go
+++ b/test/e2e/nutanix_test.go
@@ -763,3 +763,52 @@ func TestNutanixKubernetes126OIDC(t *testing.T) {
 	)
 	runOIDCFlow(test)
 }
+
+// IAMAuthenticator Tests
+func TestNutanixKubernetes123AWSIamAuth(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t, framework.WithUbuntu123Nutanix()),
+		framework.WithAWSIam(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube123)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runAWSIamAuthFlow(test)
+}
+
+func TestNutanixKubernetes124AWSIamAuth(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t, framework.WithUbuntu124Nutanix()),
+		framework.WithAWSIam(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runAWSIamAuthFlow(test)
+}
+
+func TestNutanixKubernetes125AWSIamAuth(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t, framework.WithUbuntu125Nutanix()),
+		framework.WithAWSIam(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runAWSIamAuthFlow(test)
+}
+
+func TestNutanixKubernetes126AWSIamAuth(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewNutanix(t, framework.WithUbuntu126Nutanix()),
+		framework.WithAWSIam(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runAWSIamAuthFlow(test)
+}


### PR DESCRIPTION
* Propagate AWS IAM Authenticator config, CA key, and CA cert files to KubeadmControlPlane config
* Propagate ServiceAccountIssuer to the KubeadmControlPlane API Server ExtraArgs

**How has this been tested?**
- Create a cluster with identityProviderRefs set to the AWSIamConfig manifest present and podIamConfig.serviceAccountIssuer set to the keycloak uri as prescribed [here](https://anywhere.eks.amazonaws.com/docs/reference/clusterspec/optional/iamauth/)
- Verified the generated Kubeconfig for the IAM user can authenticate with API Server and access the resources in the cluster
- Followed the guide to [configure IRSA](https://anywhere.eks.amazonaws.com/docs/reference/clusterspec/optional/irsa/) to wire up cluster keys with Keycloak instance, configure AWS roles and policies, and get aws-pod-identity-webhook up and running
- Verified whether pod's service account has access to AWS resources of the corresponding IAM role using awscli pod