### PR TITLE
Add docs detailing how to uninstall EKS-A Cilium

### DIFF
--- a/docs/content/en/docs/reference/clusterspec/optional/cni.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/cni.md
@@ -171,7 +171,7 @@ via `cilium uninstall`.
 
 {{% alert title="Warning" color="warning" %}}
 When uninstalling EKS Anywhere Cilium, nodes will become unhealthy. If nodes are left without a CNI 
-for longer than 5m the nodes will begin rolling. To maintain a healthy cluster operators should 
+for longer than 5m the nodes will begin rolling. To maintain a healthy cluster, operators should 
 immediately install a CNI after uninstalling EKS Anywhere Cilium.
 {{% /alert %}}
 

--- a/docs/content/en/docs/reference/clusterspec/optional/cni.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/cni.md
@@ -137,8 +137,8 @@ will not delete any of the existing NetworkPolicy objects, including the ones re
 
 ### Use a custom CNI
 
-EKS Anywhere can be configured to skip EKS Anywhere's default Cilium CNI upgrades via the `skipUpgrade` field. `skipUpgrade` 
-can be `true` or `false`. When not set, it defaults to `false`.
+EKS Anywhere can be configured to skip EKS Anywhere's default Cilium CNI upgrades via the `skipUpgrade` field. 
+`skipUpgrade` can be `true` or `false`. When not set, it defaults to `false`.
 
 When creating a new cluster with `skipUpgrade` enabled, EKS Anywhere Cilium will be installed as it 
 is required to successfully provision an EKS Anywhere cluster. 
@@ -165,6 +165,15 @@ spec:
       cilium: 
         skipUpgrade: true
 ```
+
+The [Cilium CLI](https://github.com/cilium/cilium-cli) can be used to uninstall EKS Anywhere Cilium 
+via `cilium uninstall`.
+
+{{% alert title="Warning" color="warning" %}}
+When uninstalling EKS Anywhere Cilium, nodes will become unhealthy. If nodes are left without a CNI 
+for longer than 5m the nodes will begin rolling. To maintain a healthy cluster operators should 
+immediately install a CNI after uninstalling EKS Anywhere Cilium.
+{{% /alert %}}
 
 {{% alert title="Warning" color="warning" %}}
 Clusters created using the Full Lifecycle Controller prior to v0.15 that have removed the EKS Anywhere Cilium CNI must manually populate their `cluster.anywhere.eks.amazonaws.com` object with the following annotation to ensure EKS Anywhere does not attempt to re-install EKS Anywhere Cilium.

--- a/docs/content/en/docs/reference/clusterspec/optional/cni.md
+++ b/docs/content/en/docs/reference/clusterspec/optional/cni.md
@@ -168,6 +168,7 @@ spec:
 
 The [Cilium CLI](https://github.com/cilium/cilium-cli) can be used to uninstall EKS Anywhere Cilium 
 via `cilium uninstall`.
+See the [replacing Cilium task]({{< ref "/docs/tasks/cluster/cluster-replace-cilium" >}}) for a walkthrough on how to successfully replace EKS Anywhere Cilium.
 
 {{% alert title="Warning" color="warning" %}}
 When uninstalling EKS Anywhere Cilium, nodes will become unhealthy. If nodes are left without a CNI 

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -1,0 +1,107 @@
+# Replace EKS Anywhere Cilium with a custom CNI
+
+## Prerequisites
+
+* EKS Anywhere v0.15+.
+* A recent version of [Cilium CLI](https://github.com/cilium/cilium-cli).
+
+## Creating new clusters
+
+If an operator intends to uninstall EKS Anywhere Cilium from a new cluster they can enable the `skipUpgrade`
+option when creating the cluster. 
+Any future upgrades to the newly created cluster will not have EKS Anywhere Cilium upgraded.
+
+1. Generate a cluster configuration according to the [Getting Started]({{< ref "/docs/getting-started" >}}) section.
+
+2. Modify the `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
+
+    ```yaml
+    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    kind: Cluster
+    metadata:
+        name: eks-anywhere
+    spec:
+      clusterNetwork:
+        cniConfig:
+          cilium:
+            skipUpgrade: true
+      ...
+    ```
+
+3. Create the cluster according to the [Getting Started]({{< ref "/docs/getting-started" >}}) section.
+
+4. Uninstall EKS Anywhere Cilium:
+
+    ```bash
+    cilium uninstall
+    ```
+
+5. Install the custom CNI.
+
+## Modifying existing clusters using EKS Anywhere CLI
+
+1. Modify the existing `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
+
+    ```yaml
+    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    kind: Cluster
+    metadata:
+        name: eks-anywhere
+    spec:
+      clusterNetwork:
+        cniConfig:
+          cilium:
+            skipUpgrade: true
+      ...
+    ```
+
+3. [Upgrade the EKS Anywhere cluster]({{< ref "/docs/tasks/cluster/cluster-upgrades" >}}).
+
+4. Uninstall EKS Anywhere Cilium:
+
+    ```bash
+    cilium uninstall
+    ```
+
+5. Install the custom CNI.
+
+## Modifying existing clusters using EKS Anywhere Lifecycle Controller
+
+{{% alert title="Warning" color="warning" %}}
+Clusters created using the Full Lifecycle Controller prior to v0.15 that have removed the EKS Anywhere Cilium CNI must manually populate their `cluster.anywhere.eks.amazonaws.com` object with the following annotation to ensure EKS Anywhere does not attempt to re-install EKS Anywhere Cilium.
+
+```
+anywhere.eks.amazonaws.com/eksa-cilium: ""
+```
+{{% /alert %}}
+
+1. Modify the existing `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
+
+    ```yaml
+    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    kind: Cluster
+    metadata:
+        name: eks-anywhere
+    spec:
+      clusterNetwork:
+        cniConfig:
+          cilium:
+            skipUpgrade: true
+      ...
+    ```
+
+3. Apply the cluster configuration to the cluster.
+
+    ```bash
+    kubectl apply -f <cluster config path>
+    ```
+
+5. Await the cluster to reconcile.
+
+4. Uninstall EKS Anywhere Cilium:
+
+    ```bash
+    cilium uninstall
+    ```
+
+5. Install the custom CNI.

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -71,7 +71,7 @@ Any future upgrades to the newly created cluster will not have EKS Anywhere Cili
 
 5. Install the custom CNI.
 
-## Modifying existing clusters using EKS Anywhere Lifecycle Controller
+## Add a custom CNI to an existing cluster with Lifecycle Controller
 
 {{% alert title="Warning" color="warning" %}}
 Clusters created using the Full Lifecycle Controller prior to v0.15 that have removed the EKS Anywhere Cilium CNI must manually populate their `cluster.anywhere.eks.amazonaws.com` object with the following annotation to ensure EKS Anywhere does not attempt to re-install EKS Anywhere Cilium.

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -38,7 +38,7 @@ Any future upgrades to the newly created cluster will not have EKS Anywhere Cili
 
 5. Install the custom CNI.
 
-## Modifying existing clusters using EKS Anywhere CLI
+## Add a custom CNI to an existing cluster with eksctl
 
 1. Modify the existing `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
 

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -1,4 +1,10 @@
-# Replace EKS Anywhere Cilium with a custom CNI
+---
+title: "Replace EKS Anywhere Cilium with a custom CNI"
+linkTitle: "Add custom CNI"
+weight: 21
+description: >
+ Replace EKS Anywhere Cilium with a custom CNI
+---
 
 ## Prerequisites
 

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -9,6 +9,10 @@ description: >
 This page provides walkthroughs on replacing the EKS Anywhere Cilium with a custom CNI. 
 For more information on CNI customization see [Use a custom CNI]({{< ref "/docs/reference/clusterspec/optional/cni#use-a-custom-cni"  >}}).
 
+{{% alert title="Note" color="primary" %}}
+When replacing EKS Anywhere Cilium with a custom CNI, it is your responsibility to manage the custom CNI, including version upgrades and support.
+{{% /alert %}}
+
 ## Prerequisites
 
 * EKS Anywhere v0.15+.

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -6,6 +6,9 @@ description: >
  Replace EKS Anywhere Cilium with a custom CNI
 ---
 
+This page provides walkthroughs on replacing the EKS Anywhere Cilium with a custom CNI. 
+For more information on CNI customization see [Use a custom CNI]({{< ref "/docs/reference/clusterspec/optional/cni#use-a-custom-cni"  >}}).
+
 ## Prerequisites
 
 * EKS Anywhere v0.15+.
@@ -13,63 +16,86 @@ description: >
 
 ## Add a custom CNI to a new cluster
 
-If an operator intends to uninstall EKS Anywhere Cilium from a new cluster they can enable the `skipUpgrade`
-option when creating the cluster. 
+If an operator intends to uninstall EKS Anywhere Cilium from a new cluster they can enable the `skipUpgrade` option when creating the cluster. 
 Any future upgrades to the newly created cluster will not have EKS Anywhere Cilium upgraded.
 
 1. Generate a cluster configuration according to the [Getting Started]({{< ref "/docs/getting-started" >}}) section.
 
 2. Modify the `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
 
-    ```yaml
-    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-    kind: Cluster
-    metadata:
-        name: eks-anywhere
-    spec:
-      clusterNetwork:
-        cniConfig:
-          cilium:
-            skipUpgrade: true
-      ...
-    ```
+  ```yaml
+  apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+  kind: Cluster
+  metadata:
+      name: eks-anywhere
+  spec:
+    clusterNetwork:
+      cniConfig:
+        cilium:
+          skipUpgrade: true
+    ...
+  ```
 
-3. Create the cluster according to the [Getting Started]({{< ref "/docs/getting-started" >}}) section.
+3. Create the cluster according to the [Getting Started]({{< ref "/docs/getting-started" >}}) guide.
 
-4. Uninstall EKS Anywhere Cilium:
+4. Pause reconciliation of the cluster. This ensures EKS Anywhere components do not attempt to remediate issues arising from a missing CNI.
+
+  ```bash
+  kubectl --kubeconfig=MANAGEMENT_KUBECONFIG -n eksa-system annotate clusters.cluster.x-k8s.io WORKLOAD_CLUSTER_NAME cluster.x-k8s.io/paused=true
+  ```
+
+5. Uninstall EKS Anywhere Cilium.
 
     ```bash
     cilium uninstall
     ```
 
-5. Install the custom CNI.
+6. Install a custom CNI.
+
+7. Resume reconciliation of the cluster object.
+
+  ```bash
+  kubectl --kubeconfig=MANAGEMENT_KUBECONFIG -n eksa-system annotate clusters.cluster.x-k8s.io WORKLOAD_CLUSTER_NAME cluster.x-k8s.io/paused-
+  ```
 
 ## Add a custom CNI to an existing cluster with eksctl
 
 1. Modify the existing `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
 
-    ```yaml
-    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-    kind: Cluster
-    metadata:
-        name: eks-anywhere
-    spec:
-      clusterNetwork:
-        cniConfig:
-          cilium:
-            skipUpgrade: true
-      ...
-    ```
+  ```yaml
+  apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+  kind: Cluster
+  metadata:
+      name: eks-anywhere
+  spec:
+    clusterNetwork:
+      cniConfig:
+        cilium:
+          skipUpgrade: true
+    ...
+  ```
 
-3. [Upgrade the EKS Anywhere cluster]({{< ref "/docs/tasks/cluster/cluster-upgrades" >}}).
+2. [Upgrade the EKS Anywhere cluster]({{< ref "/docs/tasks/cluster/cluster-upgrades" >}}).
 
-4. Uninstall EKS Anywhere Cilium:
+3. Pause reconciliation of the cluster. This ensures EKS Anywhere components do not attempt to remediate issues arising from a missing CNI.
+
+  ```bash
+  kubectl --kubeconfig=MANAGEMENT_KUBECONFIG -n eksa-system annotate clusters.cluster.x-k8s.io WORKLOAD_CLUSTER_NAME cluster.x-k8s.io/paused=true
+  ```
+
+4. Uninstall EKS Anywhere Cilium.
 
     ```bash
     cilium uninstall
     ```
 
-5. Install the custom CNI.
+5. Install a custom CNI.
+
+6. Resume reconciliation of the cluster object.
+
+  ```bash
+  kubectl --kubeconfig=MANAGEMENT_KUBECONFIG -n eksa-system annotate clusters.cluster.x-k8s.io WORKLOAD_CLUSTER_NAME cluster.x-k8s.io/paused-
+  ```
 
 ## Add a custom CNI to an existing cluster with Lifecycle Controller
 
@@ -83,31 +109,41 @@ anywhere.eks.amazonaws.com/eksa-cilium: ""
 
 1. Modify the existing `Cluster` object's `spec.clusterNetwork.cniConfig.cilium.skipUpgrade` field to equal `true`.
 
-    ```yaml
-    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-    kind: Cluster
-    metadata:
-        name: eks-anywhere
-    spec:
-      clusterNetwork:
-        cniConfig:
-          cilium:
-            skipUpgrade: true
-      ...
-    ```
+  ```yaml
+  apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+  kind: Cluster
+  metadata:
+      name: eks-anywhere
+  spec:
+    clusterNetwork:
+      cniConfig:
+        cilium:
+          skipUpgrade: true
+    ...
+  ```
 
-3. Apply the cluster configuration to the cluster.
+2. Apply the cluster configuration to the cluster and _await successful object reconciliation_.
 
     ```bash
     kubectl apply -f <cluster config path>
     ```
 
-5. Await the cluster to reconcile.
+3. Pause reconciliation of the cluster. This ensures EKS Anywhere components do not attempt to remediate issues arising from a missing CNI.
 
-4. Uninstall EKS Anywhere Cilium:
+  ```bash
+  kubectl --kubeconfig=MANAGEMENT_KUBECONFIG -n eksa-system annotate clusters.cluster.x-k8s.io WORKLOAD_CLUSTER_NAME cluster.x-k8s.io/paused=true
+  ```
 
-    ```bash
-    cilium uninstall
-    ```
+4. Uninstall EKS Anywhere Cilium.
 
-5. Install the custom CNI.
+  ```bash
+  cilium uninstall
+  ```
+
+5. Install a custom CNI.
+
+6. Resume reconciliation of the cluster object.
+
+  ```bash
+  kubectl --kubeconfig=MANAGEMENT_KUBECONFIG -n eksa-system annotate clusters.cluster.x-k8s.io WORKLOAD_CLUSTER_NAME cluster.x-k8s.io/paused-
+  ```

--- a/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-replace-cilium.md
@@ -11,7 +11,7 @@ description: >
 * EKS Anywhere v0.15+.
 * A recent version of [Cilium CLI](https://github.com/cilium/cilium-cli).
 
-## Creating new clusters
+## Add a custom CNI to a new cluster
 
 If an operator intends to uninstall EKS Anywhere Cilium from a new cluster they can enable the `skipUpgrade`
 option when creating the cluster. 


### PR DESCRIPTION
## Summary

This PR adds documentation detailing how a user can uninstall the EKS Anywhere Cilium CNI and provides e2e walk throughs of the process.