### PR TITLE
add syslog port to the list of used ports for Bare Metal provider

### DIFF
--- a/docs/content/en/docs/getting-started/ports/_index.md
+++ b/docs/content/en/docs/getting-started/ports/_index.md
@@ -65,6 +65,7 @@ On the Admin machine for a Bare Metal provider, the following ports need to be a
 |----------|-----------|------------|-------------------------|------------------------------ |
 | UDP      | Inbound   | 67         | Boots DHCP              | All nodes, for network boot   |
 | UDP      | Inbound   | 69         | Boots TFTP              | All nodes, for network boot   |
+| UDP      | Inbound   | 514        | Boots Syslog            | All nodes, for provisioning logs |
 | TCP      | Inbound   | 80         | Boots HTTP              | All nodes, for network boot   |
 | TCP      | Inbound   | 42113      | Tink-server gRPC        | All nodes, talk to Tinkerbell |
 | TCP      | Inbound   | 50061      | Hegel HTTP              | All nodes, talk to Tinkerbell |


### PR DESCRIPTION
*Description of changes:*
Seems syslog messages are sent from the host that is getting provisioned to boots. Example logs from hubble observe (using host firewall with cilium community):
```
Jun  5 08:17:26.198: HOSTIP:56019 (remote-node) -> BOOTSIP:514 (host) policy-verdict:none INGRESS AUDITED (UDP)
Jun  5 08:17:28.266: HOSTIP:35963 (remote-node) -> BOOTSIP:514 (host) policy-verdict:none INGRESS AUDITED (UDP)
```

This PR will add the UDP 514 to the list of ports for bare-metal provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

