### PR TITLE
Add e2e tests for modular upgrades

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -661,63 +661,13 @@ func TestCloudStackUpgradeKubernetes124MulticlusterWorkloadClusterWithGithubFlux
 }
 
 func TestCloudStackKubernetes123WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	runTestCloudstackManagementClusterUpgradeSideEffects(t, anywherev1.RedHat, anywherev1.Kube123)
+	cloudstack := framework.NewCloudStack(t)
+	runTestManagementClusterUpgradeSideEffects(t, cloudstack, anywherev1.RedHat, anywherev1.Kube123)
 }
 
 func TestCloudStackKubernetes124WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	runTestCloudstackManagementClusterUpgradeSideEffects(t, anywherev1.RedHat, anywherev1.Kube124)
-}
-
-func runTestCloudstackManagementClusterUpgradeSideEffects(t *testing.T, osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) {
-	latestRelease := latestMinorRelease(t)
-
 	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(t, cloudstack, framework.PersistentCluster())
-	managementCluster.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
-	managementCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithEtcdCountIfExternal(1),
-		),
-		cloudstack.WithKubeVersion(osFamily, kubeVersion),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	workloadCluster := framework.NewClusterE2ETest(t, cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	)
-	workloadCluster.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
-	workloadCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithControlPlaneCount(2),
-			api.WithControlPlaneLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"),
-			api.RemoveAllWorkerNodeGroups(),
-			api.WithWorkerNodeGroup("workers-0",
-				api.WithCount(3),
-				api.WithLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"),
-			),
-			api.WithEtcdCountIfExternal(3),
-			api.WithCiliumPolicyEnforcementMode(anywherev1.CiliumPolicyModeAlways),
-		),
-		cloudstack.WithWorkerNodeGroup("workers-0",
-			framework.WithWorkerNodeGroup("workers-0",
-				api.WithCount(2),
-				api.WithLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"),
-			),
-		),
-		framework.WithOIDCClusterConfig(t),
-		cloudstack.WithKubeVersion(osFamily, kubeVersion),
-	)
-
-	test.WithWorkloadClusters(workloadCluster)
-
-	runFlowUpgradeManagementClusterCheckForSideEffects(test,
-		framework.NewEKSAReleasePackagedBinary(latestRelease),
-		newEKSAPackagedBinaryForLocalBinary(t),
-	)
+	runTestManagementClusterUpgradeSideEffects(t, cloudstack, anywherev1.RedHat, anywherev1.Kube124)
 }
 
 // OIDC

--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -37,8 +37,8 @@ func cloudStackAPIUpdateTestBaseStep(e *framework.ClusterE2ETest, cloudstack *fr
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
 			// Add new WorkerNodeGroups
-			cloudstack.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
-			cloudstack.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
+			cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
+			cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
 			cloudstack.WithRedhatVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion),
 		),
 	}
@@ -64,8 +64,8 @@ func cloudstackAPIManagementClusterUpgradeTests(e *framework.ClusterE2ETest, clo
 						api.ClusterToConfigFiller(
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
 						cloudstack.WithRedhatVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},
@@ -100,8 +100,8 @@ func cloudstackAPIManagementClusterUpgradeTests(e *framework.ClusterE2ETest, clo
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
 						// Add new WorkerNodeGroups
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
 						cloudstack.WithRedhatVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},
@@ -133,8 +133,8 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 							api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-0", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-0", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-1", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-1", clusterName), api.WithCount(1))),
 						cloudstack.WithRedhatVersion(wc.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},
@@ -175,8 +175,8 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
 						// Add new WorkerNodeGroups
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
-						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
+						cloudstack.WithNewWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
 						cloudstack.WithRedhatVersion(wc.ClusterConfig.Cluster.Spec.KubernetesVersion),
 					),
 				},

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -843,6 +843,11 @@ func TestDockerKubernetes126to127GithubFluxEnabledUpgradeFromLatestMinorRelease(
 	)
 }
 
+func TestDockerKubernetes126ManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+	provider := framework.NewDocker(t)
+	runTestManagementClusterUpgradeSideEffects(t, provider, "", v1alpha1.Kube126)
+}
+
 func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
 	provider := framework.NewDocker(t)
 	test := framework.NewClusterE2ETest(
@@ -854,10 +859,10 @@ func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
-		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-		provider.WithWorkerNodeGroup(
-			framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend")),
+		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
+		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+		provider.WithNewWorkerNodeGroup(
+			"", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend")),
 		),
 	)
 
@@ -869,7 +874,7 @@ func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
 			api.RemoveWorkerNodeGroup("worker-3"),
 			api.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint())),
 		),
-		provider.WithWorkerNodeGroup(framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
+		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
 	)
 }
 

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2288,6 +2288,11 @@ func TestVSphereKubernetes124UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	)
 }
 
+func TestVSphereKubernetes126ManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+	provider := framework.NewVSphere(t)
+	runTestManagementClusterUpgradeSideEffects(t, provider, v1alpha1.Ubuntu, v1alpha1.Kube126)
+}
+
 func TestVSphereKubernetes124UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPolicy(t *testing.T) {
 	release := latestMinorRelease(t)
 	provider := framework.NewVSphere(t,
@@ -2474,9 +2479,9 @@ func TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testin
 			api.WithControlPlaneCount(1),
 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 		),
-		provider.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
-		provider.WithWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-		provider.WithWorkerNodeGroup("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend"))),
+		provider.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
+		provider.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+		provider.WithNewWorkerNodeGroup("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend"))),
 		provider.WithUbuntu124(),
 	)
 
@@ -2637,9 +2642,9 @@ func TestVSphereUpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			vsphere.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
 			vsphere.WithUbuntu124(),
 		),
 	)
@@ -2680,8 +2685,8 @@ func TestVSphereUpgradeWorkerNodeGroupsUbuntuAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
 			vsphere.WithUbuntu124(),
 		),
 	)
@@ -2771,7 +2776,7 @@ func TestVSphereUpgradeKubernetes123to124UbuntuWorkloadClusterAPI(t *testing.T) 
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
 			vsphere.WithUbuntu123(),
 		),
 	)
@@ -2806,7 +2811,7 @@ func TestVSphereCiliumDisableCSIUbuntuAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
 			vsphere.WithUbuntu124(),
 		),
 	)
@@ -2858,9 +2863,9 @@ func TestVSphereUpgradeLabelsTaintsBottleRocketGitHubFluxAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			vsphere.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
 			vsphere.WithBottleRocket124(),
 		),
 	)
@@ -2902,8 +2907,8 @@ func TestVSphereUpgradeWorkerNodeGroupsUbuntuGitHubFluxAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
 			vsphere.WithUbuntu124(),
 		),
 	)
@@ -2943,7 +2948,7 @@ func TestVSphereUpgradeKubernetesCiliumDisableCSIUbuntuGitHubFluxAPI(t *testing.
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 			),
-			vsphere.WithWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
 			vsphere.WithUbuntu123(),
 		),
 	)

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -261,11 +261,11 @@ func (c *CloudStack) WithNewCloudStackWorkerNodeGroup(name string, workerNodeGro
 	}
 }
 
-// WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// WithNewWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
 // a corresponding CloudStackMachineConfig to the cluster config.
-func (c *CloudStack) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, fillers ...api.CloudStackMachineConfigFiller) api.ClusterConfigFiller {
+func (c *CloudStack) WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
 	return api.JoinClusterConfigFillers(
-		api.CloudStackToConfigFiller(cloudStackMachineConfig(name, fillers...)),
+		api.CloudStackToConfigFiller(cloudStackMachineConfig(name)),
 		api.ClusterToConfigFiller(buildCloudStackWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
 	)
 }
@@ -402,9 +402,9 @@ func (c *CloudStack) searchTemplate(ctx context.Context, template string) (strin
 	return template, nil
 }
 
-// WithKubeVersion returns a cluster config filler that sets the cluster kube version and the right template for all
+// WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
 // cloudstack machine configs.
-func (c *CloudStack) WithKubeVersion(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (c *CloudStack) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	return api.JoinClusterConfigFillers(
 		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
 		api.CloudStackToConfigFiller(

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -318,6 +318,8 @@ type Provider interface {
 	CleanupVMs(clusterName string) error
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	ClusterStateValidations() []clusterf.StateValidation
+	WithKubeVersionAndOS(osFamily v1alpha1.OSFamily, kubeVersion v1alpha1.KubernetesVersion) api.ClusterConfigFiller
+	WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller
 }
 
 func (e *ClusterE2ETest) GenerateClusterConfig(opts ...CommandOpt) {
@@ -564,9 +566,9 @@ func (e *ClusterE2ETest) baseClusterConfigUpdates(opts ...CommandOpt) []api.Clus
 
 	// If we are persisting an existing cluster, set the control plane endpoint back to the original, since
 	// it is immutable
-	if e.PersistentCluster && e.ClusterConfig.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
+	if e.ClusterConfig.Cluster.Spec.DatacenterRef.Kind != v1alpha1.DockerDatacenterKind && e.PersistentCluster && e.ClusterConfig.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
 		endpoint := e.ClusterConfig.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
-		e.T.Logf("Resseting CP endpoint for persistent cluster to %s", endpoint)
+		e.T.Logf("Resetting CP endpoint for persistent cluster to %s", endpoint)
 		configFillers = append(configFillers,
 			api.ClusterToConfigFiller(api.WithControlPlaneEndpointIP(endpoint)),
 		)

--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/providers/docker"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
@@ -71,13 +72,20 @@ func (d *Docker) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	return []api.ClusterConfigFiller{api.ClusterToConfigFiller(f...)}
 }
 
-// WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// WithNewWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
 // a corresponding DockerMachineConfig to the cluster config.
-func (d *Docker) WithWorkerNodeGroup(workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+func (d *Docker) WithNewWorkerNodeGroup(machineConfig string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
 	return api.ClusterToConfigFiller(workerNodeGroup.ClusterFiller())
 }
 
 // ClusterStateValidations returns a list of provider specific validations.
 func (d *Docker) ClusterStateValidations() []clusterf.StateValidation {
 	return []clusterf.StateValidation{}
+}
+
+// WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version.
+func (d *Docker) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
+	)
 }

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -166,6 +166,20 @@ func (s *Nutanix) WithProviderUpgrade(fillers ...api.NutanixFiller) ClusterE2ETe
 	}
 }
 
+// WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
+// nutanix machine configs.
+func (s *Nutanix) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+	// TODO: Update tests to use this
+	panic("Not implemented for Nutanix yet")
+}
+
+// WithNewWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// a corresponding NutanixMachineConfig to the cluster config.
+func (s *Nutanix) WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	// TODO: Implement for Nutanix provider
+	panic("Not implemented for Nutanix yet")
+}
+
 // WithUbuntu123Nutanix returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template for k8s 1.23
 // and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu123Nutanix() NutanixOpt {

--- a/test/framework/snow.go
+++ b/test/framework/snow.go
@@ -299,7 +299,7 @@ func (s *Snow) WithBottlerocketStaticIP127() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu123() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.withKubeVersionAndOS(anywherev1.Kube123, anywherev1.Ubuntu)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube123)
 }
 
 // WithUbuntu124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
@@ -307,7 +307,7 @@ func (s *Snow) WithUbuntu123() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu124() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.withKubeVersionAndOS(anywherev1.Kube124, anywherev1.Ubuntu)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube124)
 }
 
 // WithUbuntu125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
@@ -315,7 +315,7 @@ func (s *Snow) WithUbuntu124() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu125() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.withKubeVersionAndOS(anywherev1.Kube125, anywherev1.Ubuntu)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube125)
 }
 
 // WithUbuntu126 returns a cluster config filler that sets the kubernetes version of the cluster to 1.26
@@ -323,7 +323,7 @@ func (s *Snow) WithUbuntu125() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu126() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.withKubeVersionAndOS(anywherev1.Kube126, anywherev1.Ubuntu)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube126)
 }
 
 // WithUbuntu127 returns a cluster config filler that sets the kubernetes version of the cluster to 1.27
@@ -331,12 +331,12 @@ func (s *Snow) WithUbuntu126() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu127() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.withKubeVersionAndOS(anywherev1.Kube127, anywherev1.Ubuntu)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube127)
 }
 
 func (s *Snow) withBottlerocketForKubeVersion(kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	return api.JoinClusterConfigFillers(
-		s.withKubeVersionAndOS(kubeVersion, anywherev1.Bottlerocket),
+		s.WithKubeVersionAndOS(anywherev1.Bottlerocket, kubeVersion),
 		api.SnowToConfigFiller(api.WithChangeForAllSnowMachines(api.WithSnowContainersVolumeSize(100))),
 	)
 }
@@ -344,14 +344,16 @@ func (s *Snow) withBottlerocketForKubeVersion(kubeVersion anywherev1.KubernetesV
 func (s *Snow) withBottlerocketStaticIPForKubeVersion(kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	poolName := "pool-1"
 	return api.JoinClusterConfigFillers(
-		s.withKubeVersionAndOS(kubeVersion, anywherev1.Bottlerocket),
+		s.WithKubeVersionAndOS(anywherev1.Bottlerocket, kubeVersion),
 		api.SnowToConfigFiller(api.WithChangeForAllSnowMachines(api.WithSnowContainersVolumeSize(100))),
 		api.SnowToConfigFiller(api.WithChangeForAllSnowMachines(api.WithStaticIP(poolName))),
 		api.SnowToConfigFiller(s.withIPPoolFromEnvVar(poolName)),
 	)
 }
 
-func (s *Snow) withKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, osFamily anywherev1.OSFamily) api.ClusterConfigFiller {
+// WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the correct AMI ID
+// and devices for the Snow machine configs.
+func (s *Snow) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	envar := fmt.Sprintf("T_SNOW_AMIID_%s_%s", strings.ToUpper(string(osFamily)), strings.ReplaceAll(string(kubeVersion), ".", "_"))
 
 	return api.JoinClusterConfigFillers(
@@ -458,6 +460,14 @@ func (s *Snow) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup
 	return api.JoinClusterConfigFillers(
 		api.ClusterToConfigFiller(buildSnowWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
 		api.SnowToConfigFiller(snowMachineConfig(name, fillers...)),
+	)
+}
+
+// WithNewWorkerNodeGroup returns a filler that updates/creates the provided worker node group with its corresponding SnowMachineConfig.
+func (s *Snow) WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(buildSnowWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
+		api.SnowToConfigFiller(snowMachineConfig(name)),
 	)
 }
 

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -153,6 +153,20 @@ func (t *Tinkerbell) CleanupVMs(_ string) error {
 	return nil
 }
 
+// WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
+// tinkerbell machine configs.
+func (t *Tinkerbell) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+	// TODO: Update tests to use this
+	panic("Not implemented for Tinkerbell yet")
+}
+
+// WithNewWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// a corresponding TinkerbellMachineConfig to the cluster config.
+func (t *Tinkerbell) WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	// TODO: Implement for Tinkerbell provider
+	panic("Not implemented for Tinkerbell yet")
+}
+
 func WithUbuntu123Tinkerbell() TinkerbellOpt {
 	return func(t *Tinkerbell) {
 		t.fillers = append(t.fillers,

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -449,10 +449,10 @@ func WithVSphereWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, f
 	}
 }
 
-// WithWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
+// WithNewWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and
 // a corresponding VSphereMachineConfig to the cluster config.
-func (v *VSphere) WithWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup, fillers ...api.VSphereMachineConfigFiller) api.ClusterConfigFiller {
-	machineConfigFillers := append([]api.VSphereMachineConfigFiller{updateMachineSSHAuthorizedKey()}, fillers...)
+func (v *VSphere) WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller {
+	machineConfigFillers := []api.VSphereMachineConfigFiller{updateMachineSSHAuthorizedKey()}
 	return api.JoinClusterConfigFillers(
 		api.VSphereToConfigFiller(vSphereMachineConfig(name, machineConfigFillers...)),
 		api.ClusterToConfigFiller(buildVSphereWorkerNodeGroupClusterFiller(name, workerNodeGroup)),
@@ -501,6 +501,18 @@ func (v *VSphere) ClusterConfigUpdates() []api.ClusterConfigFiller {
 	f = append(f, api.WithControlPlaneEndpointIP(clusterIP))
 
 	return []api.ClusterConfigFiller{api.ClusterToConfigFiller(f...), api.VSphereToConfigFiller(v.fillers...)}
+}
+
+// WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
+// vsphere machine configs.
+func (v *VSphere) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
+		api.VSphereToConfigFiller(
+			api.WithTemplateForAllMachines(v.templateForDevRelease(osFamily, kubeVersion)),
+			api.WithOsFamilyForAllMachines(osFamily),
+		),
+	)
 }
 
 // CleanupVMs deletes all the VMs owned by the test EKS-A cluster. It satisfies the test framework Provider.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
E2E tests for modular upgrades. 

This verifies that upgrading the mgmt cluster EKS-A minor version does not affect workload custers

*Testing (if applicable):*
Ran docker E2E

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

