### PR TITLE
Move force cleanup of bootstrap cluster after preflight validations

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -47,6 +47,7 @@ type CommandContext struct {
 	Profiler                  *Profiler
 	OriginalError             error
 	ManagementClusterStateDir string
+	ForceCleanup              bool
 }
 
 func (c *CommandContext) SetError(err error) {

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -57,14 +57,6 @@ func NewUpgrade(bootstrapper interfaces.Bootstrapper, provider providers.Provide
 }
 
 func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, managementCluster *types.Cluster, workloadCluster *types.Cluster, validator interfaces.Validator, forceCleanup bool) error {
-	if forceCleanup {
-		if err := c.bootstrapper.DeleteBootstrapCluster(ctx, &types.Cluster{
-			Name: clusterSpec.Cluster.Name,
-		}, constants.Upgrade, forceCleanup); err != nil {
-			return err
-		}
-	}
-
 	commandContext := &task.CommandContext{
 		Bootstrapper:      c.bootstrapper,
 		Provider:          c.provider,
@@ -80,6 +72,7 @@ func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, management
 		EksdUpgrader:      c.eksdUpgrader,
 		ClusterUpgrader:   c.clusterUpgrader,
 		UpgradeChangeDiff: c.upgradeChangeDiff,
+		ForceCleanup:      forceCleanup,
 	}
 	if features.IsActive(features.CheckpointEnabled()) {
 		return task.NewTaskRunner(&setupAndValidateTasks{}, c.writer, task.WithCheckpointFile()).RunTask(ctx, commandContext)
@@ -379,6 +372,14 @@ func (s *pauseEksaReconcile) Restore(ctx context.Context, commandContext *task.C
 }
 
 func (s *createBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	if commandContext.ForceCleanup {
+		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, &types.Cluster{
+			Name: commandContext.ClusterSpec.Cluster.Name,
+		}, constants.Upgrade, commandContext.ForceCleanup); err != nil {
+			commandContext.SetError(err)
+			return nil
+		}
+	}
 	if commandContext.ManagementCluster != nil && commandContext.ManagementCluster.ExistingManagement {
 		return &upgradeWorkloadClusterTask{}
 	}


### PR DESCRIPTION
*Issue #, if available:*
#5891 

*Description of changes:*
Moving the force cleanup to right before the creation of the bootstrap cluster to ensure we have the bootstrap cluster until it is absolutely needed to clean up. 

*Testing (if applicable):*
unit tests, functional test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

