### PR TITLE
Reduce controller's log verbosity

### DIFF
--- a/config/tilt/kustomization.yaml
+++ b/config/tilt/kustomization.yaml
@@ -12,6 +12,9 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --logging-format=text
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --v=2
   target:
     kind: Deployment
     name: eksa-controller-manager

--- a/manager/main.go
+++ b/manager/main.go
@@ -78,7 +78,7 @@ func newConfig() *config {
 		logging: logsv1.NewLoggingConfiguration(),
 	}
 	c.logging.Format = logsv1.JSONLogFormat
-	c.logging.Verbosity = logsv1.VerbosityLevel(4)
+	c.logging.Verbosity = logsv1.VerbosityLevel(0)
 
 	return c
 }

--- a/pkg/controller/clusters/ipvalidator.go
+++ b/pkg/controller/clusters/ipvalidator.go
@@ -41,7 +41,7 @@ func (i *IPValidator) ValidateControlPlaneIP(ctx context.Context, log logr.Logge
 	if capiCluster != nil {
 		// If CAPI cluster exists, the control plane IP has already been validated,
 		// and it's possibly already in use so no need to validate it again
-		log.V(3).Info("CAPI cluster already exists, skipping control plane IP validation")
+		log.Info("CAPI cluster already exists, skipping control plane IP validation")
 		return controller.Result{}, nil
 	}
 	if err := i.ipUniquenessValidator.ValidateControlPlaneIPUniqueness(spec.Cluster); err != nil {


### PR DESCRIPTION
## Description of changes

Defaulting to v=4 was printing a lot of client-go and controller-runtime "debug" logs that added a lot of noise but no value.

Now it defaults to 0 and for tilt we bump it to 2, which adds a little more information from controller-runtime, specially during startup, but still avoids unnecessary noise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

