### PR TITLE
Assign buildNumber as bundle number for Dev Build

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -151,11 +151,17 @@ var releaseCmd = &cobra.Command{
 		releaseConfig.ReleaseClients = releaseClients
 
 		if devRelease {
-			releaseVersion, err = filereader.GetCurrentEksADevReleaseVersion(releaseVersion, releaseConfig)
+			buildNumber, err := filereader.GetNextEksADevBuildNumber(releaseVersion, releaseConfig)
 			if err != nil {
 				fmt.Printf("Error getting previous EKS-A dev release number: %v\n", err)
 				os.Exit(1)
 			}
+			releaseVersion, err = filereader.GetCurrentEksADevReleaseVersion(releaseVersion, releaseConfig, buildNumber)
+			if err != nil {
+				fmt.Printf("Error getting previous EKS-A dev release number: %v\n", err)
+				os.Exit(1)
+			}
+			releaseConfig.BundleNumber = buildNumber
 			releaseConfig.ReleaseVersion = releaseVersion
 		}
 		releaseConfig.DevReleaseUriVersion = strings.ReplaceAll(releaseVersion, "+", "-")

--- a/release/pkg/assets/archives/archives_test.go
+++ b/release/pkg/assets/archives/archives_test.go
@@ -151,7 +151,7 @@ func TestGenerateArchiveAssets(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			releaseConfig.BuildRepoBranchName = tt.buildRepoBranchName
 
-			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig)
+			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig, 0)
 			if err != nil {
 				t.Fatalf("Error getting previous EKS-A dev release number: %v\n", err)
 			}

--- a/release/pkg/assets/images/images_test.go
+++ b/release/pkg/assets/images/images_test.go
@@ -193,7 +193,7 @@ func TestGenerateImageAssets(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			releaseConfig.BuildRepoBranchName = tt.buildRepoBranchName
 
-			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig)
+			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig, 0)
 			if err != nil {
 				t.Fatalf("Error getting previous EKS-A dev release number: %v\n", err)
 			}

--- a/release/pkg/assets/manifests/manifests_test.go
+++ b/release/pkg/assets/manifests/manifests_test.go
@@ -138,7 +138,7 @@ func TestGenerateManifestAssets(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			releaseConfig.BuildRepoBranchName = tt.buildRepoBranchName
 
-			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig)
+			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig, 0)
 			if err != nil {
 				t.Fatalf("Error getting previous EKS-A dev release number: %v\n", err)
 			}

--- a/release/pkg/filereader/file_reader_test.go
+++ b/release/pkg/filereader/file_reader_test.go
@@ -18,78 +18,57 @@ import (
 	"testing"
 )
 
-func TestGenerateNewDevReleaseVersion(t *testing.T) {
+func TestNewBuildNumberFromLastVersion(t *testing.T) {
 	testCases := []struct {
 		testName           string
 		latestBuildVersion string
 		releaseVersion     string
 		branch             string
-		want               string
+		want               int
 	}{
-		{
-			testName:           "vDev release",
-			latestBuildVersion: "vDev.build.68",
-			releaseVersion:     "vDev",
-			branch:             "main",
-			want:               "v0.0.0-dev+build.69",
-		},
 		{
 			testName:           "vDev release with latest v0.0.0",
 			latestBuildVersion: "v0.0.0-dev+build.5",
 			releaseVersion:     "vDev",
 			branch:             "main",
-			want:               "v0.0.0-dev+build.6",
-		},
-		{
-			testName:           "v0.0.0 release with latest vDev",
-			latestBuildVersion: "vDev.build.5",
-			releaseVersion:     "v0.0.0",
-			branch:             "main",
-			want:               "v0.0.0-dev+build.6",
+			want:               6,
 		},
 		{
 			testName:           "v0.0.0 release with latest v0.0.0",
 			latestBuildVersion: "v0.0.0-dev+build.68",
 			releaseVersion:     "v0.0.0",
 			branch:             "main",
-			want:               "v0.0.0-dev+build.69",
+			want:               69,
 		},
 		{
 			testName:           "different semver",
 			latestBuildVersion: "v0.0.0-dev+build.5",
 			releaseVersion:     "v0.0.1",
 			branch:             "main",
-			want:               "v0.0.1-dev+build.0",
-		},
-		{
-			testName:           "vDev release, non-main",
-			latestBuildVersion: "vDev.build.68",
-			releaseVersion:     "vDev",
-			branch:             "v1beta1",
-			want:               "v0.0.0-dev-v1beta1+build.69",
+			want:               0,
 		},
 		{
 			testName:           "vDev release with latest v0.0.0, non-main",
 			latestBuildVersion: "v0.0.0-dev-v1beta+build.5",
 			releaseVersion:     "vDev",
 			branch:             "v1beta1",
-			want:               "v0.0.0-dev-v1beta1+build.6",
+			want:               6,
 		},
 		{
 			testName:           "v0.0.0 release with latest v0.0.0, non-main branch",
 			latestBuildVersion: "v0.0.0-dev-v1beta1+build.0",
 			releaseVersion:     "v0.0.0",
 			branch:             "v1beta1",
-			want:               "v0.0.0-dev-v1beta1+build.1",
+			want:               1,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			if got, err := GenerateNewDevReleaseVersion(tt.latestBuildVersion, tt.releaseVersion, tt.branch); err != nil {
-				t.Fatalf("generateNewDevReleaseVersion err = %s, want err = nil", err)
+			if got, err := NewBuildNumberFromLastVersion(tt.latestBuildVersion, tt.releaseVersion, tt.branch); err != nil {
+				t.Fatalf("NewBuildNumberFromLastVersion err = %s, want err = nil", err)
 			} else if got != tt.want {
-				t.Fatalf("generateNewDevReleaseVersion version = %s, want %s", got, tt.want)
+				t.Fatalf("NewBuildNumberFromLastVersion version = %d, want %d", got, tt.want)
 			}
 		})
 	}

--- a/release/pkg/images/images.go
+++ b/release/pkg/images/images.go
@@ -258,9 +258,13 @@ func GetReleaseImageURI(r *releasetypes.ReleaseConfig, name, repoName string, ta
 					semver = previousReleaseImageSemver
 					fmt.Printf("Image digest for %s image has not changed, tagging with previous dev release semver: %s\n", repoName, semver)
 				} else {
-					newSemver, err := filereader.GenerateNewDevReleaseVersion(previousReleaseImageSemver, "vDev", r.BuildRepoBranchName)
+					buildNumber, err := filereader.NewBuildNumberFromLastVersion(previousReleaseImageSemver, "vDev", r.BuildRepoBranchName)
 					if err != nil {
-						return "", errors.Cause(err)
+						return "", err
+					}
+					newSemver, err := filereader.GetCurrentEksADevReleaseVersion("vDev", r, buildNumber)
+					if err != nil {
+						return "", err
 					}
 					semver = strings.ReplaceAll(newSemver, "+", "-")
 					fmt.Printf("Image digest for %s image has changed, tagging with new dev release semver: %s\n", repoName, semver)

--- a/release/pkg/operations/bundle_release_test.go
+++ b/release/pkg/operations/bundle_release_test.go
@@ -111,7 +111,7 @@ func TestGenerateBundleManifest(t *testing.T) {
 			releaseConfig.BuildRepoBranchName = tt.buildRepoBranchName
 			releaseConfig.CliRepoBranchName = tt.cliRepoBranchName
 
-			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig)
+			releaseVersion, err := filereader.GetCurrentEksADevReleaseVersion(releaseConfig.ReleaseVersion, releaseConfig, 0)
 			if err != nil {
 				t.Fatalf("Error getting previous EKS-A dev release number: %v\n", err)
 			}

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -57,7 +57,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-23-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -244,13 +244,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-23-22 release
-          name: bottlerocket-v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-23-23 release
+          name: bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-23/1-23-22/bottlerocket-v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-23/1-23-23/bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.0-amd64.img.gz
       channel: 1-23
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       containerd:
@@ -298,32 +298,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.23.17
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-22.yaml
-      name: kubernetes-1-23-eks-22
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-23.yaml
+      name: kubernetes-1-23-eks-23
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-22 release
-          name: bottlerocket-v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-23 release
+          name: bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-22/bottlerocket-v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-23/1-23-23/bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-22 release
-          name: bottlerocket-v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-23 release
+          name: bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-22/bottlerocket-v1.23.17-eks-d-1-23-22-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-23/1-23-23/bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -516,7 +516,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-23-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
@@ -852,7 +852,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-17-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-18-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1039,13 +1039,13 @@ spec:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-24-17 release
-          name: bottlerocket-v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-24-18 release
+          name: bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-24/1-24-17/bottlerocket-v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ami/1-24/1-24-18/bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
       channel: 1-24
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
       containerd:
@@ -1093,32 +1093,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.24.13
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-17.yaml
-      name: kubernetes-1-24-eks-17
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-18.yaml
+      name: kubernetes-1-24-eks-18
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-24-17 release
-          name: bottlerocket-v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-24-18 release
+          name: bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-24/1-24-17/bottlerocket-v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-24/1-24-18/bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-24-17 release
-          name: bottlerocket-v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-24-18 release
+          name: bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-24/1-24-17/bottlerocket-v1.24.13-eks-d-1-24-17-eks-a-v0.0.0-dev-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/eks-distro/raw/1-24/1-24-18/bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1311,7 +1311,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-17-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-18-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
@@ -1647,7 +1647,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-13-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-14-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1879,10 +1879,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.9-eks-d-1-25-13-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.9-eks-d-1-25-14-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.25.9
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-13.yaml
-      name: kubernetes-1-25-eks-13
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-14.yaml
+      name: kubernetes-1-25-eks-14
       ova:
         bottlerocket: {}
       raw:
@@ -2079,7 +2079,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-13-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-14-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
@@ -2415,7 +2415,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-26-9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-26-10-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -2647,10 +2647,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.26.4-eks-d-1-26-9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.26.4-eks-d-1-26-10-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.26.4
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-26/kubernetes-1-26-eks-9.yaml
-      name: kubernetes-1-26-eks-9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-26/kubernetes-1-26-eks-10.yaml
+      name: kubernetes-1-26-eks-10
       ova:
         bottlerocket: {}
       raw:
@@ -2847,7 +2847,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-10-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
@@ -3183,7 +3183,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-27-3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-27-4-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -3415,10 +3415,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.27.1-eks-d-1-27-3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.27.1-eks-d-1-27-4-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.27.1
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-27/kubernetes-1-27-eks-3.yaml
-      name: kubernetes-1-27-eks-3
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-27/kubernetes-1-27-eks-4.yaml
+      name: kubernetes-1-27-eks-4
       ova:
         bottlerocket: {}
       raw:
@@ -3615,7 +3615,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-27-3-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-27-4-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:


### PR DESCRIPTION
*Issue #, if available:*
The bundle number for dev bundles currently are defaulted to 1. This prevents us from running E2E test for workload cluster creation with previous minor release when management cluster is created from main, as there is a pre-flight validation checking the bundle numbers of workload and management cluster. This change assigns the build number as bundle number for dev builds. 

*Description of changes:*

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

