### PR TITLE
Add Users and SSH key validation in cloudstackmachineconfig webhook

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -217,7 +217,7 @@ func (c *CloudStackMachineConfig) Validate() error {
 }
 
 // SetUserDefaults initializes Spec.Users for the CloudStackMachineConfig with default values.
-// This only runs in the CLI, as we support don't support user defaults through the webhook.
+// This only runs in the CLI, as we don't support user defaults through the webhook.
 func (c *CloudStackMachineConfig) SetUserDefaults() {
 	c.Spec.Users = defaultMachineConfigUsers(DefaultCloudStackUser, c.Spec.Users)
 }

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -217,9 +217,9 @@ func (c *CloudStackMachineConfig) Validate() error {
 }
 
 // SetUserDefaults initializes Spec.Users for the CloudStackMachineConfig with default values.
-// This only runs in the CLI, as we support do support user defaults through the webhook.
+// This only runs in the CLI, as we support don't support user defaults through the webhook.
 func (c *CloudStackMachineConfig) SetUserDefaults() {
-	c.Spec.Users = defaultMachineConfigUsers(c.Spec.Users)
+	c.Spec.Users = defaultMachineConfigUsers(DefaultCloudStackUser, c.Spec.Users)
 }
 
 // CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig.

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -147,6 +147,16 @@ func (r SymlinkMaps) Validate() (err error, field string, value string) {
 	return nil, "", ""
 }
 
+// ValidateUsers verifies a CloudStackMachineConfig object must have a users with ssh authorized keys.
+// This validation only runs in CloudStackMachineConfig validation webhook, as we support
+// auto-generate and import ssh key when creating a cluster via CLI.
+func (c *CloudStackMachineConfig) ValidateUsers() error {
+	if err := validateMachineConfigUsers(c.Name, CloudStackMachineConfigKind, c.Spec.Users); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *CloudStackMachineConfig) PauseReconcile() {
 	c.Annotations[pausedAnnotation] = "true"
 }
@@ -204,6 +214,12 @@ func (c *CloudStackMachineConfig) GetName() string {
 
 func (c *CloudStackMachineConfig) Validate() error {
 	return validateCloudStackMachineConfig(c)
+}
+
+// SetUserDefaults initializes Spec.Users for the CloudStackMachineConfig with default values.
+// This only runs in the CLI, as we support do support user defaults through the webhook.
+func (c *CloudStackMachineConfig) SetUserDefaults() {
+	c.Spec.Users = defaultMachineConfigUsers(c.Spec.Users)
 }
 
 // CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig.

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -439,3 +439,80 @@ status: {}
 		})
 	}
 }
+
+func TestCloudStackMachineConfigValidateUsers(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name          string
+		machineConfig *v1alpha1.CloudStackMachineConfig
+		wantErr       string
+	}{
+		{
+			name: "users valid",
+			machineConfig: &v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{
+					Users: []v1alpha1.UserConfiguration{{
+						Name:              "capc",
+						SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
+					}},
+				},
+			},
+		},
+		{
+			name: "users not set",
+			machineConfig: &v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{},
+			},
+			wantErr: "users is not set for CloudStackMachineConfig , please provide specify a user",
+		},
+		{
+			name: "user name empty",
+			machineConfig: &v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{
+					Users: []v1alpha1.UserConfiguration{{
+						Name:              "",
+						SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
+					}},
+				},
+			},
+			wantErr: "users[0].name is not set or is empty for CloudStackMachineConfig , please provide a username",
+		},
+		{
+			name: "user ssh authorized key empty or not set",
+			machineConfig: &v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{
+					Users: []v1alpha1.UserConfiguration{{
+						Name:              "Jeff",
+						SshAuthorizedKeys: []string{""},
+					}},
+				},
+			},
+			wantErr: "users[0].SshAuthorizedKeys is not set or is empty for CloudStackMachineConfig , please provide a valid ssh authorized key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.machineConfig.ValidateUsers()
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+}
+
+func TestCloudStackMachineConfigSetDefaultUsers(t *testing.T) {
+	g := NewWithT(t)
+	machineConfig := &v1alpha1.CloudStackMachineConfig{
+		Spec: v1alpha1.CloudStackMachineConfigSpec{},
+	}
+	machineConfig.SetUserDefaults()
+	g.Expect(machineConfig.Spec.Users).To(Equal([]v1alpha1.UserConfiguration{
+		{
+			Name:              v1alpha1.DefaultCloudStackUser,
+			SshAuthorizedKeys: []string{""},
+		},
+	}))
+}

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
@@ -36,6 +36,8 @@ func (r *CloudStackMachineConfig) ValidateCreate() error {
 	if err, fieldName, fieldValue := r.Spec.Symlinks.Validate(); err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("symlinks %s:%v, preventing CloudStackMachineConfig resource creation: %v", fieldName, fieldValue, err))
 	}
+
+	// This is only needed for the webhook, which is why it is separate from the Validate method
 	if err := r.ValidateUsers(); err != nil {
 		return err
 	}
@@ -61,6 +63,7 @@ func (r *CloudStackMachineConfig) ValidateUpdate(old runtime.Object) error {
 		return nil
 	}
 
+	// This is only needed for the webhook, which is why it is separate from the Validate method
 	if err := r.ValidateUsers(); err != nil {
 		return apierrors.NewInvalid(GroupVersion.WithKind(CloudStackMachineConfigKind).GroupKind(),
 			r.Name,

--- a/pkg/api/v1alpha1/machine_types.go
+++ b/pkg/api/v1alpha1/machine_types.go
@@ -16,7 +16,7 @@ type UserConfiguration struct {
 	SshAuthorizedKeys []string `json:"sshAuthorizedKeys"`
 }
 
-func defaultMachineConfigUsers(users []UserConfiguration) []UserConfiguration {
+func defaultMachineConfigUsers(defaultUsername string, users []UserConfiguration) []UserConfiguration {
 	if len(users) <= 0 {
 		users = []UserConfiguration{{}}
 	}
@@ -24,7 +24,7 @@ func defaultMachineConfigUsers(users []UserConfiguration) []UserConfiguration {
 		users[0].SshAuthorizedKeys = []string{""}
 	}
 	if users[0].Name == "" {
-		users[0].Name = DefaultCloudStackUser
+		users[0].Name = defaultUsername
 	}
 
 	return users

--- a/pkg/api/v1alpha1/machine_types.go
+++ b/pkg/api/v1alpha1/machine_types.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import "fmt"
+
 type OSFamily string
 
 const (
@@ -12,4 +14,31 @@ const (
 type UserConfiguration struct {
 	Name              string   `json:"name"`
 	SshAuthorizedKeys []string `json:"sshAuthorizedKeys"`
+}
+
+func defaultMachineConfigUsers(users []UserConfiguration) []UserConfiguration {
+	if len(users) <= 0 {
+		users = []UserConfiguration{{}}
+	}
+	if len(users[0].SshAuthorizedKeys) <= 0 {
+		users[0].SshAuthorizedKeys = []string{""}
+	}
+	if users[0].Name == "" {
+		users[0].Name = DefaultCloudStackUser
+	}
+
+	return users
+}
+
+func validateMachineConfigUsers(machineConfigName string, machineConfigKind string, users []UserConfiguration) error {
+	if len(users) == 0 {
+		return fmt.Errorf("users is not set for %s %s, please provide specify a user", machineConfigKind, machineConfigName)
+	}
+	if users[0].Name == "" {
+		return fmt.Errorf("users[0].name is not set or is empty for %s %s, please provide a username", machineConfigKind, machineConfigName)
+	}
+	if len(users[0].SshAuthorizedKeys) == 0 || users[0].SshAuthorizedKeys[0] == "" {
+		return fmt.Errorf("users[0].SshAuthorizedKeys is not set or is empty for %s %s, please provide a valid ssh authorized key for user %s", machineConfigKind, machineConfigName, users[0].Name)
+	}
+	return nil
 }

--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -27,6 +27,12 @@ func cloudstackEntry() *ConfigManagerEntry {
 				}
 				return nil
 			},
+			func(c *Config) error {
+				for _, mc := range c.CloudStackMachineConfigs {
+					mc.SetUserDefaults()
+				}
+				return nil
+			},
 		},
 		Validations: []Validation{
 			func(c *Config) error {

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -292,6 +292,12 @@ func (p *cloudstackProvider) generateSSHKeysIfNotSet(machineConfigs map[string]*
 	return nil
 }
 
+func (p *cloudstackProvider) setMachineConfigDefaults(clusterSpec *cluster.Spec) {
+	for _, mc := range clusterSpec.CloudStackMachineConfigs {
+		mc.SetUserDefaults()
+	}
+}
+
 func (p *cloudstackProvider) validateManagementApiEndpoint(rawurl string) error {
 	_, err := url.ParseRequestURI(rawurl)
 	if err != nil {
@@ -396,6 +402,8 @@ func (p *cloudstackProvider) SetupAndValidateUpgradeCluster(ctx context.Context,
 	if err := p.validateK8sVersion(clusterSpec.Cluster.Spec.KubernetesVersion); err != nil {
 		return fmt.Errorf("validating K8s version for provider: %v", err)
 	}
+
+	p.setMachineConfigDefaults(clusterSpec)
 
 	if err := p.validateClusterSpec(ctx, clusterSpec); err != nil {
 		return fmt.Errorf("validating cluster spec: %v", err)

--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -139,15 +138,6 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, clusterSp
 	}
 
 	for _, machineConfig := range clusterSpec.CloudStackMachineConfigs {
-		if len(machineConfig.Spec.Users) <= 0 {
-			machineConfig.Spec.Users = []anywherev1.UserConfiguration{{}}
-		}
-		if len(machineConfig.Spec.Users[0].SshAuthorizedKeys) <= 0 {
-			machineConfig.Spec.Users[0].SshAuthorizedKeys = []string{""}
-		}
-		if machineConfig.Spec.Users[0].Name == "" {
-			machineConfig.Spec.Users[0].Name = v1alpha1.DefaultCloudStackUser
-		}
 		if err := v.validateMachineConfig(ctx, clusterSpec.CloudStackDatacenter, machineConfig); err != nil {
 			return fmt.Errorf("machine config %s validation failed: %v", machineConfig.Name, err)
 		}


### PR DESCRIPTION
*Issue #, if available:*
Part of [Provider validations for ssh key #1217]( https://github.com/aws/eks-anywhere-internal/issues/1217)


*Description of changes:*
This PR adds user and ssh key validation to the `cloudstackmachineconfig` webhook. This doesn't affect the current behavior for the CLI, because it defaults users and ssh keys if not provided.

*Testing (if applicable):*
Unit tests
- Create and upgrade a mgmt cluster:
- Create workload cluster with API.
    - No users, user with empty name,  user with empty SSHAuthorizedKeys throws webhook error
    - User specified with name and valid sshAuthorizationKey succeeds
- Update workload cluster with API.
    - No users, user with empty name,  user with empty SSHAuthorizedKeys throws webhook error
    - User specified with name and valid sshAuthorizationKey succeeds
    
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

