### PR TITLE
Clarify multi workload cluster creation limits for Tinkerbell controller

### DIFF
--- a/docs/content/en/docs/getting-started/production-environment/baremetal-getstarted.md
+++ b/docs/content/en/docs/getting-started/production-environment/baremetal-getstarted.md
@@ -195,7 +195,9 @@ Follow these steps if you want to use your initial cluster to create and manage 
      >   eksctl anywhere generate hardware -z updated-hardware.csv > updated-hardware.yaml
      >   kubectl apply -f updated-hardware.yaml
      >   ```
-     > * If you want to create multiple workload clusters, you should create them one by one, and make sure its completely up and running successfully by checking tinkerbell machines, before attempting to create the next workload cluster. Attempting to create multiple workload clusters without letting the requests complete successfully can cause hardware race conditions. In a situation where sufficient hardware is not provisioned, the creation would fail at the CAPT level.
+     > * For creating multiple workload clusters, it is essential that the hardware labels and selectors defined for a given workload cluster are unique to that workload cluster. For instance, for an EKS Anywhere cluster named `eksa-workload1`, the hardware that is assigned for this cluster should have labels that are only going to be used for this cluster like `type=eksa-workload1-cp` and `type=eksa-workload1-worker`.
+     Another workload cluster named `eksa-workload2` can have labels like `type=eksa-workload2-cp` and `type=eksa-workload2-worker`. Please note that even though labels can be arbitrary, they need to be unique for each workload cluster. Not specifying unique cluster labels can cause cluster creations to behave in unexpected ways which may lead to unsuccessful creations and unstable clusters.
+     See the [hardware selectors]({{< relref "../../reference/clusterspec/baremetal/#hardwareselector" >}}) section for more information
 
 1. Check the workload cluster:
 

--- a/docs/content/en/docs/reference/baremetal/bare-preparation.md
+++ b/docs/content/en/docs/reference/baremetal/bare-preparation.md
@@ -28,6 +28,8 @@ This file will be used:
 * When you generate the hardware file to be included in the cluster creation process described in the [Create Bare Metal production cluster]({{< relref "../../getting-started/production-environment" >}}) Getting Started guide.
 * To provide information that is passed to each machine from the Tinkerbell DHCP server when the machine is initially network booted.
 
+ >**NOTE**:While using kubectl, GitOps and Terraform for workload cluster creation, please make sure to refer [this]({{< relref "../../getting-started/production-environment/baremetal-getstarted/#create-separate-workload-clusters" >}}) section.
+
 The following is an example of an EKS Anywhere Bare Metal hardware CSV file:
 
 ```

--- a/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-scale/baremetal-scale.md
@@ -79,10 +79,7 @@ If you don't have any available hardware that match this requirement in the clus
    >   eksctl anywhere generate hardware -z updated-hardware.csv > updated-hardware.yaml
    >   kubectl apply -f updated-hardware.yaml
    >   ```
-   > *  If you want to scale up multiple workload clusters, you should scale them up one by one. Make sure each is completely up and running successfully by checking Tinkerbell machines, before attempting to scale the next workload cluster. Attempting to scale up multiple workload clusters without letting the requests complete successfully can cause hardware race conditions. In a situation where sufficient hardware is not provisioned, the creation would fail at the CAPT level.
-   >
-   >  This also applied to sending scaling requests to the same workload cluster. 
-
+   > *  For scaling multiple workload clusters, it is essential that the hardware that will be used for scaling up clusters has labels and selectors that are unique to the target workload cluster. For instance, for an EKSA cluster named `eksa-workload1`, the hardware that is assigned for this cluster should have labels that are only going to be used for this cluster like `type=eksa-workload1-cp` and `type=eksa-workload1-worker`. Another workload cluster named `eksa-workload2` can have labels like `type=eksa-workload2-cp` and `type=eksa-workload2-worker`. Please note that even though labels can be arbitrary, they need to be unique for each workload cluster. Not specifying unique cluster labels can cause cluster upgrades to behave in unexpected ways which may lead to unsuccessful upgrades and unstable clusters.
 ### Autoscaling
 
 EKS Anywhere supports autoscaling of worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/) and as a [curated package](../../../../reference/packagespec/cluster-autoscaler/).

--- a/docs/content/en/docs/tasks/cluster/cluster-upgrades/baremetal-upgrades.md
+++ b/docs/content/en/docs/tasks/cluster/cluster-upgrades/baremetal-upgrades.md
@@ -154,9 +154,7 @@ and then you will run the [upgrade cluster command]({{< relref "baremetal-upgrad
   >   kubectl apply -f updated-hardware.yaml
   >   ```
   >
-  > *  If you want to update multiple workload clusters, you should update them one by one, and make sure its completely up and running successfully by checking tinkerbell machines, before attempting to update the next workload cluster. Attempting to update multiple workload clusters without letting the requests complete successfully can cause hardware race conditions. In a situation where sufficient hardware is not provisioned, the creation would fail at the CAPT level.
-  > 
-  >  This also applied to sending upgrade requests to the same workload cluster.
+  > *  If you want to upgrade multiple workload clusters, make sure that the spare hardware that is available for new nodes to rollout has labels unique to the workload cluster you are trying to upgrade. For instance, for an EKSA cluster named `eksa-workload1`, the hardware that is assigned for this cluster should have labels that are only going to be used for this cluster like `type=eksa-workload1-cp` and `type=eksa-workload1-worker`. Another workload cluster named `eksa-workload2` can have labels like `type=eksa-workload2-cp` and `type=eksa-workload2-worker`. Please note that even though labels can be arbitrary, they need to be unique for each workload cluster. Not specifying unique cluster labels can cause cluster upgrades to behave in unexpected ways which may lead to unsuccessful upgrades and unstable clusters.
 
 * **eksctl CLI**: To create a workload cluster with eksctl, run:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clarify multi workload cluster creation limits for Tinkerbell controller. This unblocks the users from being able to simultaneously create multiple workload clusters using the controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

