### PR TITLE
Add Proxy support for Nutanix

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -165,6 +165,15 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
 {{- end }}
+{{- if .proxyConfig }}
+    - content: |
+        [Service]
+        Environment="HTTP_PROXY={{.httpProxy}}"
+        Environment="HTTPS_PROXY={{.httpsProxy}}"
+        Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
+      owner: root:root
+      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+{{- end }}
 {{- if .registryMirrorMap }}
     - content: |
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
@@ -276,8 +285,10 @@ spec:
         sshAuthorizedKeys:
           - "{{.controlPlaneSshAuthorizedKey}}"
     preKubeadmCommands:
-{{- if and .registryMirrorMap }}
+{{- if .registryMirrorMap }}
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
+{{- end }}
+{{- if or .proxyConfig .registryMirrorMap }}
       - sudo systemctl daemon-reload
       - sudo systemctl restart containerd
 {{- end }}

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -91,6 +91,8 @@ spec:
       preKubeadmCommands:
 {{- if .registryMirrorMap }}
         - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
+{{- end }}
+{{- if or .proxyConfig .registryMirrorMap }}
         - sudo systemctl daemon-reload
         - sudo systemctl restart containerd
 {{- end }}
@@ -123,8 +125,17 @@ spec:
           sudo: ALL=(ALL) NOPASSWD:ALL
           sshAuthorizedKeys:
             - "{{.workerSshAuthorizedKey}}"
-{{- if .registryMirrorMap }}
+{{- if or .proxyConfig .registryMirrorMap }}
       files:
+{{- end }}
+{{- if .proxyConfig }}
+      - content: |
+          [Service]
+          Environment="HTTP_PROXY={{.httpProxy}}"
+          Environment="HTTPS_PROXY={{.httpsProxy}}"
+          Environment="NO_PROXY={{ stringsJoin .noProxy "," }}"
+        owner: root:root
+        path: /etc/systemd/system/containerd.service.d/http-proxy.conf
 {{- end }}
 {{- if .registryCACert }}
       - content: |

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -241,24 +241,9 @@ func buildTemplateMapCP(
 
 	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
 		values["proxyConfig"] = true
-		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
-			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
-			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
-		noProxyList := make([]string, 0, capacity)
-		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
-
-		// Add no-proxy defaults
-		noProxyList = append(noProxyList, clusterapi.NoProxyDefaults()...)
-		noProxyList = append(noProxyList,
-			datacenterSpec.Endpoint,
-			clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
-		)
-
 		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
 		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
-		values["noProxy"] = noProxyList
+		values["noProxy"] = generateNoProxyList(clusterSpec)
 	}
 
 	return values, nil
@@ -327,24 +312,10 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 
 	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
 		values["proxyConfig"] = true
-		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
-			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
-			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
-		noProxyList := make([]string, 0, capacity)
-		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
-		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
-
-		// Add no-proxy defaults
-		noProxyList = append(noProxyList, clusterapi.NoProxyDefaults()...)
-		noProxyList = append(noProxyList,
-			clusterSpec.Config.NutanixDatacenter.Spec.Endpoint,
-			clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
-		)
 
 		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
 		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
-		values["noProxy"] = noProxyList
+		values["noProxy"] = generateNoProxyList(clusterSpec)
 	}
 
 	return values, nil
@@ -372,4 +343,24 @@ func buildTemplateMapSecret(secretName string, creds credentials.BasicAuthCreden
 	}
 
 	return values, nil
+}
+
+func generateNoProxyList(clusterSpec *cluster.Spec) []string {
+	capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+		len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+		len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
+
+	noProxyList := make([]string, 0, capacity)
+	noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+	noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+	noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
+
+	// Add no-proxy defaults
+	noProxyList = append(noProxyList, clusterapi.NoProxyDefaults()...)
+	noProxyList = append(noProxyList,
+		clusterSpec.Config.NutanixDatacenter.Spec.Endpoint,
+		clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
+	)
+
+	return noProxyList
 }

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -239,6 +239,28 @@ func buildTemplateMapCP(
 		values["awsIamAuth"] = true
 	}
 
+	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
+		values["proxyConfig"] = true
+		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
+		noProxyList := make([]string, 0, capacity)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
+
+		// Add no-proxy defaults
+		noProxyList = append(noProxyList, clusterapi.NoProxyDefaults()...)
+		noProxyList = append(noProxyList,
+			datacenterSpec.Endpoint,
+			clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
+		)
+
+		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
+		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
+		values["noProxy"] = noProxyList
+	}
+
 	return values, nil
 }
 
@@ -301,6 +323,28 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		values["projectIDType"] = workerNodeGroupMachineSpec.Project.Type
 		values["projectName"] = workerNodeGroupMachineSpec.Project.Name
 		values["projectUUID"] = workerNodeGroupMachineSpec.Project.UUID
+	}
+
+	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
+		values["proxyConfig"] = true
+		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 4
+		noProxyList := make([]string, 0, capacity)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
+
+		// Add no-proxy defaults
+		noProxyList = append(noProxyList, clusterapi.NoProxyDefaults()...)
+		noProxyList = append(noProxyList,
+			clusterSpec.Config.NutanixDatacenter.Spec.Endpoint,
+			clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
+		)
+
+		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
+		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
+		values["noProxy"] = noProxyList
 	}
 
 	return values, nil

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -336,6 +336,40 @@ func TestNewNutanixTemplateBuilderIRSA(t *testing.T) {
 	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
 }
 
+func TestNewNutanixTemplateBuilderProxy(t *testing.T) {
+	dcConf, machineConf, workerConfs := minimalNutanixConfigSpec(t)
+
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-proxy.yaml")
+
+	cpSpec, err := builder.GenerateCAPISpecControlPlane(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+
+	expectedControlPlaneSpec, err := os.ReadFile("testdata/expected_results_proxy.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
+
+	workloadTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	kubeadmconfigTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	workerSpec, err := builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
+	assert.NoError(t, err)
+	assert.NotNil(t, workerSpec)
+
+	expectedWorkersSpec, err := os.ReadFile("testdata/expected_results_proxy_md.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedWorkersSpec, workerSpec)
+}
+
 func minimalNutanixConfigSpec(t *testing.T) (*anywherev1.NutanixDatacenterConfig, *anywherev1.NutanixMachineConfig, map[string]anywherev1.NutanixMachineConfigSpec) {
 	dcConf := &anywherev1.NutanixDatacenterConfig{}
 	err := yaml.Unmarshal([]byte(nutanixDatacenterConfigSpec), dcConf)

--- a/pkg/providers/nutanix/testdata/eksa-cluster-proxy.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-proxy.yaml
@@ -39,6 +39,10 @@ spec:
   proxyConfiguration:
     httpProxy: proxy.nutanix.com:8888
     httpsProxy: proxy.nutanix.com:8888
+    noProxy:
+      - noproxy1.nutanix.com
+      - noproxy2.nutanix.com
+      - noproxy3.nutanix.com
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: NutanixDatacenterConfig

--- a/pkg/providers/nutanix/testdata/eksa-cluster-proxy.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-proxy.yaml
@@ -1,0 +1,78 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: eksa-unit-test
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  proxyConfiguration:
+    httpProxy: proxy.nutanix.com:8888
+    httpsProxy: proxy.nutanix.com:8888
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -136,7 +136,7 @@ spec:
         [Service]
         Environment="HTTP_PROXY=proxy.nutanix.com:8888"
         Environment="HTTPS_PROXY=proxy.nutanix.com:8888"
-        Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
+        Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,noproxy1.nutanix.com,noproxy2.nutanix.com,noproxy3.nutanix.com,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
       owner: root:root
       path: /etc/systemd/system/containerd.service.d/http-proxy.conf
     initConfiguration:

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -1,0 +1,199 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  prismCentral:
+    address: "prism.nutanix.com"
+    port: 9440
+    insecure: false
+    credentialRef:
+      name: "capx-eksa-unit-test"
+      kind: Secret
+  controlPlaneEndpoint:
+    host: "test-ip"
+    port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: [10.96.0.0/12]
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    serviceDomain: "cluster.local"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: "eksa-unit-test"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixCluster
+    name: "eksa-unit-test"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  replicas: 3
+  version: "v1.19.8-eks-1-19-4"
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: NutanixMachineTemplate
+      name: "<no value>"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: "public.ecr.aws/eks-distro/kubernetes"
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.8.0-eks-1-19-4
+      etcd:
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+            - name: kube-vip
+              image: 
+              imagePullPolicy: IfNotPresent
+              args:
+                - manager
+              env:
+                - name: vip_arp
+                  value: "true"
+                - name: address
+                  value: "test-ip"
+                - name: port
+                  value: "6443"
+                - name: vip_cidr
+                  value: "32"
+                - name: cp_enable
+                  value: "true"
+                - name: cp_namespace
+                  value: kube-system
+                - name: vip_ddns
+                  value: "false"
+                - name: vip_leaderelection
+                  value: "true"
+                - name: vip_leaseduration
+                  value: "15"
+                - name: vip_renewdeadline
+                  value: "10"
+                - name: vip_retryperiod
+                  value: "2"
+                - name: svc_enable
+                  value: "false"
+                - name: lb_enable
+                  value: "false"
+              securityContext:
+                capabilities:
+                  add:
+                    - NET_ADMIN
+                    - SYS_TIME
+                    - NET_RAW
+              volumeMounts:
+                - mountPath: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              resources: {}
+          hostNetwork: true
+          volumes:
+            - name: kubeconfig
+              hostPath:
+                type: FileOrCreate
+                path: /etc/kubernetes/admin.conf
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    - content: |
+        [Service]
+        Environment="HTTP_PROXY=proxy.nutanix.com:8888"
+        Environment="HTTPS_PROXY=proxy.nutanix.com:8888"
+        Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
+      owner: root:root
+      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+          #cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
+    users:
+      - name: "mySshUsername"
+        lockPassword: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        sshAuthorizedKeys:
+          - "mySshAuthorizedKey"
+    preKubeadmCommands:
+      - sudo systemctl daemon-reload
+      - sudo systemctl restart containerd
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+    postKubeadmCommands:
+      - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    useExperimentalRetryJoin: true
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "<no value>"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---

--- a/pkg/providers/nutanix/testdata/expected_results_proxy_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy_md.yaml
@@ -83,7 +83,7 @@ spec:
           [Service]
           Environment="HTTP_PROXY=proxy.nutanix.com:8888"
           Environment="HTTPS_PROXY=proxy.nutanix.com:8888"
-          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
+          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,noproxy1.nutanix.com,noproxy2.nutanix.com,noproxy3.nutanix.com,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
         owner: root:root
         path: /etc/systemd/system/containerd.service.d/http-proxy.conf
 

--- a/pkg/providers/nutanix/testdata/expected_results_proxy_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy_md.yaml
@@ -1,0 +1,90 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test-eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterName: "eksa-unit-test"
+  replicas: 4
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: "eksa-unit-test"
+      clusterName: "eksa-unit-test"
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        name: "eksa-unit-test"
+      version: "v1.19.8-eks-1-19-4"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      preKubeadmCommands:
+        - sudo systemctl daemon-reload
+        - sudo systemctl restart containerd
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            #cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      users:
+        - name: "mySshUsername"
+          lockPassword: false
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          sshAuthorizedKeys:
+            - "mySshAuthorizedKey"
+      files:
+      - content: |
+          [Service]
+          Environment="HTTP_PROXY=proxy.nutanix.com:8888"
+          Environment="HTTPS_PROXY=proxy.nutanix.com:8888"
+          Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
+        owner: root:root
+        path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+
+---


### PR DESCRIPTION
Propagate Proxy config for Nutanix templates.

**How has this been tested?**
- Created a proxy with tinyproxy on a ubuntu server VM
- Configure `proxyConfiguration` on cluster spec to point to the proxy and create a cluster successfully ([logs](https://app.warp.dev/block/vBn52cJUC5EGcLJuEUZLSK))
- Correlate whether the traffic from cluster is being routed through  the proxy