### PR TITLE
Remove incorrect e2e for external etcd

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1107,18 +1107,6 @@ func TestTinkerbellKubernetes126BottleRocketSimpleFlow(t *testing.T) {
 	runTinkerbellSimpleFlow(test)
 }
 
-func TestTinkerbellKubernetes127UbuntuExternalEtcdSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu127Tinkerbell(), framework.WithTinkerbellExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithExternalEtcdHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
 func TestTinkerbellKubernetes127UbuntuThreeControlPlaneReplicasSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tinkerbell does not support external etcd, removing e2e for 1.27 for external etcd.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

