### PR TITLE
Update curated package cmd doc with bundles override

### DIFF
--- a/docs/content/en/docs/reference/eksctl/anywhere_apply_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_apply_package(s).md
@@ -18,9 +18,10 @@ anywhere apply package(s) [flags]
 ### Options
 
 ```
-  -f, --filename string     Filename that contains curated packages custom resources to apply
-  -h, --help                help for package(s)
-      --kubeconfig string   Path to an optional kubeconfig file to use.
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains curated packages custom resources to apply
+  -h, --help                      help for package(s)
+      --kubeconfig string         Path to an optional kubeconfig file to use.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_copy_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_copy_packages.md
@@ -12,7 +12,7 @@ Copy curated package images and charts from a source to a destination
 Copy all the EKS Anywhere curated package images and helm charts from a source to a destination.
 
 ```
-anywhere copy packages [flags]
+anywhere copy packages <destination-registry> [flags]
 ```
 
 ### Options

--- a/docs/content/en/docs/reference/eksctl/anywhere_create_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_create_package(s).md
@@ -18,9 +18,10 @@ anywhere create package(s) [flags]
 ### Options
 
 ```
-  -f, --filename string     Filename that contains curated packages custom resources to create
-  -h, --help                help for package(s)
-      --kubeconfig string   Path to an optional kubeconfig file to use.
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains curated packages custom resources to create
+  -h, --help                      help for package(s)
+      --kubeconfig string         Path to an optional kubeconfig file to use.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_delete_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_delete_package(s).md
@@ -18,9 +18,10 @@ anywhere delete package(s) [flags]
 ### Options
 
 ```
-      --cluster string      Cluster for package deletion.
-  -h, --help                help for package(s)
-      --kubeconfig string   Path to an optional kubeconfig file to use.
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Cluster for package deletion.
+  -h, --help                      help for package(s)
+      --kubeconfig string         Path to an optional kubeconfig file to use.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_describe_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_describe_package(s).md
@@ -14,9 +14,10 @@ anywhere describe package(s) [flags]
 ### Options
 
 ```
-      --cluster string      Cluster to describe packages.
-  -h, --help                help for package(s)
-      --kubeconfig string   Path to an optional kubeconfig file to use.
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Cluster to describe packages.
+  -h, --help                      help for package(s)
+      --kubeconfig string         Path to an optional kubeconfig file to use.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_packages.md
@@ -18,11 +18,12 @@ anywhere generate packages [flags] package
 ### Options
 
 ```
-      --cluster string        Name of cluster for package generation
-  -h, --help                  help for packages
-      --kube-version string   Kubernetes Version of the cluster to be used. Format <major>.<minor>
-      --kubeconfig string     Path to an optional kubeconfig file to use.
-      --registry string       Used to specify an alternative registry for package generation
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Name of cluster for package generation
+  -h, --help                      help for packages
+      --kube-version string       Kubernetes Version of the cluster to be used. Format <major>.<minor>
+      --kubeconfig string         Path to an optional kubeconfig file to use.
+      --registry string           Used to specify an alternative registry for package generation
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_package(s).md
@@ -18,10 +18,11 @@ anywhere get package(s) [flags]
 ### Options
 
 ```
-      --cluster string      Cluster to get list of packages.
-  -h, --help                help for package(s)
-      --kubeconfig string   Path to an optional kubeconfig file.
-  -o, --output string       Specifies the output format (valid option: json, yaml)
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Cluster to get list of packages.
+  -h, --help                      help for package(s)
+      --kubeconfig string         Path to an optional kubeconfig file.
+  -o, --output string             Specifies the output format (valid option: json, yaml)
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundle(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundle(s).md
@@ -18,9 +18,10 @@ anywhere get packagebundle(s) [flags]
 ### Options
 
 ```
-  -h, --help                help for packagebundle(s)
-      --kubeconfig string   Path to an optional kubeconfig file.
-  -o, --output string       Specifies the output format (valid option: json, yaml)
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -h, --help                      help for packagebundle(s)
+      --kubeconfig string         Path to an optional kubeconfig file.
+  -o, --output string             Specifies the output format (valid option: json, yaml)
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundlecontroller(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundlecontroller(s).md
@@ -18,9 +18,10 @@ anywhere get packagebundlecontroller(s) [flags]
 ### Options
 
 ```
-  -h, --help                help for packagebundlecontroller(s)
-      --kubeconfig string   Path to an optional kubeconfig file.
-  -o, --output string       Specifies the output format (valid option: json, yaml)
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -h, --help                      help for packagebundlecontroller(s)
+      --kubeconfig string         Path to an optional kubeconfig file.
+  -o, --output string             Specifies the output format (valid option: json, yaml)
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_install_package.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_install_package.md
@@ -18,13 +18,14 @@ anywhere install package [flags] package
 ### Options
 
 ```
-      --cluster string        Target cluster for installation.
-  -h, --help                  help for package
-      --kube-version string   Kubernetes Version of the cluster to be used. Format <major>.<minor>
-      --kubeconfig string     Path to an optional kubeconfig file to use.
-  -n, --package-name string   Custom name of the curated package to install
-      --registry string       Used to specify an alternative registry for discovery
-      --set stringArray       Provide custom configurations for curated packages. Format key:value
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Target cluster for installation.
+  -h, --help                      help for package
+      --kube-version string       Kubernetes Version of the cluster to be used. Format <major>.<minor>
+      --kubeconfig string         Path to an optional kubeconfig file to use.
+  -n, --package-name string       Custom name of the curated package to install
+      --registry string           Used to specify an alternative registry for discovery
+      --set stringArray           Provide custom configurations for curated packages. Format key:value
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_install_packagecontroller.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_install_packagecontroller.md
@@ -18,9 +18,10 @@ anywhere install packagecontroller [flags]
 ### Options
 
 ```
-  -f, --filename string     Filename that contains EKS-A cluster configuration
-  -h, --help                help for packagecontroller
-      --kubeConfig string   Management cluster kubeconfig file
+      --bundles-override string   Override default Bundles manifest (not recommended)
+  -f, --filename string           Filename that contains EKS-A cluster configuration
+  -h, --help                      help for packagecontroller
+      --kubeConfig string         Management cluster kubeconfig file
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_list_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_list_packages.md
@@ -14,11 +14,12 @@ anywhere list packages [flags]
 ### Options
 
 ```
-      --cluster string        Name of cluster for package list.
-  -h, --help                  help for packages
-      --kube-version string   Kubernetes version <major>.<minor> of the packages to list, for example: "1.23".
-      --kubeconfig string     Path to a kubeconfig file to use when source is a cluster.
-      --registry string       Specifies an alternative registry for packages discovery.
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Name of cluster for package list.
+  -h, --help                      help for packages
+      --kube-version string       Kubernetes version <major>.<minor> of the packages to list, for example: "1.23".
+      --kubeconfig string         Path to a kubeconfig file to use when source is a cluster.
+      --registry string           Specifies an alternative registry for packages discovery.
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_packages.md
@@ -14,10 +14,11 @@ anywhere upgrade packages [flags]
 ### Options
 
 ```
-      --bundle-version string   Bundle version to use
-      --cluster string          Cluster to upgrade.
-  -h, --help                    help for packages
-      --kubeconfig string       Path to an optional kubeconfig file to use.
+      --bundle-version string     Bundle version to use
+      --bundles-override string   Override default Bundles manifest (not recommended)
+      --cluster string            Cluster to upgrade.
+  -h, --help                      help for packages
+      --kubeconfig string         Path to an optional kubeconfig file to use.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
*Issue #, if available:*

#5396 

*Description of changes:*

Update EKS-A official doc w the --bundles-override flag for curated packages cmd with `make docgen`

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

