### PR TITLE
Fix TestVSphereKubernetes126BottlerocketTo127Upgrade E2E test

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -1697,7 +1697,7 @@ func TestVSphereKubernetes126BottlerocketTo127Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube127,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
-		provider.WithProviderUpgrade(provider.Bottlerocket126Template()),
+		provider.WithProviderUpgrade(provider.Bottlerocket127Template()),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes TestVSphereKubernetes126BottlerocketTo127Upgrade to use the proper k8s version.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
