### PR TITLE
Enable simple snow e2e tests in CI

### DIFF
--- a/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 180
-    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 180
+    INTEGRATION_TEST_MAX_EC2_COUNT: 3
+    INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 3
     EKSA_GIT_KNOWN_HOSTS: "/tmp/known_hosts"
     EKSA_GIT_PRIVATE_KEY: "/tmp/private-key"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
@@ -21,6 +21,10 @@ env:
     T_REGISTRY_MIRROR_PASSWORD: "harbor-registry-data:password"
     T_REGISTRY_MIRROR_CA_CERT: "harbor-registry-data:caCert"
     T_AWS_IAM_ROLE_ARN: "aws-iam-auth-role:ec2_role_arn"
+    T_SNOW_DEVICES: "snow_ci:snow_devices"
+    T_SNOW_CREDENTIALS_S3_PATH: "snow_ci:snow_credentials_s3_path"
+    T_SNOW_CERTIFICATES_S3_PATH: "snow_ci:snow_certificates_s3_path"
+    T_SNOW_CONTROL_PLANE_CIDRS: "snow_ci:control_plane_cidrs"
 phases:
   pre_build:
     commands:
@@ -49,11 +53,12 @@ phases:
         -v 4
         --skip ${SKIPPED_TESTS}
         --bundles-override=${BUNDLES_OVERRIDE}
+        --cleanup-vms=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
         --baremetal-branch=${BAREMETAL_BRANCH}
-# reports:
-#   e2e-reports:
-#     files:
-#       - reports/junit-testing-*.xml
-#     file-format: "JUNITXML"
+reports:
+  e2e-reports:
+    files:
+      - reports/junit-testing-*.xml
+    file-format: "JUNITXML"

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -60,6 +60,7 @@ type (
 	}
 )
 
+// RunTestsInParallel Run Tests in parallel by spawning multiple admin machines.
 func RunTestsInParallel(conf ParallelRunConf) error {
 	testsList, skippedTests, err := listTests(conf.Regex, conf.TestsToSkip)
 	if err != nil {

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -118,6 +118,11 @@ func (e *E2ESession) setup(regex string) error {
 		return err
 	}
 
+	err = e.setupSnowEnv(regex)
+	if err != nil {
+		return err
+	}
+
 	err = e.setupFluxEnv(regex)
 	if err != nil {
 		return err

--- a/internal/test/e2e/snow.go
+++ b/internal/test/e2e/snow.go
@@ -1,0 +1,90 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/aws/eks-anywhere/internal/pkg/s3"
+)
+
+const (
+	snowCredentialsS3Path  = "T_SNOW_CREDENTIALS_S3_PATH"
+	snowCertificatesS3Path = "T_SNOW_CERTIFICATES_S3_PATH"
+	snowDevices            = "T_SNOW_DEVICES"
+	snowCPCidr             = "T_SNOW_CONTROL_PLANE_CIDR"
+	snowCPCidrs            = "T_SNOW_CONTROL_PLANE_CIDRS"
+	snowCredsFile          = "EKSA_AWS_CREDENTIALS_FILE"
+	snowCertsFile          = "EKSA_AWS_CA_BUNDLES_FILE"
+
+	snowTestsRe       = `^.*Snow.*$`
+	snowCredsFilename = "snow_creds"
+	snowCertsFilename = "snow_certs"
+)
+
+var (
+	snowCPCidrArray  []string
+	snowCPCidrArrayM sync.Mutex
+)
+
+func init() {
+	snowCPCidrArray = strings.Split(os.Getenv(snowCPCidrs), ",")
+}
+
+// Note that this function cannot be called more than the the number of cidrs in the list.
+func getSnowCPCidr() (string, error) {
+	snowCPCidrArrayM.Lock()
+	defer snowCPCidrArrayM.Unlock()
+
+	if len(snowCPCidrArray) == 0 {
+		return "", fmt.Errorf("no more snow control plane cidrs available")
+	}
+	var r string
+	r, snowCPCidrArray = snowCPCidrArray[0], snowCPCidrArray[1:]
+	return r, nil
+}
+
+func (e *E2ESession) setupSnowEnv(testRegex string) error {
+	re := regexp.MustCompile(snowTestsRe)
+	if !re.MatchString(testRegex) {
+		return nil
+	}
+
+	e.testEnvVars[snowDevices] = os.Getenv(snowDevices)
+	cpCidr, err := getSnowCPCidr()
+	if err != nil {
+		return err
+	}
+	e.testEnvVars[snowCPCidr] = cpCidr
+	e.logger.V(1).Info("Assigned control plane CIDR to admin instance", "cidr", cpCidr, "instanceId", e.instanceId)
+
+	if err := sendFileViaS3(e, os.Getenv(snowCredentialsS3Path), snowCredsFilename); err != nil {
+		return err
+	}
+	if err := sendFileViaS3(e, os.Getenv(snowCertificatesS3Path), snowCertsFilename); err != nil {
+		return err
+	}
+	e.testEnvVars[snowCredsFile] = "bin/" + snowCredsFilename
+	e.testEnvVars[snowCertsFile] = "bin/" + snowCertsFilename
+
+	return nil
+}
+
+func sendFileViaS3(e *E2ESession, s3Path string, filename string) error {
+	if err := s3.DownloadToDisk(e.session, s3Path, e.storageBucket, "bin/"+filename); err != nil {
+		return err
+	}
+
+	err := e.uploadRequiredFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to upload file (%s) : %v", filename, err)
+	}
+
+	err = e.downloadRequiredFileInInstance(filename)
+	if err != nil {
+		return fmt.Errorf("failed to download file (%s) in admin instance : %v", filename, err)
+	}
+	return nil
+}

--- a/pkg/providers/snow/validator.go
+++ b/pkg/providers/snow/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -208,6 +209,10 @@ func (v *Validator) ValidateControlPlaneIP(ctx context.Context, controlPlaneIP s
 
 	instanceIP, err := v.imds.EC2InstanceIP(ctx)
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			// the admin instance is not running inside snow devices or doesn't have a public IP
+			return nil
+		}
 		return fmt.Errorf("fetching host instance ip: %v", err)
 	}
 

--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -22,11 +22,11 @@ skipped_tests:
 - TestSnowKubernetes126UbuntuRemoveWorkerNodeGroups
 - TestSnowKubernetes126OIDC
 - TestSnowKubernetes126UbuntuProxyConfig
-- TestSnowKubernetes122SimpleFlow
-- TestSnowKubernetes123SimpleFlow
-- TestSnowKubernetes124SimpleFlow
-- TestSnowKubernetes125SimpleFlow
-- TestSnowKubernetes126SimpleFlow
+# - TestSnowKubernetes122SimpleFlow
+# - TestSnowKubernetes123SimpleFlow
+# - TestSnowKubernetes124SimpleFlow
+# - TestSnowKubernetes125SimpleFlow
+# - TestSnowKubernetes126SimpleFlow
 - TestSnowKubernetes122UbuntuTo123Upgrade
 - TestSnowKubernetes123UbuntuTo124Upgrade
 - TestSnowKubernetes124UbuntuTo125Upgrade


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere-internal/issues/1192

*Description of changes:* Enable simple snow e2e tests using the new snow CI devices

*Testing (if applicable):* Manually invoked the tests with codebuild, test was successful and verified that snow devices have been cleaned after testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

