### PR TITLE
Add Tinkerbell Cluster Autoscaler E2E Test

### DIFF
--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -7,12 +7,29 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
+const (
+		autoscalerName = "cluster-autoscaler"
+		metricServerName = "metrics-server"
+		targetNamespace = "eksa-packages"
+)
+
 func runAutoscalerWithMetricsServerSimpleFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(e *framework.ClusterE2ETest) {
-		autoscalerName := "cluster-autoscaler"
-		metricServerName := "metrics-server"
-		targetNamespace := "eksa-packages"
 		test.InstallAutoScalerWithMetricServer(targetNamespace)
 		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
 	})
+}
+
+func runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test *framework.ClusterE2ETest) {
+	test.GenerateHardwareConfig()
+	test.PowerOffHardware()
+	test.GenerateClusterConfig()
+	test.PowerOnHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneNoTaints, framework.ValidateControlPlaneLabels)
+	test.InstallAutoScalerWithMetricServer(targetNamespace)
+	test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
+	test.DeleteCluster()
+	test.PowerOffHardware()
+	test.ValidateHardwareDecommissioned()
 }

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -288,6 +288,23 @@ func TestTinkerbellKubernetes125UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
 }
 
 // Curated packages
+
+func TestTinkerbellKubernetes128UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	minNodes := 1
+	maxNodes := 2
+	test := framework.NewClusterE2ETest(t,
+		framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
+		framework.WithControlPlaneHardware(1),
+		framework.WithWorkerHardware(2),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube128),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+	)
+	runAutoscalerWithMetricsServerSimpleFlow(test)
+}
+
 func TestTinkerbellKubernetes127UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewTinkerbell(t, framework.WithUbuntu127Tinkerbell()),
@@ -410,6 +427,22 @@ func TestTinkerbellKubernetes127BottleRocketCuratedPackagesPrometheusSimpleFlow(
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
 	runCuratedPackagesPrometheusInstallTinkerbellSimpleFlow(test)
+}
+
+func TestTinkerbellKubernetes127UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	minNodes := 1
+	maxNodes := 2
+	test := framework.NewClusterE2ETest(t,
+		framework.NewTinkerbell(t, framework.WithUbuntu127Tinkerbell()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
+		framework.WithControlPlaneHardware(1),
+		framework.WithWorkerHardware(2),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube127),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+	)
+	runAutoscalerWithMetricsServerSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes126UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -302,7 +302,7 @@ func TestTinkerbellKubernetes128UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes127UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
@@ -442,7 +442,7 @@ func TestTinkerbellKubernetes127UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes126UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2007,7 +2007,7 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName, metr
 		e.T.Fatalf("Failed waiting for test workload deployent %s", err)
 	}
 
-	params := []string{"autoscale", "deployment", name, "--cpu-percent=50", "--min=1", "--max=20", "--kubeconfig", e.KubeconfigFilePath()}
+	params := []string{"autoscale", "deployment", name, "--cpu-percent=50", "--min=1", "--max=150", "--kubeconfig", e.KubeconfigFilePath()}
 	_, err = e.KubectlClient.ExecuteCommand(ctx, params...)
 	if err != nil {
 		e.T.Fatalf("Failed to autoscale deployent: %s", err)

--- a/test/framework/testdata/hpa_busybox.yaml
+++ b/test/framework/testdata/hpa_busybox.yaml
@@ -20,7 +20,7 @@ spec:
               cpu: 50m
             requests:
               cpu: 10m
-              memory: 500Mi
+              memory: 1000Mi
           command: ["sh", "-c"]
           args:
             - while [ 1 ]; do


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/5883

*Description of changes:*
This PR adds an end to end test verifying that cluster autoscaler works on tinkerbell.

*Testing (if applicable):*
Ran e2e test manually and verified success.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->