### PR TITLE
Make different cluster name across loops within the same e2e test

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -5,6 +5,8 @@
 package e2e
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -118,8 +120,9 @@ func TestDockerInstallGithubFluxDuringUpgrade(t *testing.T) {
 
 // Curated packages
 func TestDockerCuratedPackagesSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewDocker(t),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -132,8 +135,9 @@ func TestDockerCuratedPackagesSimpleFlow(t *testing.T) {
 }
 
 func TestDockerCuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewDocker(t),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -146,8 +150,9 @@ func TestDockerCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 }
 
 func TestDockerCuratedPackagesHarborSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewDocker(t),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -160,8 +165,9 @@ func TestDockerCuratedPackagesHarborSimpleFlow(t *testing.T) {
 }
 
 func TestDockerCuratedPackagesAdotSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
 			framework.WithPackageConfig(t, packageBundleURI(version),
@@ -173,8 +179,9 @@ func TestDockerCuratedPackagesAdotSimpleFlow(t *testing.T) {
 }
 
 func TestDockerCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
 			framework.WithPackageConfig(t, packageBundleURI(version),
@@ -186,8 +193,9 @@ func TestDockerCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 }
 
 func TestDockerCuratedPackagesDisabled(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
 			framework.WithPackageConfig(t, packageBundleURI(version),

--- a/test/e2e/metallb.go
+++ b/test/e2e/metallb.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,10 +30,11 @@ type MetalLBSuite struct {
 }
 
 func RunMetalLBDockerTests(t *testing.T) {
-	for _, v := range KubeVersions {
+	for i, v := range KubeVersions {
 		s := new(MetalLBSuite)
 		s.provider = framework.NewDocker(t)
 		s.kubernetesVersion = v
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		suite.Run(t, s)
 	}
 }

--- a/test/e2e/nutanix_test.go
+++ b/test/e2e/nutanix_test.go
@@ -6,6 +6,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
@@ -33,7 +34,9 @@ func kubeVersionNutanixOpt(version v1alpha1.KubernetesVersion) framework.Nutanix
 }
 
 func TestNutanixCuratedPackagesSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewNutanix(t, kubeVersionNutanixOpt(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -46,8 +49,9 @@ func TestNutanixCuratedPackagesSimpleFlow(t *testing.T) {
 }
 
 func TestNutanixCuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewNutanix(t, kubeVersionNutanixOpt(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -60,8 +64,9 @@ func TestNutanixCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 }
 
 func TestNutanixCuratedPackagesHarborSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewNutanix(t, kubeVersionNutanixOpt(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -74,8 +79,9 @@ func TestNutanixCuratedPackagesHarborSimpleFlow(t *testing.T) {
 }
 
 func TestNutanixCuratedPackagesAdotUpdateFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewNutanix(t, kubeVersionNutanixOpt(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -90,8 +96,9 @@ func TestNutanixCuratedPackagesAdotUpdateFlow(t *testing.T) {
 func TestNutanixCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewNutanix(t, kubeVersionNutanixOpt(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
@@ -104,8 +111,9 @@ func TestNutanixCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 }
 
 func TestNutanixCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewNutanix(t, kubeVersionNutanixOpt(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -6,6 +6,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -151,7 +152,9 @@ func kubeVersionTinkerbellOpt(version v1alpha1.KubernetesVersion) framework.Tink
 }
 
 func TestTinkerbellUbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, kubeVersionTinkerbellOpt(version)),
 			framework.WithClusterSingleNode(version),
@@ -165,7 +168,9 @@ func TestTinkerbellUbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
 }
 
 func TestTinkerbellBottleRocketSingleNodeCuratedPackagesFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
 			framework.WithClusterSingleNode(version),
@@ -180,7 +185,9 @@ func TestTinkerbellBottleRocketSingleNodeCuratedPackagesFlow(t *testing.T) {
 }
 
 func TestTinkerbellUbuntuSingleNodeCuratedPackagesEmissaryFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, kubeVersionTinkerbellOpt(version)),
 			framework.WithClusterSingleNode(version),
@@ -194,7 +201,9 @@ func TestTinkerbellUbuntuSingleNodeCuratedPackagesEmissaryFlow(t *testing.T) {
 }
 
 func TestTinkerbellBottleRocketSingleNodeCuratedPackagesEmissaryFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
 			framework.WithClusterSingleNode(version),
@@ -208,7 +217,9 @@ func TestTinkerbellBottleRocketSingleNodeCuratedPackagesEmissaryFlow(t *testing.
 }
 
 func TestTinkerbellUbuntuSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, kubeVersionTinkerbellOpt(version)),
 			framework.WithClusterSingleNode(version),
@@ -222,7 +233,9 @@ func TestTinkerbellUbuntuSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
 }
 
 func TestTinkerbellBottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
 			framework.WithClusterSingleNode(version),
@@ -236,8 +249,9 @@ func TestTinkerbellBottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T)
 }
 
 func TestTinkerbellUbuntuSingleNodeCuratedPackagesAdotSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, kubeVersionTinkerbellOpt(version)),
 			framework.WithClusterSingleNode(version),
@@ -251,8 +265,9 @@ func TestTinkerbellUbuntuSingleNodeCuratedPackagesAdotSimpleFlow(t *testing.T) {
 }
 
 func TestTinkerbellBottleRocketSingleNodeCuratedPackagesAdotSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
 			framework.WithClusterSingleNode(version),
@@ -266,8 +281,9 @@ func TestTinkerbellBottleRocketSingleNodeCuratedPackagesAdotSimpleFlow(t *testin
 }
 
 func TestTinkerbellUbuntuSingleNodeCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, kubeVersionTinkerbellOpt(version)),
 			framework.WithClusterSingleNode(version),
@@ -281,8 +297,9 @@ func TestTinkerbellUbuntuSingleNodeCuratedPackagesPrometheusSimpleFlow(t *testin
 }
 
 func TestTinkerbellBottleRocketSingleNodeCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
 			framework.WithClusterSingleNode(version),

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -247,8 +247,9 @@ func kubeVersionVSphereOptBottleRocket(version v1alpha1.KubernetesVersion) frame
 }
 
 func TestVSphereCuratedPackagesSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -261,7 +262,9 @@ func TestVSphereCuratedPackagesSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereBottleRocketCuratedPackagesSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -274,8 +277,9 @@ func TestVSphereBottleRocketCuratedPackagesSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereCuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -288,8 +292,9 @@ func TestVSphereCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 }
 
 func TestVSphereBottleRocketCuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -302,8 +307,9 @@ func TestVSphereBottleRocketCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 }
 
 func TestVSphereCuratedPackagesHarborSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -316,7 +322,9 @@ func TestVSphereCuratedPackagesHarborSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereBottleRocketCuratedPackagesHarborSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
+		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -329,8 +337,9 @@ func TestVSphereBottleRocketCuratedPackagesHarborSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereCuratedPackagesAdotUpdateFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -343,8 +352,9 @@ func TestVSphereCuratedPackagesAdotUpdateFlow(t *testing.T) {
 }
 
 func TestVSphereBottleRocketCuratedPackagesAdotUpdateFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -359,8 +369,9 @@ func TestVSphereBottleRocketCuratedPackagesAdotUpdateFlow(t *testing.T) {
 func TestVSphereUbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
@@ -375,8 +386,9 @@ func TestVSphereUbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 func TestVSphereBottleRocketCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version), api.WithWorkerNodeAutoScalingConfig(minNodes, maxNodes)),
@@ -389,8 +401,9 @@ func TestVSphereBottleRocketCuratedPackagesClusterAutoscalerSimpleFlow(t *testin
 }
 
 func TestVSphereUbuntuCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -403,8 +416,9 @@ func TestVSphereUbuntuCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereBottleRocketCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		test := framework.NewClusterE2ETest(t,
 			framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version)),
 			framework.WithClusterFiller(api.WithKubernetesVersion(version)),
@@ -417,8 +431,9 @@ func TestVSphereBottleRocketCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereUbuntuWorkloadClusterCuratedPackagesSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		provider := framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version))
 		test := SetupSimpleMultiCluster(t, provider, version)
 		runCuratedPackageRemoteClusterInstallSimpleFlow(test)
@@ -426,8 +441,9 @@ func TestVSphereUbuntuWorkloadClusterCuratedPackagesSimpleFlow(t *testing.T) {
 }
 
 func TestVSphereBottleRocketWorkloadClusterCuratedPackagesSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		provider := framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version))
 		test := SetupSimpleMultiCluster(t, provider, version)
 		runCuratedPackageRemoteClusterInstallSimpleFlow(test)
@@ -435,8 +451,9 @@ func TestVSphereBottleRocketWorkloadClusterCuratedPackagesSimpleFlow(t *testing.
 }
 
 func TestVSphereUbuntuWorkloadClusterCuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		provider := framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version))
 		test := SetupSimpleMultiCluster(t, provider, version)
 		runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test)
@@ -444,8 +461,9 @@ func TestVSphereUbuntuWorkloadClusterCuratedPackagesEmissarySimpleFlow(t *testin
 }
 
 func TestVSphereBottleRocketWorkloadClusterCuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		provider := framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version))
 		test := SetupSimpleMultiCluster(t, provider, version)
 		runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test)
@@ -453,9 +471,10 @@ func TestVSphereBottleRocketWorkloadClusterCuratedPackagesEmissarySimpleFlow(t *
 }
 
 func TestVSphereUbuntuWorkloadClusterCuratedPackagesCertManagerSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
 		framework.CheckCertManagerCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		provider := framework.NewVSphere(t, kubeVersionVSphereOptUbuntu(version))
 		test := SetupSimpleMultiCluster(t, provider, version)
 		runCertManagerRemoteClusterInstallSimpleFlow(test)
@@ -463,9 +482,10 @@ func TestVSphereUbuntuWorkloadClusterCuratedPackagesCertManagerSimpleFlow(t *tes
 }
 
 func TestVSphereBottleRocketWorkloadClusterCuratedPackagesCertManagerSimpleFlow(t *testing.T) {
-	for _, version := range KubeVersions {
+	for i, version := range KubeVersions {
 		framework.CheckCuratedPackagesCredentials(t)
 		framework.CheckCertManagerCredentials(t)
+		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
 		provider := framework.NewVSphere(t, kubeVersionVSphereOptBottleRocket(version))
 		test := SetupSimpleMultiCluster(t, provider, version)
 		runCertManagerRemoteClusterInstallSimpleFlow(test)


### PR DESCRIPTION
*Issue #, if available:*
Based on the current logic (https://github.com/aws/eks-anywhere/blob/main/test/framework/cluster.go#L1076-L1085), cluster name by default consists of default cluster name and hashing of the test name. This results in the same cluster name across loops within the same e2e test.

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

