### PR TITLE
Enable proxy configuration for tinkerbell workload cluster

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -217,13 +217,16 @@ func GetHelmValueArgs(values []string) []string {
 
 // UpgradeChartWithValuesFile tuns a helm upgrade with the provided values file and waits for the
 // chart deployment to be ready.
-func (h *Helm) UpgradeChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string) error {
+func (h *Helm) UpgradeChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string, opts ...HelmOpt) error {
 	params := []string{
 		"upgrade", chart, ociURI,
 		"--version", version,
 		"--values", valuesFilePath,
 		"--kubeconfig", kubeconfigFilePath,
 		"--wait",
+	}
+	for _, opt := range opts {
+		opt(h)
 	}
 	params = h.addInsecureFlagIfProvided(params)
 	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).Run()

--- a/pkg/providers/tinkerbell/stack/mocks/stack.go
+++ b/pkg/providers/tinkerbell/stack/mocks/stack.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	executables "github.com/aws/eks-anywhere/pkg/executables"
 	stack "github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack"
 	v1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
@@ -136,17 +137,22 @@ func (mr *MockHelmMockRecorder) RegistryLogin(ctx, endpoint, username, password 
 }
 
 // UpgradeChartWithValuesFile mocks base method.
-func (m *MockHelm) UpgradeChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string) error {
+func (m *MockHelm) UpgradeChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, valuesFilePath string, opts ...executables.HelmOpt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpgradeChartWithValuesFile", ctx, chart, ociURI, version, kubeconfigFilePath, valuesFilePath)
+	varargs := []interface{}{ctx, chart, ociURI, version, kubeconfigFilePath, valuesFilePath}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpgradeChartWithValuesFile", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpgradeChartWithValuesFile indicates an expected call of UpgradeChartWithValuesFile.
-func (mr *MockHelmMockRecorder) UpgradeChartWithValuesFile(ctx, chart, ociURI, version, kubeconfigFilePath, valuesFilePath interface{}) *gomock.Call {
+func (mr *MockHelmMockRecorder) UpgradeChartWithValuesFile(ctx, chart, ociURI, version, kubeconfigFilePath, valuesFilePath interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeChartWithValuesFile", reflect.TypeOf((*MockHelm)(nil).UpgradeChartWithValuesFile), ctx, chart, ociURI, version, kubeconfigFilePath, valuesFilePath)
+	varargs := append([]interface{}{ctx, chart, ociURI, version, kubeconfigFilePath, valuesFilePath}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeChartWithValuesFile", reflect.TypeOf((*MockHelm)(nil).UpgradeChartWithValuesFile), varargs...)
 }
 
 // MockStackInstaller is a mock of StackInstaller interface.
@@ -170,6 +176,18 @@ func NewMockStackInstaller(ctrl *gomock.Controller) *MockStackInstaller {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStackInstaller) EXPECT() *MockStackInstallerMockRecorder {
 	return m.recorder
+}
+
+// AddNoProxyIP mocks base method.
+func (m *MockStackInstaller) AddNoProxyIP(IP string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddNoProxyIP", IP)
+}
+
+// AddNoProxyIP indicates an expected call of AddNoProxyIP.
+func (mr *MockStackInstallerMockRecorder) AddNoProxyIP(IP interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNoProxyIP", reflect.TypeOf((*MockStackInstaller)(nil).AddNoProxyIP), IP)
 }
 
 // CleanupLocalBoots mocks base method.

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
@@ -117,7 +117,7 @@ spec:
           [Service]
           Environment="HTTP_PROXY=1.1.1.1:8080"
           Environment="HTTPS_PROXY=1.1.1.1:8443"
-          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,2.3.4.5,5.6.7.8"
+          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,2.3.4.5"
         owner: root:root
         path: /etc/systemd/system/containerd.service.d/http-proxy.conf
     preKubeadmCommands:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
@@ -165,7 +165,7 @@ spec:
             [Service]
             Environment="HTTP_PROXY=1.1.1.1:8080"
             Environment="HTTPS_PROXY=1.1.1.1:8443"
-            Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,2.3.4.5,5.6.7.8"
+            Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,1.2.3.4,2.3.4.5"
           owner: root:root
           path: /etc/systemd/system/containerd.service.d/http-proxy.conf
       preKubeadmCommands:

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -119,6 +119,16 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 	}
 
 	if p.clusterConfig.IsManaged() {
+
+		// Update stack helm enviorment variable NO_PROXY value and append management cluster's Control plane Endpoint IP in case of workload cluster upgrade
+		if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
+			managementCluster, err := p.providerKubectlClient.GetEksaCluster(ctx, clusterSpec.ManagementCluster, clusterSpec.Cluster.Spec.ManagementCluster.Name)
+			if err != nil {
+				return err
+			}
+			p.stackInstaller.AddNoProxyIP(managementCluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
+		}
+
 		if err := p.applyHardwareUpgrade(ctx, clusterSpec.ManagementCluster); err != nil {
 			return err
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With this PR, I am adding a functionality to enable proxy configuration for workload cluster create and upgrade for tinkerbell provider.

*Testing (if applicable):*
I have ran the following tests manually,
1. Management cluster create
2. Management cluster upgrade
3. Workload cluster create
4. Workload cluster upgrade (TODO)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

