### PR TITLE
Add validation for taints for API E2E tests

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_nutanixmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_nutanixmachineconfigs.yaml
@@ -191,8 +191,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address

--- a/internal/pkg/api/taints.go
+++ b/internal/pkg/api/taints.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// MasterTaint will be deprecated from kubernetes version 1.25 onwards.
+func MasterTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "node-role.kubernetes.io/master",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+// ControlPlaneTaint has been added from 1.24 onwards.
+func ControlPlaneTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "node-role.kubernetes.io/control-plane",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+// ValidateControlPlaneTaints will validate that a controlPlane node has the expected taints.
+func ValidateControlPlaneTaints(controlPlane v1alpha1.ControlPlaneConfiguration, node corev1.Node) (err error) {
+	cpTaints := controlPlane.Taints
+
+	// if no taints are specified, kubeadm defaults it to a well-known control plane taint.
+	// so, we make sure to check for that well-known taint if no taints are provided in the spec.
+	var taintsValid bool
+	if cpTaints == nil {
+		taintsValid = validateDefaultControlPlaneTaints(node)
+	} else {
+		taintsValid = v1alpha1.TaintsSliceEqual(cpTaints, node.Spec.Taints)
+	}
+
+	if !taintsValid {
+		return fmt.Errorf("taints on control plane node %v and corresponding control plane configuration do not match; configured taints: %v; node taints: %v",
+			node.Name, cpTaints, node.Spec.Taints)
+	}
+	return nil
+}
+
+// ValidateControlPlaneNoTaints will validate that a controlPlane has no taints, for example in the case of a single node cluster.
+func ValidateControlPlaneNoTaints(controlPlane v1alpha1.ControlPlaneConfiguration, node corev1.Node) (err error) {
+	valid := len(controlPlane.Taints) == 0 && len(node.Spec.Taints) == 0
+	if !valid {
+		return fmt.Errorf("taints on control plane node %v or corresponding control plane configuration found; configured taints: %v; node taints: %v",
+			node.Name, controlPlane.Taints, node.Spec.Taints)
+	}
+	return nil
+}
+
+// ValidateWorkerNodeTaints will validate that a worker node has the expected taints in the worker node group configuration.
+func ValidateWorkerNodeTaints(w v1alpha1.WorkerNodeGroupConfiguration, node corev1.Node) (err error) {
+	valid := v1alpha1.TaintsSliceEqual(node.Spec.Taints, w.Taints)
+	if !valid {
+		return fmt.Errorf("taints on node %v and corresponding worker node group configuration %v do not match", node.Name, w.Name)
+	}
+	return nil
+}
+
+func validateDefaultControlPlaneTaints(node corev1.Node) bool {
+	// Due to the transition from "master" to "control-plane", CP nodes can have one or both
+	// of these taints, depending on the k8s version. So checking that the node has at least one
+	// of them.
+
+	masterTaint := MasterTaint()
+	cpTaint := ControlPlaneTaint()
+
+	for _, v := range node.Spec.Taints {
+		if taintEqual(v, masterTaint) || taintEqual(v, cpTaint) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func taintEqual(a, b corev1.Taint) bool {
+	return a.Key == b.Key && a.Effect == b.Effect && a.Value == b.Value
+}

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1143,6 +1143,12 @@ func (c *Cluster) ManagementClusterEqual(s2 *Cluster) bool {
 	return c.IsSelfManaged() && s2.IsSelfManaged() || c.Spec.ManagementCluster.Equal(s2.Spec.ManagementCluster)
 }
 
+// IsSingleNode checks if the cluster has only a single node specified between the controlplane and worker nodes.
+func (c *Cluster) IsSingleNode() bool {
+	return c.Spec.ControlPlaneConfiguration.Count == 1 &&
+		len(c.Spec.WorkerNodeGroupConfigurations) <= 0
+}
+
 func (c *Cluster) MachineConfigRefs() []Ref {
 	machineConfigRefMap := make(refSet, 1)
 

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2686,3 +2686,56 @@ func TestKubeVersionToValidSemver(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterIsSingleNode(t *testing.T) {
+	testCases := []struct {
+		testName string
+		cluster  *v1alpha1.Cluster
+		want     bool
+	}{
+		{
+			testName: "cluster with single node",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+						Count: 1,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			testName: "cluster with cp and worker",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+						Count: 1,
+					},
+					WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
+						{
+							Count: ptr.Int(3),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			testName: "cluster with multiple cp",
+			cluster: &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+						Count: 3,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.cluster.IsSingleNode()).To(Equal(tt.want))
+		})
+	}
+}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -44,7 +44,7 @@ import (
 const (
 	defaultClusterConfigFile               = "cluster.yaml"
 	defaultBundleReleaseManifestFile       = "bin/local-bundle-release.yaml"
-	defaultEksaBinaryLocation              = "eksctl-anywhere"
+	defaultEksaBinaryLocation              = "eksctl anywhere"
 	defaultClusterName                     = "eksa-test"
 	defaultDownloadArtifactsOutputLocation = "eks-anywhere-downloads.tar.gz"
 	defaultDownloadImagesOutputLocation    = "images.tar"

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -44,7 +44,7 @@ import (
 const (
 	defaultClusterConfigFile               = "cluster.yaml"
 	defaultBundleReleaseManifestFile       = "bin/local-bundle-release.yaml"
-	defaultEksaBinaryLocation              = "eksctl anywhere"
+	defaultEksaBinaryLocation              = "eksctl-anywhere"
 	defaultClusterName                     = "eksa-test"
 	defaultDownloadArtifactsOutputLocation = "eks-anywhere-downloads.tar.gz"
 	defaultDownloadImagesOutputLocation    = "images.tar"

--- a/test/framework/taints.go
+++ b/test/framework/taints.go
@@ -1,8 +1,6 @@
 package framework
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
@@ -12,41 +10,28 @@ import (
 
 const ownerAnnotation = "cluster.x-k8s.io/owner-name"
 
+// ValidateControlPlaneTaints will validate that a controlPlane node has the expected taints.
 func ValidateControlPlaneTaints(controlPlane v1alpha1.ControlPlaneConfiguration, node corev1.Node) (err error) {
-	cpTaints := controlPlane.Taints
-
-	// if no taints are specified, kubeadm defaults it to a well-known control plane taint.
-	// so, we make sure to check for that well-known taint if no taints are provided in the spec.
-	var taintsValid bool
-	if cpTaints == nil {
-		taintsValid = validateDefaultControlPlaneTaints(node)
-	} else {
-		taintsValid = v1alpha1.TaintsSliceEqual(cpTaints, node.Spec.Taints)
+	if err := api.ValidateControlPlaneTaints(controlPlane, node); err != nil {
+		return err
 	}
-
-	if !taintsValid {
-		return fmt.Errorf("taints on control plane node %v and corresponding control plane configuration do not match; configured taints: %v; node taints: %v",
-			node.Name, cpTaints, node.Spec.Taints)
-	}
-	logger.V(4).Info("Expected taints from cluster spec control plane configuration are present on corresponding node", "node", node.Name, "node taints", node.Spec.Taints, "control plane configuration taints", cpTaints)
+	logger.V(4).Info("Expected taints from cluster spec control plane configuration are present on corresponding node", "node", node.Name, "node taints", node.Spec.Taints, "control plane configuration taints", controlPlane.Taints)
 	return nil
 }
 
 // ValidateControlPlaneNoTaints will validate that a controlPlane has no taints, for example in the case of a single node cluster.
 func ValidateControlPlaneNoTaints(controlPlane v1alpha1.ControlPlaneConfiguration, node corev1.Node) (err error) {
-	valid := len(controlPlane.Taints) == 0 && len(node.Spec.Taints) == 0
-	if !valid {
-		return fmt.Errorf("taints on control plane node %v or corresponding control plane configuration found; configured taints: %v; node taints: %v",
-			node.Name, controlPlane.Taints, node.Spec.Taints)
+	if err := api.ValidateControlPlaneNoTaints(controlPlane, node); err != nil {
+		return err
 	}
 	logger.V(4).Info("expected no taints on cluster spec control plane configuration and on corresponding node", "node", node.Name, "node taints", node.Spec.Taints, "control plane configuration taints", controlPlane.Taints)
 	return nil
 }
 
+// ValidateWorkerNodeTaints will validate that a worker node has the expected taints in the worker node group configuration.
 func ValidateWorkerNodeTaints(w v1alpha1.WorkerNodeGroupConfiguration, node corev1.Node) (err error) {
-	valid := v1alpha1.TaintsSliceEqual(node.Spec.Taints, w.Taints)
-	if !valid {
-		return fmt.Errorf("taints on node %v and corresponding worker node group configuration %v do not match", node.Name, w.Name)
+	if err := api.ValidateWorkerNodeTaints(w, node); err != nil {
+		return err
 	}
 	logger.V(4).Info("expected taints from cluster spec are present on corresponding node", "worker node group", w.Name, "worker node group taints", w.Taints, "node", node.Name, "node taints", node.Spec.Taints)
 	return nil
@@ -76,47 +61,10 @@ func PreferNoScheduleTaint() corev1.Taint {
 	}
 }
 
-// MasterTaint will be deprecated from kubernetes version 1.25 onwards.
-func MasterTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:    "node-role.kubernetes.io/master",
-		Effect: corev1.TaintEffectNoSchedule,
-	}
-}
-
-// ControlPlaneTaint has been added from 1.24 onwards.
-func ControlPlaneTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:    "node-role.kubernetes.io/control-plane",
-		Effect: corev1.TaintEffectNoSchedule,
-	}
-}
-
 func NoScheduleWorkerNodeGroup(name string, count int) *WorkerNodeGroup {
 	return WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(NoScheduleTaint()))
 }
 
 func PreferNoScheduleWorkerNodeGroup(name string, count int) *WorkerNodeGroup {
 	return WithWorkerNodeGroup(name, api.WithCount(count), api.WithTaint(PreferNoScheduleTaint()))
-}
-
-func validateDefaultControlPlaneTaints(node corev1.Node) bool {
-	// Due to the transition from "master" to "control-plane", CP nodes can have one or both
-	// of these taints, depending on the k8s version. So checking that the node has at least one
-	// of them.
-
-	masterTaint := MasterTaint()
-	cpTaint := ControlPlaneTaint()
-
-	for _, v := range node.Spec.Taints {
-		if taintEqual(v, masterTaint) || taintEqual(v, cpTaint) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func taintEqual(a, b corev1.Taint) bool {
-	return a.Key == b.Key && a.Effect == b.Effect && a.Value == b.Value
 }


### PR DESCRIPTION
*Issue #, if available:*
[#1019 internal](https://github.com/aws/eks-anywhere-internal/issues/1019)

*Description of changes:*
Currently, the API e2e tests containing taints do not verify that they are added correctly. This PR adds that validation for the api e2e test to verify taints using the cluster state validator.

*Testing (if applicable):*
Locally ran the api e2e tests:

`--- PASS: TestVSphereUpgradeLabelsTaintsUbuntuAPI`
`--- PASS: TestVSphereUpgradeLabelsTaintsBottleRocketGitHubFluxAPI `

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

