### PR TITLE
Fixed broken alias to supportbundle

### DIFF
--- a/docs/content/en/docs/clustermgmt/support/supportbundle.md
+++ b/docs/content/en/docs/clustermgmt/support/supportbundle.md
@@ -5,7 +5,7 @@ weight: 30
 description: >
     Using the Support Bundle with your EKS Anywhere Cluster
 aliases:
-   - /docs/tasks/troubleshoot/_supportbundle
+   - /docs/tasks/troubleshoot/supportbundle
 ---
 
 This guide covers the use of the EKS Anywhere Support Bundle for troubleshooting and support.


### PR DESCRIPTION
*Description of changes:* There was a small typo in the alias to redirect requests for https://anywhere.eks.amazonaws.com/docs/tasks/troubleshoot/supportbundle/ to https://anywhere.eks.amazonaws.com/docs/clustermgmt/support/supportbundle/. This PR fixes that.

