### PR TITLE
Skip tinkerbell tests that cannot be run in CI

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -56,6 +56,8 @@ skipped_tests:
 - TestTinkerbellUpgrade125MulticlusterWorkloadClusterWorkerScaleupWithAPI
 - TestTinkerbellUpgrade126MulticlusterWorkloadClusterWorkerScaleupWithFluxAPI
 - TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI
+- TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleDown
+- TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleup
 # Skipping ETCD tests
 - TestTinkerbellKubernetes126UbuntuExternalEtcdSimpleFlow
 # Skipping skip power action tests - Not going to work because e2e test powers on CP and worker node at the same time and worker node times out early waiting for ipxe
@@ -67,6 +69,7 @@ skipped_tests:
 - TestTinkerbellKubernetes124RedHatSimpleFlow
 - TestTinkerbellKubernetes125RedHatSimpleFlow
 - TestTinkerbellKubernetes126RedHatSimpleFlow
+- TestTinkerbellKubernetes127RedHatSimpleFlow
 - TestTinkerbellKubernetes123UbuntuSimpleFlow
 - TestTinkerbellKubernetes124UbuntuSimpleFlow
 - TestTinkerbellKubernetes125UbuntuSimpleFlow
@@ -91,10 +94,8 @@ skipped_tests:
 - TestTinkerbellKubernetes127BottleRocketCuratedPackagesPrometheusSimpleFlow
 - TestTinkerbellUbuntuSingleNodeCuratedPackagesFlow
 - TestTinkerbellBottleRocketSingleNodeCuratedPackagesFlow
-- TestTinkerbellUbuntuSingleNodeCuratedPackagesEmissaryFlow
 - TestTinkerbellBottleRocketSingleNodeCuratedPackagesEmissaryFlow
 - TestTinkerbellUbuntuSingleNodeCuratedPackagesHarborFlow
-- TestTinkerbellBottleRocketSingleNodeCuratedPackagesHarborFlow
 - TestTinkerbellUbuntuSingleNodeCuratedPackagesAdotSimpleFlow
 - TestTinkerbellBottleRocketSingleNodeCuratedPackagesAdotSimpleFlow
 - TestTinkerbellUbuntuSingleNodeCuratedPackagesPrometheusSimpleFlow

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -884,8 +884,8 @@ func TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleDown(t *testi
 			t,
 			provider,
 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
-			framework.WithControlPlaneHardware(1),
-			framework.WithWorkerHardware(2),
+			framework.WithControlPlaneHardware(2),
+			framework.WithWorkerHardware(3),
 		),
 		framework.NewClusterE2ETest(
 			t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Skips `TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleup` and `TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleDown` due to hardware limitations

Skips `TestTinkerbellKubernetes127RedHatSimpleFlow` as it cannot be run in our CI right now

Re-enables a couple packages tests as well

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

