### PR TITLE
Improve CloudStack E2E template selection logic

### DIFF
--- a/pkg/executables/cmk_test.go
+++ b/pkg/executables/cmk_test.go
@@ -870,6 +870,96 @@ func TestCmkListOperations(t *testing.T) {
 			wantResultCount:  0,
 		},
 		{
+			testName:         "searchtemplate success on name filter",
+			jsonResponseFile: "testdata/cmk_list_template_singular.json",
+			argumentsExecCall: []string{
+				"-c", configFilePath,
+				"list", "templates", "templatefilter=all", "listall=true", fmt.Sprintf("name=\"%s\"", resourceName.Name),
+			},
+			cmkFunc: func(cmk executables.Cmk, ctx context.Context) error {
+				_, err := cmk.SearchTemplate(ctx, execConfig.Profiles[0].Name, resourceName)
+				return err
+			},
+			cmkResponseError: nil,
+			wantErr:          false,
+			wantResultCount:  1,
+		},
+		{
+			testName:         "searchtemplate success on id filter",
+			jsonResponseFile: "testdata/cmk_list_template_singular.json",
+			argumentsExecCall: []string{
+				"-c", configFilePath,
+				"list", "templates", "templatefilter=all", "listall=true", fmt.Sprintf("id=\"%s\"", resourceID.Id),
+			},
+			cmkFunc: func(cmk executables.Cmk, ctx context.Context) error {
+				_, err := cmk.SearchTemplate(ctx, execConfig.Profiles[0].Name, resourceID)
+				return err
+			},
+			cmkResponseError: nil,
+			wantErr:          false,
+			wantResultCount:  1,
+		},
+		{
+			testName:         "searchtemplate on none results",
+			jsonResponseFile: "testdata/cmk_list_template_none.json",
+			argumentsExecCall: []string{
+				"-c", configFilePath,
+				"list", "templates", "templatefilter=all", "listall=true", fmt.Sprintf("name=\"%s\"", resourceName.Name),
+			},
+			cmkFunc: func(cmk executables.Cmk, ctx context.Context) error {
+				_, err := cmk.SearchTemplate(ctx, execConfig.Profiles[0].Name, resourceName)
+				return err
+			},
+			cmkResponseError: nil,
+			wantErr:          false,
+			wantResultCount:  1,
+		},
+		{
+			testName:         "searchtemplate failure on cmk failure",
+			jsonResponseFile: "testdata/cmk_list_template_none.json",
+			argumentsExecCall: []string{
+				"-c", configFilePath,
+				"list", "templates", "templatefilter=all", "listall=true", fmt.Sprintf("name=\"%s\"", resourceName.Name),
+			},
+			cmkFunc: func(cmk executables.Cmk, ctx context.Context) error {
+				_, err := cmk.SearchTemplate(ctx, execConfig.Profiles[0].Name, resourceName)
+				return err
+			},
+			cmkResponseError: errors.New("cmk calling return exception"),
+			wantErr:          true,
+			wantResultCount:  1,
+		},
+		{
+			testName:         "searchtemplate no results",
+			jsonResponseFile: "testdata/cmk_list_empty_response.json",
+			argumentsExecCall: []string{
+				"-c", configFilePath,
+				"list", "templates", "templatefilter=all", "listall=true", fmt.Sprintf("name=\"%s\"", resourceName.Name),
+			},
+			cmkFunc: func(cmk executables.Cmk, ctx context.Context) error {
+				_, err := cmk.SearchTemplate(ctx, execConfig.Profiles[0].Name, resourceName)
+				return err
+			},
+			cmkResponseError: nil,
+			wantErr:          false,
+			wantResultCount:  0,
+		},
+		{
+			testName:         "searchtemplate json parse exception",
+			jsonResponseFile: "testdata/cmk_non_json_response.txt",
+			argumentsExecCall: []string{
+				"-c", configFilePath,
+				"list", "templates", "templatefilter=all", "listall=true", fmt.Sprintf("name=\"%s\"", resourceName.Name),
+			},
+			cmkFunc: func(cmk executables.Cmk, ctx context.Context) error {
+				_, err := cmk.SearchTemplate(ctx, execConfig.Profiles[0].Name, resourceName)
+				return err
+			},
+			cmkResponseError: nil,
+			wantErr:          true,
+			wantResultCount:  0,
+		},
+		{
 			testName:         "listaffinitygroups success on id filter",
 			jsonResponseFile: "testdata/cmk_list_affinitygroup_singular.json",
 			argumentsExecCall: []string{

--- a/test/framework/executables.go
+++ b/test/framework/executables.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
+	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
 
 func buildKubectl(t T) *executables.Kubectl {
@@ -59,4 +60,27 @@ func buildHelm(t T) *executables.Helm {
 
 func buildSSH(t T) *executables.SSH {
 	return executables.NewLocalExecutablesBuilder().BuildSSHExecutable()
+}
+
+func buildCmk(t T) *executables.Cmk {
+	ctx := context.Background()
+	tmpWriter, err := filewriter.NewWriter("cmk")
+	if err != nil {
+		t.Fatalf("Error creating tmp writer")
+	}
+
+	execConfig, err := decoder.ParseCloudStackCredsFromEnv()
+	if err != nil {
+		t.Fatalf("parsing cloudstack credentials from environment: %v", err)
+	}
+
+	cmk, err := executableBuilder(ctx, t).BuildCmkExecutable(tmpWriter, execConfig)
+	if err != nil {
+		t.Fatalf("Error creating cmk client: %v", err)
+	}
+	t.Cleanup(func() {
+		cmk.Close(ctx)
+	})
+
+	return cmk
 }

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -1,0 +1,90 @@
+package framework
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+// providerTemplateNameGenerator is an interface for getting template name for each provider.
+type providerTemplateNameGenerator interface {
+	envVarForTemplate(osFamilyStr, eksDName string) string
+	defaultNameForTemplate(osFamilyStr, eksDName string) string
+	searchTemplate(ctx context.Context, template string) (string, error)
+	defaultEnvVarForTemplate(osFamilyStr string, kubeVersion anywherev1.KubernetesVersion) string
+}
+
+// templateCache is a map of template name.
+type templateRegistry struct {
+	cache     map[string]string
+	generator providerTemplateNameGenerator
+}
+
+// templateForRelease tries to find a suitable template for a particular eks-a release, k8s version and OS family.
+// It follows these steps:
+//
+// 1. Look for explicit configuration through an env var: "T_{provider}_TEMPLATE_{osFamily}_{eks-d version}"
+// eg. T_CLOUDSTACK_TEMPLATE_REDHAT_KUBERNETES_1_23_EKS_22, T_VSPHERE_TEMPLATE_REDHAT_KUBERNETES_1_23_EKS_22
+// This should be used for explicit configuration, mostly in local development for overrides.
+//
+// 2. If not present, look for a template if the default templates: "{eks-d version}-{osFamily}"
+// eg. kubernetes-1-23-eks-22-redhat (CloudStack),  /SDDC-Datacenter/vm/Templates/kubernetes-1-23-eks-22-redhat (vSphere)
+// This is what should be used most of the time in CI, the explicit configuration is not present but the right template has already been
+// imported to cloudstack.
+//
+// 3. If the template doesn't exist, default to the value of the default template env vars: eg. "T_CLOUDSTACK_TEMPLATE_REDHAT_1_23".
+// This is a catch all condition. Mostly for edge cases where the bundle has been updated with a new eks-d version, but the
+// the new template hasn't been imported yet. It also preserves backwards compatibility.
+func (tc *templateRegistry) templateForRelease(t *testing.T, osFamily anywherev1.OSFamily, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) string {
+	t.Helper()
+	osFamilyStr := string(osFamily)
+	versionsBundle := readVersionsBundles(t, release, kubeVersion)
+	eksDName := versionsBundle.EksD.Name
+	templateEnvVarName := tc.generator.envVarForTemplate(osFamilyStr, eksDName)
+	cacheKey := templateEnvVarName
+	if template, ok := tc.cache[cacheKey]; ok {
+		t.Logf("Template for release found in cache, using %s template.", template)
+		return template
+	}
+
+	template, ok := os.LookupEnv(templateEnvVarName)
+	if ok && template != "" {
+		t.Logf("Env var %s is set, using %s template", templateEnvVarName, template)
+		tc.cache[cacheKey] = template
+		return template
+	}
+	t.Logf("Env var %s not is set, trying default generated template name", templateEnvVarName)
+
+	// Env var is not set, try default template name
+	template = tc.generator.defaultNameForTemplate(osFamilyStr, eksDName)
+	if template != "" {
+		foundTemplate, err := tc.generator.searchTemplate(context.Background(), template)
+		if err != nil {
+			t.Logf("Failed checking if default template exists: %v", err)
+		}
+
+		if foundTemplate != "" {
+			t.Logf("Default template for release exists, using %s template.", template)
+			tc.cache[cacheKey] = template
+			return template
+		}
+		t.Logf("Default template %s for release doesn't exit.", template)
+	}
+	// Default template doesn't exist, try legacy generic env var
+	// It is not guaranteed that this template will work for the given release, if they don't match the
+	// same ekd-d release, the test will fail. This is just a catch all last try for cases where the new template
+	// hasn't been imported with its own name but the default one matches the same eks-d release.
+	templateEnvVarName = tc.generator.defaultEnvVarForTemplate(osFamilyStr, kubeVersion)
+	template, ok = os.LookupEnv(templateEnvVarName)
+	if !ok || template == "" {
+		t.Fatalf("Env var %s for default template is not set, can't determine which template to use", templateEnvVarName)
+	}
+
+	t.Logf("Env var %s is set, using %s template. There are no guarantees this template will be valid. Cluster validation might fail.", templateEnvVarName, template)
+
+	tc.cache[cacheKey] = template
+	return template
+}


### PR DESCRIPTION
*Description of changes:*
For CloudStack e2e tests we get the template names from the secret value. When we change eks-d version, template names get out of sync which makes e2e test failure until we change the template name in the secret.

To avoid this, this PR includes a logic to select the right template from the test runner itself and by not depending on the secret value. It looks for template name in below order,

1. Look for explicit configuration through an env var: "T_CLOUDSTACK_TEMPLATE_{osFamily}_{eks-d version}" eg. T_CLOUDSTACK_TEMPLATE_REDHAT_KUBERNETES_1_23_EKS_22. This should be used for explicit configuration, mostly in local development for overrides.

2. If not present, look for a template if the default templates: "{eks-d version}-{osFamily}" eg. kubernetes-1-23-eks-22-redhat. This is what should be used most of the time in CI, the explicit configuration is not present but the right template has already been imported to cloudstack.

3. If the template doesn't exist, default to the value of the default template env vars: eg. "T_CLOUDSTACK_TEMPLATE_REDHAT_1_23". This is a catch all condition. Mostly for edge cases where the bundle has been updated with a new eks-d version, but the the new template hasn't been imported yet. It also preserves backwards compatibility.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

