### PR TITLE
Add validation for tinkerbell ip for workload cluster to match management cluster

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -152,8 +152,10 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 		if err != nil {
 			return fmt.Errorf("getting TinkerbellIP of management cluster: %s", err)
 		}
-
-		p.datacenterConfig.Spec.TinkerbellIP = managementDatacenterConfig.Spec.TinkerbellIP
+		// Checking for empty first as that returns a different error in the datacenter config validate method below
+		if p.datacenterConfig.Spec.TinkerbellIP != "" && p.datacenterConfig.Spec.TinkerbellIP != managementDatacenterConfig.Spec.TinkerbellIP {
+			return fmt.Errorf("TinkerbellIP %v does not match management cluster ip %v", p.datacenterConfig.Spec.TinkerbellIP, managementDatacenterConfig.Spec.TinkerbellIP)
+		}
 	}
 	// TODO(chrisdoherty4) Look to inject the validator. Possibly look to use a builder for
 	// constructing the validations rather than injecting flags into the provider.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are disallowing the ability to specify a different workload cluster tinkerbellip from the management cluster as we only look at the management cluster one as the source of truth. It is misleading when we override the value specified by the user in the CLI, so this will throw an error if the wrong ip is specified. 

This behavior matches what we do in the controller now: https://github.com/aws/eks-anywhere/pull/4808

*Testing (if applicable):*
unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

