### PR TITLE
Support overriding HookImage for tinkerbell cluster upgrade

### DIFF
--- a/pkg/providers/tinkerbell/stack/mocks/stack.go
+++ b/pkg/providers/tinkerbell/stack/mocks/stack.go
@@ -252,15 +252,15 @@ func (mr *MockStackInstallerMockRecorder) UninstallLocal(ctx interface{}) *gomoc
 }
 
 // Upgrade mocks base method.
-func (m *MockStackInstaller) Upgrade(arg0 context.Context, arg1 v1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig string) error {
+func (m *MockStackInstaller) Upgrade(arg0 context.Context, arg1 v1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, tinkerbellIP, kubeconfig)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, tinkerbellIP, kubeconfig, hookOverride)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockStackInstallerMockRecorder) Upgrade(arg0, arg1, tinkerbellIP, kubeconfig interface{}) *gomock.Call {
+func (mr *MockStackInstallerMockRecorder) Upgrade(arg0, arg1, tinkerbellIP, kubeconfig, hookOverride interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockStackInstaller)(nil).Upgrade), arg0, arg1, tinkerbellIP, kubeconfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockStackInstaller)(nil).Upgrade), arg0, arg1, tinkerbellIP, kubeconfig, hookOverride)
 }

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -385,6 +385,7 @@ func (p *Provider) PreCoreComponentsUpgrade(
 		clusterSpec.VersionsBundle.Tinkerbell,
 		p.datacenterConfig.Spec.TinkerbellIP,
 		cluster.KubeconfigFile,
+		p.datacenterConfig.Spec.HookImagesURLPath,
 	)
 	if err != nil {
 		return fmt.Errorf("upgrading stack: %v", err)

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -78,6 +78,7 @@ func TestProviderPreCoreComponentsUpgrade_StackUpgradeError(t *testing.T) {
 			tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
 			tconfig.DatacenterConfig.Spec.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
+			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
 		).
 		Return(errors.New(expect))
 
@@ -101,6 +102,7 @@ func TestProviderPreCoreComponentsUpgrade_HasBaseboardManagementCRDError(t *test
 			tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
 			tconfig.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
+			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
 		).
 		Return(nil)
 
@@ -133,6 +135,7 @@ func TestProviderPreCoreComponentsUpgrade_NoBaseboardManagementCRD(t *testing.T)
 			tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
 			tconfig.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
+			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
 		).
 		Return(nil)
 
@@ -441,6 +444,7 @@ func TestProviderPreCoreComponentsUpgrade_RufioConversions(t *testing.T) {
 					tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
 					tconfig.DatacenterConfig.Spec.TinkerbellIP,
 					tconfig.Management.KubeconfigFile,
+					tconfig.DatacenterConfig.Spec.HookImagesURLPath,
 				).
 				Return(nil)
 			tconfig.KubeClient.EXPECT().
@@ -608,6 +612,7 @@ func (t *PreCoreComponentsUpgradeTestConfig) WithStackUpgrade() *PreCoreComponen
 			t.ClusterSpec.VersionsBundle.Tinkerbell,
 			t.TinkerbellIP,
 			t.Management.KubeconfigFile,
+			t.DatacenterConfig.Spec.HookImagesURLPath,
 		).
 		Return(nil)
 	t.KubeClient.EXPECT().


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, we don't override HookImagesURLPath even if a user specifies that in the clusterconfig file during an upgrade operation of a cluster. Thus, during upgrade it takes hookImage from the bundle only. This PR enables HookImage override for the upgrade operation for Tinkerbell provider.


*Testing (if applicable):*
I have tested these changes by upgrading a Tinkerbell cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

