### PR TITLE
cloudstack validate machine config

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -415,7 +415,7 @@ func (f *Factory) withTinkerbellClusterReconciler() *Factory {
 }
 
 func (f *Factory) withCloudStackClusterReconciler() *Factory {
-	f.withCNIReconciler().withTracker().withIPValidator()
+	f.withCNIReconciler().withTracker().withIPValidator().withCloudStackValidatorRegistry()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.cloudstackClusterReconciler != nil {
@@ -427,6 +427,7 @@ func (f *Factory) withCloudStackClusterReconciler() *Factory {
 			f.ipValidator,
 			f.cniReconciler,
 			f.tracker,
+			f.cloudStackValidatorRegistry,
 		)
 		f.registryBuilder.Add(anywherev1.CloudStackDatacenterKind, f.cloudstackClusterReconciler)
 


### PR DESCRIPTION
*Issue #, if available:*
closes [Validate Machine Config#1260](https://github.com/aws/eks-anywhere-internal/issues/1260)

*Description of changes:*
use cmk client to perform run time machine config validation

*Testing (if applicable):*
unit tests and manual testing
- successfully create wl cluster
- fail on nonexistent secret
- fail on nonexistent template
- fail on unmatched template between cp and worker node

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

