### PR TITLE
Improve cloudstack side effects e2e test

### DIFF
--- a/internal/pkg/api/oidc.go
+++ b/internal/pkg/api/oidc.go
@@ -5,67 +5,80 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
-type OIDCConfigOpt func(o *v1alpha1.OIDCConfig)
+// OIDCConfigOpt updates an OIDC config.
+type OIDCConfigOpt func(o *anywherev1.OIDCConfig)
 
-func NewOIDCConfig(name string, opts ...OIDCConfigOpt) *v1alpha1.OIDCConfig {
-	config := &v1alpha1.OIDCConfig{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha1.SchemeBuilder.GroupVersion.String(),
-			Kind:       v1alpha1.OIDCConfigKind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1alpha1.OIDCConfigSpec{},
+// WithOIDCConfig builds a ClusterConfigFiller that adds a OIDCConfig with the
+// given name and spec to the cluster config.
+func WithOIDCConfig(name string, opts ...OIDCConfigOpt) ClusterConfigFiller {
+	return func(c *cluster.Config) {
+		if c.OIDCConfigs == nil {
+			c.OIDCConfigs = make(map[string]*anywherev1.OIDCConfig, 1)
+		}
+
+		oidc, ok := c.OIDCConfigs[name]
+		if !ok {
+			oidc = &anywherev1.OIDCConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+					Kind:       anywherev1.OIDCConfigKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			}
+			c.OIDCConfigs[name] = oidc
+		}
+
+		for _, opt := range opts {
+			opt(oidc)
+		}
 	}
-	for _, opt := range opts {
-		opt(config)
-	}
-	return config
 }
 
 func WithOIDCClientId(id string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
+	return func(o *anywherev1.OIDCConfig) {
 		o.Spec.ClientId = id
 	}
 }
 
 func WithOIDCIssuerUrl(url string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
+	return func(o *anywherev1.OIDCConfig) {
 		o.Spec.IssuerUrl = url
 	}
 }
 
 func WithOIDCUsernameClaim(claim string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
+	return func(o *anywherev1.OIDCConfig) {
 		o.Spec.UsernameClaim = claim
 	}
 }
 
 func WithOIDCUsernamePrefix(prefix string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
+	return func(o *anywherev1.OIDCConfig) {
 		o.Spec.UsernamePrefix = prefix
 	}
 }
 
 func WithOIDCGroupsClaim(claim string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
+	return func(o *anywherev1.OIDCConfig) {
 		o.Spec.GroupsClaim = claim
 	}
 }
 
 func WithOIDCGroupsPrefix(prefix string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
+	return func(o *anywherev1.OIDCConfig) {
 		o.Spec.GroupsPrefix = prefix
 	}
 }
 
 func WithOIDCRequiredClaims(claim, value string) OIDCConfigOpt {
-	return func(o *v1alpha1.OIDCConfig) {
-		o.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{
+	return func(o *anywherev1.OIDCConfig) {
+		o.Spec.RequiredClaims = []anywherev1.OIDCConfigRequiredClaim{{
 			Claim: claim,
 			Value: value,
 		}}

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -7,12 +7,14 @@ package e2e
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/test/framework"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // AWS IAM Auth
@@ -820,72 +822,62 @@ func TestCloudStackUpgradeKubernetes124MulticlusterWorkloadClusterWithGithubFlux
 	)
 }
 
-func TestCloudStackKubernetes123ManagementClusterUpgradeFromLatest(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat123())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube123),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithEtcdCountIfExternal(1),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithClusterFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithKubernetesVersion(v1alpha1.Kube123),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithEtcdCountIfExternal(1),
-			),
-		),
-	)
-
-	runFlowUpgradeManagementClusterCheckForSideEffects(test,
-		framework.NewEKSAReleasePackagedBinary(latestMinorRelease(t)),
-		newEKSAPackagedBinaryForLocalBinary(t),
-	)
+func TestCloudStackKubernetes123WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+	runTestCloudstackManagementClusterUpgradeSideEffects(t, anywherev1.RedHat, anywherev1.Kube123)
 }
 
-func TestCloudStackKubernetes124ManagementClusterUpgradeFromLatest(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat124())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube124),
+func TestCloudStackKubernetes124WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+	runTestCloudstackManagementClusterUpgradeSideEffects(t, anywherev1.RedHat, anywherev1.Kube124)
+}
+
+func runTestCloudstackManagementClusterUpgradeSideEffects(t *testing.T, osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) {
+	latestRelease := latestMinorRelease(t)
+
+	cloudstack := framework.NewCloudStack(t)
+	managementCluster := framework.NewClusterE2ETest(t, cloudstack, framework.PersistentCluster())
+	managementCluster.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	managementCluster.UpdateClusterConfig(
+		api.ClusterToConfigFiller(
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
 			api.WithEtcdCountIfExternal(1),
 		),
+		cloudstack.WithKubeVersion(osFamily, kubeVersion),
 	)
+
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
 
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithClusterFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithKubernetesVersion(v1alpha1.Kube124),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithEtcdCountIfExternal(1),
+	workloadCluster := framework.NewClusterE2ETest(t, cloudstack,
+		framework.WithClusterName(test.NewWorkloadClusterName()),
+	)
+	workloadCluster.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	workloadCluster.UpdateClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithManagementCluster(managementCluster.ClusterName),
+			api.WithControlPlaneCount(2),
+			api.WithControlPlaneLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"),
+			api.RemoveAllWorkerNodeGroups(),
+			api.WithWorkerNodeGroup("workers-0",
+				api.WithCount(3),
+				api.WithLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"),
+			),
+			api.WithEtcdCountIfExternal(3),
+			api.WithCiliumPolicyEnforcementMode(anywherev1.CiliumPolicyModeAlways),
+		),
+		cloudstack.WithWorkerNodeGroup("workers-0",
+			framework.WithWorkerNodeGroup("workers-0",
+				api.WithCount(2),
+				api.WithLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"),
 			),
 		),
+		framework.WithOIDCClusterConfig(t),
+		cloudstack.WithKubeVersion(osFamily, kubeVersion),
 	)
 
+	test.WithWorkloadClusters(workloadCluster)
+
 	runFlowUpgradeManagementClusterCheckForSideEffects(test,
-		framework.NewEKSAReleasePackagedBinary(latestMinorRelease(t)),
+		framework.NewEKSAReleasePackagedBinary(latestRelease),
 		newEKSAPackagedBinaryForLocalBinary(t),
 	)
 }
@@ -2334,7 +2326,7 @@ func TestCloudStackWorkloadClusterOIDCAuthAPI(t *testing.T) {
 				api.WithManagementCluster(managementCluster.ClusterName),
 				api.WithStackedEtcdTopology(),
 			),
-			framework.WithOIDCConfig(),
+			framework.WithOIDCClusterConfig(t),
 			cloudstack.WithRedhat123(),
 		),
 	)
@@ -2387,7 +2379,7 @@ func TestCloudStackWorkloadClusterOIDCAuthGithubFluxAPI(t *testing.T) {
 				api.WithManagementCluster(managementCluster.ClusterName),
 				api.WithStackedEtcdTopology(),
 			),
-			framework.WithOIDCConfig(),
+			framework.WithOIDCClusterConfig(t),
 			cloudstack.WithRedhat123(),
 		),
 	)

--- a/test/e2e/side_effects.go
+++ b/test/e2e/side_effects.go
@@ -26,12 +26,10 @@ type eksaPackagedBinary interface {
 // and checks that this doesn't cause any side effects (machine rollout) in the workload clusters.
 func runFlowUpgradeManagementClusterCheckForSideEffects(test *framework.MulticlusterE2ETest, currentEKSA, newEKSA eksaPackagedBinary) {
 	test.T.Logf("Creating management cluster with EKS-A version %s", currentEKSA.Version())
-	test.ManagementCluster.GenerateClusterConfigForVersion(currentEKSA.Version(), framework.ExecuteWithBinary(currentEKSA))
 	test.CreateManagementCluster(framework.ExecuteWithBinary(currentEKSA))
 
 	test.T.Logf("Creating workload clusters with EKS-A version %s", currentEKSA.Version())
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.GenerateClusterConfigForVersion(currentEKSA.Version(), framework.ExecuteWithBinary(currentEKSA))
 		w.CreateCluster(framework.ExecuteWithBinary(currentEKSA))
 	})
 

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -401,3 +401,14 @@ func (c *CloudStack) searchTemplate(ctx context.Context, template string) (strin
 	}
 	return template, nil
 }
+
+// WithKubeVersion returns a cluster config filler that sets the cluster kube version and the right template for all
+// cloudstack machine configs.
+func (c *CloudStack) WithKubeVersion(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
+		api.CloudStackToConfigFiller(
+			api.WithCloudStackTemplateForAllMachines(c.templateForDevRelease(osFamily, kubeVersion)),
+		),
+	)
+}


### PR DESCRIPTION
*Description of changes:*
This makes the test more realistic. It uses more eks-a features which increases the tested surface area and reduces the chances of a bug eluding this check.

*Testing (if applicable):*
Ran the 1.23 test manually. The 1.24 won't pass until we cut a new release, since 0.15 didn't support kubernetes 1.24 for cloudstack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

