### PR TITLE
Add users and ssh key validation to all provider machineconfig webhooks

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types_test.go
@@ -463,7 +463,7 @@ func TestCloudStackMachineConfigValidateUsers(t *testing.T) {
 			machineConfig: &v1alpha1.CloudStackMachineConfig{
 				Spec: v1alpha1.CloudStackMachineConfigSpec{},
 			},
-			wantErr: "users is not set for CloudStackMachineConfig , please provide specify a user",
+			wantErr: "users is not set for CloudStackMachineConfig , please provide a user",
 		},
 		{
 			name: "user name empty",

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
@@ -87,6 +87,11 @@ func (r *CloudStackMachineConfig) ValidateUpdate(old runtime.Object) error {
 			field.Invalid(field.NewPath("spec", "symlinks", fieldName), fieldValue, err.Error()),
 		)
 	}
+	if err := r.ValidateUsers(); err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "users"), r.Spec.Users, err.Error()))
+	}
 	if err := r.Validate(); err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), r.Spec, err.Error()))
 	}

--- a/pkg/api/v1alpha1/machine_types.go
+++ b/pkg/api/v1alpha1/machine_types.go
@@ -32,7 +32,7 @@ func defaultMachineConfigUsers(defaultUsername string, users []UserConfiguration
 
 func validateMachineConfigUsers(machineConfigName string, machineConfigKind string, users []UserConfiguration) error {
 	if len(users) == 0 {
-		return fmt.Errorf("users is not set for %s %s, please provide specify a user", machineConfigKind, machineConfigName)
+		return fmt.Errorf("users is not set for %s %s, please provide a user", machineConfigKind, machineConfigName)
 	}
 	if users[0].Name == "" {
 		return fmt.Errorf("users[0].name is not set or is empty for %s %s, please provide a username", machineConfigKind, machineConfigName)

--- a/pkg/api/v1alpha1/nutanixmachineconfig.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig.go
@@ -183,8 +183,8 @@ func validateNutanixMachineConfig(c *NutanixMachineConfig) error {
 		)
 	}
 
-	if len(c.Spec.Users) <= 0 {
-		return fmt.Errorf("NutanixMachineConfig: missing spec.Users: %s", c.Name)
+	if err := validateMachineConfigUsers(c.Name, NutanixMachineConfigKind, c.Spec.Users); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
@@ -41,7 +41,8 @@ func nutanixMachineConfig() *v1alpha1.NutanixMachineConfig {
 			SystemDiskSize: resource.MustParse("100Gi"),
 			Users: []v1alpha1.UserConfiguration{
 				{
-					Name: "test-user",
+					Name:              "test-user",
+					SshAuthorizedKeys: []string{"ssh AAA..."},
 				},
 			},
 		},
@@ -136,6 +137,37 @@ func TestValidateCreate_Invalid(t *testing.T) {
 			name: "no user",
 			fn: func(config *v1alpha1.NutanixMachineConfig) {
 				config.Spec.Users = []v1alpha1.UserConfiguration{}
+			},
+		},
+		{
+			name: "no user name",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Users = []v1alpha1.UserConfiguration{
+					{
+						SshAuthorizedKeys: []string{"ssh AAA..."},
+					},
+				}
+			},
+		},
+		{
+			name: "no ssh authorized key",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Users = []v1alpha1.UserConfiguration{
+					{
+						Name: "eksa",
+					},
+				}
+			},
+		},
+		{
+			name: "invalid ssh authorized key",
+			fn: func(config *v1alpha1.NutanixMachineConfig) {
+				config.Spec.Users = []v1alpha1.UserConfiguration{
+					{
+						Name:              "eksa",
+						SshAuthorizedKeys: []string{""},
+					},
+				}
 			},
 		},
 	}

--- a/pkg/api/v1alpha1/vspheremachineconfig_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_test.go
@@ -375,7 +375,7 @@ func TestVSphereMachineConfigValidate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "SSHUsername test is invalid",
+			wantErr: "users[0].name test is invalid. Please use 'ec2-user' for Bottlerocket",
 		},
 		{
 			name: "invalid hostOSConfiguration",
@@ -415,6 +415,166 @@ func TestVSphereMachineConfigValidate(t *testing.T) {
 			} else {
 				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
 			}
+		})
+	}
+}
+
+func TestVSphereMachineConfigValidateUsers(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name          string
+		machineConfig *VSphereMachineConfig
+		wantErr       string
+	}{
+		{
+			name: "machineconfig with bottlerocket user valid",
+			machineConfig: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "bottlerocket",
+					Users: []UserConfiguration{{
+						Name:              "ec2-user",
+						SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
+					}},
+				},
+			},
+		},
+		{
+			name: "machineconfig with bottlerocket user valid",
+			machineConfig: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "ubuntu",
+					Users: []UserConfiguration{{
+						Name:              "capv",
+						SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
+					}},
+				},
+			},
+		},
+		{
+			name: "machineconfig users not set",
+			machineConfig: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cp",
+				},
+				Spec: VSphereMachineConfigSpec{},
+			},
+			wantErr: "users is not set for VSphereMachineConfig test-cp, please provide a user",
+		},
+		{
+			name: "machineconfig with bottlerocket user name invalid",
+			machineConfig: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cp",
+				},
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "bottlerocket",
+					Users: []UserConfiguration{
+						{
+							Name:              "capv",
+							SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
+						},
+					},
+				},
+			},
+			wantErr: "users[0].name capv is invalid. Please use 'ec2-user' for Bottlerocket",
+		},
+		{
+			name: "machineconfig user name empty",
+			machineConfig: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cp",
+				},
+				Spec: VSphereMachineConfigSpec{
+					Users: []UserConfiguration{
+						{
+							Name:              "",
+							SshAuthorizedKeys: []string{"ssh-rsa AAAA..."},
+						},
+					},
+				},
+			},
+			wantErr: "users[0].name is not set or is empty for VSphereMachineConfig test-cp, please provide a username",
+		},
+		{
+			name: "user ssh authorized key empty or not set",
+			machineConfig: &VSphereMachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cp",
+				},
+				Spec: VSphereMachineConfigSpec{
+					Users: []UserConfiguration{{
+						Name:              "Jeff",
+						SshAuthorizedKeys: []string{""},
+					}},
+				},
+			},
+			wantErr: "users[0].SshAuthorizedKeys is not set or is empty for VSphereMachineConfig test-cp, please provide a valid ssh authorized key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.machineConfig.ValidateUsers()
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+}
+
+func TestVSphereMachineConfigSetDefaultUsers(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name                  string
+		machineConfig         *VSphereMachineConfig
+		expectedMachineConfig *VSphereMachineConfig
+	}{
+		{
+			name: "machine config with bottlerocket",
+			machineConfig: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "bottlerocket",
+				},
+			},
+			expectedMachineConfig: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "bottlerocket",
+					Users: []UserConfiguration{
+						{
+							Name:              "ec2-user",
+							SshAuthorizedKeys: []string{""},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "machine config with ubuntu",
+			machineConfig: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "ubuntu",
+				},
+			},
+			expectedMachineConfig: &VSphereMachineConfig{
+				Spec: VSphereMachineConfigSpec{
+					OSFamily: "ubuntu",
+					Users: []UserConfiguration{
+						{
+							Name:              "capv",
+							SshAuthorizedKeys: []string{""},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.machineConfig.SetUserDefaults()
+			g.Expect(tt.machineConfig).To(Equal(tt.expectedMachineConfig))
 		})
 	}
 }

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -30,6 +30,7 @@ func vsphereEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				for _, m := range c.VSphereMachineConfigs {
 					m.SetDefaults()
+					m.SetUserDefaults()
 				}
 				return nil
 			},

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -28,6 +28,7 @@ func (d *Defaulter) setDefaultsForMachineConfig(ctx context.Context, spec *Spec)
 	setDefaultsForEtcdMachineConfig(spec.etcdMachineConfig())
 	for _, m := range spec.machineConfigs() {
 		m.SetDefaults()
+		m.SetUserDefaults()
 		if err := d.setDefaultTemplateIfMissing(ctx, spec, m); err != nil {
 			return err
 		}


### PR DESCRIPTION
*Issue #, if available:*
closes [#1217](https://github.com/aws/eks-anywhere-internal/issues/1217)
*Description of changes:*

*Testing (if applicable):*
- Unit tests
- Manual testing
  - Create a management cluster:
  - Create and update workload cluster with API .
    - No users
    - User with empty name
    - User with empty SSHAuthorizedKeys
    - User specified with name and valid sshAuthorizationKey (succeeds)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

