### PR TITLE
Define KubeVersions in e2e framework for all providers to access

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -2,6 +2,7 @@
 package e2e
 
 import (
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -45,3 +46,4 @@ const (
 )
 
 var EksaPackageControllerHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
+var KubeVersions = []v1alpha1.KubernetesVersion{v1alpha1.Kube123, v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127}

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -212,8 +212,6 @@ func TestVSphereKubernetes126To127AWSIamAuthUpgrade(t *testing.T) {
 }
 
 // Curated packages
-var KubeVersions = []v1alpha1.KubernetesVersion{v1alpha1.Kube123, v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127}
-
 func kubeVersionVSphereOptUbuntu(version v1alpha1.KubernetesVersion) framework.VSphereOpt {
 	switch version {
 	case v1alpha1.Kube123:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The individual e2e test binaries would not build because this was defined in a provider specific file. Moving this to a central location allows binaries to be built correctly

*Testing (if applicable):*
`make e2e-tests-binary`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

