### PR TITLE
Fixed minor version issue for getting template name for vSphere provider

### DIFF
--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -643,14 +643,14 @@ func WithBottlerocketFromRelease(release *releasev1.EksARelease, kubeVersion any
 
 func (v *VSphere) WithBottleRocketForRelease(release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	return api.VSphereToConfigFiller(
-		api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, anywherev1.Bottlerocket, v.getDevRelease(), kubeVersion)),
+		api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, anywherev1.Bottlerocket, release, kubeVersion)),
 	)
 }
 
 func optionToSetTemplateForRelease(osFamily anywherev1.OSFamily, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, osFamily, v.getDevRelease(), kubeVersion)),
+			api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, osFamily, release, kubeVersion)),
 		)
 	}
 }


### PR DESCRIPTION
*Description of changes:*
For vSphere provider, e2e tests for ex TestVSphereKubernetes124UbuntuUpgradeFromLatestMinorRelease, TestVSphereKubernetes123to124UpgradeFromLatestMinorReleaseBottleRocketAPI, etc to upgrade from minor latest release to current latest release were failing. This PR resolves that issue. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

