### PR TITLE
Add cloudstack workload cluster API e2e tests 

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -1083,9 +1083,7 @@ func TestCloudStackMulticlusterWorkloadClusterAPI(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				wc.UpdateClusterConfig(tt.upgradeFiller)
-				wc.ApplyClusterManifest()
-				wc.ValidateClusterState()
+				runCloudStackAPIUpgradeTest(t, wc, tt)
 			})
 		}
 
@@ -1144,8 +1142,7 @@ func TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				test.PushWorkloadClusterToGit(wc, tt.upgradeFiller)
-				wc.ValidateClusterState()
+				runCloudStackAPIUpgradeTestWithFlux(t, test, wc, tt)
 			})
 		}
 

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -1028,10 +1028,6 @@ func TestCloudStackKubernetes123UbuntuAirgappedRegistryMirror(t *testing.T) {
 	runAirgapConfigFlow(test, "10.0.0.1/8")
 }
 
-func runCloudStackMulticlusterWorkloadClusterAPITest() {
-
-}
-
 // Workload API
 
 func TestCloudStackMulticlusterWorkloadClusterAPI(t *testing.T) {

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -1025,4 +1026,124 @@ func TestCloudStackKubernetes123UbuntuAirgappedRegistryMirror(t *testing.T) {
 	)
 
 	runAirgapConfigFlow(test, "10.0.0.1/8")
+}
+
+func runCloudStackMulticlusterWorkloadClusterAPITest() {
+
+}
+
+// Workload API
+
+func TestCloudStackMulticlusterWorkloadClusterAPI(t *testing.T) {
+	cloudstack := framework.NewCloudStack(t)
+	managementCluster := framework.NewClusterE2ETest(
+		t, cloudstack, framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithStackedEtcdTopology(),
+		),
+		cloudstack.WithRedhat123(),
+	)
+
+	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			cloudstack,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+		).WithClusterConfig(
+			cloudStackAPIWorkloadTestFillers(cloudstack),
+			api.ClusterToConfigFiller(
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithExternalEtcdTopology(1),
+			),
+		),
+	)
+
+	test.CreateManagementCluster()
+
+	// Create workload clusters
+	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+		wc.ApplyClusterManifest()
+		wc.WaitForKubeconfig()
+		wc.ValidateClusterState()
+		tests := cloudStackAPIUpgradeTests(cloudstack)
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				wc.UpdateClusterConfig(tt.upgradeFiller)
+				wc.ApplyClusterManifest()
+				wc.ValidateClusterState()
+			})
+		}
+
+		wc.DeleteClusterWithKubectl()
+		wc.ValidateClusterDelete()
+	})
+
+	test.ManagementCluster.StopIfFailed()
+	test.DeleteManagementCluster()
+}
+
+// Workload GitOps API
+
+func TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
+	cloudstack := framework.NewCloudStack(t)
+	managementCluster := framework.NewClusterE2ETest(
+		t,
+		cloudstack,
+		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+		framework.WithFluxGithubEnvVarCheck(),
+		framework.WithFluxGithubCleanup(),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithStackedEtcdTopology(),
+		),
+		cloudstack.WithRedhat123(),
+		framework.WithFluxGithubConfig(),
+	)
+
+	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			cloudstack,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+		).WithClusterConfig(
+			cloudStackAPIWorkloadTestFillers(cloudstack),
+			api.ClusterToConfigFiller(
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithExternalEtcdTopology(1),
+			),
+		),
+	)
+
+	test.CreateManagementCluster()
+
+	// Create workload clusters
+	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+		test.PushWorkloadClusterToGit(wc)
+		wc.WaitForKubeconfig()
+		wc.ValidateClusterState()
+		tests := cloudStackAPIUpgradeTests(cloudstack)
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				test.PushWorkloadClusterToGit(wc, tt.upgradeFiller)
+				wc.ValidateClusterState()
+			})
+		}
+
+		test.DeleteWorkloadClusterFromGit(wc)
+		wc.ValidateClusterDelete()
+	})
+
+	test.ManagementCluster.StopIfFailed()
+	test.DeleteManagementCluster()
 }

--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/test/framework"
+)
+
+type cloudStackAPIUpgradeTest struct {
+	name          string
+	upgradeFiller api.ClusterConfigFiller
+}
+
+func cloudStackAPIUpgradeTests(cloudstack *framework.CloudStack) []cloudStackAPIUpgradeTest {
+	return []cloudStackAPIUpgradeTest{
+		{
+			name: "add and remove labels and taints",
+			upgradeFiller: api.ClusterToConfigFiller(
+				// Add label
+				api.WithWorkerNodeGroup("md-0", api.WithLabel(key1, val2)),
+				// Remove label
+				api.WithWorkerNodeGroup("md-1"),
+				// Add taint
+				api.WithWorkerNodeGroup("md-2", api.WithTaint(framework.NoExecuteTaint())),
+				// Remove taint
+				api.WithWorkerNodeGroup("md-3", api.WithNoTaints()),
+			),
+		},
+		{
+			name: "scale up cp and replace existing worker node groups",
+			upgradeFiller: api.JoinClusterConfigFillers(
+				api.ClusterToConfigFiller(
+					// Scale up CP
+					api.WithControlPlaneCount(3),
+					api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+				),
+				// Add new WorkerNodeGroups and use md-1's machineConfig
+				cloudstack.WithWorkerNodeGroupConfiguration("md-1", framework.WithWorkerNodeGroup("md-4", api.WithCount(2))),
+				cloudstack.WithWorkerNodeGroupConfiguration("md-1", framework.WithWorkerNodeGroup("md-5", api.WithCount(1))),
+			),
+		},
+		{
+			name: "scale down cp and scaling worker node groups",
+			upgradeFiller: api.ClusterToConfigFiller(
+				// Scaling down cp
+				api.WithControlPlaneCount(1),
+				// Scaling down wng
+				api.WithWorkerNodeGroup("md-4", api.WithCount(1)),
+				// Scaling up wng
+				api.WithWorkerNodeGroup("md-5", api.WithCount(2)),
+			),
+		},
+	}
+
+}
+
+func cloudStackAPIWorkloadTestFillers(cloudstack *framework.CloudStack) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+		cloudstack.WithWorkerNodeGroup("md-1", framework.WithWorkerNodeGroup("md-1", api.WithCount(1), api.WithLabel(key1, val2))),
+		cloudstack.WithWorkerNodeGroup("md-2", framework.WithWorkerNodeGroup("md-2", api.WithCount(1))),
+		cloudstack.WithWorkerNodeGroup("md-3", framework.WithWorkerNodeGroup("md-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint()))),
+		cloudstack.WithRedhat123(),
+	)
+}

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -227,6 +227,20 @@ func (c *CloudStack) WithNewCloudStackWorkerNodeGroup(name string, workerNodeGro
 	}
 }
 
+// WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// a corresponding CloudStackMachineConfig to the cluster config.
+func (c *CloudStack) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, fillers ...api.CloudStackMachineConfigFiller) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.CloudStackToConfigFiller(cloudStackMachineConfig(name, fillers...)),
+		api.ClusterToConfigFiller(buildCloudStackWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
+	)
+}
+
+// WithWorkerNodeGroupConfiguration returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration item to the cluster config.
+func (c *CloudStack) WithWorkerNodeGroupConfiguration(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	return api.ClusterToConfigFiller(buildCloudStackWorkerNodeGroupClusterFiller(name, workerNodeGroup))
+}
+
 func cloudStackMachineConfig(name string, fillers ...api.CloudStackMachineConfigFiller) api.CloudStackFiller {
 	f := make([]api.CloudStackMachineConfigFiller, 0, len(fillers)+2)
 	// Need to add these because at this point the default fillers that assign these
@@ -255,4 +269,15 @@ func buildCloudStackWorkerNodeGroupClusterFiller(machineConfigName string, worke
 // ClusterStateValidations returns a list of provider specific validations.
 func (c *CloudStack) ClusterStateValidations() []clusterf.StateValidation {
 	return []clusterf.StateValidation{}
+}
+
+// WithRedhat123 returns a cluster config filler that sets the kubernetes version of the cluster to 1.23
+// as well as the right redhat template for all CloudStackMachineConfigs.
+func (c *CloudStack) WithRedhat123() api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(api.WithKubernetesVersion(anywherev1.Kube123)),
+		api.CloudStackToConfigFiller(
+			UpdateRedhatTemplate123Var(),
+		),
+	)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	rapi "github.com/tinkerbell/rufio/api/v1alpha1"
@@ -2005,7 +2006,16 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName strin
 
 // ValidateClusterState runs a set of validations against the cluster to identify an invalid cluster state.
 func (e *ClusterE2ETest) ValidateClusterState() {
-	e.T.Logf("Validating cluster %s", e.ClusterName)
+	validateClusterState(e.T.(*testing.T), e)
+}
+
+// ValidateClusterStateWithT runs a set of validations against the cluster to identify an invalid cluster state and accepts *testing.T as a parameter.
+func (e *ClusterE2ETest) ValidateClusterStateWithT(t *testing.T) {
+	validateClusterState(e.T.(*testing.T), e)
+}
+
+func validateClusterState(t *testing.T, e *ClusterE2ETest) {
+	t.Logf("Validating cluster %s", e.ClusterName)
 	ctx := context.Background()
 	e.buildClusterStateValidationConfig(ctx)
 	clusterStateValidator := newClusterStateValidator(e.clusterStateValidationConfig)

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -81,14 +81,18 @@ func buildClusterClient(kubeconfigFileName string) (client.Client, error) {
 }
 
 func buildClusterSpec(ctx context.Context, client client.Client, config *cluster.Config) (*cluster.Spec, error) {
-	clus := &v1alpha1.Cluster{}
-	key := machinerytypes.NamespacedName{Namespace: config.Cluster.Namespace, Name: config.Cluster.Name}
-	if err := client.Get(ctx, key, clus); err != nil {
-		return nil, fmt.Errorf("failed to get cluster to build spec: %s", err)
+	clusterConfig := config.DeepCopy()
+	// The cluster config built by the test does not have certain defaults like the bundle reference,
+	// so fetch that information from the cluster if missing. This is needed inorder to build the cluster spec.
+	if clusterConfig.Cluster.Spec.BundlesRef == nil {
+		clus := &v1alpha1.Cluster{}
+		key := machinerytypes.NamespacedName{Namespace: clusterConfig.Cluster.Namespace, Name: clusterConfig.Cluster.Name}
+		if err := client.Get(ctx, key, clus); err != nil {
+			return nil, fmt.Errorf("failed to get cluster to build spec: %s", err)
+		}
+		clusterConfig.Cluster.Spec.BundlesRef = clus.Spec.BundlesRef
 	}
-	configCp := config.DeepCopy()
-	configCp.Cluster = clus
-	spec, err := cluster.BuildSpecFromConfig(ctx, clientutil.NewKubeClient(client), configCp)
+	spec, err := cluster.BuildSpecFromConfig(ctx, clientutil.NewKubeClient(client), clusterConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build cluster spec from config: %s", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*
[#1237 (internal)](https://github.com/aws/eks-anywhere-internal/issues/1237)

*Description of changes:*

This PR add an e2e test that that tests the following features for the CloudStack API. Here we create a management cluster and workload cluster(s) and test it's features using sub tests. The benefits of this approach is the test utilizes a single management cluster rather than spinning a new one up every time to test a workload cluster feature.
- create and delete workload clusters for all supported k8 versions
- add and remove labels and taints
- scale up cp and replace existing worker node groups
- scale down cp and scaling worker node groups

See the testing doc for the full list of scenarios we are going to eventually cover [here](https://quip-amazon.com/99bUA1xK7bt0/CloudStack-Full-Lifecycle-API-Testing
*Testing (if applicable):*
- Ran the e2e tests locally

```
--- PASS: TestCloudStackMulticlusterWorkloadClusterAPI (1846.19s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/add_and_remove_labels_and_taints (5.26s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/scale_up/down_cp_and_worker_node_group (415.61s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/replace_existing_worker_node_groups (115.70s)
PASS

```

```
--- PASS: TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI (2112.32s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI/add_and_remove_labels_and_taints (6.31s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI/scale_up_and_down_cp_and_worker_node_group (530.08s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI/replace_existing_worker_node_groups (140.74s)
PASS

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

