### PR TITLE
Display timeout flags in help command and doc

### DIFF
--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -34,21 +34,11 @@ type timeoutOptions struct {
 }
 
 func applyTimeoutFlags(flagSet *pflag.FlagSet, t *timeoutOptions) {
-	flagSet.StringVar(&t.cpWaitTimeout, cpWaitTimeoutFlag, clustermanager.DefaultControlPlaneWait.String(), "Override the default control plane wait timeout (60m).")
-	markFlagHidden(flagSet, cpWaitTimeoutFlag)
-
-	flagSet.StringVar(&t.externalEtcdWaitTimeout, externalEtcdWaitTimeoutFlag, clustermanager.DefaultEtcdWait.String(), "Override the default external etcd wait timeout (60m)")
-	markFlagHidden(flagSet, externalEtcdWaitTimeoutFlag)
-
-	flagSet.StringVar(&t.perMachineWaitTimeout, perMachineWaitTimeoutFlag, clustermanager.DefaultMaxWaitPerMachine.String(), "Override the default machine wait timeout (10m)/per machine ")
-	markFlagHidden(flagSet, perMachineWaitTimeoutFlag)
-
-	flagSet.StringVar(&t.unhealthyMachineTimeout, unhealthyMachineTimeoutFlag, clustermanager.DefaultUnhealthyMachineTimeout.String(), "Override the default unhealthy machine timeout (5m) ")
-	markFlagHidden(flagSet, unhealthyMachineTimeoutFlag)
-
-	flagSet.StringVar(&t.nodeStartupTimeout, nodeStartupTimeoutFlag, clustermanager.DefaultNodeStartupTimeout.String(), "Override the default node startup timeout (10m) ")
-	markFlagHidden(flagSet, nodeStartupTimeoutFlag)
-
+	flagSet.StringVar(&t.cpWaitTimeout, cpWaitTimeoutFlag, clustermanager.DefaultControlPlaneWait.String(), "Override the default control plane wait timeout")
+	flagSet.StringVar(&t.externalEtcdWaitTimeout, externalEtcdWaitTimeoutFlag, clustermanager.DefaultEtcdWait.String(), "Override the default external etcd wait timeout")
+	flagSet.StringVar(&t.perMachineWaitTimeout, perMachineWaitTimeoutFlag, clustermanager.DefaultMaxWaitPerMachine.String(), "Override the default machine wait timeout per machine")
+	flagSet.StringVar(&t.unhealthyMachineTimeout, unhealthyMachineTimeoutFlag, clustermanager.DefaultUnhealthyMachineTimeout.String(), "Override the default unhealthy machine timeout")
+	flagSet.StringVar(&t.nodeStartupTimeout, nodeStartupTimeoutFlag, clustermanager.DefaultNodeStartupTimeout.String(), "Override the default node startup timeout")
 	flagSet.BoolVar(&t.noTimeouts, noTimeoutsFlag, false, "Disable timeout for all wait operations")
 }
 

--- a/docs/content/en/docs/reference/eksctl/anywhere_create_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_create_cluster.md
@@ -18,16 +18,21 @@ anywhere create cluster -f <cluster-config-file> [flags]
 ### Options
 
 ```
-      --bundles-override string          Override default Bundles manifest (not recommended)
-  -f, --filename string                  Filename that contains EKS-A cluster configuration
-      --force-cleanup                    Force deletion of previously created bootstrap cluster
-  -z, --hardware-csv string              Path to a CSV file containing hardware data.
-  -h, --help                             help for cluster
-      --install-packages string          Location of curated packages configuration files to install to the cluster
-      --kubeconfig string                Management cluster kubeconfig file
-      --no-timeouts                      Disable timeout for all wait operations
-      --skip-ip-check                    Skip check for whether cluster control plane ip is in use
-      --tinkerbell-bootstrap-ip string   Override the local tinkerbell IP in the bootstrap cluster
+      --bundles-override string             Override default Bundles manifest (not recommended)
+      --control-plane-wait-timeout string   Override the default control plane wait timeout (default "1h0m0s")
+      --external-etcd-wait-timeout string   Override the default external etcd wait timeout (default "1h0m0s")
+  -f, --filename string                     Filename that contains EKS-A cluster configuration
+      --force-cleanup                       Force deletion of previously created bootstrap cluster
+  -z, --hardware-csv string                 Path to a CSV file containing hardware data.
+  -h, --help                                help for cluster
+      --install-packages string             Location of curated packages configuration files to install to the cluster
+      --kubeconfig string                   Management cluster kubeconfig file
+      --no-timeouts                         Disable timeout for all wait operations
+      --node-startup-timeout string         Override the default node startup timeout (default "10m0s")
+      --per-machine-wait-timeout string     Override the default machine wait timeout per machine (default "10m0s")
+      --skip-ip-check                       Skip check for whether cluster control plane ip is in use
+      --tinkerbell-bootstrap-ip string      Override the local tinkerbell IP in the bootstrap cluster
+      --unhealthy-machine-timeout string    Override the default unhealthy machine timeout (default "5m0s")
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_cluster.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_cluster.md
@@ -18,14 +18,19 @@ anywhere upgrade cluster [flags]
 ### Options
 
 ```
-      --bundles-override string   Override default Bundles manifest (not recommended)
-  -f, --filename string           Filename that contains EKS-A cluster configuration
-      --force-cleanup             Force deletion of previously created bootstrap cluster
-  -z, --hardware-csv string       Path to a CSV file containing hardware data.
-  -h, --help                      help for cluster
-      --kubeconfig string         Management cluster kubeconfig file
-      --no-timeouts               Disable timeout for all wait operations
-  -w, --w-config string           Kubeconfig file to use when upgrading a workload cluster
+      --bundles-override string             Override default Bundles manifest (not recommended)
+      --control-plane-wait-timeout string   Override the default control plane wait timeout (default "1h0m0s")
+      --external-etcd-wait-timeout string   Override the default external etcd wait timeout (default "1h0m0s")
+  -f, --filename string                     Filename that contains EKS-A cluster configuration
+      --force-cleanup                       Force deletion of previously created bootstrap cluster
+  -z, --hardware-csv string                 Path to a CSV file containing hardware data.
+  -h, --help                                help for cluster
+      --kubeconfig string                   Management cluster kubeconfig file
+      --no-timeouts                         Disable timeout for all wait operations
+      --node-startup-timeout string         Override the default node startup timeout (default "10m0s")
+      --per-machine-wait-timeout string     Override the default machine wait timeout per machine (default "10m0s")
+      --unhealthy-machine-timeout string    Override the default unhealthy machine timeout (default "5m0s")
+  -w, --w-config string                     Kubeconfig file to use when upgrading a workload cluster
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
*Issue #, if available:*

Related issue: #5637 

*Description of changes:*

Display the timeout flags in CLI help and doc.

*Testing (if applicable):*

```
$ eksctl anywhere create cluster -h

This command is used to create workload clusters

Usage:
  anywhere create cluster -f <cluster-config-file> [flags]

Flags:
      --bundles-override string             Override default Bundles manifest (not recommended)
      --control-plane-wait-timeout string   Override the default control plane wait timeout (default "1h0m0s")
      --external-etcd-wait-timeout string   Override the default external etcd wait timeout (default "1h0m0s")
  -f, --filename string                     Filename that contains EKS-A cluster configuration
      --force-cleanup                       Force deletion of previously created bootstrap cluster
  -z, --hardware-csv string                 Path to a CSV file containing hardware data.
  -h, --help                                help for cluster
      --install-packages string             Location of curated packages configuration files to install to the cluster
      --kubeconfig string                   Management cluster kubeconfig file
      --no-timeouts                         Disable timeout for all wait operations
      --node-startup-timeout string         Override the default node startup timeout (default "10m0s")
      --per-machine-wait-timeout string     Override the default machine wait timeout per machine (default "10m0s")
      --skip-ip-check                       Skip check for whether cluster control plane ip is in use
      --tinkerbell-bootstrap-ip string      Override the local tinkerbell IP in the bootstrap cluster
      --unhealthy-machine-timeout string    Override the default unhealthy machine timeout (default "5m0s")

Global Flags:
  -v, --verbosity int   Set the log level verbosity
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

