### PR TITLE
Patch incorrect CloudStack upgrade comparison

### DIFF
--- a/pkg/providers/cloudstack/machinetemplate.go
+++ b/pkg/providers/cloudstack/machinetemplate.go
@@ -23,5 +23,9 @@ func GetMachineTemplate(ctx context.Context, client kubernetes.Client, name, nam
 
 // machineTemplateEqual returns a boolean indicating whether the provided CloudStackMachineTemplates are equal.
 func machineTemplateEqual(new, old *cloudstackv1.CloudStackMachineTemplate) bool {
-	return equality.Semantic.DeepDerivative(new.Spec, old.Spec)
+	// Compare new -> old and old -> new because DeepDerivative ignores fields in the first param
+	// that are default values. This is important for cases where an optional field is removed
+	// from the spec.
+	return equality.Semantic.DeepDerivative(new.Spec, old.Spec) &&
+		equality.Semantic.DeepDerivative(old.Spec, new.Spec)
 }

--- a/pkg/providers/cloudstack/testdata/test_worker_spec.yaml
+++ b/pkg/providers/cloudstack/testdata/test_worker_spec.yaml
@@ -1,0 +1,109 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test-cp
+  datacenterRef:
+    kind: CloudStackDatacenterConfig
+    name: test
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test-etcd
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+  - count: 3
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test
+    name: md-0
+    taints:
+    - key: key2
+      value: val2
+      effect: PreferNoSchedule
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  account: "admin"
+  domain: "domain1"
+  zones:
+  - name: "zone1"
+    network:
+      name: "net1"
+  managementApiEndpoint: "http://127.16.0.1:8080/client/api"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+  affinityGroupIds:
+  - control-plane-anti-affinity
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+  affinityGroupIds:
+  - worker-affinity
+  userCustomDetails:
+    foo: bar
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test-etcd
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+  affinityGroupIds:
+  - etcd-affinity
+
+---

--- a/pkg/providers/cloudstack/workers_test.go
+++ b/pkg/providers/cloudstack/workers_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
-func TestWorkersSpecUpgradeCluster(t *testing.T) {
+func TestWorkersSpec(t *testing.T) {
 	logger := test.NewNullLogger()
 	ctx := context.Background()
 

--- a/pkg/providers/cloudstack/workers_test.go
+++ b/pkg/providers/cloudstack/workers_test.go
@@ -2,9 +2,11 @@ package cloudstack_test
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"testing"
-	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,192 +17,605 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
-func TestWorkersSpecNewCluster(t *testing.T) {
-	g := NewWithT(t)
-	logger := test.NewNullLogger()
-	ctx := context.Background()
-	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
-	client := test.NewFakeKubeClient()
-	workers, err := cloudstack.WorkersSpec(ctx, logger, client, spec)
-
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(workers).NotTo(BeNil())
-	g.Expect(workers.Groups).To(HaveLen(2))
-	g.Expect(workers.Groups).To(ConsistOf(
-		clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
-			KubeadmConfigTemplate:   kubeadmConfigTemplate(),
-			MachineDeployment:       machineDeployment(),
-			ProviderMachineTemplate: machineTemplate(),
-		},
-		clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
-			KubeadmConfigTemplate: kubeadmConfigTemplate(
-				func(kct *bootstrapv1.KubeadmConfigTemplate) {
-					kct.Name = "test-md-1-1"
-				},
-			),
-			MachineDeployment: machineDeployment(
-				func(md *clusterv1.MachineDeployment) {
-					md.Name = "test-md-1"
-					md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
-					md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
-					md.Spec.Replicas = ptr.Int32(2)
-				},
-			),
-			ProviderMachineTemplate: machineTemplate(
-				func(vmt *cloudstackv1.CloudStackMachineTemplate) {
-					vmt.Name = "test-md-1-1"
-				},
-			),
-		},
-	))
-}
-
 func TestWorkersSpecUpgradeCluster(t *testing.T) {
-	g := NewWithT(t)
 	logger := test.NewNullLogger()
 	ctx := context.Background()
-	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
-	oldGroup1 := &clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
-		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
-		MachineDeployment:       machineDeployment(),
-		ProviderMachineTemplate: machineTemplate(),
-	}
-	oldGroup2 := &clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
-		KubeadmConfigTemplate: kubeadmConfigTemplate(
-			func(kct *bootstrapv1.KubeadmConfigTemplate) {
-				kct.Name = "test-md-1-1"
+
+	spec := test.NewFullClusterSpec(t, "testdata/test_worker_spec.yaml")
+
+	for _, tc := range []struct {
+		Name      string
+		Configure func(*cluster.Spec)
+		Exists    func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]
+		Expect    func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]
+	}{
+		// Create
+		{
+			Name: "Create",
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
 			},
-		),
-		MachineDeployment: machineDeployment(
-			func(md *clusterv1.MachineDeployment) {
-				md.Name = "test-md-1"
-				md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
-				md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
-				md.Spec.Replicas = ptr.Int32(2)
+		},
+		{
+			Name: "CreateMultipleWorkerNodeGroups",
+			Configure: func(s *cluster.Spec) {
+				// Re-use the existing worker node group.
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = append(
+					s.Cluster.Spec.WorkerNodeGroupConfigurations,
+					s.Cluster.Spec.WorkerNodeGroupConfigurations[0],
+				)
+				s.Cluster.Spec.WorkerNodeGroupConfigurations[1].Name = "md-1"
 			},
-		),
-		ProviderMachineTemplate: machineTemplate(
-			func(vmt *cloudstackv1.CloudStackMachineTemplate) {
-				vmt.Name = "test-md-1-1"
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Name = "test-md-1-1"
+						}),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Name = "test-md-1"
+							md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-1-1"
+						}),
+					},
+				}
 			},
-		),
-	}
-
-	// Always make copies before passing to client since it does modifies the api objects
-	// Like for example, the ResourceVersion
-	expectedGroup1 := oldGroup1.DeepCopy()
-	expectedGroup2 := oldGroup2.DeepCopy()
-	objs := make([]kubernetes.Object, 0, 6)
-	objs = append(objs, oldGroup1.Objects()...)
-	objs = append(objs, oldGroup2.Objects()...)
-	client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(objs)...)
-
-	computeOffering := anywherev1.CloudStackResourceIdentifier{
-		Name: "m4-medium",
-	}
-
-	// This will cause a change in the cloudstack machine templates, which is immutable
-	spec.CloudStackMachineConfigs["test"].Spec.ComputeOffering = *computeOffering.DeepCopy()
-
-	// This will cause a change in the kubeadmconfigtemplate which we also treat as immutable
-	spec.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints = []corev1.Taint{}
-	spec.Cluster.Spec.WorkerNodeGroupConfigurations[1].Taints = []corev1.Taint{}
-
-	expectedGroup1.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
-	expectedGroup1.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
-	expectedGroup1.KubeadmConfigTemplate.Name = "test-md-0-2"
-	expectedGroup1.KubeadmConfigTemplate.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{}
-	expectedGroup1.ProviderMachineTemplate.Name = "test-md-0-2"
-	expectedGroup1.ProviderMachineTemplate.Spec.Spec.Spec.Offering = cloudstackv1.CloudStackResourceIdentifier{
-		ID:   computeOffering.Id,
-		Name: computeOffering.Name,
-	}
-
-	expectedGroup2.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-2"
-	expectedGroup2.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-2"
-	expectedGroup2.KubeadmConfigTemplate.Name = "test-md-1-2"
-	expectedGroup2.KubeadmConfigTemplate.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{}
-	expectedGroup2.ProviderMachineTemplate.Name = "test-md-1-2"
-	expectedGroup2.ProviderMachineTemplate.Spec.Spec.Spec.Offering = cloudstackv1.CloudStackResourceIdentifier{
-		ID:   computeOffering.Id,
-		Name: computeOffering.Name,
-	}
-
-	workers, err := cloudstack.WorkersSpec(ctx, logger, client, spec)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(workers).NotTo(BeNil())
-	g.Expect(workers.Groups).To(HaveLen(2))
-	g.Expect(workers.Groups).To(ConsistOf(*expectedGroup1, *expectedGroup2))
-}
-
-func TestWorkersSpecUpgradeClusterNoMachineTemplateChanges(t *testing.T) {
-	g := NewWithT(t)
-	logger := test.NewNullLogger()
-	ctx := context.Background()
-	spec := test.NewFullClusterSpec(t, "testdata/cluster_main_multiple_worker_node_groups.yaml")
-	oldGroup1 := &clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
-		KubeadmConfigTemplate:   kubeadmConfigTemplate(),
-		MachineDeployment:       machineDeployment(),
-		ProviderMachineTemplate: machineTemplate(),
-	}
-	oldGroup2 := &clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
-		KubeadmConfigTemplate: kubeadmConfigTemplate(
-			func(kct *bootstrapv1.KubeadmConfigTemplate) {
-				kct.Name = "test-md-1-1"
+		},
+		{
+			Name: "CreateTaints",
+			Configure: func(s *cluster.Spec) {
+				s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints = []corev1.Taint{
+					{
+						Key:    "test-taint",
+						Value:  "value",
+						Effect: "Effect",
+					},
+				}
 			},
-		),
-		MachineDeployment: machineDeployment(
-			func(md *clusterv1.MachineDeployment) {
-				md.Name = "test-md-1"
-				md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-1-1"
-				md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-1-1"
-				md.Spec.Replicas = ptr.Int32(2)
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{
+								{
+									Key:    "test-taint",
+									Value:  "value",
+									Effect: "Effect",
+								},
+							}
+						}),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {}),
+					},
+				}
 			},
-		),
-		ProviderMachineTemplate: machineTemplate(
-			func(vmt *cloudstackv1.CloudStackMachineTemplate) {
-				vmt.Name = "test-md-1-1"
+		},
+		{
+			Name: "CreateDiskOffering",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.DiskOffering = &anywherev1.CloudStackResourceDiskOffering{
+					CustomSize: 10,
+					MountPath:  "/mnt/sda",
+					Device:     "/dev/sda",
+					Filesystem: "ext3",
+					Label:      "label",
+				}
 			},
-		),
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment:     machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							spec := &csmt.Spec.Spec.Spec
+
+							clientutil.AddAnnotation(csmt, "device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "/dev/sda")
+							clientutil.AddAnnotation(csmt, "filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "ext3")
+							clientutil.AddAnnotation(csmt, "label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "label")
+							clientutil.AddAnnotation(csmt, "mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "/mnt/sda")
+
+							spec.DiskOffering = cloudstackv1.CloudStackResourceDiskOffering{
+								CustomSize: 10,
+								MountPath:  "/mnt/sda",
+								Device:     "/dev/sda",
+								Filesystem: "ext3",
+								Label:      "label",
+							}
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "CreateSymlinks",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.Symlinks = map[string]string{"foo": "bar"}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Spec.Template.Spec.PreKubeadmCommands = append(
+								kct.Spec.Template.Spec.PreKubeadmCommands,
+								"if [ ! -L foo ] ;\n  then\n    mv foo foo-$(tr -dc A-Za-z0-9 \u003c /dev/urandom | head -c 10) ;\n    mkdir -p bar \u0026\u0026 ln -s bar foo ;\n  else echo \"foo already symlnk\" ;\nfi",
+							)
+						}),
+						MachineDeployment: machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							clientutil.AddAnnotation(csmt, "symlinks.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "foo:bar")
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "CreateAffinityGroupIDs",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.AffinityGroupIds = []string{"affinity_group_id"}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment:     machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Spec.Spec.Spec.AffinityGroupIDs = []string{"affinity_group_id"}
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "CreateUserCustomDetails",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.UserCustomDetails = map[string]string{"qux": "baz"}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment:     machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Spec.Spec.Spec.Details = map[string]string{"qux": "baz"}
+						}),
+					},
+				}
+			},
+		},
+
+		// Upgrade
+		{
+			Name: "UpgradeTaints",
+			Configure: func(s *cluster.Spec) {
+				s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Taints = []corev1.Taint{
+					{
+						Key:    "change-taint",
+						Value:  "value",
+						Effect: "Effect",
+					},
+				}
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{
+								{
+									Key:    "test-taint",
+									Value:  "value",
+									Effect: "Effect",
+								},
+							}
+						}),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Name = "test-md-0-2"
+							kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.Taints = []corev1.Taint{
+								{
+									Key:    "change-taint",
+									Value:  "value",
+									Effect: "Effect",
+								},
+							}
+						}),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+		},
+		{
+			Name: "UpgradeComputeOffering",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.ComputeOffering = anywherev1.CloudStackResourceIdentifier{
+					Name: "m4-medium",
+				}
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Name = "test-md-0-1"
+						}),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+							md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-1"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.Offering = cloudstackv1.CloudStackResourceIdentifier{
+								Name: "m4-medium",
+							}
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "UpgradeDiskOffering",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.DiskOffering = &anywherev1.CloudStackResourceDiskOffering{
+					CustomSize: 10,
+					MountPath:  "/mnt/sda",
+					Device:     "/dev/sda",
+					Filesystem: "ext3",
+					Label:      "label",
+				}
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.DiskOffering = cloudstackv1.CloudStackResourceDiskOffering{
+								CustomSize: 10,
+								MountPath:  "/mnt/sda",
+								Device:     "/dev/sda",
+								Filesystem: "ext3",
+								Label:      "label",
+							}
+							clientutil.AddAnnotation(csmt, "device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "/dev/sda")
+							clientutil.AddAnnotation(csmt, "filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "ext3")
+							clientutil.AddAnnotation(csmt, "label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "label")
+							clientutil.AddAnnotation(csmt, "mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "/mnt/sda")
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "UpgradeSymlinks",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.Symlinks = map[string]string{"foo": "bar"}
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Name = "test-md-0-2"
+							kct.Spec.Template.Spec.PreKubeadmCommands = append(
+								kct.Spec.Template.Spec.PreKubeadmCommands,
+								"if [ ! -L foo ] ;\n  then\n    mv foo foo-$(tr -dc A-Za-z0-9 \u003c /dev/urandom | head -c 10) ;\n    mkdir -p bar \u0026\u0026 ln -s bar foo ;\n  else echo \"foo already symlnk\" ;\nfi",
+							)
+						}),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							clientutil.AddAnnotation(csmt, "symlinks.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "foo:bar")
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "UpgradeAffinityGroups",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.AffinityGroupIds = []string{"changed"}
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate:   kubeadmConfigTemplate(),
+						MachineDeployment:       machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.AffinityGroupIDs = []string{"changed"}
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "UpgradeUserCustomDetails",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.UserCustomDetails = map[string]string{"qux": "baz"}
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment:     machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Spec.Spec.Spec.Details = map[string]string{"foo": "bar"}
+						}),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.Details = map[string]string{"qux": "baz"}
+						}),
+					},
+				}
+			},
+		},
+
+		// Remove
+		{
+			Name: "RemoveDiskOffering",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.DiskOffering = nil
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.DiskOffering = cloudstackv1.CloudStackResourceDiskOffering{
+								CustomSize: 10,
+								MountPath:  "/mnt/sda",
+								Device:     "/dev/sda",
+								Filesystem: "ext3",
+								Label:      "label",
+							}
+							clientutil.AddAnnotation(csmt, "device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "/dev/sda")
+							clientutil.AddAnnotation(csmt, "filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "ext3")
+							clientutil.AddAnnotation(csmt, "label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "label")
+							clientutil.AddAnnotation(csmt, "mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "/mnt/sda")
+						}),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-3"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-3"
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "RemoveSymlinks",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.Symlinks = nil
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Name = "test-md-0-2"
+							kct.Spec.Template.Spec.PreKubeadmCommands = append(
+								kct.Spec.Template.Spec.PreKubeadmCommands,
+								"if [ ! -L foo ] ;\n  then\n    mv foo foo-$(tr -dc A-Za-z0-9 \u003c /dev/urandom | head -c 10) ;\n    mkdir -p bar \u0026\u0026 ln -s bar foo ;\n  else echo \"foo already symlnk\" ;\nfi",
+							)
+						}),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							clientutil.AddAnnotation(csmt, "symlinks.cloudstack.anywhere.eks.amazonaws.com/v1alpha1", "foo:bar")
+						}),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(func(kct *bootstrapv1.KubeadmConfigTemplate) {
+							kct.Name = "test-md-0-2"
+						}),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(),
+					},
+				}
+			},
+		},
+		{
+			Name: "RemoveAffinityGroups",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.AffinityGroupIds = nil
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment:     machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Spec.Spec.Spec.AffinityGroupIDs = []string{"affinity_group_id"}
+						}),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.AffinityGroupIDs = nil
+						}),
+					},
+				}
+			},
+		},
+		{
+			Name: "RemoveUserCustomDetails",
+			Configure: func(s *cluster.Spec) {
+				s.CloudStackMachineConfigs["test"].Spec.UserCustomDetails = nil
+			},
+			Exists: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment:     machineDeployment(),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Spec.Spec.Spec.Details = map[string]string{"foo": "bar"}
+						}),
+					},
+				}
+			},
+			Expect: func() []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate] {
+				return []clusterapi.WorkerGroup[*cloudstackv1.CloudStackMachineTemplate]{
+					{
+						KubeadmConfigTemplate: kubeadmConfigTemplate(),
+						MachineDeployment: machineDeployment(func(md *clusterv1.MachineDeployment) {
+							md.Spec.Template.Spec.InfrastructureRef.Name = "test-md-0-2"
+						}),
+						ProviderMachineTemplate: machineTemplate(func(csmt *cloudstackv1.CloudStackMachineTemplate) {
+							csmt.Name = "test-md-0-2"
+							csmt.Spec.Spec.Spec.Details = nil
+						}),
+					},
+				}
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Copy the foundational spec already read from disk so we don't pollute tests.
+			spec := spec.DeepCopy()
+
+			if tc.Configure != nil {
+				tc.Configure(spec)
+			}
+
+			// Build a client with all the objects that should already exist in the cluster.
+			var objects []kubernetes.Object
+			if tc.Exists != nil {
+				for _, group := range tc.Exists() {
+					objects = append(objects, group.Objects()...)
+				}
+			}
+			client := test.NewFakeKubeClient(clientutil.ObjectsToClientObjects(objects)...)
+
+			expect := tc.Expect()
+
+			workers, err := cloudstack.WorkersSpec(ctx, logger, client, spec)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Optionally dump expect and got. This proved useful in debugging as the Ginkgo output
+			// gets truncated. Compare the files in your IDE.
+			if os.Getenv("T_DUMP") == "true" {
+				expectGroups, _ := json.MarshalIndent(expect, "", "\t")
+				receivedGroups, _ := json.MarshalIndent(workers.Groups, "", "\t")
+				_ = os.WriteFile("groups_expected.json", expectGroups, 0o666)
+				_ = os.WriteFile("groups_received.json", receivedGroups, 0o666)
+				_ = os.WriteFile("groups_expected_received.diff", []byte(cmp.Diff(expectGroups, receivedGroups)), 0o666)
+			}
+
+			g.Expect(workers).NotTo(BeNil())
+			g.Expect(workers.Groups).To(HaveLen(len(expect)))
+			for _, e := range expect {
+				g.Expect(workers.Groups).To(ContainElement(e))
+			}
+		})
 	}
-
-	// Always make copies before passing to client since it does modifies the api objects
-	// Like for example, the ResourceVersion
-	expectedGroup1 := oldGroup1.DeepCopy()
-	expectedGroup2 := oldGroup2.DeepCopy()
-
-	// This mimics what would happen if the objects were returned by a real api server
-	// It helps make sure that the immutable object comparison is able to deal with these
-	// kind of changes.
-	oldGroup1.ProviderMachineTemplate.CreationTimestamp = metav1.NewTime(time.Now())
-	oldGroup2.ProviderMachineTemplate.CreationTimestamp = metav1.NewTime(time.Now())
-
-	// This is testing defaults. We don't set ID in our machine templates,
-	// but it's possible that some default logic does. We need to take this into
-	// consideration when checking for equality.
-	oldGroup1.ProviderMachineTemplate.Spec.Spec.Spec.ProviderID = ptr.String("default-id")
-	oldGroup2.ProviderMachineTemplate.Spec.Spec.Spec.ProviderID = ptr.String("default-id")
-
-	client := test.NewFakeKubeClient(
-		oldGroup1.MachineDeployment,
-		oldGroup1.KubeadmConfigTemplate,
-		oldGroup1.ProviderMachineTemplate,
-		oldGroup2.MachineDeployment,
-		oldGroup2.KubeadmConfigTemplate,
-		oldGroup2.ProviderMachineTemplate,
-	)
-
-	workers, err := cloudstack.WorkersSpec(ctx, logger, client, spec)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(workers).NotTo(BeNil())
-	g.Expect(workers.Groups).To(HaveLen(2))
-	g.Expect(workers.Groups).To(ConsistOf(*expectedGroup1, *expectedGroup2))
 }
 
 func TestWorkersSpecErrorFromClient(t *testing.T) {


### PR DESCRIPTION
# Summary

A subset of fields for the EKSA CloudStack API do not trigger creation of new CAPI templates when they are removed. The issue stems from the DeepDerivative function used to compare old with new to identify a diff. It does not compare fields when their type is defaulted meaning removal of the data all together isn't considered a change.

This change ensures we identify a diff when removing the fields that would have previously gone unnoticed.

__Example__

```go
old := CloudStackMachineConfig{
  ... 
  UserCustomDetails: map[string]string{"foo": "bar"}
}

new := CloudStackMachineConfig{
  ...
  UserCustomDetails: nil
}

// DeepDerivative(new, old) wouldn't identify a diff because UserCustomDetails is set
// to its default value.
```



Also see https://github.com/aws/eks-anywhere-internal/issues/1327.