### PR TITLE
Modify regex to pick Harbor Regsitry for CloudStack tests

### DIFF
--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -32,7 +32,7 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 
 	// Since Tinkerbell uses a separate harbor registry,
 	// we need to setup cert for that registry for Tinkerbell tests.
-	re = regexp.MustCompile(`^.*Tinkerbell.*$`)
+	re = regexp.MustCompile(`^.*(Tinkerbell|CloudStack).*$`)
 	if re.MatchString(testRegex) {
 		endpoint = e.testEnvVars[e2etests.RegistryEndpointTinkerbellVar]
 		port = e.testEnvVars[e2etests.RegistryPortTinkerbellVar]
@@ -49,7 +49,7 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 		endpoint = e.testEnvVars[e2etests.PrivateRegistryEndpointVar]
 		port = e.testEnvVars[e2etests.PrivateRegistryPortVar]
 		caCert = e.testEnvVars[e2etests.PrivateRegistryCACertVar]
-	} else if re = regexp.MustCompile(`^.*Tinkerbell.*Authenticated.*$`); re.MatchString(testRegex) {
+	} else if re = regexp.MustCompile(`^.*(Tinkerbell|CloudStack).*Authenticated.*$`); re.MatchString(testRegex) {
 		endpoint = e.testEnvVars[e2etests.PrivateRegistryEndpointTinkerbellVar]
 		port = e.testEnvVars[e2etests.PrivateRegistryPortTinkerbellVar]
 		caCert = e.testEnvVars[e2etests.PrivateRegistryCACertTinkerbellVar]


### PR DESCRIPTION
*Issue #, if available:*
Since Tinkerbell and CloudStack use the same Harbor registry for CI tests, modify the regex to pick CloudStack tests and point them to the same harbor registry.
 
*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

