### PR TITLE
Set default and validate control plane host port when generating CloudStack CAPI objects

### DIFF
--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -76,7 +76,6 @@ func givenClusterSpec(t *testing.T, fileName string) *cluster.Spec {
 // TODO: Validate against validator operations instead of using wildcard, now that it's mocked. https://github.com/aws/eks-anywhere/issues/3944
 func givenWildcardValidator(mockCtrl *gomock.Controller, clusterSpec *cluster.Spec) *MockProviderValidator {
 	validator := NewMockProviderValidator(mockCtrl)
-	setClusterSpecDefaultHostPort(clusterSpec)
 	validator.EXPECT().ValidateClusterMachineConfigs(gomock.Any(), gomock.Any()).SetArg(1, *clusterSpec).AnyTimes()
 	validator.EXPECT().ValidateCloudStackDatacenterConfig(gomock.Any(), clusterSpec.CloudStackDatacenter).AnyTimes()
 	validator.EXPECT().ValidateControlPlaneEndpointUniqueness(gomock.Any()).AnyTimes()
@@ -253,11 +252,6 @@ func newProviderWithKubectl(t *testing.T, datacenterConfig *v1alpha1.CloudStackD
 func newProvider(t *testing.T, datacenterConfig *v1alpha1.CloudStackDatacenterConfig, clusterConfig *v1alpha1.Cluster, kubectl ProviderKubectlClient, validator ProviderValidator) *cloudstackProvider {
 	_, writer := test.NewWriter(t)
 	return NewProvider(datacenterConfig, clusterConfig, kubectl, validator, writer, test.FakeNow, test.NewNullLogger())
-}
-
-func setClusterSpecDefaultHostPort(clusterSpec *cluster.Spec) {
-	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host = fmt.Sprintf("%s:%s",
-		clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host, controlEndpointDefaultPort)
 }
 
 func TestProviderGenerateCAPISpecForCreate(t *testing.T) {

--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -216,7 +216,8 @@ func capiCluster() *clusterv1.Cluster {
 				},
 			},
 			ControlPlaneEndpoint: clusterv1.APIEndpoint{
-				Host: "",
+				Host: "1.2.3.4",
+				Port: 6443,
 			},
 			ControlPlaneRef: &corev1.ObjectReference{
 				Kind:       "KubeadmControlPlane",
@@ -263,6 +264,10 @@ func cloudstackCluster() *cloudstackv1.CloudStackCluster {
 						Namespace: "eksa-system",
 					},
 				},
+			},
+			ControlPlaneEndpoint: clusterv1.APIEndpoint{
+				Host: "1.2.3.4",
+				Port: 6443,
 			},
 		},
 	}
@@ -354,7 +359,7 @@ func kubeadmControlPlane(opts ...func(*controlplanev1.KubeadmControlPlane)) *con
 						Permissions: "",
 						Encoding:    "",
 						Append:      false,
-						Content:     "apiVersion: v1\nkind: Pod\nmetadata:\n  creationTimestamp: null\n  name: kube-vip\n  namespace: kube-system\nspec:\n  containers:\n  - args:\n    - manager\n    env:\n    - name: vip_arp\n      value: \"true\"\n    - name: port\n      value: \"6443\"\n    - name: vip_cidr\n      value: \"32\"\n    - name: cp_enable\n      value: \"true\"\n    - name: cp_namespace\n      value: kube-system\n    - name: vip_ddns\n      value: \"false\"\n    - name: vip_leaderelection\n      value: \"true\"\n    - name: vip_leaseduration\n      value: \"15\"\n    - name: vip_renewdeadline\n      value: \"10\"\n    - name: vip_retryperiod\n      value: \"2\"\n    - name: address\n      value: \n    image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158\n    imagePullPolicy: IfNotPresent\n    name: kube-vip\n    resources: {}\n    securityContext:\n      capabilities:\n        add:\n        - NET_ADMIN\n        - NET_RAW\n    volumeMounts:\n    - mountPath: /etc/kubernetes/admin.conf\n      name: kubeconfig\n  hostNetwork: true\n  volumes:\n  - hostPath:\n      path: /etc/kubernetes/admin.conf\n    name: kubeconfig\nstatus: {}\n",
+						Content:     "apiVersion: v1\nkind: Pod\nmetadata:\n  creationTimestamp: null\n  name: kube-vip\n  namespace: kube-system\nspec:\n  containers:\n  - args:\n    - manager\n    env:\n    - name: vip_arp\n      value: \"true\"\n    - name: port\n      value: \"6443\"\n    - name: vip_cidr\n      value: \"32\"\n    - name: cp_enable\n      value: \"true\"\n    - name: cp_namespace\n      value: kube-system\n    - name: vip_ddns\n      value: \"false\"\n    - name: vip_leaderelection\n      value: \"true\"\n    - name: vip_leaseduration\n      value: \"15\"\n    - name: vip_renewdeadline\n      value: \"10\"\n    - name: vip_retryperiod\n      value: \"2\"\n    - name: address\n      value: 1.2.3.4\n    image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.158\n    imagePullPolicy: IfNotPresent\n    name: kube-vip\n    resources: {}\n    securityContext:\n      capabilities:\n        add:\n        - NET_ADMIN\n        - NET_RAW\n    volumeMounts:\n    - mountPath: /etc/kubernetes/admin.conf\n      name: kubeconfig\n  hostNetwork: true\n  volumes:\n  - hostPath:\n      path: /etc/kubernetes/admin.conf\n    name: kubeconfig\nstatus: {}\n",
 					},
 					{
 						Path:  "/etc/kubernetes/audit-policy.yaml",

--- a/pkg/providers/cloudstack/spec.go
+++ b/pkg/providers/cloudstack/spec.go
@@ -1,8 +1,13 @@
 package cloudstack
 
 import (
+	"fmt"
+	"net"
+	"strings"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
 )
 
 func etcdMachineConfig(s *cluster.Spec) *anywherev1.CloudStackMachineConfig {
@@ -18,4 +23,31 @@ func controlPlaneMachineConfig(s *cluster.Spec) *anywherev1.CloudStackMachineCon
 
 func workerMachineConfig(s *cluster.Spec, workers anywherev1.WorkerNodeGroupConfiguration) *anywherev1.CloudStackMachineConfig {
 	return s.CloudStackMachineConfigs[workers.MachineGroupRef.Name]
+}
+
+func controlPlaneEndpointHost(clusterSpec *cluster.Spec) (string, error) {
+	host, port, err := getControlPlaneHostPort(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	if err != nil {
+		return "", err
+	}
+
+	return net.JoinHostPort(host, port), nil
+}
+
+// getControlPlaneHostPort retrieves the ControlPlaneConfiguration host and port split defined in the cluster.Spec. If it's valid, it checks the port
+// to see if the default port should be used and returns it.
+func getControlPlaneHostPort(pHost string) (string, string, error) {
+	host, port, err := net.SplitHostPort(pHost)
+	if err != nil {
+		if strings.Contains(err.Error(), "missing port") {
+			host = pHost
+			port = controlEndpointDefaultPort
+		} else {
+			return "", "", fmt.Errorf("host %s is invalid: %v", pHost, err.Error())
+		}
+	}
+	if !networkutils.IsPortValid(port) {
+		return "", "", fmt.Errorf("host %s has an invalid port", pHost)
+	}
+	return host, port, nil
 }


### PR DESCRIPTION
*Issue #, if available:*
[Set Default And Validate Control Plane Host Port when generate CAPI object#1280](https://github.com/aws/eks-anywhere-internal/issues/1280)

*Description of changes:*
When creating a CloudStack cluster, the endpoint provided by the user should have a port specified. This is already done for the CLI, but not for clusters created through the API yet. However, it modifies the user input in the cluster.Spec to achieve this: This PR:
- Validates and sets a default control plane host port when generating the CloudStack CAPI objects. This will allow clusters created through the API to utilize a default port for the control plane endpoint if not specified, bringing it up to parity with the CLI. 
- Removes the side effect of editing the user input in the `cluster.Spec`. The cluster.Spec represents data input by the user to create the cluster. It follow good practice to not permanently modify user input, and to instead transform it into other  non user input constructs.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

