### PR TITLE
changing example keys in doc to not get caught by appsec scans

### DIFF
--- a/docs/content/en/docs/reference/packagespec/credential-provider-package/v0.1.0.md
+++ b/docs/content/en/docs/reference/packagespec/credential-provider-package/v0.1.0.md
@@ -48,8 +48,8 @@ The secret can exist in two forms: either a base64 encoding of a credential conf
 Example credential
 ```
 [default]
-aws_access_key_id=AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_access_key_id=EXAMPLE_ACCESS_KEY
+aws_secret_access_key=EXAMPLE_SECRET_KEY
 region=us-west-2
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

