### PR TITLE
Check Cilium DS based on desired number and the number ready

### DIFF
--- a/pkg/networking/cilium/ready.go
+++ b/pkg/networking/cilium/ready.go
@@ -25,8 +25,8 @@ func CheckPreflightDaemonSetReady(ciliumDaemonSet, preflightDaemonSet *v1.Daemon
 		return err
 	}
 
-	if ciliumDaemonSet.Status.NumberReady != preflightDaemonSet.Status.NumberReady {
-		return fmt.Errorf("cilium preflight check DS is not ready: %d want and %d ready", ciliumDaemonSet.Status.NumberReady, preflightDaemonSet.Status.NumberReady)
+	if preflightDaemonSet.Status.DesiredNumberScheduled != preflightDaemonSet.Status.NumberReady {
+		return fmt.Errorf("cilium preflight check DS is not ready: %d want and %d ready", preflightDaemonSet.Status.DesiredNumberScheduled, preflightDaemonSet.Status.NumberReady)
 	}
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This updates the cilium DS preflight to check if the desired number matches the number ready when upgrading Cilium version

*Testing (if applicable):*
Manual upgrade from EKS-A v0.15.4 which uses Cilium v1.11 to main which uses Cilium v1.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

