### PR TITLE
Add missing methods to support Tinkerbell upgrade tests

### DIFF
--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -144,7 +144,35 @@ func WithTinkerbellEtcdMachineConfig() TinkerbellFiller {
 	}
 }
 
-func WithCustomTinkerbellMachineConfig(selector string) TinkerbellFiller {
+// WithStringFromEnvVarTinkerbellMachineFiller runs a TinkerbellMachineFiller function with an envVar value.
+func WithStringFromEnvVarTinkerbellMachineFiller(envVar string, opt func(string) TinkerbellMachineFiller) TinkerbellMachineFiller {
+	return opt(os.Getenv(envVar))
+}
+
+// TinkerbellMachineFiller updates a TinkerbellMachineConfig.
+type TinkerbellMachineFiller func(machineConfig *anywherev1.TinkerbellMachineConfig)
+
+// WithSSHAuthorizedKeyForTinkerbellMachineConfig updates the SSHAuthorizedKey for a TinkerbellMachineConfig.
+func WithSSHAuthorizedKeyForTinkerbellMachineConfig(key string) TinkerbellMachineFiller {
+	return func(machineConfig *anywherev1.TinkerbellMachineConfig) {
+		if len(machineConfig.Spec.Users) == 0 {
+			machineConfig.Spec.Users = []anywherev1.UserConfiguration{{}}
+		}
+
+		machineConfig.Spec.Users[0].Name = "ec2-user"
+		machineConfig.Spec.Users[0].SshAuthorizedKeys = []string{key}
+	}
+}
+
+// WithOsFamilyForTinkerbellMachineConfig updates the OSFamily of a TinkerbellMachineConfig.
+func WithOsFamilyForTinkerbellMachineConfig(value anywherev1.OSFamily) TinkerbellMachineFiller {
+	return func(machineConfig *anywherev1.TinkerbellMachineConfig) {
+		machineConfig.Spec.OSFamily = value
+	}
+}
+
+// WithCustomTinkerbellMachineConfig generates a TinkerbellMachineConfig from a hardware selector.
+func WithCustomTinkerbellMachineConfig(selector string, machineConfigFillers ...TinkerbellMachineFiller) TinkerbellFiller {
 	return func(config TinkerbellConfig) {
 		if _, ok := config.machineConfigs[selector]; !ok {
 			m := &anywherev1.TinkerbellMachineConfig{

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -48,6 +48,18 @@ func runUpgradeFlowWithAPI(test *framework.ClusterE2ETest, fillers ...api.Cluste
 	test.DeleteCluster()
 }
 
+func runUpgradeFlowForBareMetalWithAPI(test *framework.ClusterE2ETest, fillers ...api.ClusterConfigFiller) {
+	test.GenerateClusterConfig()
+	test.GenerateHardwareConfig()
+	test.PowerOffHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.UpgradeClusterWithKubectl(fillers...)
+	test.ValidateClusterState()
+	test.StopIfFailed()
+	test.DeleteCluster()
+	test.ValidateHardwareDecommissioned()
+}
+
 func runWorkloadClusterUpgradeFlowAPI(test *framework.MulticlusterE2ETest, filler ...api.ClusterConfigFiller) {
 	test.CreateManagementCluster()
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -80,6 +80,11 @@ func UpdateTinkerbellUbuntuTemplate126Var() api.TinkerbellFiller {
 	return api.WithStringFromEnvVarTinkerbell(tinkerbellImageUbuntu126EnvVar, api.WithTinkerbellOSImageURL)
 }
 
+// UpdateTinkerbellMachineSSHAuthorizedKey updates a tinkerbell machine configs SSHAuthorizedKey.
+func UpdateTinkerbellMachineSSHAuthorizedKey() api.TinkerbellMachineFiller {
+	return api.WithStringFromEnvVarTinkerbellMachineFiller(tinkerbellSSHAuthorizedKey, api.WithSSHAuthorizedKeyForTinkerbellMachineConfig)
+}
+
 func NewTinkerbell(t *testing.T, opts ...TinkerbellOpt) *Tinkerbell {
 	checkRequiredEnvVars(t, requiredTinkerbellEnvVars)
 	cidr := os.Getenv(tinkerbellControlPlaneNetworkCidrEnvVar)


### PR DESCRIPTION
Add some Tinkerbell helper methods to support new upgrade tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

