### PR TITLE
Add CloudStack API e2e tests

### DIFF
--- a/internal/pkg/api/cloudstack.go
+++ b/internal/pkg/api/cloudstack.go
@@ -124,6 +124,19 @@ func WithCloudStackAccount(value string) CloudStackFiller {
 	}
 }
 
+// WithCloudStackCredentialsRef returns a CloudStackFiller that updates the edentialsRef of all availability zones.
+func WithCloudStackCredentialsRef(value string) CloudStackFiller {
+	return func(config CloudStackConfig) {
+		zones := []anywherev1.CloudStackAvailabilityZone{}
+		for _, az := range config.datacenterConfig.Spec.AvailabilityZones {
+			az.CredentialsRef = value
+			zones = append(zones, az)
+		}
+
+		config.datacenterConfig.Spec.AvailabilityZones = zones
+	}
+}
+
 func WithCloudStackStringFromEnvVar(envVar string, opt func(string) CloudStackFiller) CloudStackFiller {
 	return opt(os.Getenv(envVar))
 }

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -1753,15 +1753,42 @@ func TestCloudStackKubernetes123RedHatAPI(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t, cloudstack, framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
 	).WithClusterConfig(
-		cloudStackAPIClusterBaseChanges(cloudstack),
 		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
 		),
+		cloudstack.WithRedhat123(),
 	)
 
 	test.CreateCluster()
 	// Run mgmt cluster API tests
-	tests := cloudstackAPIManagementClusterUpgradeTests(cloudstack)
+	tests := cloudstackAPIManagementClusterUpgradeTests(test, cloudstack)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCloudStackAPIUpgradeTest(t, test, tt)
+		})
+	}
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
+func TestCloudStackKubernetes124RedHatAPI(t *testing.T) {
+	cloudstack := framework.NewCloudStack(t)
+	test := framework.NewClusterE2ETest(
+		t, cloudstack, framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithStackedEtcdTopology(),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+		cloudstack.WithRedhat124(),
+	)
+
+	test.CreateCluster()
+	// Run mgmt cluster API tests
+	tests := cloudstackAPIManagementClusterUpgradeTests(test, cloudstack)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runCloudStackAPIUpgradeTest(t, test, tt)
@@ -1792,21 +1819,40 @@ func TestCloudStackMulticlusterWorkloadClusterAPI(t *testing.T) {
 			framework.WithClusterName(test.NewWorkloadClusterName()),
 			framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
 		).WithClusterConfig(
-			cloudStackAPIClusterBaseChanges(cloudstack),
+			api.ClusterToConfigFiller(
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithStackedEtcdTopology(),
+				api.WithControlPlaneCount(1),
+			),
+			cloudstack.WithRedhat123(),
+		),
+	)
+
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			cloudstack,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+		).WithClusterConfig(
 			api.ClusterToConfigFiller(
 				api.WithManagementCluster(managementCluster.ClusterName),
 				api.WithExternalEtcdTopology(1),
+				api.WithControlPlaneCount(1),
 			),
+			cloudstack.WithRedhat124(),
 		),
 	)
 
 	test.CreateManagementCluster()
+
 	// Create workload clusters
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		wc.ApplyClusterManifest()
 		wc.WaitForKubeconfig()
 		wc.ValidateClusterState()
-		tests := cloudStackAPIWorkloadUpgradeTests(cloudstack)
+
+		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -1822,7 +1868,72 @@ func TestCloudStackMulticlusterWorkloadClusterAPI(t *testing.T) {
 	test.DeleteManagementCluster()
 }
 
-func TestCloudStackKubernetesRedHat123UpgradeFromLatestMinorReleaseAPI(t *testing.T) {
+func TestCloudStackMulticlusterWorkloadClusterWithNewSecretCredentialsAPI(t *testing.T) {
+	cloudstack := framework.NewCloudStack(t)
+	managementCluster := framework.NewClusterE2ETest(
+		t, cloudstack, framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithStackedEtcdTopology(),
+		),
+		cloudstack.WithRedhat124(),
+	)
+
+	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+		t,
+		cloudstack,
+		framework.WithClusterName(test.NewWorkloadClusterName()),
+		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithManagementCluster(managementCluster.ClusterName),
+			api.WithStackedEtcdTopology(),
+			api.WithControlPlaneCount(1),
+		),
+		api.CloudStackToConfigFiller(
+			api.WithCloudStackCredentialsRef("test-creds"),
+		),
+		cloudstack.WithRedhat123(),
+	))
+
+	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+		t,
+		cloudstack,
+		framework.WithClusterName(test.NewWorkloadClusterName()),
+		framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithManagementCluster(managementCluster.ClusterName),
+			api.WithStackedEtcdTopology(),
+			api.WithControlPlaneCount(1),
+		),
+		api.CloudStackToConfigFiller(
+			api.WithCloudStackCredentialsRef("test-creds"),
+		),
+		cloudstack.WithRedhat124(),
+	))
+
+	test.CreateManagementCluster()
+	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
+
+	// Create workload clusters
+	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+		wc.ApplyClusterManifest()
+		wc.WaitForKubeconfig()
+		wc.ValidateClusterState()
+		wc.DeleteClusterWithKubectl()
+		wc.ValidateClusterDelete()
+	})
+
+	test.ManagementCluster.StopIfFailed()
+	test.DeleteManagementCluster()
+}
+
+func TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI(t *testing.T) {
 	release := latestMinorRelease(t)
 	cloudstack := framework.NewCloudStack(t)
 	managementCluster := framework.NewClusterE2ETest(
@@ -1887,11 +1998,28 @@ func TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
 			framework.WithClusterName(test.NewWorkloadClusterName()),
 			framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
 		).WithClusterConfig(
-			cloudStackAPIClusterBaseChanges(cloudstack),
 			api.ClusterToConfigFiller(
 				api.WithManagementCluster(managementCluster.ClusterName),
 				api.WithExternalEtcdTopology(1),
+				api.WithControlPlaneCount(1),
 			),
+			cloudstack.WithRedhat123(),
+		),
+	)
+
+	test.WithWorkloadClusters(
+		framework.NewClusterE2ETest(
+			t,
+			cloudstack,
+			framework.WithClusterName(test.NewWorkloadClusterName()),
+			framework.WithEnvVar(features.FullLifecycleAPIEnvVar, "true"),
+		).WithClusterConfig(
+			api.ClusterToConfigFiller(
+				api.WithManagementCluster(managementCluster.ClusterName),
+				api.WithStackedEtcdTopology(),
+				api.WithControlPlaneCount(1),
+			),
+			cloudstack.WithRedhat124(),
 		),
 	)
 
@@ -1902,7 +2030,7 @@ func TestCloudStackMulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
 		test.PushWorkloadClusterToGit(wc)
 		wc.WaitForKubeconfig()
 		wc.ValidateClusterState()
-		tests := cloudStackAPIWorkloadUpgradeTests(cloudstack)
+		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -3,11 +3,19 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
+	corev1 "k8s.io/api/core/v1"
 )
+
+type cloudStackAPIUpgradeTestStep struct {
+	name         string
+	configFiller api.ClusterConfigFiller
+}
 
 type cloudStackAPIUpgradeTest struct {
 	name string
@@ -15,49 +23,50 @@ type cloudStackAPIUpgradeTest struct {
 	steps []cloudStackAPIUpgradeTestStep
 }
 
-type cloudStackAPIUpgradeTestStep struct {
-	name         string
-	configFiller api.ClusterConfigFiller
+func clusterPrefix(value string, prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, value)
 }
 
-func defaultCloudStackAPIUpgradeTestFillers(cloudstack *framework.CloudStack) api.ClusterConfigFiller {
-	return api.JoinClusterConfigFillers(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-		// Add new WorkerNodeGroups
-		cloudstack.WithWorkerNodeGroup("md-0", framework.WithWorkerNodeGroup("md-0", api.WithCount(1))),
-		cloudstack.WithWorkerNodeGroup("md-1", framework.WithWorkerNodeGroup("md-1", api.WithCount(1))),
-		cloudstack.WithRedhat123(),
-	)
-}
-
-func defaultCloudStackAPIUpgradeTestStep(cloudstack *framework.CloudStack) cloudStackAPIUpgradeTestStep {
+func cloudStackAPIUpdateTestBaseStep(e *framework.ClusterE2ETest, cloudstack *framework.CloudStack) cloudStackAPIUpgradeTestStep {
+	clusterName := e.ClusterName
 	return cloudStackAPIUpgradeTestStep{
-		name:         "resetting to default state if needed",
-		configFiller: defaultCloudStackAPIUpgradeTestFillers(cloudstack),
+		name: "setting base state",
+		configFiller: api.JoinClusterConfigFillers(
+			api.ClusterToConfigFiller(
+				api.WithControlPlaneCount(1),
+				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+			),
+			// Add new WorkerNodeGroups
+			cloudstack.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
+			cloudstack.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
+			cloudstack.WithRedhatVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion),
+		),
 	}
 }
 
-func cloudstackAPIManagementClusterUpgradeTests(cloudstack *framework.CloudStack) []cloudStackAPIUpgradeTest {
+func cloudstackAPIManagementClusterUpgradeTests(e *framework.ClusterE2ETest, cloudstack *framework.CloudStack) []cloudStackAPIUpgradeTest {
+	clusterName := e.ClusterName
 	return []cloudStackAPIUpgradeTest{
 		{
 			name: "add and remove labels and taints",
 			steps: []cloudStackAPIUpgradeTestStep{
-				defaultCloudStackAPIUpgradeTestStep(cloudstack),
+				cloudStackAPIUpdateTestBaseStep(e, cloudstack),
 				{
 					name: "adding label and taint to worker node groups",
 					configFiller: api.ClusterToConfigFiller(
-						api.WithWorkerNodeGroup("md-0", api.WithLabel(key1, val2)),
-						api.WithWorkerNodeGroup("md-1", api.WithTaint(framework.NoExecuteTaint())),
+						api.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithLabel(key1, val2)),
+						api.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithTaint(framework.NoExecuteTaint())),
 					),
 				},
 				{
 					name: "removing label and taint from worker node groups",
-					configFiller: api.ClusterToConfigFiller(
-						api.WithWorkerNodeGroup("md-0"),
-						api.WithWorkerNodeGroup("md-1", api.WithNoTaints()),
+					configFiller: api.JoinClusterConfigFillers(
+						api.ClusterToConfigFiller(
+							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+						),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
+						cloudstack.WithRedhatVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},
 			},
@@ -65,17 +74,17 @@ func cloudstackAPIManagementClusterUpgradeTests(cloudstack *framework.CloudStack
 		{
 			name: "scale up and down worker node group",
 			steps: []cloudStackAPIUpgradeTestStep{
-				defaultCloudStackAPIUpgradeTestStep(cloudstack),
+				cloudStackAPIUpdateTestBaseStep(e, cloudstack),
 				{
 					name: "scaling up worker node group",
 					configFiller: api.ClusterToConfigFiller(
-						api.WithWorkerNodeGroup("md-0", api.WithCount(2)),
+						api.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(2)),
 					),
 				},
 				{
 					name: "scaling down worker node group",
 					configFiller: api.ClusterToConfigFiller(
-						api.WithWorkerNodeGroup("md-0", api.WithCount(1)),
+						api.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1)),
 					),
 				},
 			},
@@ -83,7 +92,7 @@ func cloudstackAPIManagementClusterUpgradeTests(cloudstack *framework.CloudStack
 		{
 			name: "replace existing worker node groups",
 			steps: []cloudStackAPIUpgradeTestStep{
-				defaultCloudStackAPIUpgradeTestStep(cloudstack),
+				cloudStackAPIUpdateTestBaseStep(e, cloudstack),
 				{
 					name: "replacing existing worker node groups",
 					configFiller: api.JoinClusterConfigFillers(
@@ -91,9 +100,9 @@ func cloudstackAPIManagementClusterUpgradeTests(cloudstack *framework.CloudStack
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
 						// Add new WorkerNodeGroups
-						cloudstack.WithWorkerNodeGroup("md-2", framework.WithWorkerNodeGroup("md-2", api.WithCount(1))),
-						cloudstack.WithWorkerNodeGroup("md-3", framework.WithWorkerNodeGroup("md-3", api.WithCount(1))),
-						cloudstack.WithRedhat123(),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
+						cloudstack.WithRedhatVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},
 			},
@@ -101,44 +110,56 @@ func cloudstackAPIManagementClusterUpgradeTests(cloudstack *framework.CloudStack
 	}
 }
 
-func cloudStackAPIWorkloadUpgradeTests(cloudstack *framework.CloudStack) []cloudStackAPIUpgradeTest {
+func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack *framework.CloudStack) []cloudStackAPIUpgradeTest {
+	clusterName := wc.ClusterName
+
 	return []cloudStackAPIUpgradeTest{
 		{
 			name: "add and remove labels and taints",
 			steps: []cloudStackAPIUpgradeTestStep{
-				defaultCloudStackAPIUpgradeTestStep(cloudstack),
+				cloudStackAPIUpdateTestBaseStep(wc.ClusterE2ETest, cloudstack),
 				{
 					name: "adding label and taint to worker node groups",
 					configFiller: api.ClusterToConfigFiller(
-						api.WithWorkerNodeGroup("md-0", api.WithLabel(key1, val2)),
-						api.WithWorkerNodeGroup("md-1", api.WithTaint(framework.NoExecuteTaint())),
+						api.WithControlPlaneLabel(cpKey1, cpVal1),
+						api.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithLabel(key1, val2)),
+						api.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithTaint(framework.NoExecuteTaint())),
 					),
 				},
 				{
 					name: "removing label and taint from worker node groups",
-					configFiller: api.ClusterToConfigFiller(
-						api.WithWorkerNodeGroup("md-0"),
-						api.WithWorkerNodeGroup("md-1", api.WithNoTaints()),
+					configFiller: api.JoinClusterConfigFillers(
+						api.ClusterToConfigFiller(
+							api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+						),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
+						cloudstack.WithRedhatVersion(wc.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},
 			},
 		},
 		{
-			name: "scale up and down cp and worker node group",
+			name: "scale up and down cp and worker node group and availability zones ",
 			steps: []cloudStackAPIUpgradeTestStep{
-				defaultCloudStackAPIUpgradeTestStep(cloudstack),
+				cloudStackAPIUpdateTestBaseStep(wc.ClusterE2ETest, cloudstack),
 				{
 					name: "scaling up cp and worker node group",
-					configFiller: api.ClusterToConfigFiller(
-						api.WithControlPlaneCount(3),
-						api.WithWorkerNodeGroup("md-0", api.WithCount(2)),
+					configFiller: api.JoinClusterConfigFillers(
+						api.ClusterToConfigFiller(
+							api.WithControlPlaneCount(3),
+							api.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(2)),
+						),
 					),
 				},
 				{
-					name: "scaling down cp and worker node group",
-					configFiller: api.ClusterToConfigFiller(
-						api.WithControlPlaneCount(1),
-						api.WithWorkerNodeGroup("md-0", api.WithCount(1)),
+					name: "scaling down cp and worker node group + remove availability zone",
+					configFiller: api.JoinClusterConfigFillers(
+						api.ClusterToConfigFiller(
+							api.WithControlPlaneCount(1),
+							api.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1)),
+						),
 					),
 				},
 			},
@@ -146,7 +167,6 @@ func cloudStackAPIWorkloadUpgradeTests(cloudstack *framework.CloudStack) []cloud
 		{
 			name: "replace existing worker node groups",
 			steps: []cloudStackAPIUpgradeTestStep{
-				defaultCloudStackAPIUpgradeTestStep(cloudstack),
 				{
 					name: "replacing existing worker node groups",
 					configFiller: api.JoinClusterConfigFillers(
@@ -154,25 +174,40 @@ func cloudStackAPIWorkloadUpgradeTests(cloudstack *framework.CloudStack) []cloud
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
 						// Add new WorkerNodeGroups
-						cloudstack.WithWorkerNodeGroup("md-2", framework.WithWorkerNodeGroup("md-2", api.WithCount(1))),
-						cloudstack.WithWorkerNodeGroup("md-3", framework.WithWorkerNodeGroup("md-3", api.WithCount(1))),
-						cloudstack.WithRedhat123(),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
+						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
+						cloudstack.WithRedhatVersion(wc.ClusterConfig.Cluster.Spec.KubernetesVersion),
+					),
+				},
+			},
+		},
+		{
+			name: "availability zones and cilium policy enforcement mode",
+			steps: []cloudStackAPIUpgradeTestStep{
+				{
+					name: "add availability zone + update cilium policy enforcement mode always",
+					configFiller: api.JoinClusterConfigFillers(
+						api.ClusterToConfigFiller(
+							api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
+						),
+						api.CloudStackToConfigFiller(
+							framework.UpdateAddCloudStackAz2(),
+						),
+					),
+				},
+				{
+					name: "remove cloudstack availability zone",
+					configFiller: api.JoinClusterConfigFillers(
+						api.CloudStackToConfigFiller(
+							framework.RemoveAllCloudStackAzs(),
+							framework.UpdateAddCloudStackAz1(),
+						),
 					),
 				},
 			},
 		},
 	}
 
-}
-
-func cloudStackAPIClusterBaseChanges(cloudstack *framework.CloudStack) api.ClusterConfigFiller {
-	return api.JoinClusterConfigFillers(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-		defaultCloudStackAPIUpgradeTestFillers(cloudstack),
-	)
 }
 
 func runCloudStackAPIUpgradeTest(t *testing.T, test *framework.ClusterE2ETest, ut cloudStackAPIUpgradeTest) {
@@ -185,7 +220,7 @@ func runCloudStackAPIUpgradeTest(t *testing.T, test *framework.ClusterE2ETest, u
 
 func runCloudStackAPIWorkloadUpgradeTest(t *testing.T, wc *framework.WorkloadCluster, ut cloudStackAPIUpgradeTest) {
 	for _, step := range ut.steps {
-		t.Logf("Running API upgrade test: %s", step.name)
+		t.Logf("Running API workload upgrade test: %s", step.name)
 		wc.UpdateClusterConfig(step.configFiller)
 		wc.ApplyClusterManifest()
 		wc.ValidateClusterStateWithT(t)

--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -141,7 +141,7 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 			},
 		},
 		{
-			name: "scale up and down cp and worker node group and availability zones ",
+			name: "scale up and down cp and worker node group ",
 			steps: []cloudStackAPIUpgradeTestStep{
 				cloudStackAPIUpdateTestBaseStep(wc.ClusterE2ETest, cloudstack),
 				{
@@ -154,7 +154,7 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 					),
 				},
 				{
-					name: "scaling down cp and worker node group + remove availability zone",
+					name: "scaling down cp and worker node group",
 					configFiller: api.JoinClusterConfigFillers(
 						api.ClusterToConfigFiller(
 							api.WithControlPlaneCount(1),

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2023,7 +2023,7 @@ func (e *ClusterE2ETest) ValidateClusterState() {
 
 // ValidateClusterStateWithT runs a set of validations against the cluster to identify an invalid cluster state and accepts *testing.T as a parameter.
 func (e *ClusterE2ETest) ValidateClusterStateWithT(t *testing.T) {
-	validateClusterState(e.T.(*testing.T), e)
+	validateClusterState(t, e)
 }
 
 func validateClusterState(t *testing.T, e *ClusterE2ETest) {

--- a/test/framework/cluster/validations/cloudstack.go
+++ b/test/framework/cluster/validations/cloudstack.go
@@ -1,0 +1,30 @@
+package validations
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
+)
+
+// ValidateAvailabilityZones checks each availability zones defined cloudstackdatacenterconfig in the cluster.Spec
+// have corresponding cloudstackfailuredomains objects within the cluster.
+func ValidateAvailabilityZones(ctx context.Context, vc clusterf.StateValidationConfig) error {
+	c := vc.ManagementClusterClient
+	for _, az := range vc.ClusterSpec.CloudStackDatacenter.Spec.AvailabilityZones {
+		fdName := cloudstackv1.FailureDomainHashedMetaName(az.Name, vc.ClusterSpec.Cluster.Name)
+		key := types.NamespacedName{Namespace: constants.EksaSystemNamespace, Name: fdName}
+
+		failureDomain := &cloudstackv1.CloudStackFailureDomain{}
+		if err := c.Get(context.Background(), key, failureDomain); err != nil {
+			return fmt.Errorf("failed to find failure domain %s corresponding to availability zone %s: %v", az.Name, fdName, err)
+		}
+
+	}
+
+	return nil
+}

--- a/test/framework/cluster/validations/cloudstack_test.go
+++ b/test/framework/cluster/validations/cloudstack_test.go
@@ -1,0 +1,166 @@
+package validations_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/test/framework/cluster/validations"
+)
+
+const (
+	azName1          = "test-az-1"
+	azAccount        = "test-account-1"
+	azDomain         = "test-domain-1"
+	azCredentialsRef = "global"
+)
+
+// type failureDomainOpts func(fd *cloudstackv1.CloudStackFailureDomain)
+
+// func failureDomain(opts ...failureDomainOpts) *cloudstackv1.CloudStackFailureDomain {
+// 	fd := &cloudstackv1.CloudStackFailureDomain{
+// 		TypeMeta: metav1.TypeMeta{
+// 			Kind:       "CloudStackFailureDomain",
+// 			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+// 		},
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Namespace: constants.EksaSystemNamespace,
+// 			Name:      "test-failure-domain",
+// 		},
+// 		Spec: cloudstackv1.CloudStackFailureDomainSpec{
+// 			Name:    azName1,
+// 			Zone:    cloudstackv1.CloudStackZoneSpec{},
+// 			Account: azAccount,
+// 			Domain:  azDomain,
+// 			ACSEndpoint: corev1.SecretReference{
+// 				Name:      azCredentialsRef,
+// 				Namespace: constants.EksaSystemNamespace,
+// 			},
+// 		},
+// 	}
+
+// 	for _, opt := range opts {
+// 		opt(fd)
+// 	}
+
+// 	return fd
+// }
+
+// type availabilityZoneOpts func(az *v1alpha1.CloudStackAvailabilityZone)
+
+// func availabilityZone(opts ...availabilityZoneOpts) *v1alpha1.CloudStackAvailabilityZone {
+// 	az := &v1alpha1.CloudStackAvailabilityZone{
+// 		Name:                  azName1,
+// 		CredentialsRef:        azCredentialsRef,
+// 		Domain:                azDomain,
+// 		Account:               azAccount,
+// 		ManagementApiEndpoint: "test-api-endpoint",
+// 		Zone:                  v1alpha1.CloudStackZone{},
+// 	}
+
+// 	for _, opt := range opts {
+// 		opt(az)
+// 	}
+
+// 	return az
+// }
+
+func TestValidateAvailabilityZones(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	tests := []struct {
+		name                 string
+		availabilityZones    []v1alpha1.CloudStackAvailabilityZone
+		failureDomainObjects []client.Object
+		wantErr              string
+	}{
+		{
+			name: "found az failure domain",
+			availabilityZones: []v1alpha1.CloudStackAvailabilityZone{
+				{
+					Name:                  azName1,
+					CredentialsRef:        azCredentialsRef,
+					Domain:                azDomain,
+					Account:               azAccount,
+					ManagementApiEndpoint: "test-api-endpoint",
+					Zone:                  v1alpha1.CloudStackZone{},
+				},
+			},
+			failureDomainObjects: []client.Object{
+				&cloudstackv1.CloudStackFailureDomain{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CloudStackFailureDomain",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: constants.EksaSystemNamespace,
+						Name:      cloudstackv1.FailureDomainHashedMetaName(azName1, clusterName),
+					},
+					Spec: cloudstackv1.CloudStackFailureDomainSpec{
+						Name:    azName1,
+						Zone:    cloudstackv1.CloudStackZoneSpec{},
+						Account: azAccount,
+						Domain:  azDomain,
+						ACSEndpoint: corev1.SecretReference{
+							Name:      azCredentialsRef,
+							Namespace: constants.EksaSystemNamespace,
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+
+		{
+			name: "missing az failure domain",
+			availabilityZones: []v1alpha1.CloudStackAvailabilityZone{
+				{
+					Name:                  azName1,
+					CredentialsRef:        azCredentialsRef,
+					Domain:                azDomain,
+					Account:               azAccount,
+					ManagementApiEndpoint: "test-api-endpoint",
+					Zone:                  v1alpha1.CloudStackZone{},
+				},
+			},
+			failureDomainObjects: []client.Object{},
+			wantErr:              "failed to find failure domain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster = testCluster()
+				s.CloudStackDatacenter = &v1alpha1.CloudStackDatacenterConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: clusterNamespace,
+						Name:      clusterName,
+					},
+					Spec: v1alpha1.CloudStackDatacenterConfigSpec{
+						AvailabilityZones: tt.availabilityZones,
+					},
+				}
+			})
+
+			vt := newStateValidatorTest(t, spec)
+			vt.createTestObjects(ctx)
+			vt.createManagementClusterObjects(ctx, tt.failureDomainObjects...)
+			err := validations.ValidateAvailabilityZones(ctx, vt.config)
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}

--- a/test/framework/cluster/validations/cloudstack_test.go
+++ b/test/framework/cluster/validations/cloudstack_test.go
@@ -24,56 +24,6 @@ const (
 	azCredentialsRef = "global"
 )
 
-// type failureDomainOpts func(fd *cloudstackv1.CloudStackFailureDomain)
-
-// func failureDomain(opts ...failureDomainOpts) *cloudstackv1.CloudStackFailureDomain {
-// 	fd := &cloudstackv1.CloudStackFailureDomain{
-// 		TypeMeta: metav1.TypeMeta{
-// 			Kind:       "CloudStackFailureDomain",
-// 			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
-// 		},
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Namespace: constants.EksaSystemNamespace,
-// 			Name:      "test-failure-domain",
-// 		},
-// 		Spec: cloudstackv1.CloudStackFailureDomainSpec{
-// 			Name:    azName1,
-// 			Zone:    cloudstackv1.CloudStackZoneSpec{},
-// 			Account: azAccount,
-// 			Domain:  azDomain,
-// 			ACSEndpoint: corev1.SecretReference{
-// 				Name:      azCredentialsRef,
-// 				Namespace: constants.EksaSystemNamespace,
-// 			},
-// 		},
-// 	}
-
-// 	for _, opt := range opts {
-// 		opt(fd)
-// 	}
-
-// 	return fd
-// }
-
-// type availabilityZoneOpts func(az *v1alpha1.CloudStackAvailabilityZone)
-
-// func availabilityZone(opts ...availabilityZoneOpts) *v1alpha1.CloudStackAvailabilityZone {
-// 	az := &v1alpha1.CloudStackAvailabilityZone{
-// 		Name:                  azName1,
-// 		CredentialsRef:        azCredentialsRef,
-// 		Domain:                azDomain,
-// 		Account:               azAccount,
-// 		ManagementApiEndpoint: "test-api-endpoint",
-// 		Zone:                  v1alpha1.CloudStackZone{},
-// 	}
-
-// 	for _, opt := range opts {
-// 		opt(az)
-// 	}
-
-// 	return az
-// }
-
 func TestValidateAvailabilityZones(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -358,8 +358,7 @@ func (e *ClusterE2ETest) pushStagedChanges(ctx context.Context, commitMessage st
 	return nil
 }
 
-// PushWorkloadClusterToGit builds the workload cluster config file for git and pushing changes to git.
-func (e *ClusterE2ETest) PushWorkloadClusterToGit(w *WorkloadCluster, opts ...api.ClusterConfigFiller) {
+func (e *ClusterE2ETest) pushWorkloadClusterToGit(w *WorkloadCluster, opts ...api.ClusterConfigFiller) error {
 	ctx := context.Background()
 	e.initGit(ctx)
 	// Pull remote config using managment cluster
@@ -380,13 +379,15 @@ func (e *ClusterE2ETest) PushWorkloadClusterToGit(w *WorkloadCluster, opts ...ap
 	// Marshall w.ClusterConfig and write it to the repo path
 	e.buildWorkloadClusterConfigFileForGit(w)
 	if err := e.addWorkloadClusterConfigToGit(ctx, w); err != nil {
-		e.T.Fatalf("Error pushing local changes to remote git repo: %v", err)
+		return fmt.Errorf("failed to push local changes to remote git repo: %v", err)
 	}
+
 	e.T.Logf("Successfully pushed version controlled cluster configuration")
+
+	return nil
 }
 
-// DeleteWorkloadClusterFromGit deletes a workload cluster config file and pushes the changes to git.
-func (e *ClusterE2ETest) DeleteWorkloadClusterFromGit(w *WorkloadCluster) {
+func (e *ClusterE2ETest) deleteWorkloadClusterFromGit(w *WorkloadCluster) error {
 	ctx := context.Background()
 	e.initGit(ctx)
 
@@ -397,13 +398,15 @@ func (e *ClusterE2ETest) DeleteWorkloadClusterFromGit(w *WorkloadCluster) {
 
 	e.T.Log("Deleting local cluster directory in git repo")
 	if err := os.Remove(e.workloadClusterConfigGitPath(w)); err != nil {
-		e.T.Fatalf("Error removing local cluster config: %v", err)
+		return fmt.Errorf("failed to remove local cluster config: %v", err)
 	}
 
 	if err := e.deleteWorkloadClusterConfigFromGit(ctx, w); err != nil {
-		w.T.Fatalf("Error pushing local changes to remote git repo: %v", err)
+		return fmt.Errorf("failed to push local changes to remote git repo: %v", err)
 	}
 	w.T.Logf("Successfully deleted version controlled cluster")
+
+	return nil
 }
 
 func (e *ClusterE2ETest) parseClusterConfigFromLocalGitRepo() {

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
 type MulticlusterE2ETest struct {
@@ -139,10 +141,20 @@ func (m *MulticlusterE2ETest) DeleteTinkerbellManagementCluster() {
 
 // PushWorkloadClusterToGit builds the workload cluster config file for git and pushing changes to git.
 func (m *MulticlusterE2ETest) PushWorkloadClusterToGit(w *WorkloadCluster, opts ...api.ClusterConfigFiller) {
-	m.ManagementCluster.PushWorkloadClusterToGit(w, opts...)
+	err := retrier.Retry(10, 5*time.Second, func() error {
+		return m.ManagementCluster.pushWorkloadClusterToGit(w, opts...)
+	})
+	if err != nil {
+		w.T.Fatalf("Error pushing workload cluster changes to git: %v", err)
+	}
 }
 
 // DeleteWorkloadClusterFromGit deletes a workload cluster config file and pushes the changes to git.
 func (m *MulticlusterE2ETest) DeleteWorkloadClusterFromGit(w *WorkloadCluster) {
-	m.ManagementCluster.DeleteWorkloadClusterFromGit(w)
+	err := retrier.Retry(10, 5*time.Second, func() error {
+		return m.ManagementCluster.deleteWorkloadClusterFromGit(w)
+	})
+	if err != nil {
+		w.T.Fatalf("Error deleting workload cluster changes from git: %v", err)
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*
[#1237 internal](https://github.com/aws/eks-anywhere-internal/issues/1237)

*Description of changes:*
This PR add an e2e test that that tests the following features for the CloudStack API
- Added TestCloudStackKubernetes124RedHatAPI that tests the API with k8s 1.24
- Added new workload cluster TestCloudStackMulticlusterWorkloadClusterAPI that tests the API with k8s 1.24
- Added more upgrade tests to TestCloudStackMulticlusterWorkloadClusterAPI (and for GitOps):
   - add and remove cloudstack availability zones
   - update cilium enforcement policy mode to 'always'
 - Added TestCloudStackMulticlusterWorkloadClusterWithNewSecretCredentialsAPI  (and for GitOps) that tests:
   - creating new secret and creating a workload cluster that uses the new secret

See the testing doc for the full list of scenarios we are going to eventually cover [here](https://quip-amazon.com/99bUA1xK7bt0/CloudStack-Full-Lifecycle-API-Testing



*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

