### PR TITLE
Add Control Plane IP Analyzer for all providers

### DIFF
--- a/pkg/diagnostics/analyzers.go
+++ b/pkg/diagnostics/analyzers.go
@@ -90,6 +90,10 @@ func (a *analyzerFactory) managementClusterDeploymentAnalyzers() []*Analyze {
 			Namespace:        constants.CapcSystemNamespace,
 			ExpectedReplicas: 1,
 		}, {
+			Name:             "capx-controller-manager",
+			Namespace:        constants.CapxSystemNamespace,
+			ExpectedReplicas: 1,
+		}, {
 			Name:             "cert-manager-webhook",
 			Namespace:        constants.CertManagerNamespace,
 			ExpectedReplicas: 1,
@@ -161,6 +165,8 @@ func (a *analyzerFactory) DataCenterConfigAnalyzers(datacenter v1alpha1.Ref) []*
 		return a.eksaCloudstackAnalyzers()
 	case v1alpha1.SnowDatacenterKind:
 		return a.eksaSnowAnalyzers()
+	case v1alpha1.NutanixDatacenterKind:
+		return a.eksaNutanixAnalyzers()
 	default:
 		return nil
 	}
@@ -182,7 +188,8 @@ func (a *analyzerFactory) eksaCloudstackAnalyzers() []*Analyze {
 		fmt.Sprintf("cloudstackdatacenterconfigs.%s", v1alpha1.GroupVersion.Group),
 		fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group),
 	}
-	return a.generateCrdAnalyzers(crds)
+	analyzers := a.generateCrdAnalyzers(crds)
+	return append(analyzers, a.validControlPlaneIPAnalyzer())
 }
 
 func (a *analyzerFactory) eksaSnowAnalyzers() []*Analyze {
@@ -211,6 +218,15 @@ func (a *analyzerFactory) eksaDockerAnalyzers() []*Analyze {
 
 	analyazers = append(analyazers, a.generateCrdAnalyzers(crds)...)
 	return append(analyazers, a.generateDeploymentAnalyzers(deployments)...)
+}
+
+func (a *analyzerFactory) eksaNutanixAnalyzers() []*Analyze {
+	crds := []string{
+		fmt.Sprintf("nutanixdatacenterconfigs.%s", v1alpha1.GroupVersion.Group),
+		fmt.Sprintf("nutanixmachineconfigs.%s", v1alpha1.GroupVersion.Group),
+	}
+	analyzers := a.generateCrdAnalyzers(crds)
+	return append(analyzers, a.validControlPlaneIPAnalyzer())
 }
 
 // EksaLogTextAnalyzers given a slice of Collectors will check which namespaced log collectors are present

--- a/pkg/diagnostics/analyzers_test.go
+++ b/pkg/diagnostics/analyzers_test.go
@@ -14,12 +14,13 @@ func TestManagementClusterAnalyzers(t *testing.T) {
 	g := NewGomegaWithT(t)
 	factory := diagnostics.NewAnalyzerFactory()
 	analyzers := factory.ManagementClusterAnalyzers()
-	g.Expect(analyzers).To(HaveLen(12), "DataCenterConfigCollectors() mismatch between desired collectors and actual")
+	g.Expect(analyzers).To(HaveLen(13), "DataCenterConfigCollectors() mismatch between desired collectors and actual")
 	g.Expect(getDeploymentStatusAnalyzer(analyzers, "capc-controller-manager")).ToNot(BeNil(), "capc controller manager analyzer should be present")
 	g.Expect(getDeploymentStatusAnalyzer(analyzers, "capv-controller-manager")).ToNot(BeNil(), "capv controller manager analyzer should be present")
 	g.Expect(getDeploymentStatusAnalyzer(analyzers, "capt-controller-manager")).ToNot(BeNil(), "capt controller manager analyzer should be present")
-	g.Expect(analyzers[10].CustomResourceDefinition.CheckName).To(Equal("clusters.anywhere.eks.amazonaws.com"))
-	g.Expect(analyzers[11].CustomResourceDefinition.CheckName).To(Equal("bundles.anywhere.eks.amazonaws.com"))
+	g.Expect(getDeploymentStatusAnalyzer(analyzers, "capx-controller-manager")).ToNot(BeNil(), "capx controller manager analyzer should be present")
+	g.Expect(analyzers[11].CustomResourceDefinition.CheckName).To(Equal("clusters.anywhere.eks.amazonaws.com"))
+	g.Expect(analyzers[12].CustomResourceDefinition.CheckName).To(Equal("bundles.anywhere.eks.amazonaws.com"))
 }
 
 func getDeploymentStatusAnalyzer(analyzers []*diagnostics.Analyze, name string) *diagnostics.Analyze {
@@ -74,7 +75,21 @@ func TestCloudStackDataCenterConfigAnalyzers(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.CloudStackDatacenterKind}
 	analyzerFactory := diagnostics.NewAnalyzerFactory()
 	analyzers := analyzerFactory.DataCenterConfigAnalyzers(datacenter)
-	g.Expect(analyzers).To(HaveLen(2), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
+	g.Expect(analyzers).To(HaveLen(3), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
+}
+
+func TestNutanixDataCenterConfigAnalyzers(t *testing.T) {
+	g := NewGomegaWithT(t)
+	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.NutanixDatacenterKind}
+	analyzerFactory := diagnostics.NewAnalyzerFactory()
+	analyzers := analyzerFactory.DataCenterConfigAnalyzers(datacenter)
+	g.Expect(analyzers).To(HaveLen(3), "DataCenterConfigAnalyzers() mismatch between desired analyzers and actual")
+	g.Expect(analyzers[0].CustomResourceDefinition.CustomResourceDefinitionName).To(Equal("nutanixdatacenterconfigs.anywhere.eks.amazonaws.com"),
+		"Nutanix generateCrdAnalyzers() mismatch between desired datacenter config group version and actual")
+	g.Expect(analyzers[1].CustomResourceDefinition.CustomResourceDefinitionName).To(Equal("nutanixmachineconfigs.anywhere.eks.amazonaws.com"),
+		"Nutanix generateCrdAnalyzers() mismatch between desired machine config group version and actual")
+	g.Expect(analyzers[2].TextAnalyze.RegexPattern).To(Equal("exit code: 0"),
+		"validControlPlaneIPAnalyzer() mismatch between desired regexPattern and actual")
 }
 
 func TestSnowAnalyzers(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/5704

*Description of changes:*
Adds Control plane IP validator analyzer for Nutanix and Cloudstack

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

