### PR TITLE
E2E test for workload cluster creation from prev eksa version

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -589,6 +589,36 @@ func TestCloudStackKubernetes124MulticlusterWorkloadCluster(t *testing.T) {
 	runWorkloadClusterFlow(test)
 }
 
+// WL cluster with prev release version from management cluster
+func TestCloudStackKubernetes123MulticlusterWorkloadClusterPrevVersion(t *testing.T) {
+	prevLatestRel := prevLatestMinorRelease(t)
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat123())
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube123),
+				api.WithControlPlaneCount(1),
+				api.WithWorkerNodeCount(1),
+				api.WithStackedEtcdTopology(),
+			),
+		),
+		framework.NewClusterE2ETest(
+			t,
+			provider,
+			framework.WithClusterFiller(
+				api.WithKubernetesVersion(v1alpha1.Kube123),
+				api.WithControlPlaneCount(1),
+				api.WithWorkerNodeCount(1),
+				api.WithStackedEtcdTopology(),
+			),
+		),
+	)
+	runWorkloadClusterPrevVersionCreateFlow(test, prevLatestRel)
+}
+
 // TODO: Add TestCloudStackUpgradeKubernetes124MulticlusterWorkloadClusterWithGithubFlux
 func TestCloudStackUpgradeKubernetes124MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat123())

--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -19,6 +20,16 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 		w.DeleteCluster()
 	})
 	time.Sleep(5 * time.Minute)
+	test.DeleteManagementCluster()
+}
+
+func runWorkloadClusterPrevVersionCreateFlow(test *framework.MulticlusterE2ETest, latestMinorRelease *releasev1.EksARelease) {
+	test.CreateManagementClusterWithConfig()
+	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.GenerateClusterConfigForVersion(latestMinorRelease.Version, framework.ExecuteWithEksaRelease(latestMinorRelease))
+		w.CreateCluster(framework.ExecuteWithEksaRelease(latestMinorRelease))
+		w.DeleteCluster()
+	})
 	test.DeleteManagementCluster()
 }
 

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/semver"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -20,6 +21,23 @@ func latestMinorRelease(t testing.TB) *releasev1.EksARelease {
 	}
 
 	return latestRelease
+}
+
+func prevLatestMinorRelease(t testing.TB) *releasev1.EksARelease {
+	t.Helper()
+	currLatestRelease := latestMinorRelease(t)
+
+	semCurrLatestRel, err := semver.New(currLatestRelease.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fetch the previous latest minor release for workload creation For ex. curr latest release 15.x prev latest minor release: 14.x
+	prevLatestRel, err := framework.GetPreviousMinorReleaseFromVersion(semCurrLatestRel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return prevLatestRel
 }
 
 func runUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *releasev1.EksARelease, wantVersion anywherev1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {


### PR DESCRIPTION
*Issue #, if available:*
E2E test for Creating Management Cluster with current eks-a version and create workload cluster with the previous eks-a version to check for backward workload cluster create support. The change also alters the pre-flight that checks for bundle number to skip the bundle validation during dev build to enable running this test against main. 

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

