### PR TITLE
Expand GITHUB_TOKEN regex to support fine-grained access tokens

### DIFF
--- a/pkg/git/providers/github/github.go
+++ b/pkg/git/providers/github/github.go
@@ -20,7 +20,7 @@ const (
 	EksaGithubTokenEnv = "EKSA_GITHUB_TOKEN"
 	GithubTokenEnv     = "GITHUB_TOKEN"
 	githubUrlTemplate  = "https://github.com/%v/%v.git"
-	patRegex           = "^[A-Za-z0-9_]{40}$"
+	patRegex           = "^ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$"
 	repoPermissions    = "repo"
 )
 

--- a/pkg/git/providers/github/github_test.go
+++ b/pkg/git/providers/github/github_test.go
@@ -3,6 +3,7 @@ package github_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -16,9 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/git/providers/github/mocks"
 )
 
-const (
-	validPATValue = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-)
+var validPATValues = []string{"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "github_pat_abcdefghijklmnopqrstuv_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"}
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
@@ -68,6 +67,7 @@ func TestValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
+			validPATValue := validPATValues[rand.Intn(len(validPATValues))]
 
 			ctx := context.Background()
 			githubproviderclient := mocks.NewMockGithubClient(mockCtrl)
@@ -107,6 +107,7 @@ func TestValidate(t *testing.T) {
 }
 
 func setupContext(t *testing.T) {
+	validPATValue := validPATValues[rand.Intn(len(validPATValues))]
 	t.Setenv(github.EksaGithubTokenEnv, validPATValue)
 	t.Setenv(github.GithubTokenEnv, validPATValue)
 }
@@ -169,6 +170,7 @@ func TestGetRepoSucceeds(t *testing.T) {
 				Personal:   tt.personal,
 			}
 
+			validPATValue := validPATValues[rand.Intn(len(validPATValues))]
 			auth := git.TokenAuth{Token: validPATValue, Username: tt.owner}
 			githubProvider, err := github.New(githubproviderclient, config, auth)
 			if err != nil {
@@ -223,6 +225,7 @@ func TestGetNonExistantRepoSucceeds(t *testing.T) {
 				Personal:   tt.personal,
 			}
 
+			validPATValue := validPATValues[rand.Intn(len(validPATValues))]
 			auth := git.TokenAuth{Token: validPATValue, Username: tt.owner}
 			githubProvider, err := github.New(githubproviderclient, config, auth)
 			if err != nil {


### PR DESCRIPTION
The current regular expression for GitHub personal access tokens only supports specifying classic PATs. If a user tries to use a fine-grained access token, EKS-A blocks it because it doesn't conform to the regex. This PR expands this regex to support both types of tokens.

Fixes: #5764

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

