### PR TITLE
Not erroring on VMs not found for cloudstack cleanup

### DIFF
--- a/pkg/executables/cmk.go
+++ b/pkg/executables/cmk.go
@@ -370,7 +370,8 @@ func (c *Cmk) CleanupVms(ctx context.Context, profile string, clusterName string
 		return fmt.Errorf("listing virtual machines in cluster %s: %s: %v", clusterName, result.String(), err)
 	}
 	if result.Len() == 0 {
-		return fmt.Errorf("virtual machines for cluster %s not found", clusterName)
+		logger.Info("virtual machines not found", "cluster", clusterName)
+		return nil
 	}
 	response := struct {
 		CmkVirtualMachines []cmkResourceIdentifier `json:"virtualmachine"`

--- a/pkg/executables/cmk_test.go
+++ b/pkg/executables/cmk_test.go
@@ -153,7 +153,7 @@ func TestCmkCleanupVms(t *testing.T) {
 				return cmk.CleanupVms(ctx, execConfig.Profiles[0].Name, clusterName, false)
 			},
 			cmkResponseError: nil,
-			wantErr:          true,
+			wantErr:          false,
 		},
 		{
 			testName:         "listaffinitygroups json parse exception",


### PR DESCRIPTION
*Description of changes:*

```bash
2023-05-10T23:27:45.958Z    V-2 Failed to cleanup e2e vms on cloudstack {"error": "running cleanup for cloudstack vms: cleaning up VMs: map[***:virtual machines for cluster main not found]"}
```
We dont want to error when VMs were not found.

*Testing:*
```bash
./test e2e cleanup cloudstack -n "not-a-vm"
```

Also tested delete still works fine by deleting existing VMs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

