### PR TITLE
Add exp flag for self managed cluster API upgrades

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -99,7 +99,8 @@ func (f *Factory) Close(ctx context.Context) error {
 	return f.deps.Close(ctx)
 }
 
-func (f *Factory) WithClusterReconciler(capiProviders []clusterctlv1.Provider) *Factory {
+// WithClusterReconciler builds the cluster reconciler.
+func (f *Factory) WithClusterReconciler(capiProviders []clusterctlv1.Provider, opts ...ClusterReconcilerOption) *Factory {
 	f.dependencyFactory.WithGovc()
 	f.withTracker().
 		WithProviderClusterReconcilerRegistry(capiProviders).
@@ -117,6 +118,7 @@ func (f *Factory) WithClusterReconciler(capiProviders []clusterctlv1.Provider) *
 			f.awsIamConfigReconciler,
 			clusters.NewClusterValidator(f.manager.GetClient()),
 			f.packageControllerClient,
+			opts...,
 		)
 
 		return nil

--- a/manager/main.go
+++ b/manager/main.go
@@ -177,8 +177,15 @@ func setupFullLifecycleReconcilers(ctx context.Context, setupLog logr.Logger, mg
 		os.Exit(1)
 	}
 
+	expUpgrades := features.IsActive(features.ExperimentalSelfManagedClusterUpgrade())
+	if expUpgrades {
+		setupLog.Info("[EXPERIMENTAL] Self-managed cluster upgrades enabled. Proceed with caution, this is not intended for production scenarios.")
+	}
+
 	factory := controllers.NewFactory(ctrl.Log, mgr).
-		WithClusterReconciler(providers).
+		WithClusterReconciler(
+			providers, controllers.WithExperimentalSelfManagedClusterUpgrades(expUpgrades),
+		).
 		WithVSphereDatacenterReconciler().
 		WithSnowMachineConfigReconciler().
 		WithNutanixDatacenterReconciler().

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -8,6 +8,9 @@ const (
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
 	K8s127SupportEnvVar             = "K8S_1_27_SUPPORT"
+
+	experimentalSelfManagedClusterUpgradeEnvVar = "EXP_SELF_MANAGED_API_UPGRADE"
+	experimentalSelfManagedClusterUpgradeGate   = "ExpSelfManagedAPIUpgrade"
 )
 
 func FeedGates(featureGates []string) {
@@ -32,6 +35,17 @@ func FullLifecycleAPI() Feature {
 	return Feature{
 		Name:     "Full lifecycle API support through the EKS-A controller",
 		IsActive: globalFeatures.isActiveForEnvVarOrGate(FullLifecycleAPIEnvVar, FullLifecycleGate),
+	}
+}
+
+// ExperimentalSelfManagedClusterUpgrade allows self managed cluster upgrades through the API.
+func ExperimentalSelfManagedClusterUpgrade() Feature {
+	return Feature{
+		Name: "[EXPERIMENTAL] Upgrade self-managed clusters through the API",
+		IsActive: globalFeatures.isActiveForEnvVarOrGate(
+			experimentalSelfManagedClusterUpgradeEnvVar,
+			experimentalSelfManagedClusterUpgradeGate,
+		),
 	}
 }
 


### PR DESCRIPTION
## Description of changes

This allows us to test management cluster CP upgrades through the controller.

Not intended for the final user, only for internal testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

