### PR TITLE
Skip http e2e tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -9,6 +9,8 @@ skipped_tests:
 - TestCloudStackKubernetes124UpgradeFromLatestMinorRelease
 - TestCloudStackKubernetes123RedhatProxyConfig
 - TestCloudStackKubernetes124RedhatProxyConfig
+- TestCloudStackKubernetes123RedhatProxyConfigAPI
+- TestCloudStackKubernetes124RedhatProxyConfigAPI
 - TestCloudStackKubernetes123AddRemoveAz
 - TestCloudStackKubernetes124AddRemoveAz
 - TestCloudStackKubernetes123MultiEndpointSimpleFlow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Skip http proxy e2e tests. We don't yet have a tested set up for http proxy in our e2e infrastructure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

