### PR TITLE
Reuse same IP Manager for all tinkerbell tests

### DIFF
--- a/internal/test/e2e/ipmanager.go
+++ b/internal/test/e2e/ipmanager.go
@@ -37,7 +37,7 @@ func (ipman *E2EIPManager) getUniqueIP(cidr string, usedIPs map[string]bool) str
 	ip, err := ipgen.GenerateUniqueIP(cidr)
 	for ; err != nil || usedIPs[ip]; ip, err = ipgen.GenerateUniqueIP(cidr) {
 		if err != nil {
-			ipman.logger.V(2).Info("Warning: getting unique IP for vsphere failed", "error", err)
+			ipman.logger.V(2).Info("Warning: getting unique IP failed", "error", err)
 		}
 		if usedIPs[ip] {
 			ipman.logger.V(2).Info("Warning: generated IP is already taken", "IP", ip)


### PR DESCRIPTION
*Description of changes:*
Currently, the regular and airgapped tinkerbell tests are using independent IP managers.
This causes these tests to potentially end up with the same IPs causing conflicts.

This PR solves this problem by reusing same IP Manager for all tinkerbell tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

