### PR TITLE
Patch skip Cilium upgrade tests

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -951,7 +951,7 @@ func TestDockerUpgradeWorkloadClusterScaleAddRemoveWorkerNodeGroupsGitHubFluxAPI
 	)
 }
 
-func TestDockerCiliumUpgradeSkip_Create(t *testing.T) {
+func TestDockerCiliumSkipUpgrade_CLICreate(t *testing.T) {
 	provider := framework.NewDocker(t)
 	test := framework.NewClusterE2ETest(t, provider,
 		framework.WithClusterFiller(
@@ -971,7 +971,7 @@ func TestDockerCiliumUpgradeSkip_Create(t *testing.T) {
 	test.DeleteCluster()
 }
 
-func TestDockerCiliumSkipUpgrade_Upgrade(t *testing.T) {
+func TestDockerCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
 	release, err := framework.GetLatestMinorReleaseFromTestBranch()
 	if err != nil {
 		t.Fatal(err)
@@ -1007,7 +1007,7 @@ func TestDockerCiliumSkipUpgrade_Upgrade(t *testing.T) {
 	test.DeleteCluster()
 }
 
-func TestDockerCiliumUpgradeSkip_WorkloadCreate(t *testing.T) {
+func TestDockerCiliumSkipUpgrade_ControllerCreate(t *testing.T) {
 	provider := framework.NewDocker(t)
 	management := framework.NewClusterE2ETest(t, provider).WithClusterConfig(
 		api.ClusterToConfigFiller(
@@ -1053,7 +1053,7 @@ func TestDockerCiliumUpgradeSkip_WorkloadCreate(t *testing.T) {
 	test.DeleteManagementCluster()
 }
 
-func TestDockerCiliumUpgradeSkip_WorkloadUpgrade(t *testing.T) {
+func TestDockerCiliumSkipUpgrade_ControllerUpgrade(t *testing.T) {
 	provider := framework.NewDocker(t)
 	management := framework.NewClusterE2ETest(t, provider).WithClusterConfig(
 		api.ClusterToConfigFiller(

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -104,7 +104,7 @@ func (w *WorkloadCluster) WaitForKubeconfig() {
 // ValidateClusterDelete verifies the cluster has been deleted.
 func (w *WorkloadCluster) ValidateClusterDelete() {
 	ctx := context.Background()
-	w.buildClusterStateValidationConfig(ctx)
+	// w.buildClusterStateValidationConfig(ctx)
 	w.T.Logf("Validating cluster deletion %s", w.ClusterName)
 	clusterStateValidator := newClusterStateValidator(w.clusterStateValidationConfig)
 	clusterStateValidator.WithValidations(


### PR DESCRIPTION
Skip Cilium upgrade tests introduced a problem where a subset of tests that validate a cluster was deleted failed because it attempted to build a client to the workload cluster. 

Building the clients isn't necessary for the Skip Cilium upgrade tests, this PR removes it.