### PR TITLE
Moving cloudstack registry mirror regex checks

### DIFF
--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -32,7 +32,7 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 
 	// Since Tinkerbell uses a separate harbor registry,
 	// we need to setup cert for that registry for Tinkerbell tests.
-	re = regexp.MustCompile(`^.*(Tinkerbell|CloudStack).*$`)
+	re = regexp.MustCompile(`^.*Tinkerbell.*$`)
 	if re.MatchString(testRegex) {
 		endpoint = e.testEnvVars[e2etests.RegistryEndpointTinkerbellVar]
 		port = e.testEnvVars[e2etests.RegistryPortTinkerbellVar]
@@ -44,12 +44,12 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 	}
 
 	// Since Authenticated tests needs to use separate harbor registries.
-	re = regexp.MustCompile(`^.*VSphere.*Authenticated.*$`)
+	re = regexp.MustCompile(`^.*(VSphere|CloudStack).*Authenticated.*$`)
 	if re.MatchString(testRegex) {
 		endpoint = e.testEnvVars[e2etests.PrivateRegistryEndpointVar]
 		port = e.testEnvVars[e2etests.PrivateRegistryPortVar]
 		caCert = e.testEnvVars[e2etests.PrivateRegistryCACertVar]
-	} else if re = regexp.MustCompile(`^.*(Tinkerbell|CloudStack).*Authenticated.*$`); re.MatchString(testRegex) {
+	} else if re = regexp.MustCompile(`^.*Tinkerbell.*Authenticated.*$`); re.MatchString(testRegex) {
 		endpoint = e.testEnvVars[e2etests.PrivateRegistryEndpointTinkerbellVar]
 		port = e.testEnvVars[e2etests.PrivateRegistryPortTinkerbellVar]
 		caCert = e.testEnvVars[e2etests.PrivateRegistryCACertTinkerbellVar]


### PR DESCRIPTION
*Description of changes:*
We are setting the general registry mirror env var but using values from Tinkerbell i.e. the colo lab.
Hence moving the regex check around to set the right variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

