### PR TITLE
Skipping tests that can not be run today

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -48,11 +48,14 @@ skipped_tests:
 # Skipping Workload upgrade tests due to hardware limitation
 - TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade
 - TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade125To126
+- TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade126To127
 - TestTinkerbellUpgrade126MulticlusterWorkloadClusterWorkerScaleup
 - TestTinkerbellUpgrade126MulticlusterWorkloadClusterCPScaleup
+- TestTinkerbellUpgrade127MulticlusterWorkloadClusterCPScaleup
 - TestTinkerbellUpgrade126MulticlusterWorkloadClusterWorkerScaleDown
 - TestTinkerbellUpgrade125MulticlusterWorkloadClusterWorkerScaleupWithAPI
 - TestTinkerbellUpgrade126MulticlusterWorkloadClusterWorkerScaleupWithFluxAPI
+- TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI
 # Skipping ETCD tests
 - TestTinkerbellKubernetes126UbuntuExternalEtcdSimpleFlow
 # Skipping skip power action tests - Not going to work because e2e test powers on CP and worker node at the same time and worker node times out early waiting for ipxe
@@ -68,6 +71,7 @@ skipped_tests:
 - TestTinkerbellKubernetes123UbuntuSimpleFlow
 - TestTinkerbellKubernetes124UbuntuSimpleFlow
 - TestTinkerbellKubernetes125UbuntuSimpleFlow
+- TestTinkerbellKubernetes126SimpleFlow
 - TestTinkerbellKubernetes122BottleRocketSimpleFlow
 - TestTinkerbellKubernetes123BottleRocketSimpleFlow
 - TestTinkerbellKubernetes124BottleRocketSimpleFlow
@@ -76,6 +80,9 @@ skipped_tests:
 - TestTinkerbellKubernetes126UbuntuThreeWorkersSimpleFlow
 - TestTinkerbellKubernetes126BottleRocketThreeWorkersSimpleFlow
 - TestTinkerbellAirgappedKubernetes126BottleRocketRegistryMirror
+- TestTinkerbellKubernetes124UbuntuTo125Upgrade
+- TestTinkerbellKubernetes126BottleRocketThreeControlPlaneReplicasSimpleFlow
+- TestTinkerbellKubernetes126BottleRocketThreeWorkersSimpleFlow
 # Conformance
 - TestSnowKubernetes122ThreeWorkersConformanceFlow
 - TestSnowKubernetes123ThreeWorkersConformanceFlow

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -997,7 +997,7 @@ func TestTinkerbellKubernetes126SimpleFlow(t *testing.T) {
 	runTinkerbellSimpleFlow(test)
 }
 
-func TestTinkerbellKubernetes127SimpleFlow(t *testing.T) {
+func TestTinkerbellKubernetes127UbuntuSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t, framework.WithUbuntu127Tinkerbell()),


### PR DESCRIPTION
*Description of changes:*
Some of the e2e tests can not be run due to CI limitations. Hence skipping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

