### PR TITLE
Only move management cluster objects during management cluster upgrade

### DIFF
--- a/internal/aws-sdk-go-v2/service/snowballdevice/doc.go
+++ b/internal/aws-sdk-go-v2/service/snowballdevice/doc.go
@@ -2,5 +2,4 @@
 
 // Package snowballdevice provides the API client, operations, and parameter types
 // for AWS Snowball Device.
-//
 package snowballdevice

--- a/internal/test/timer.go
+++ b/internal/test/timer.go
@@ -2,8 +2,10 @@ package test
 
 import "time"
 
-var defaultNow = time.Unix(0, 1234567890000*int64(time.Millisecond))
-var newNow = time.Unix(0, 987654321000*int64(time.Millisecond))
+var (
+	defaultNow = time.Unix(0, 1234567890000*int64(time.Millisecond))
+	newNow     = time.Unix(0, 987654321000*int64(time.Millisecond))
+)
 
 func FakeNow() time.Time {
 	return defaultNow

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -99,7 +99,7 @@ type ClusterManager struct {
 type ClusterClient interface {
 	KubernetesClient
 	BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
-	MoveManagement(ctx context.Context, org, target *types.Cluster) error
+	MoveManagement(ctx context.Context, from, target *types.Cluster, clusterName string) error
 	WaitForClusterReady(ctx context.Context, cluster *types.Cluster, timeout string, clusterName string) error
 	WaitForControlPlaneAvailable(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error
 	WaitForControlPlaneReady(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error
@@ -122,6 +122,8 @@ type ClusterClient interface {
 	SaveLog(ctx context.Context, cluster *types.Cluster, deployment *types.Deployment, fileName string, writer filewriter.FileWriter) error
 	GetMachines(ctx context.Context, cluster *types.Cluster, clusterName string) ([]types.Machine, error)
 	GetClusters(ctx context.Context, cluster *types.Cluster) ([]types.CAPICluster, error)
+	PauseCAPICluster(ctx context.Context, cluster, kubeconfig string) error
+	ResumeCAPICluster(ctx context.Context, cluster, kubeconfig string) error
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error)
 	GetEksaVSphereDatacenterConfig(ctx context.Context, VSphereDatacenterName string, kubeconfigFile string, namespace string) (*v1alpha1.VSphereDatacenterConfig, error)
 	UpdateEnvironmentVariablesInNamespace(ctx context.Context, resourceType, resourceName string, envMap map[string]string, cluster *types.Cluster, namespace string) error
@@ -313,8 +315,8 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 		return err
 	}
 
-	logger.V(3).Info("Waiting for all clusters to be ready before move")
-	if err := c.waitForAllClustersReady(ctx, from, c.clusterWaitTimeout.String()); err != nil {
+	logger.V(3).Info("Waiting for management cluster to be ready before move")
+	if err := c.clusterClient.WaitForClusterReady(ctx, from, c.clusterWaitTimeout.String(), clusterName); err != nil {
 		return err
 	}
 
@@ -327,14 +329,14 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 
 	r := retrier.New(c.clusterctlMoveTimeout, retrier.WithRetryPolicy(clusterctlMoveRetryPolicy))
 	err := r.Retry(func() error {
-		return c.clusterClient.MoveManagement(ctx, from, to)
+		return c.clusterClient.MoveManagement(ctx, from, to, clusterName)
 	})
 	if err != nil {
 		return fmt.Errorf("moving CAPI management from source to target: %v", err)
 	}
 
-	logger.V(3).Info("Waiting for control planes to be ready after move")
-	err = c.waitForAllControlPlanes(ctx, to, c.controlPlaneWaitAfterMoveTimeout)
+	logger.V(3).Info("Waiting for workload cluster control plane to be ready after move")
+	err = c.clusterClient.WaitForControlPlaneReady(ctx, to, c.controlPlaneWaitAfterMoveTimeout.String(), clusterName)
 	if err != nil {
 		return err
 	}
@@ -1139,6 +1141,44 @@ func (c *ClusterManager) ApplyBundles(ctx context.Context, clusterSpec *cluster.
 	err = c.clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, bundleObj)
 	if err != nil {
 		return fmt.Errorf("applying bundle spec: %v", err)
+	}
+	return nil
+}
+
+// PauseCAPIWorkloadClusters pauses all workload CAPI clusters except the management cluster
+func (c *ClusterManager) PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error {
+	clusters, err := c.clusterClient.GetClusters(ctx, managementCluster)
+	if err != nil {
+		return err
+	}
+
+	for _, w := range clusters {
+		// skip pausing management cluster
+		if w.Metadata.Name == managementCluster.Name {
+			continue
+		}
+		if err = c.clusterClient.PauseCAPICluster(ctx, w.Metadata.Name, managementCluster.KubeconfigFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ResumeCAPIWorkloadClusters resumes all workload CAPI clusters except the management cluster
+func (c *ClusterManager) ResumeCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error {
+	clusters, err := c.clusterClient.GetClusters(ctx, managementCluster)
+	if err != nil {
+		return err
+	}
+
+	for _, w := range clusters {
+		// skip resuming management cluster
+		if w.Metadata.Name == managementCluster.Name {
+			continue
+		}
+		if err = c.clusterClient.ResumeCAPICluster(ctx, w.Metadata.Name, managementCluster.KubeconfigFile); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -1145,7 +1145,7 @@ func (c *ClusterManager) ApplyBundles(ctx context.Context, clusterSpec *cluster.
 	return nil
 }
 
-// PauseCAPIWorkloadClusters pauses all workload CAPI clusters except the management cluster
+// PauseCAPIWorkloadClusters pauses all workload CAPI clusters except the management cluster.
 func (c *ClusterManager) PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error {
 	clusters, err := c.clusterClient.GetClusters(ctx, managementCluster)
 	if err != nil {
@@ -1164,7 +1164,7 @@ func (c *ClusterManager) PauseCAPIWorkloadClusters(ctx context.Context, manageme
 	return nil
 }
 
-// ResumeCAPIWorkloadClusters resumes all workload CAPI clusters except the management cluster
+// ResumeCAPIWorkloadClusters resumes all workload CAPI clusters except the management cluster.
 func (c *ClusterManager) ResumeCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error {
 	clusters, err := c.clusterClient.GetClusters(ctx, managementCluster)
 	if err != nil {

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -235,6 +235,68 @@ func TestClusterManagerPauseCAPIWorkloadClusters(t *testing.T) {
 	}
 }
 
+func TestClusterManagerPauseCAPIWorkloadClustersErrorGetClusters(t *testing.T) {
+	ctx := context.Background()
+	mgmtClusterName := "cluster-name"
+	mgmtCluster := &types.Cluster{
+		Name:           mgmtClusterName,
+		KubeconfigFile: "mgmt-kubeconfig",
+	}
+	c, m := newClusterManager(t)
+	m.client.EXPECT().GetClusters(ctx, mgmtCluster).Return(nil, errors.New("Error: failed to get clusters"))
+
+	if err := c.PauseCAPIWorkloadClusters(ctx, mgmtCluster); err == nil {
+		t.Error("ClusterManager.PauseCAPIWorkloadClusters() error = nil, wantErr not nil")
+	}
+}
+
+func TestClusterManagerPauseCAPIWorkloadClustersErrorPause(t *testing.T) {
+	ctx := context.Background()
+	mgmtClusterName := "cluster-name"
+	mgmtCluster := &types.Cluster{
+		Name:           mgmtClusterName,
+		KubeconfigFile: "mgmt-kubeconfig",
+	}
+	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: mgmtClusterName}}}
+	c, m := newClusterManager(t)
+	m.client.EXPECT().GetClusters(ctx, mgmtCluster).Return(clusters, nil)
+
+	if err := c.PauseCAPIWorkloadClusters(ctx, mgmtCluster); err != nil {
+		t.Errorf("ClusterManager.PauseCAPIWorkloadClusters() error = %v", err)
+	}
+}
+
+func TestClusterManagerResumeCAPIWorkloadClustersErrorGetClusters(t *testing.T) {
+	ctx := context.Background()
+	mgmtClusterName := "cluster-name"
+	mgmtCluster := &types.Cluster{
+		Name:           mgmtClusterName,
+		KubeconfigFile: "mgmt-kubeconfig",
+	}
+	c, m := newClusterManager(t)
+	m.client.EXPECT().GetClusters(ctx, mgmtCluster).Return(nil, errors.New("Error: failed to get clusters"))
+
+	if err := c.ResumeCAPIWorkloadClusters(ctx, mgmtCluster); err == nil {
+		t.Error("ClusterManager.PauseCAPIWorkloadClusters() error = nil, wantErr not nil")
+	}
+}
+
+func TestClusterManagerResumeCAPIWorkloadClustersErrorResume(t *testing.T) {
+	ctx := context.Background()
+	mgmtClusterName := "cluster-name"
+	mgmtCluster := &types.Cluster{
+		Name:           mgmtClusterName,
+		KubeconfigFile: "mgmt-kubeconfig",
+	}
+	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: mgmtClusterName}}}
+	c, m := newClusterManager(t)
+	m.client.EXPECT().GetClusters(ctx, mgmtCluster).Return(clusters, nil)
+
+	if err := c.ResumeCAPIWorkloadClusters(ctx, mgmtCluster); err != nil {
+		t.Errorf("ClusterManager.PauseCAPIWorkloadClusters() error = %v", err)
+	}
+}
+
 func TestClusterManagerResumeCAPIWorkloadClusters(t *testing.T) {
 	ctx := context.Background()
 	mgmtClusterName := "cluster-name"

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -217,6 +217,42 @@ func TestClusterManagerSaveLogsSuccess(t *testing.T) {
 	}
 }
 
+func TestClusterManagerPauseCAPIWorkloadClusters(t *testing.T) {
+	ctx := context.Background()
+	mgmtClusterName := "cluster-name"
+	mgmtCluster := &types.Cluster{
+		Name:           mgmtClusterName,
+		KubeconfigFile: "mgmt-kubeconfig",
+	}
+	capiClusterName := "capi-cluster"
+	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
+	c, m := newClusterManager(t)
+	m.client.EXPECT().GetClusters(ctx, mgmtCluster).Return(clusters, nil)
+	m.client.EXPECT().PauseCAPICluster(ctx, capiClusterName, mgmtCluster.KubeconfigFile).Return(nil)
+
+	if err := c.PauseCAPIWorkloadClusters(ctx, mgmtCluster); err != nil {
+		t.Errorf("ClusterManager.PauseCAPIWorkloadClusters() error = %v", err)
+	}
+}
+
+func TestClusterManagerResumeCAPIWorkloadClusters(t *testing.T) {
+	ctx := context.Background()
+	mgmtClusterName := "cluster-name"
+	mgmtCluster := &types.Cluster{
+		Name:           mgmtClusterName,
+		KubeconfigFile: "mgmt-kubeconfig",
+	}
+	capiClusterName := "capi-cluster"
+	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
+	c, m := newClusterManager(t)
+	m.client.EXPECT().GetClusters(ctx, mgmtCluster).Return(clusters, nil)
+	m.client.EXPECT().ResumeCAPICluster(ctx, capiClusterName, mgmtCluster.KubeconfigFile).Return(nil)
+
+	if err := c.ResumeCAPIWorkloadClusters(ctx, mgmtCluster); err != nil {
+		t.Errorf("ClusterManager.ResumeCAPIWorkloadClusters() error = %v", err)
+	}
+}
+
 func TestClusterManagerCreateWorkloadClusterSuccess(t *testing.T) {
 	ctx := context.Background()
 	clusterName := "cluster-name"
@@ -1406,19 +1442,6 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
-	capiClusterName := "capi-cluster"
-	clustersNotReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
-		Conditions: []types.Condition{{
-			Type:   "Ready",
-			Status: "False",
-		}},
-	}}}
-	clustersReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
-		Conditions: []types.Condition{{
-			Type:   "Ready",
-			Status: "True",
-		}},
-	}}}
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
@@ -1435,11 +1458,9 @@ func TestClusterManagerMoveCAPISuccess(t *testing.T) {
 		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, to.Name)
-	m.client.EXPECT().GetClusters(ctx, from).Return(clustersNotReady, nil)
-	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", capiClusterName)
-	m.client.EXPECT().MoveManagement(ctx, from, to)
-	m.client.EXPECT().GetClusters(ctx, to).Return(clustersReady, nil)
-	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", to.Name)
+	m.client.EXPECT().MoveManagement(ctx, from, to, to.Name)
+	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", to.Name)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
 	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetKubeadmControlPlane(ctx,
@@ -1472,19 +1493,6 @@ func TestClusterManagerMoveCAPIRetrySuccess(t *testing.T) {
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-wn"}}}
 	})
-	capiClusterName := "capi-cluster"
-	clustersNotReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
-		Conditions: []types.Condition{{
-			Type:   "Ready",
-			Status: "False",
-		}},
-	}}}
-	clustersReady := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}, Status: types.ClusterStatus{
-		Conditions: []types.Condition{{
-			Type:   "Ready",
-			Status: "True",
-		}},
-	}}}
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
@@ -1501,16 +1509,14 @@ func TestClusterManagerMoveCAPIRetrySuccess(t *testing.T) {
 		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, to.Name)
-	m.client.EXPECT().GetClusters(ctx, from).Return(clustersNotReady, nil)
-	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", capiClusterName)
-	firstTry := m.client.EXPECT().MoveManagement(ctx, from, to).Return(errors.New("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": EOF"))
-	secondTry := m.client.EXPECT().MoveManagement(ctx, from, to).Return(nil)
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", to.Name)
+	firstTry := m.client.EXPECT().MoveManagement(ctx, from, to, to.Name).Return(errors.New("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": EOF"))
+	secondTry := m.client.EXPECT().MoveManagement(ctx, from, to, to.Name).Return(nil)
 	gomock.InOrder(
 		firstTry,
 		secondTry,
 	)
-	m.client.EXPECT().GetClusters(ctx, to).Return(clustersReady, nil)
-	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName)
+	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", to.Name)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
 	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetKubeadmControlPlane(ctx,
@@ -1559,43 +1565,8 @@ func TestClusterManagerMoveCAPIErrorMove(t *testing.T) {
 		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
-	m.client.EXPECT().GetClusters(ctx, from)
-	m.client.EXPECT().MoveManagement(ctx, from, to).Return(errors.New("error moving"))
-
-	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
-		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")
-	}
-}
-
-func TestClusterManagerMoveCAPIErrorGetClustersBeforeMove(t *testing.T) {
-	from := &types.Cluster{
-		Name: "from-cluster",
-	}
-	to := &types.Cluster{
-		Name: "to-cluster",
-	}
-	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Name = to.Name
-		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
-	})
-	ctx := context.Background()
-
-	c, m := newClusterManager(t)
-	kcp, mds := getKcpAndMdsForNodeCount(0)
-	m.client.EXPECT().GetKubeadmControlPlane(ctx,
-		from,
-		from.Name,
-		gomock.AssignableToTypeOf(executables.WithCluster(from)),
-		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
-	).Return(kcp, nil)
-	m.client.EXPECT().GetMachineDeploymentsForCluster(ctx,
-		from.Name,
-		gomock.AssignableToTypeOf(executables.WithCluster(from)),
-		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
-	).Return(mds, nil)
-	m.client.EXPECT().GetMachines(ctx, from, from.Name)
-	m.client.EXPECT().GetClusters(ctx, from).Return(nil, errors.New("error getting clusters"))
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", from.Name)
+	m.client.EXPECT().MoveManagement(ctx, from, to, from.Name).Return(errors.New("error moving"))
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
 		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")
@@ -1630,47 +1601,7 @@ func TestClusterManagerMoveCAPIErrorWaitForClusterReady(t *testing.T) {
 		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
-	capiClusterName := "capi-cluster"
-	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
-	m.client.EXPECT().GetClusters(ctx, from).Return(clusters, nil)
-	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", capiClusterName).Return(errors.New("error waitinf for cluster to be ready"))
-
-	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
-		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")
-	}
-}
-
-func TestClusterManagerMoveCAPIErrorGetClusters(t *testing.T) {
-	from := &types.Cluster{
-		Name: "from-cluster",
-	}
-	to := &types.Cluster{
-		Name: "to-cluster",
-	}
-	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Name = to.Name
-		s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-		s.Cluster.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
-	})
-	ctx := context.Background()
-
-	c, m := newClusterManager(t)
-	kcp, mds := getKcpAndMdsForNodeCount(0)
-	m.client.EXPECT().GetKubeadmControlPlane(ctx,
-		from,
-		from.Name,
-		gomock.AssignableToTypeOf(executables.WithCluster(from)),
-		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
-	).Return(kcp, nil)
-	m.client.EXPECT().GetMachineDeploymentsForCluster(ctx,
-		from.Name,
-		gomock.AssignableToTypeOf(executables.WithCluster(from)),
-		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
-	).Return(mds, nil)
-	m.client.EXPECT().GetMachines(ctx, from, from.Name)
-	m.client.EXPECT().GetClusters(ctx, from)
-	m.client.EXPECT().MoveManagement(ctx, from, to)
-	m.client.EXPECT().GetClusters(ctx, to).Return(nil, errors.New("error getting clusters"))
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", from.Name).Return(errors.New("error waiting for cluster to be ready"))
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
 		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")
@@ -1692,9 +1623,8 @@ func TestClusterManagerMoveCAPIErrorWaitForControlPlane(t *testing.T) {
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
-	m.client.EXPECT().MoveManagement(ctx, from, to)
-	capiClusterName := "capi-cluster"
-	clusters := []types.CAPICluster{{Metadata: types.Metadata{Name: capiClusterName}}}
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", from.Name)
+	m.client.EXPECT().MoveManagement(ctx, from, to, from.Name)
 	kcp, mds := getKcpAndMdsForNodeCount(0)
 	m.client.EXPECT().GetKubeadmControlPlane(ctx,
 		from,
@@ -1708,9 +1638,7 @@ func TestClusterManagerMoveCAPIErrorWaitForControlPlane(t *testing.T) {
 		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
-	m.client.EXPECT().GetClusters(ctx, from)
-	m.client.EXPECT().GetClusters(ctx, to).Return(clusters, nil)
-	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", capiClusterName).Return(errors.New("error waiting for control plane"))
+	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", from.Name).Return(errors.New("error waiting for control plane"))
 
 	if err := c.MoveCAPI(ctx, from, to, from.Name, clusterSpec); err == nil {
 		t.Error("ClusterManager.MoveCAPI() error = nil, wantErr not nil")
@@ -1745,9 +1673,9 @@ func TestClusterManagerMoveCAPIErrorGetMachines(t *testing.T) {
 		gomock.AssignableToTypeOf(executables.WithNamespace(constants.EksaSystemNamespace)),
 	).Return(mds, nil)
 	m.client.EXPECT().GetMachines(ctx, from, from.Name)
-	m.client.EXPECT().GetClusters(ctx, from)
-	m.client.EXPECT().MoveManagement(ctx, from, to)
-	m.client.EXPECT().GetClusters(ctx, to)
+	m.client.EXPECT().WaitForClusterReady(ctx, from, "1h0m0s", from.Name)
+	m.client.EXPECT().MoveManagement(ctx, from, to, from.Name)
+	m.client.EXPECT().WaitForControlPlaneReady(ctx, to, "15m0s", from.Name)
 	m.client.EXPECT().ValidateControlPlaneNodes(ctx, to, to.Name)
 	m.client.EXPECT().CountMachineDeploymentReplicasReady(ctx, to.Name, to.KubeconfigFile)
 	m.client.EXPECT().GetKubeadmControlPlane(ctx,

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -559,17 +559,31 @@ func (mr *MockClusterClientMockRecorder) ListObjects(arg0, arg1, arg2, arg3, arg
 }
 
 // MoveManagement mocks base method.
-func (m *MockClusterClient) MoveManagement(arg0 context.Context, arg1, arg2 *types.Cluster) error {
+func (m *MockClusterClient) MoveManagement(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MoveManagement", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "MoveManagement", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MoveManagement indicates an expected call of MoveManagement.
-func (mr *MockClusterClientMockRecorder) MoveManagement(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) MoveManagement(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveManagement", reflect.TypeOf((*MockClusterClient)(nil).MoveManagement), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveManagement", reflect.TypeOf((*MockClusterClient)(nil).MoveManagement), arg0, arg1, arg2, arg3)
+}
+
+// PauseCAPICluster mocks base method.
+func (m *MockClusterClient) PauseCAPICluster(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PauseCAPICluster", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PauseCAPICluster indicates an expected call of PauseCAPICluster.
+func (mr *MockClusterClientMockRecorder) PauseCAPICluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseCAPICluster", reflect.TypeOf((*MockClusterClient)(nil).PauseCAPICluster), arg0, arg1, arg2)
 }
 
 // RemoveAnnotationInNamespace mocks base method.
@@ -584,6 +598,20 @@ func (m *MockClusterClient) RemoveAnnotationInNamespace(arg0 context.Context, ar
 func (mr *MockClusterClientMockRecorder) RemoveAnnotationInNamespace(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAnnotationInNamespace", reflect.TypeOf((*MockClusterClient)(nil).RemoveAnnotationInNamespace), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// ResumeCAPICluster mocks base method.
+func (m *MockClusterClient) ResumeCAPICluster(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResumeCAPICluster", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResumeCAPICluster indicates an expected call of ResumeCAPICluster.
+func (mr *MockClusterClientMockRecorder) ResumeCAPICluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeCAPICluster", reflect.TypeOf((*MockClusterClient)(nil).ResumeCAPICluster), arg0, arg1, arg2)
 }
 
 // SaveLog mocks base method.

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -42,6 +42,26 @@ func (c *RetrierClient) Apply(ctx context.Context, kubeconfigPath string, obj ru
 	)
 }
 
+// PauseCAPICluster adds a `spec.Paused: true` to the CAPI cluster resource. This will cause all
+// downstream CAPI + provider controllers to skip reconciling on the paused cluster's objects.
+func (c *RetrierClient) PauseCAPICluster(ctx context.Context, cluster, kubeconfig string) error {
+	return c.retrier.Retry(
+		func() error {
+			return c.ClusterClient.PauseCAPICluster(ctx, cluster, kubeconfig)
+		},
+	)
+}
+
+// ResumeCAPICluster removes the `spec.Paused` on the CAPI cluster resource. This will cause all
+// downstream CAPI + provider controllers to resume reconciling on the paused cluster's objects.
+func (c *RetrierClient) ResumeCAPICluster(ctx context.Context, cluster, kubeconfig string) error {
+	return c.retrier.Retry(
+		func() error {
+			return c.ClusterClient.ResumeCAPICluster(ctx, cluster, kubeconfig)
+		},
+	)
+}
+
 // ApplyKubeSpecFromBytesForce creates/updates the objects defined in a yaml manifest against the api server following a client side apply mechanism.
 // It forces the operation, so if api validation failed, it will delete and re-create the object.
 func (c *RetrierClient) ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *types.Cluster, data []byte) error {

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -172,10 +172,14 @@ func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluste
 	return nil
 }
 
-func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster) error {
+func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster, clusterName string) error {
 	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	if from.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", from.KubeconfigFile)
+	}
+
+	if clusterName != "" {
+		params = append(params, "--filter-cluster", clusterName)
 	}
 
 	_, err := c.Execute(

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -172,6 +172,8 @@ func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluste
 	return nil
 }
 
+// MoveManagement moves management components `from` cluster `to` cluster
+// If `clusterName` is provided, it filters and moves only the provided cluster.
 func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster, clusterName string) error {
 	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
 	if from.KubeconfigFile != "" {

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -175,8 +175,10 @@ func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluste
 // MoveManagement moves management components `from` cluster `to` cluster
 // If `clusterName` is provided, it filters and moves only the provided cluster.
 func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster, clusterName string) error {
-	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace,
-		"--filter-cluster", clusterName}
+	params := []string{
+		"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace,
+		"--filter-cluster", clusterName,
+	}
 	if from.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", from.KubeconfigFile)
 	}

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -175,13 +175,10 @@ func (c *Clusterctl) BackupManagement(ctx context.Context, cluster *types.Cluste
 // MoveManagement moves management components `from` cluster `to` cluster
 // If `clusterName` is provided, it filters and moves only the provided cluster.
 func (c *Clusterctl) MoveManagement(ctx context.Context, from, to *types.Cluster, clusterName string) error {
-	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace}
+	params := []string{"move", "--to-kubeconfig", to.KubeconfigFile, "--namespace", constants.EksaSystemNamespace,
+		"--filter-cluster", clusterName}
 	if from.KubeconfigFile != "" {
 		params = append(params, "--kubeconfig", from.KubeconfigFile)
-	}
-
-	if clusterName != "" {
-		params = append(params, "--filter-cluster", clusterName)
 	}
 
 	_, err := c.Execute(

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -285,7 +285,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			from:         &types.Cluster{},
 			to:           &types.Cluster{},
 			clusterName:  "",
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", ""},
 		},
 		{
 			testName: "no kubeconfig in 'from' cluster",
@@ -294,7 +294,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 				KubeconfigFile: "to.kubeconfig",
 			},
 			clusterName:  "",
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", ""},
 		},
 		{
 			testName: "with both kubeconfigs",
@@ -305,7 +305,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 				KubeconfigFile: "to.kubeconfig",
 			},
 			clusterName:  "",
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig"},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", "", "--kubeconfig", "from.kubeconfig"},
 		},
 		{
 			testName: "with filter cluster",
@@ -316,7 +316,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 				KubeconfigFile: "to.kubeconfig",
 			},
 			clusterName:  "test-cluster",
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig", "--filter-cluster", "test-cluster"},
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", "test-cluster", "--kubeconfig", "from.kubeconfig"},
 		},
 	}
 

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -315,9 +315,8 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			to: &types.Cluster{
 				KubeconfigFile: "to.kubeconfig",
 			},
-			clusterName: "test-cluster",
-			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig",
-				"--filter-cluster", "test-cluster"},
+			clusterName:  "test-cluster",
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig", "--filter-cluster", "test-cluster"},
 		},
 	}
 

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -277,12 +277,14 @@ func TestClusterctlMoveManagement(t *testing.T) {
 		testName     string
 		from         *types.Cluster
 		to           *types.Cluster
+		clusterName  string
 		wantMoveArgs []interface{}
 	}{
 		{
 			testName:     "no kubeconfig",
 			from:         &types.Cluster{},
 			to:           &types.Cluster{},
+			clusterName:  "",
 			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
 		},
 		{
@@ -291,6 +293,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			to: &types.Cluster{
 				KubeconfigFile: "to.kubeconfig",
 			},
+			clusterName:  "",
 			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace},
 		},
 		{
@@ -301,7 +304,20 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			to: &types.Cluster{
 				KubeconfigFile: "to.kubeconfig",
 			},
+			clusterName:  "",
 			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig"},
+		},
+		{
+			testName: "with filter cluster",
+			from: &types.Cluster{
+				KubeconfigFile: "from.kubeconfig",
+			},
+			to: &types.Cluster{
+				KubeconfigFile: "to.kubeconfig",
+			},
+			clusterName: "test-cluster",
+			wantMoveArgs: []interface{}{"move", "--to-kubeconfig", "to.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--kubeconfig", "from.kubeconfig",
+				"--filter-cluster", "test-cluster"},
 		},
 	}
 
@@ -310,7 +326,7 @@ func TestClusterctlMoveManagement(t *testing.T) {
 			tc := newClusterctlTest(t)
 			tc.e.EXPECT().Execute(tc.ctx, tt.wantMoveArgs...)
 
-			if err := tc.clusterctl.MoveManagement(tc.ctx, tt.from, tt.to); err != nil {
+			if err := tc.clusterctl.MoveManagement(tc.ctx, tt.from, tt.to, tt.clusterName); err != nil {
 				t.Fatalf("Clusterctl.MoveManagement() error = %v, want nil", err)
 			}
 		})

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -2009,7 +2009,7 @@ func (k *Kubectl) ApplyTolerationsFromTaints(ctx context.Context, oldTaints []co
 }
 
 // PauseCAPICluster adds a `spec.Paused: true` to the CAPI cluster resource. This will cause all
-// downstream CAPI + provider controllers to skip reconciling on the paused cluster's objects
+// downstream CAPI + provider controllers to skip reconciling on the paused cluster's objects.
 func (k *Kubectl) PauseCAPICluster(ctx context.Context, cluster, kubeconfig string) error {
 	patch := fmt.Sprintf("{\"spec\":{\"paused\":%t}}", true)
 	return k.MergePatchResource(ctx, capiClustersResourceType, cluster, patch, kubeconfig, constants.EksaSystemNamespace)
@@ -2017,13 +2017,13 @@ func (k *Kubectl) PauseCAPICluster(ctx context.Context, cluster, kubeconfig stri
 
 // ResumeCAPICluster removes the `spec.Paused` on the CAPI cluster resource. This will cause all
 // downstream CAPI + provider controllers to resume reconciling on the paused cluster's objects
-// `spec.Paused` is set to `null` to drop the field instead of setting it to `false`
+// `spec.Paused` is set to `null` to drop the field instead of setting it to `false`.
 func (k *Kubectl) ResumeCAPICluster(ctx context.Context, cluster, kubeconfig string) error {
 	patch := "{\"spec\":{\"paused\":null}}"
 	return k.MergePatchResource(ctx, capiClustersResourceType, cluster, patch, kubeconfig, constants.EksaSystemNamespace)
 }
 
-// MergePatchResource patches named resource using merge patch
+// MergePatchResource patches named resource using merge patch.
 func (k *Kubectl) MergePatchResource(ctx context.Context, resource, name, patch, kubeconfig, namespace string) error {
 	params := []string{
 		"patch", resource, name, "--type=merge", "-p", patch, "--kubeconfig", kubeconfig, "--namespace", namespace,

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -2008,6 +2008,34 @@ func (k *Kubectl) ApplyTolerationsFromTaints(ctx context.Context, oldTaints []co
 	return nil
 }
 
+// PauseCAPICluster adds a `spec.Paused: true` to the CAPI cluster resource. This will cause all
+// downstream CAPI + provider controllers to skip reconciling on the paused cluster's objects
+func (k *Kubectl) PauseCAPICluster(ctx context.Context, cluster, kubeconfig string) error {
+	patch := fmt.Sprintf("{\"spec\":{\"paused\":%t}}", true)
+	return k.MergePatchResource(ctx, capiClustersResourceType, cluster, patch, kubeconfig, constants.EksaSystemNamespace)
+}
+
+// ResumeCAPICluster removes the `spec.Paused` on the CAPI cluster resource. This will cause all
+// downstream CAPI + provider controllers to resume reconciling on the paused cluster's objects
+// `spec.Paused` is set to `null` to drop the field instead of setting it to `false`
+func (k *Kubectl) ResumeCAPICluster(ctx context.Context, cluster, kubeconfig string) error {
+	patch := "{\"spec\":{\"paused\":null}}"
+	return k.MergePatchResource(ctx, capiClustersResourceType, cluster, patch, kubeconfig, constants.EksaSystemNamespace)
+}
+
+// MergePatchResource patches named resource using merge patch
+func (k *Kubectl) MergePatchResource(ctx context.Context, resource, name, patch, kubeconfig, namespace string) error {
+	params := []string{
+		"patch", resource, name, "--type=merge", "-p", patch, "--kubeconfig", kubeconfig, "--namespace", namespace,
+	}
+
+	_, err := k.Execute(ctx, params...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (k *Kubectl) KubeconfigSecretAvailable(ctx context.Context, kubeconfig string, clusterName string, namespace string) (bool, error) {
 	return k.HasResource(ctx, "secret", fmt.Sprintf("%s-kubeconfig", clusterName), kubeconfig, namespace)
 }

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2277,6 +2277,22 @@ func TestKubectlMergePatchResource(t *testing.T) {
 		tt.cluster.KubeconfigFile, tt.namespace)).To(Succeed())
 }
 
+func TestKubectlMergePatchResourceError(t *testing.T) {
+	t.Parallel()
+	tt := newKubectlTest(t)
+	patch := "{\"spec\":{\"paused\":false}}"
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"patch", capiClustersResourceType, "test-cluster", "--type=merge", "-p", patch,
+		"--kubeconfig", tt.cluster.KubeconfigFile, "--namespace", tt.namespace,
+	).Return(bytes.Buffer{}, errors.New("Error with kubectl merge patch"))
+
+	err := tt.k.MergePatchResource(tt.ctx, capiClustersResourceType, "test-cluster", patch,
+		tt.cluster.KubeconfigFile, tt.namespace)
+	tt.Expect(err).To(HaveOccurred())
+}
+
 func TestKubectlGetConfigMap(t *testing.T) {
 	t.Parallel()
 	tt := newKubectlTest(t)

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2234,6 +2234,49 @@ func TestKubectlGetClusterResourceSet(t *testing.T) {
 	tt.Expect(gotResourceSet).To(Equal(wantResourceSet))
 }
 
+func TestKubectlPauseCAPICluster(t *testing.T) {
+	t.Parallel()
+	tt := newKubectlTest(t)
+	patch := "{\"spec\":{\"paused\":true}}"
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"patch", capiClustersResourceType, "test-cluster", "--type=merge", "-p", patch,
+		"--kubeconfig", tt.cluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace,
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.PauseCAPICluster(tt.ctx, "test-cluster", tt.cluster.KubeconfigFile)).To(Succeed())
+}
+
+func TestKubectlResumeCAPICluster(t *testing.T) {
+	t.Parallel()
+	tt := newKubectlTest(t)
+	patch := "{\"spec\":{\"paused\":null}}"
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"patch", capiClustersResourceType, "test-cluster", "--type=merge", "-p", patch,
+		"--kubeconfig", tt.cluster.KubeconfigFile, "--namespace", constants.EksaSystemNamespace,
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.ResumeCAPICluster(tt.ctx, "test-cluster", tt.cluster.KubeconfigFile)).To(Succeed())
+}
+
+func TestKubectlMergePatchResource(t *testing.T) {
+	t.Parallel()
+	tt := newKubectlTest(t)
+	patch := "{\"spec\":{\"paused\":false}}"
+
+	tt.e.EXPECT().Execute(
+		tt.ctx,
+		"patch", capiClustersResourceType, "test-cluster", "--type=merge", "-p", patch,
+		"--kubeconfig", tt.cluster.KubeconfigFile, "--namespace", tt.namespace,
+	).Return(bytes.Buffer{}, nil)
+
+	tt.Expect(tt.k.MergePatchResource(tt.ctx, capiClustersResourceType, "test-cluster", patch,
+		tt.cluster.KubeconfigFile, tt.namespace)).To(Succeed())
+}
+
 func TestKubectlGetConfigMap(t *testing.T) {
 	t.Parallel()
 	tt := newKubectlTest(t)

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -20,6 +20,8 @@ type ClusterManager interface {
 	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
+	PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error
+	ResumeCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error
 	RunPostCreateWorkloadCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
 	UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -343,6 +343,20 @@ func (mr *MockClusterManagerMockRecorder) MoveCAPI(arg0, arg1, arg2, arg3, arg4 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveCAPI", reflect.TypeOf((*MockClusterManager)(nil).MoveCAPI), varargs...)
 }
 
+// PauseCAPIWorkloadClusters mocks base method.
+func (m *MockClusterManager) PauseCAPIWorkloadClusters(arg0 context.Context, arg1 *types.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PauseCAPIWorkloadClusters", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PauseCAPIWorkloadClusters indicates an expected call of PauseCAPIWorkloadClusters.
+func (mr *MockClusterManagerMockRecorder) PauseCAPIWorkloadClusters(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseCAPIWorkloadClusters", reflect.TypeOf((*MockClusterManager)(nil).PauseCAPIWorkloadClusters), arg0, arg1)
+}
+
 // PauseEKSAControllerReconcile mocks base method.
 func (m *MockClusterManager) PauseEKSAControllerReconcile(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 providers.Provider) error {
 	m.ctrl.T.Helper()
@@ -355,6 +369,20 @@ func (m *MockClusterManager) PauseEKSAControllerReconcile(arg0 context.Context, 
 func (mr *MockClusterManagerMockRecorder) PauseEKSAControllerReconcile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseEKSAControllerReconcile", reflect.TypeOf((*MockClusterManager)(nil).PauseEKSAControllerReconcile), arg0, arg1, arg2, arg3)
+}
+
+// ResumeCAPIWorkloadClusters mocks base method.
+func (m *MockClusterManager) ResumeCAPIWorkloadClusters(arg0 context.Context, arg1 *types.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResumeCAPIWorkloadClusters", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResumeCAPIWorkloadClusters indicates an expected call of ResumeCAPIWorkloadClusters.
+func (mr *MockClusterManagerMockRecorder) ResumeCAPIWorkloadClusters(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeCAPIWorkloadClusters", reflect.TypeOf((*MockClusterManager)(nil).ResumeCAPIWorkloadClusters), arg0, arg1)
 }
 
 // ResumeEKSAControllerReconcile mocks base method.

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -467,7 +467,14 @@ func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext 
 		return &CollectDiagnosticsTask{}
 	}
 
-	logger.Info("Moving cluster management from workload to bootstrap cluster")
+	logger.V(3).Info("Pausing workload clusters before moving management cluster resources to bootstrap cluster")
+	err = commandContext.ClusterManager.PauseCAPIWorkloadClusters(ctx, commandContext.WorkloadCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
+	logger.Info("Moving management cluster from workload to bootstrap cluster")
 	err = commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef(), types.WithNodeHealthy())
 	if err != nil {
 		commandContext.SetError(err)
@@ -568,6 +575,14 @@ func (s *moveManagementToWorkloadTask) Run(ctx context.Context, commandContext *
 		return &CollectDiagnosticsTask{}
 	}
 	commandContext.ManagementCluster = commandContext.WorkloadCluster
+
+	logger.V(3).Info("Resuming all workload clusters after moving management cluster resources from bootstrap to workload clusters")
+	err = commandContext.ClusterManager.ResumeCAPIWorkloadClusters(ctx, commandContext.ManagementCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
+
 	return &reconcileClusterDefinitions{eksaSpecDiff: true}
 }
 

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -576,7 +576,7 @@ func (s *moveManagementToWorkloadTask) Run(ctx context.Context, commandContext *
 	}
 	commandContext.ManagementCluster = commandContext.WorkloadCluster
 
-	logger.V(3).Info("Resuming all workload clusters after moving management cluster resources from bootstrap to workload clusters")
+	logger.V(3).Info("Resuming all workload clusters after moving management cluster resources from bootstrap to management clusters")
 	err = commandContext.ClusterManager.ResumeCAPIWorkloadClusters(ctx, commandContext.ManagementCluster)
 	if err != nil {
 		commandContext.SetError(err)

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -282,6 +282,7 @@ func (c *upgradeTestSetup) expectPrepareUpgradeWorkload(managementCluster *types
 func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath),
+		c.clusterManager.EXPECT().PauseCAPIWorkloadClusters(c.ctx, c.managementCluster),
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.managementCluster, c.bootstrapCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
 		),
@@ -306,6 +307,7 @@ func (c *upgradeTestSetup) expectMoveManagementToWorkload() {
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.bootstrapCluster, c.managementCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
 		),
+		c.clusterManager.EXPECT().ResumeCAPIWorkloadClusters(c.ctx, c.managementCluster),
 	)
 }
 

--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -207,7 +207,6 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 			},
 		},
 	}
-
 }
 
 func runCloudStackAPIUpgradeTest(t *testing.T, test *framework.ClusterE2ETest, ut cloudStackAPIUpgradeTest) {

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -45,5 +45,7 @@ const (
 	vsphereResourcePoolVar              = "T_VSPHERE_RESOURCE_POOL"
 )
 
-var EksaPackageControllerHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
-var KubeVersions = []v1alpha1.KubernetesVersion{v1alpha1.Kube123, v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127}
+var (
+	EksaPackageControllerHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
+	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube123, v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127}
+)


### PR DESCRIPTION
*Description of changes:*
When a management cluster is getting upgraded, in the current workflow, all the CAPI clusters, their respective dependents including machines, secrets, etc get moved from the workload management cluster to bootstrap cluster. After the workload cluster gets upgraded, the management components are moved back from bootstrap cluster back to the workload cluster. This process is error prone and an issue could result in all CAPI objects being lost. Another issue with this is checking and expecting the status of all clusters to be ready during management cluster upgrade which is not always possible, especially in a more established environment.

This change only checks for management cluster's status and only moves the management cluster objects back and forth to the bootstrap cluster. All other clusters are paused during this process.

/hold till build tooling is updated with change for `clusterctl move --filter-cluster` flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

