### PR TITLE
Update ssh authorized in new worker node groups in API tests

### DIFF
--- a/internal/pkg/api/vspheremachines.go
+++ b/internal/pkg/api/vspheremachines.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"os"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -64,10 +66,12 @@ func WithSSHKey(value string) VSphereMachineConfigFiller {
 	}
 }
 
-func setSSHKeyForFirstUser(m *anywherev1.VSphereMachineConfig, key string) {
-	if len(m.Spec.Users) == 0 {
-		m.Spec.Users = []anywherev1.UserConfiguration{{}}
-	}
+// WithStringFromEnvVar returns a VSphereMachineConfigFiller function with the value from an envVar passed to it.
+func WithStringFromEnvVar(envVar string, opt func(string) VSphereMachineConfigFiller) VSphereMachineConfigFiller {
+	return opt(os.Getenv(envVar))
+}
 
+func setSSHKeyForFirstUser(m *anywherev1.VSphereMachineConfig, key string) {
+	m.SetUserDefaults()
 	m.Spec.Users[0].SshAuthorizedKeys = []string{key}
 }

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -457,8 +457,9 @@ func WithVSphereWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, f
 // WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
 // a corresponding VSphereMachineConfig to the cluster config.
 func (v *VSphere) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, fillers ...api.VSphereMachineConfigFiller) api.ClusterConfigFiller {
+	machineConfigFillers := append([]api.VSphereMachineConfigFiller{updateMachineSSHAuthorizedKey()}, fillers...)
 	return api.JoinClusterConfigFillers(
-		api.VSphereToConfigFiller(vSphereMachineConfig(name, fillers...)),
+		api.VSphereToConfigFiller(vSphereMachineConfig(name, machineConfigFillers...)),
 		api.ClusterToConfigFiller(buildVSphereWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
 	)
 }
@@ -466,6 +467,11 @@ func (v *VSphere) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGr
 // WithWorkerNodeGroupConfiguration returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration item to the cluster config.
 func (v *VSphere) WithWorkerNodeGroupConfiguration(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
 	return api.ClusterToConfigFiller(buildVSphereWorkerNodeGroupClusterFiller(name, workerNodeGroup))
+}
+
+// updateMachineSSHAuthorizedKey updates a vsphere machine configs SSHAuthorizedKey.
+func updateMachineSSHAuthorizedKey() api.VSphereMachineConfigFiller {
+	return api.WithStringFromEnvVar(vsphereSshAuthorizedKeyVar, api.WithSSHKey)
 }
 
 // WithVSphereFillers adds VSphereFiller to the provider default fillers.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes vSphere API e2e tests failing with:
`workload.go:47: Failed to apply workload cluster config: executing apply manifest: The VSphereMachineConfig "worker-0" is invalid: spec.users: Invalid value: []v1alpha1.UserConfiguration{v1alpha1.UserConfiguration{Name:"", SshAuthorizedKeys:[]string{"ssh-rsa...}}}: users[0].name is not set or is empty for VSphereMachineConfig worker-0, please provide a username`

We validate the username and ssh authorization key in the webhook now instead of defaulting because reconciliation would throw an error on a missing ssh key in the vsphere API e2e tests. Currently, when new worker node groups are created using `vsphere.WithWorkerNodeGroup`, the corresponding `VSphereMachineConfigs` do not get initialized with a user name. This PR adds a api.VSphereMachineConfigFiller that updates that information on the machine config.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

