### PR TITLE
Add bundle manifest URL to EKS-A version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,9 @@ eks-a-binary:
 	CGO_ENABLED=0 GOOS=$(GO_OS) GOARCH=$(GO_ARCH) $(GO) build $(BUILD_TAGS_ARG) $(LINKER_FLAGS_ARG) $(BUILD_FLAGS) -o $(OUTPUT_FILE) github.com/aws/eks-anywhere/cmd/eksctl-anywhere
 
 .PHONY: eks-a-embed-config
+eks-a-embed-config: $(EMBED_CONFIG_FOLDER)
 eks-a-embed-config: ## Build a dev release version of eks-a with embed cluster spec config
+	cp pkg/cluster/config/releases.yaml $(EMBED_CONFIG_FOLDER)/releases.yaml
 	$(MAKE) eks-a-binary GIT_VERSION=$(DEV_GIT_VERSION) RELEASE_MANIFEST_URL=embed:///config/releases.yaml BUILD_TAGS='$(BUILD_TAGS) files_embed_fs'
 
 .PHONY: eks-a-cross-platform-embed-latest-config
@@ -177,6 +179,7 @@ eks-a-cross-platform-embed-latest-config: ## Build cross platform dev release ve
 
 .PHONY: eks-a-custom-embed-config
 eks-a-custom-embed-config:
+	cp pkg/cluster/config/releases.yaml $(EMBED_CONFIG_FOLDER)/releases.yaml
 	$(MAKE) eks-a-binary GIT_VERSION=$(CUSTOM_GIT_VERSION) RELEASE_MANIFEST_URL=embed:///config/releases.yaml LINKER_FLAGS='-s -w -X github.com/aws/eks-anywhere/pkg/eksctl.enabled=true' BUILD_TAGS='$(BUILD_TAGS) files_embed_fs'
 
 .PHONY: eks-a-cross-platform-custom-embed-latest-config

--- a/cmd/eksctl-anywhere/cmd/version.go
+++ b/cmd/eksctl-anywhere/cmd/version.go
@@ -1,27 +1,65 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 
 	"github.com/aws/eks-anywhere/pkg/version"
 )
+
+type versionOptions struct {
+	output string
+}
+
+var vo = &versionOptions{}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Get the eksctl anywhere version",
 	Long:  "This command prints the version of eksctl anywhere",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return printVersion()
+		return vo.printVersion()
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().StringVarP(&vo.output, "output", "o", "", "specifies the output format (valid option: json)")
 }
 
-func printVersion() error {
-	fmt.Println(version.Get().GitVersion)
+func (vo *versionOptions) printVersion() error {
+	versionInfo, bundlesErr := version.GetFullVersionInfo()
+	switch vo.output {
+	case "":
+		fmt.Printf("Version: %s\n", versionInfo.GitVersion)
+		if bundlesErr != nil {
+			return fmt.Errorf("error getting bundle manifest URL for version %s: %v", versionInfo, bundlesErr)
+		}
+		fmt.Printf("Bundle Manifest URL: %s\n", versionInfo.BundleManifestURL)
+	case "json":
+		versionInfoJSON, unmarshalErr := json.Marshal(versionInfo)
+		if unmarshalErr != nil {
+			return fmt.Errorf("error marshaling version info to JSON: %v", unmarshalErr)
+		}
+		fmt.Printf("%s\n", versionInfoJSON)
+		if bundlesErr != nil {
+			return fmt.Errorf("error getting bundle manifest URL for version %s: %v", versionInfo, bundlesErr)
+		}
+	case "yaml":
+		versionInfoYAML, unmarshalErr := yaml.Marshal(versionInfo)
+		if unmarshalErr != nil {
+			return fmt.Errorf("error marshaling version info to YAML: %v", unmarshalErr)
+		}
+		fmt.Printf("%s\n", versionInfoYAML)
+		if bundlesErr != nil {
+			return fmt.Errorf("error getting bundle manifest URL for version %s: %v", versionInfo, bundlesErr)
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", vo.output)
+	}
+
 	return nil
 }

--- a/pkg/manifests/releases/read.go
+++ b/pkg/manifests/releases/read.go
@@ -41,6 +41,22 @@ func ReadReleasesFromURL(reader Reader, url string) (*releasev1.Release, error) 
 	return release, nil
 }
 
+// GetBundleManifestURL fetches the bundle manifest URL pertaining to this
+// release version of EKS Anywhere.
+func GetBundleManifestURL(reader Reader, version string) (string, error) {
+	eksAReleases, err := ReadReleases(reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to read releases: %v", err)
+	}
+
+	eksAReleaseForVersion, err := ReleaseForVersion(eksAReleases, version)
+	if err != nil {
+		return "", fmt.Errorf("failed to get EKS-A release for version %s: %v", version, err)
+	}
+
+	return eksAReleaseForVersion.BundleManifestUrl, nil
+}
+
 func ReadBundlesForRelease(reader Reader, release *releasev1.EksARelease) (*releasev1.Bundles, error) {
 	return bundles.Read(reader, release.BundleManifestUrl)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,13 +1,35 @@
 package version
 
+import (
+	"github.com/aws/eks-anywhere/pkg/files"
+	"github.com/aws/eks-anywhere/pkg/manifests/releases"
+)
+
 var gitVersion string
 
 type Info struct {
-	GitVersion string
+	GitVersion        string `json:"version"`
+	BundleManifestURL string `json:"bundleManifestURL,omitempty"`
 }
 
 func Get() Info {
 	return Info{
 		GitVersion: gitVersion,
 	}
+}
+
+// GetFullVersionInfo returns the complete version information for the
+// EKS Anywhere, including Git version and bundle manifest URL
+// associated with this release.
+func GetFullVersionInfo() (Info, error) {
+	reader := files.NewReader(files.WithEKSAUserAgent("cli", gitVersion))
+	bundleManifestURL, err := releases.GetBundleManifestURL(reader, gitVersion)
+	if err != nil {
+		return Info{GitVersion: gitVersion}, err
+	}
+
+	return Info{
+		GitVersion:        gitVersion,
+		BundleManifestURL: bundleManifestURL,
+	}, nil
 }


### PR DESCRIPTION
The EKS Anywhere deliverables include not just the CLI but also a bundle of artifacts used to bring up a working EKS-A cluster. There have been many cases where EKS-A customers want to know what bundle will be used by default in the cluster creation. In our docs, we have some steps to get the bundle manifest associated with an EKS-A release but this requires the customer to download additional tools like `yq`. Most customers find this only when running cluster operations but only when verbose logging is enabled, which is not ideal. Instead of all this, we can present them this info as an output in the `eksctl anywhere version` command, with an optional output flag to print in json. This will also send the message that the bundle is as much a part of EKS-A as the CLI. This is analogous to the output of Flux version which also includes the controller versions along with CLI version.
```
$ flux version
flux: v0.41.1
helm-controller: v0.12.0
kustomize-controller: v0.15.2
notification-controller: v0.17.0
source-controller: v0.16.0
```

### Sample output
#### Dev
```bash
$ eksctl anywhere version                                                             
Version: v0.0.0-dev
Bundle manifest URL: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml
```
#### Prod
```bash
$ eksctl anywhere version                                                             
Version: v0.18.3
Bundle manifest URL: https://anywhere-assets.eks.amazonaws.com/releases/bundles/54/manifest.yaml
```
#### Dev/JSON
```bash
$ eksctl anywhere version -o json
{"version":"v0.0.0-dev","bundleManifestURL":"https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml"}
```
#### Dev/YAML
```bash
$ eksctl anywhere version -o yaml
bundleManifestURL: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml
version: v0.0.0-dev
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

