### PR TITLE
Make registry mirror e2es use bundles override

### DIFF
--- a/test/e2e/registrymirror.go
+++ b/test/e2e/registrymirror.go
@@ -13,8 +13,8 @@ func runRegistryMirrorConfigFlow(test *framework.ClusterE2ETest) {
 	test.ExtractDownloadedArtifacts()
 	test.DownloadImages()
 	test.ImportImages()
-	test.CreateCluster()
-	test.DeleteCluster()
+	test.CreateCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
+	test.DeleteCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
 }
 
 func runTinkerbellRegistryMirrorFlow(test *framework.ClusterE2ETest) {
@@ -25,9 +25,9 @@ func runTinkerbellRegistryMirrorFlow(test *framework.ClusterE2ETest) {
 	test.ImportImages()
 	test.GenerateHardwareConfig()
 	test.PowerOffHardware()
-	test.CreateCluster(framework.WithForce())
+	test.CreateCluster(framework.WithForce(), framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
 	test.StopIfFailed()
-	test.DeleteCluster()
+	test.DeleteCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
 	test.ValidateHardwareDecommissioned()
 	test.CleanupDownloadedArtifactsAndImages()
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make registry mirror e2es use bundles override to avoid failing with mismatched tags during create vs delete

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


