### PR TITLE
Use controller direct access to management cluster

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,19 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
## Description of changes

By injecting the pod metadata as env vars in the controller, we allow ClusterCacheTracker to detect that a management cluster is self managed. Then it uses direct access to the control plane (through the host in the incluster config) instead of going through the host defined in the capi kubeconfig, which in our case goes through the kube-vip load balancer.

More info: https://github.com/kubernetes-sigs/cluster-api/pull/6836


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

