### PR TITLE
mgmt cluster can reconcile cp with EXP_SELF_MANAGED_API_UPGRADE flag

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -288,8 +288,6 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 	}
 
 	if !old.IsSelfManaged() || features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
-		clusterlog.Info("Cluster config is associated with workload cluster", "name", old.Name)
-
 		oldAWSIamConfig, newAWSIamConfig := &Ref{}, &Ref{}
 		for _, identityProvider := range new.Spec.IdentityProviderRefs {
 			if identityProvider.Kind == AWSIamConfigKind {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -287,7 +287,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		}
 	}
 
-	if !old.IsSelfManaged() {
+	if !old.IsSelfManaged() || features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
 		clusterlog.Info("Cluster config is associated with workload cluster", "name", old.Name)
 
 		oldAWSIamConfig, newAWSIamConfig := &Ref{}, &Ref{}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -9,7 +9,7 @@ const (
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
 	K8s127SupportEnvVar             = "K8S_1_27_SUPPORT"
 
-	experimentalSelfManagedClusterUpgradeEnvVar = "EXP_SELF_MANAGED_API_UPGRADE"
+	ExperimentalSelfManagedClusterUpgradeEnvVar = "EXP_SELF_MANAGED_API_UPGRADE"
 	experimentalSelfManagedClusterUpgradeGate   = "ExpSelfManagedAPIUpgrade"
 )
 
@@ -43,7 +43,7 @@ func ExperimentalSelfManagedClusterUpgrade() Feature {
 	return Feature{
 		Name: "[EXPERIMENTAL] Upgrade self-managed clusters through the API",
 		IsActive: globalFeatures.isActiveForEnvVarOrGate(
-			experimentalSelfManagedClusterUpgradeEnvVar,
+			ExperimentalSelfManagedClusterUpgradeEnvVar,
 			experimentalSelfManagedClusterUpgradeGate,
 		),
 	}


### PR DESCRIPTION
*Issue #, if available:*
[can't scale mgmt cluster cp with experimentalSelfManagedUpgrade flag#1328](https://github.com/aws/eks-anywhere-internal/issues/1328)

*Description of changes:*

*Testing (if applicable):*
unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

