### PR TITLE
Remove invalid update availability zone API test

### DIFF
--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -165,43 +165,19 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 			},
 		},
 		{
-			name: "replace existing worker node groups",
+			name: "replace existing worker node groups and cilium policy enforcement mode",
 			steps: []cloudStackAPIUpgradeTestStep{
 				{
-					name: "replacing existing worker node groups",
+					name: "replacing existing worker node groups + update cilium policy enforcement mode always",
 					configFiller: api.JoinClusterConfigFillers(
 						api.ClusterToConfigFiller(
+							api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
 							api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 						),
 						// Add new WorkerNodeGroups
 						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-2", clusterName), api.WithCount(1))),
 						cloudstack.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), framework.WithWorkerNodeGroup(clusterPrefix("md-3", clusterName), api.WithCount(1))),
 						cloudstack.WithRedhatVersion(wc.ClusterConfig.Cluster.Spec.KubernetesVersion),
-					),
-				},
-			},
-		},
-		{
-			name: "availability zones and cilium policy enforcement mode",
-			steps: []cloudStackAPIUpgradeTestStep{
-				{
-					name: "add availability zone + update cilium policy enforcement mode always",
-					configFiller: api.JoinClusterConfigFillers(
-						api.ClusterToConfigFiller(
-							api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
-						),
-						api.CloudStackToConfigFiller(
-							framework.UpdateAddCloudStackAz2(),
-						),
-					),
-				},
-				{
-					name: "remove cloudstack availability zone",
-					configFiller: api.JoinClusterConfigFillers(
-						api.CloudStackToConfigFiller(
-							framework.RemoveAllCloudStackAzs(),
-							framework.UpdateAddCloudStackAz1(),
-						),
 					),
 				},
 			},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Unfortunately in CloudStack networks cannot be shared between zones. So that means each zone has its own set of unique networks. The ControlPlane IP must be in the same network as the zone for a cluster to utilize it, which means this test is invalid.

*Testing (if applicable):*
```
--- PASS: TestCloudStackMulticlusterWorkloadClusterAPI (2407.06s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/add_and_remove_labels_and_taints#01 (698.41s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/add_and_remove_labels_and_taints (935.45s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/scale_up_and_down_cp_and_worker_node_group_#01 (330.54s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/scale_up_and_down_cp_and_worker_node_group_ (546.19s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/replace_existing_worker_node_groups_and_cilium_policy_enforcement_mode (124.38s)
    --- PASS: TestCloudStackMulticlusterWorkloadClusterAPI/replace_existing_worker_node_groups_and_cilium_policy_enforcement_mode#01 (114.70s)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

