### PR TITLE
Add setting webhook data via env and cli flags:

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -94,7 +95,8 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, nil).
-		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false, dc.tinkerbellBootstrapIP).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: dc.hardwareFileName, IP: dc.tinkerbellBootstrapIP}).
+		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, false).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -30,7 +30,9 @@ func bindFlagsToViper(cmd *cobra.Command, args []string) error {
 		// viper.AutomaticEnv() needs help with dashes in flag names.
 		if !flag.Changed && viper.IsSet(flag.Name) {
 			val := viper.Get(flag.Name)
-			cmd.Flags().Set(flag.Name, fmt.Sprintf("%v", val))
+			if err := cmd.Flags().Set(flag.Name, fmt.Sprintf("%v", val)); err != nil {
+				return
+			}
 		}
 	})
 

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
@@ -89,7 +90,8 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: gsbo.hardwareFileName, IP: gsbo.tinkerbellBootstrapIP}).
+		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, false).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
@@ -89,7 +90,8 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false, csbo.tinkerbellBootstrapIP).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: csbo.hardwareFileName, IP: csbo.tinkerbellBootstrapIP}).
+		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, false).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
@@ -103,7 +104,8 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).
 		WithKubeProxyCLIUpgrader().
-		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: uc.hardwareCSVPath, IP: uc.tinkerbellBootstrapIP}).
+		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.forceClean).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithCAPIManager().

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -18,6 +18,7 @@ import (
 	fluxupgrader "github.com/aws/eks-anywhere/pkg/gitops/flux"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -78,7 +79,8 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster, nil).
-		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: uc.hardwareCSVPath, IP: uc.tinkerbellBootstrapIP}).
+		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.forceClean).
 		WithGitOpsFlux(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
 		WithCAPIManager().
 		Build(ctx)

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
+	tbell "github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/registrymirror"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -69,7 +70,7 @@ func TestFactoryBuildWithProvidervSphere(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -81,7 +82,8 @@ func TestFactoryBuildWithProviderTinkerbell(t *testing.T) {
 	tt := newTest(t, tinkerbell)
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithTinkerbellConfig(tbell.Config{HardwareFile: tt.hardwareConfigFile, IP: tt.tinkerbellBootstrapIP}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -97,7 +99,7 @@ func TestFactoryBuildWithProviderSnow(t *testing.T) {
 
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -130,7 +132,7 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 
 		deps, err := dependencies.NewFactory().
 			WithLocalExecutables().
-			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 			WithNutanixValidator().
 			Build(context.Background())
 
@@ -151,7 +153,7 @@ func TestFactoryBuildWithInvalidProvider(t *testing.T) {
 
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		Build(context.Background())
 
 	tt.Expect(err).NotTo(BeNil())
@@ -196,7 +198,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithBootstrapper().
 		WithCliConfig(&tt.cliConfig).
 		WithClusterManager(tt.clusterSpec.Cluster, timeoutOpts).
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		WithGitOpsFlux(tt.clusterSpec.Cluster, tt.clusterSpec.FluxConfig, nil).
 		WithWriter().
 		WithEksdInstaller().
@@ -499,7 +501,7 @@ func TestFactoryBuildWithCNIInstallerCilium(t *testing.T) {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		Build(tt.ctx)
 	tt.Expect(err).To(BeNil())
 
@@ -521,7 +523,7 @@ func TestFactoryBuildWithCNIInstallerKindnetd(t *testing.T) {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false).
 		Build(tt.ctx)
 	tt.Expect(err).To(BeNil())
 

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -232,7 +232,7 @@ func (p *Provider) readCSVToCatalogue() error {
 		return err
 	}
 
-	var mods = []func(hardware.Machine) hardware.Machine{}
+	mods := []func(hardware.Machine) hardware.Machine{}
 	// If webhook secrets have been defined, we create a modifier that will update all
 	// machine.BMCPassword values. This modifier will run as a part of hardware.TranslateAll().
 	if p.config.Rufio.WebhookSecret != "" {

--- a/pkg/providers/tinkerbell/hardware/csv.go
+++ b/pkg/providers/tinkerbell/hardware/csv.go
@@ -92,7 +92,7 @@ func ensureRequiredColumnsInCSV(unmatched []string) error {
 }
 
 // BuildHardwareYAML builds a hardware yaml from the csv at the provided path.
-func BuildHardwareYAML(path string) ([]byte, error) {
+func BuildHardwareYAML(path string, webhookSecret string) ([]byte, error) {
 	reader, err := NewNormalizedCSVReaderFromFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading csv: %v", err)
@@ -103,7 +103,25 @@ func BuildHardwareYAML(path string) ([]byte, error) {
 
 	validator := NewDefaultMachineValidator()
 
-	err = TranslateAll(reader, writer, validator)
+	// If webhook secrets have been defined, update all machine bmc_passwords.
+	// Have to do it here since the hardware.TranslateAll call below does a validation before writing to the catalogue,
+	// so updating the catalogueWriter is not an option.
+	// If webhook secrets have been defined, update all machine bmc_passwords to use the webhook secret.
+	var mods = []func(Machine) Machine{}
+	if webhookSecret != "" {
+		mods = append(mods, func(m Machine) Machine {
+			m.BMCPassword = webhookSecret
+			if m.BMCUsername == "" {
+				// We update this to a static username so that validations pass.
+				// When the secret != "" then the BMCUsername is not relevant to the Rufio webhook provider.
+				m.BMCUsername = "rufio"
+			}
+
+			return m
+		})
+	}
+
+	err = TranslateAll(reader, writer, validator, mods...)
 	if err != nil {
 		return nil, fmt.Errorf("generating hardware yaml: %v", err)
 	}

--- a/pkg/providers/tinkerbell/hardware/csv.go
+++ b/pkg/providers/tinkerbell/hardware/csv.go
@@ -107,7 +107,7 @@ func BuildHardwareYAML(path string, webhookSecret string) ([]byte, error) {
 	// Have to do it here since the hardware.TranslateAll call below does a validation before writing to the catalogue,
 	// so updating the catalogueWriter is not an option.
 	// If webhook secrets have been defined, update all machine bmc_passwords to use the webhook secret.
-	var mods = []func(Machine) Machine{}
+	mods := []func(Machine) Machine{}
 	if webhookSecret != "" {
 		mods = append(mods, func(m Machine) Machine {
 			m.BMCPassword = webhookSecret

--- a/pkg/providers/tinkerbell/hardware/csv_test.go
+++ b/pkg/providers/tinkerbell/hardware/csv_test.go
@@ -147,7 +147,7 @@ func TestCSVReaderWithMissingRequiredColumns(t *testing.T) {
 func TestCSVBuildHardwareYamlFromCSV(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	hardwareYaml, err := hardware.BuildHardwareYAML("./testdata/hardware.csv")
+	hardwareYaml, err := hardware.BuildHardwareYAML("./testdata/hardware.csv", "")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(hardwareYaml).To(gomega.Equal([]byte(`apiVersion: tinkerbell.org/v1alpha1
 kind: Hardware

--- a/pkg/providers/tinkerbell/rufio/rufio.go
+++ b/pkg/providers/tinkerbell/rufio/rufio.go
@@ -1,0 +1,10 @@
+package rufio
+
+// Config is for Rufio specific configuration.
+type Config struct {
+	// WebhookSecret is the secret that will be used to sign webhook notifications in Rufio.
+	// Multiple secrets can be used by separating them with a comma.
+	WebhookSecret string
+	// WebhookURL is the URL that will be used when sending webhook notifications in Rufio.
+	WebhookURL string
+}

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -66,15 +66,17 @@ func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineC
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		testIP,
 		test.FakeNow,
 		forceCleanup,
 		false,
+		Config{
+			HardwareFile: hardwareFile,
+			IP:           testIP,
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -524,7 +526,7 @@ func TestPostMoveManagementToBootstrapSuccess(t *testing.T) {
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
-			provider.hardwareCSVFile = test.hardwareCSVFile
+			provider.config.HardwareFile = test.hardwareCSVFile
 			if err := provider.readCSVToCatalogue(); err != nil {
 				t.Fatalf("failed to read hardware csv: %v", err)
 			}
@@ -1309,7 +1311,7 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorBMC(t *testing.T) {
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 	provider.stackInstaller = stackInstaller
 	provider.providerKubectlClient = kubectl
-	provider.hardwareCSVFile = "testdata/hardware.csv"
+	provider.config.HardwareFile = "testdata/hardware.csv"
 
 	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -68,16 +68,7 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 	// If we've been given a CSV with additional hardware for the cluster, validate it and
 	// write it to the catalogue so it can be used for further processing.
 	if p.hardwareCSVIsProvided() {
-		machineCatalogueWriter := hardware.NewMachineCatalogueWriter(p.catalogue)
-
-		machines, err := hardware.NewNormalizedCSVReaderFromFile(p.hardwareCSVFile)
-		if err != nil {
-			return err
-		}
-
-		machineValidator := hardware.NewDefaultMachineValidator()
-
-		if err := hardware.TranslateAll(machines, machineCatalogueWriter, machineValidator); err != nil {
+		if err := p.readCSVToCatalogue(); err != nil {
 			return err
 		}
 	}
@@ -283,7 +274,7 @@ func (p *Provider) UpgradeNeeded(_ context.Context, _, _ *cluster.Spec, _ *types
 }
 
 func (p *Provider) hardwareCSVIsProvided() bool {
-	return p.hardwareCSVFile != ""
+	return p.config.HardwareFile != ""
 }
 
 func (p *Provider) isScaleUpDown(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster) bool {

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -587,15 +587,17 @@ func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
 		t.DatacenterConfig,
 		t.MachineConfigs,
 		t.ClusterSpec.Cluster,
-		"",
 		t.Writer,
 		t.Docker,
 		t.Helm,
 		t.KubeClient,
-		testIP,
 		test.FakeNow,
 		false,
 		false,
+		Config{
+			HardwareFile: "",
+			IP:           testIP,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -633,15 +635,17 @@ func newTinkerbellProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		testIP,
 		test.FakeNow,
 		forceCleanup,
 		false,
+		Config{
+			HardwareFile: hardwareFile,
+			IP:           testIP,
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -441,15 +441,17 @@ func newProvider(datacenterConfig v1alpha1.TinkerbellDatacenterConfig, machineCo
 		&datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		"1.2.3.4",
 		test.FakeNow,
 		forceCleanup,
 		false,
+		tinkerbell.Config{
+			HardwareFile: hardwareFile,
+			IP:           "1.2.3.4",
+		},
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This enables the use of the Rufio webhook provider. The webhook provider needs a secret and a URL defined. All BMC machines will use this one secret.

As part of enabling the webhook secret to be captured by the CLI as an environment variable, all CLI flags are now accessible as env vars. The env var for each flag is the flag name but in all uppercase and the dash "-" symbol converted to an underscore "_".

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

