### PR TITLE
Remove Renamed Test from SKIPPED_TESTS

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -75,4 +75,3 @@ skipped_tests:
 - TestTinkerbellKubernetes126BottleRocketThreeWorkersSimpleFlow
 - TestTinkerbellAirgappedKubernetes126BottleRocketRegistryMirror
 # vSphere tests
-- TestVSphereUpgradeKubernetesUbuntuAPI


### PR DESCRIPTION
*Issue #, if available:*
Last PR in https://github.com/aws/eks-anywhere/issues/5690

*Description of changes:*

Renamed TestVSphereUpgradeKubernetesUbuntuAPI->TestVSphereUpgradeKubernetes123to124UbuntuWorkloadClusterAPI in https://github.com/aws/eks-anywhere/pull/5689. This re-enabled the test as desired, but we still need to clean up the old name from SKIPPED_TESTS.

*Testing (if applicable):*
N/A 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.