### PR TITLE
Rework CloudStack API comments

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_types.go
@@ -22,27 +22,34 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // CloudStackMachineConfigSpec defines the desired state of CloudStackMachineConfig.
 type CloudStackMachineConfigSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Template refers to a VM image template which has been previously registered in CloudStack. It can either be specified as a UUID or name
+	// Template refers to a VM image template which has been previously registered in CloudStack.
+	// It can either be specified as a UUID or name
 	Template CloudStackResourceIdentifier `json:"template"`
-	// ComputeOffering refers to a compute offering which has been previously registered in CloudStack. It represents a VM’s instance size including number of CPU’s, memory, and CPU speed. It can either be specified as a UUID or name
+	// ComputeOffering refers to a compute offering which has been previously registered in
+	// CloudStack. It represents a VM’s instance size including number of CPU’s, memory, and CPU
+	// speed. It can either be specified as a UUID or name
 	ComputeOffering CloudStackResourceIdentifier `json:"computeOffering"`
-	// DiskOffering refers to a disk offering which has been previously registered in CloudStack. It represents a disk offering with pre-defined size or custom specified disk size. It can either be specified as a UUID or name
+	// DiskOffering refers to a disk offering which has been previously registered in CloudStack.
+	// It represents a disk offering with pre-defined size or custom specified disk size. It can
+	// either be specified as a UUID or name
 	DiskOffering *CloudStackResourceDiskOffering `json:"diskOffering,omitempty"`
-	// Users consists of an array of objects containing the username, as well as a list of their public keys. These users will be authorized to ssh into the machines
+	// Users consists of an array of objects containing the username, as well as a list of their
+	// public keys. These users will be authorized to ssh into the machines
 	Users []UserConfiguration `json:"users,omitempty"`
-	// Defaults to `no`. Can be `pro` or `anti`. If set to `pro` or `anti`, will create an affinity group per machine set of the corresponding type
+	// Defaults to `no`. Can be `pro` or `anti`. If set to `pro` or `anti`, will create an affinity
+	// group per machine set of the corresponding type
 	Affinity string `json:"affinity,omitempty"`
-	// AffinityGroupIds allows users to pass in a list of UUIDs for previously-created Affinity Groups. Any VM’s created with this spec will be added to the affinity group, which will dictate which physical host(s) they can be placed on. Affinity groups can be type “affinity” or “anti-affinity” in CloudStack. If they are type “anti-affinity”, all VM’s in the group must be on separate physical hosts for high availability. If they are type “affinity”, all VM’s in the group must be on the same physical host for improved performance
+	// AffinityGroupIds allows users to pass in a list of UUIDs for previously-created Affinity
+	// Groups. Any VM’s created with this spec will be added to the affinity group, which will
+	// dictate which physical host(s) they can be placed on. Affinity groups can be type “affinity”
+	// or “anti-affinity” in CloudStack. If they are type “anti-affinity”, all VM’s in the group
+	// must be on separate physical hosts for high availability. If they are type “affinity”, all
+	// VM’s in the group must be on the same physical host for improved performance
 	AffinityGroupIds []string `json:"affinityGroupIds,omitempty"`
-	// UserCustomDetails allows users to pass in non-standard key value inputs, outside those defined [here](https://github.com/shapeblue/cloudstack/blob/main/api/src/main/java/com/cloud/vm/VmDetailConstants.java)
+	// UserCustomDetails allows users to pass in non-standard key value inputs, outside those
+	// defined [here](https://github.com/shapeblue/cloudstack/blob/main/api/src/main/java/com/cloud/vm/VmDetailConstants.java)
 	UserCustomDetails map[string]string `json:"userCustomDetails,omitempty"`
 	// Symlinks create soft symbolic links folders. One use case is to use data disk to store logs
 	Symlinks SymlinkMaps `json:"symlinks,omitempty"`
@@ -90,12 +97,14 @@ func (r *CloudStackResourceDiskOffering) Equal(o *CloudStackResourceDiskOffering
 }
 
 // IsEmpty Introduced for backwards compatibility purposes. When CloudStackResourceDiskOffering
-// was initially added to the CloudStackMachineConfig type, it was added with omitempty at the top level, but
-// the subtypes were *not* optional, so we have old clusters today with "empty" CloudStackResourceDiskOffering objects,
-// like {CustomSize: 0, MountPath: "", Label: "", Device: "", FileSystem: ""}.
-// Since then, we have made DiskOffering an optional pointer, with everything inside it as optional. Functionally, setting DiskOffering=nil
-// is equivalent to having an "empty" DiskOffering as shown above. Introducing this check should help prevent unintended RollingUpgrades
-// when upgrading a cluster which has this "empty" DiskOffering in it.
+// was initially added to the CloudStackMachineConfig type, it was added with omitempty at the top
+// level, but the subtypes were *not* optional, so we have old clusters today with zero value
+// fields for the CloudStackResourceDiskOffering.
+//
+// Since then, we have made DiskOffering an optional pointer, with everything inside it as optional.
+// Functionally, setting DiskOffering=nil is equivalent to a CloudStackResourceDiskOffering with
+// zero values. Introducing this check should help prevent unintended RollingUpgrades when
+// upgrading a cluster which has this "empty" DiskOffering in it.
 func (r *CloudStackResourceDiskOffering) IsEmpty() bool {
 	if r == nil {
 		return true
@@ -223,9 +232,7 @@ func (c *CloudStackMachineConfig) SetUserDefaults() {
 }
 
 // CloudStackMachineConfigStatus defines the observed state of CloudStackMachineConfig.
-type CloudStackMachineConfigStatus struct { // INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
+type CloudStackMachineConfigStatus struct {
 	// SpecValid is set to true if cloudstackmachineconfig is validated.
 	SpecValid bool `json:"specValid,omitempty"`
 
@@ -316,7 +323,8 @@ func (c *CloudStackMachineConfig) Marshallable() Marshallable {
 
 // +kubebuilder:object:generate=false
 
-// Same as CloudStackMachineConfig except stripped down for generation of yaml file during generate clusterconfig.
+// CloudStackMachineConfigGenerate the same as CloudStackMachineConfig except stripped down for
+// generation of yaml file during generate  clusterconfig.
 type CloudStackMachineConfigGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`


### PR DESCRIPTION
# Summary

The CloudStack API comments didn't stick with our guidance of avoiding excessively long lines. This change carves up code comments into appropriate length lines and removes unnecessary comments.

See https://github.com/aws/eks-anywhere/blob/main/docs/developer/best-practice.md#line-length