### PR TITLE
Fix vSphere management cluster API test

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -1762,6 +1762,7 @@ func TestCloudStackKubernetes123RedHatAPI(t *testing.T) {
 	)
 
 	test.CreateCluster()
+	test.LoadClusterConfigGeneratedByCLI()
 	// Run mgmt cluster API tests
 	tests := cloudstackAPIManagementClusterUpgradeTests(test, cloudstack)
 	for _, tt := range tests {
@@ -1787,6 +1788,7 @@ func TestCloudStackKubernetes124RedHatAPI(t *testing.T) {
 	)
 
 	test.CreateCluster()
+	test.LoadClusterConfigGeneratedByCLI()
 	// Run mgmt cluster API tests
 	tests := cloudstackAPIManagementClusterUpgradeTests(test, cloudstack)
 	for _, tt := range tests {

--- a/test/e2e/cloudstack_upgrade.go
+++ b/test/e2e/cloudstack_upgrade.go
@@ -212,7 +212,8 @@ func cloudStackAPIWorkloadUpgradeTests(wc *framework.WorkloadCluster, cloudstack
 func runCloudStackAPIUpgradeTest(t *testing.T, test *framework.ClusterE2ETest, ut cloudStackAPIUpgradeTest) {
 	for _, step := range ut.steps {
 		t.Logf("Running API upgrade test: %s", step.name)
-		test.UpgradeClusterWithKubectl(step.configFiller)
+		test.UpdateClusterConfig(step.configFiller)
+		test.ApplyClusterManifest()
 		test.ValidateClusterStateWithT(t)
 	}
 }

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -42,7 +42,9 @@ func runSimpleUpgradeFlowForBareMetal(test *framework.ClusterE2ETest, updateVers
 
 func runUpgradeFlowWithAPI(test *framework.ClusterE2ETest, fillers ...api.ClusterConfigFiller) {
 	test.CreateCluster()
-	test.UpgradeClusterWithKubectl(fillers...)
+	test.LoadClusterConfigGeneratedByCLI()
+	test.UpdateClusterConfig(fillers...)
+	test.ApplyClusterManifest()
 	test.ValidateClusterState()
 	test.StopIfFailed()
 	test.DeleteCluster()
@@ -53,7 +55,9 @@ func runUpgradeFlowForBareMetalWithAPI(test *framework.ClusterE2ETest, fillers .
 	test.GenerateHardwareConfig()
 	test.PowerOffHardware()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
-	test.UpgradeClusterWithKubectl(fillers...)
+	test.LoadClusterConfigGeneratedByCLI()
+	test.UpdateClusterConfig(fillers...)
+	test.ApplyClusterManifest()
 	test.ValidateClusterState()
 	test.StopIfFailed()
 	test.DeleteCluster()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -797,22 +797,10 @@ func WithClusterUpgrade(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 	}
 }
 
-// UpgradeClusterWithKubectl uses client-side logic to upgrade a cluster that was created using the CLI.
-func (e *ClusterE2ETest) UpgradeClusterWithKubectl(fillers ...api.ClusterConfigFiller) {
-	// The CLI adds the BundlesRef field to the config and writes it to disk.
-	// We want to grab the existing BundlesRef, and update our test ClusterConfig
-	// because updating it with a nil value after previously being set will throw a webhook error.
-	if e.ClusterConfig.Cluster.Spec.BundlesRef == nil {
-		fullClusterConfigLocation := filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a-cluster.yaml")
-		e.T.Logf("Parsing cluster config from disk: %s", fullClusterConfigLocation)
-		config, err := cluster.ParseConfigFromFile(fullClusterConfigLocation)
-		if err != nil {
-			e.T.Fatalf("Failed parsing generated cluster config: %s", err)
-		}
-		e.ClusterConfig.Cluster.Spec.BundlesRef = config.Cluster.Spec.BundlesRef
-	}
-	e.UpdateClusterConfig(fillers...)
-	e.ApplyClusterManifest()
+// LoadClusterConfigGeneratedByCLI loads the full cluster config from the file generated when a cluster is created using the CLI.
+func (e *ClusterE2ETest) LoadClusterConfigGeneratedByCLI(fillers ...api.ClusterConfigFiller) {
+	fullClusterConfigLocation := filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a-cluster.yaml")
+	e.parseClusterConfigFromDisk(fullClusterConfigLocation)
 }
 
 // UpgradeClusterWithNewConfig applies the test options, re-generates the cluster config file and runs the CLI upgrade command.


### PR DESCRIPTION
…roupsAPI test

*Issue #, if available:*

*Description of changes:*
This PR aims to fix the e2e `TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI` that throws the following error during an upgrade:

```
admission webhook "validation.vspheremachineconfig.anywhere.amazonaws.com" denied the request: VSphereMachineConfig.anywhere.eks.amazonaws.com "release-i-08f80-5465421-cp" is invalid: spec.resourcePool: Forbidden: field is immutable
--- FAIL: TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI (829.46s)
```
Some changes were made recently to `ClusterE2ETest` object's `UpdateClusterWithKubectl` method. Previously, it parsed the cluster config from the full cluster config file generated by the CLI and replaced the `ClusterConfig` on the test object with it, however, it was changed to only override the `BundlesRef` due to overriding the ClusterConfig on the test every upgrade with the initial config state after creation being undesirable. 

The problem is, this full cluster config file contains extra defaults or modifications of the initial input values to create the cluster, therefore, not present in the input `ClusterConfig` object on the test. So in this case, the resourcePool value on the `VSphereMachineConfig` applied when its time to run the update did not have the same value used when creating the cluster object initially.

Therefore, this PR addresses the issue by decoupling loading the full cluster config generated by the CLI during creating from the upgrade step in the e2e tests. Rather than overriding the `ClusterConfig` on the test object, before every upgrade, the full cluster config file is loaded to the test object once after the self managed cluster is created and upgrades using an accurate `ClusterConfig` object can be performed going forward.

*Testing (if applicable):*
`--- PASS: TestVSphereKubernetes124UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI (830.28s)
`
```
--- PASS: TestCloudStackKubernetes123RedHatAPI (2020.32s)
    --- PASS: TestCloudStackKubernetes123RedHatAPI/add_and_remove_labels_and_taints (409.98s)
    --- PASS: TestCloudStackKubernetes123RedHatAPI/scale_up_and_down_worker_node_group (136.79s)
    --- PASS: TestCloudStackKubernetes123RedHatAPI/replace_existing_worker_node_groups (107.19s)
PASS
```

```
--- PASS: TestCloudStackKubernetes124RedHatAPI (1986.36s)
    --- PASS: TestCloudStackKubernetes124RedHatAPI/add_and_remove_labels_and_taints (471.74s)
    --- PASS: TestCloudStackKubernetes124RedHatAPI/scale_up_and_down_worker_node_group (144.10s)
    --- PASS: TestCloudStackKubernetes124RedHatAPI/replace_existing_worker_node_groups (137.98s)
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

