### PR TITLE
Add egress-masquerade-interfaces option to cilium

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -66,6 +66,11 @@ spec:
                     properties:
                       cilium:
                         properties:
+                          egressMasqueradeInterfaces:
+                            description: EgressMasquaradeInterfaces determines which
+                              network interfaces are used for masquerading. Accepted
+                              values are strings.
+                            type: string
                           policyEnforcementMode:
                             description: PolicyEnforcementMode determines communication
                               allowed between pods. Accepted values are default, always,

--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -69,7 +69,7 @@ spec:
                           egressMasqueradeInterfaces:
                             description: EgressMasquaradeInterfaces determines which
                               network interfaces are used for masquerading. Accepted
-                              values are strings.
+                              values are a valid interface name or interface prefix.
                             type: string
                           policyEnforcementMode:
                             description: PolicyEnforcementMode determines communication

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3676,7 +3676,7 @@ spec:
                           egressMasqueradeInterfaces:
                             description: EgressMasquaradeInterfaces determines which
                               network interfaces are used for masquerading. Accepted
-                              values are strings.
+                              values are a valid interface name or interface prefix.
                             type: string
                           policyEnforcementMode:
                             description: PolicyEnforcementMode determines communication
@@ -6547,7 +6547,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.uid
-        image: public.ecr.aws/l0g8r8j6/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-build.7080
+        image: public.ecr.aws/l0g8r8j6/eks-anywhere-cluster-controller:v0.0.0-eks-a-v0.0.0-dev-build.251
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3673,6 +3673,11 @@ spec:
                     properties:
                       cilium:
                         properties:
+                          egressMasqueradeInterfaces:
+                            description: EgressMasquaradeInterfaces determines which
+                              network interfaces are used for masquerading. Accepted
+                              values are strings.
+                            type: string
                           policyEnforcementMode:
                             description: PolicyEnforcementMode determines communication
                               allowed between pods. Accepted values are default, always,
@@ -6542,7 +6547,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.uid
-        image: public.ecr.aws/l0g8r8j6/eks-anywhere-cluster-controller:v0.0.0-eks-a-v0.0.0-dev-build.251
+        image: public.ecr.aws/l0g8r8j6/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-build.7080
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -56,12 +56,12 @@ func WithCiliumPolicyEnforcementMode(mode anywherev1.CiliumPolicyEnforcementMode
 }
 
 // WithCiliumEgressMasqueradeInterfaces sets the egressMasqueradeInterfaces with the provided interface option to use.
-func WithCiliumEgressMasqueradeInterfaces(mode string) ClusterFiller {
+func WithCiliumEgressMasqueradeInterfaces(interfaceName string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if c.Spec.ClusterNetwork.CNIConfig == nil {
 			c.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}}
 		}
-		c.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = mode
+		c.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = interfaceName
 	}
 }
 

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -55,6 +55,16 @@ func WithCiliumPolicyEnforcementMode(mode anywherev1.CiliumPolicyEnforcementMode
 	}
 }
 
+// WithCiliumEgressMasqueradeInterfaces sets the egressMasqueradeInterfaces with the provided interface option to use.
+func WithCiliumEgressMasqueradeInterfaces(mode string) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ClusterNetwork.CNIConfig == nil {
+			c.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}}
+		}
+		c.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = mode
+	}
+}
+
 // WithCiliumSkipUpgrade enables skip upgrade for EKSA Cilium installations.
 func WithCiliumSkipUpgrade() ClusterFiller {
 	return func(c *anywherev1.Cluster) {

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -678,12 +678,6 @@ func validateCiliumConfig(cilium *CiliumConfig) error {
 		return fmt.Errorf("cilium policyEnforcementMode \"%s\" not supported", cilium.PolicyEnforcementMode)
 	}
 
-	if cilium.EgressMasqueradeInterfaces == "" {
-		return nil
-	}
-
-	// TODO: add more checks for valid interface names
-
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -678,6 +678,12 @@ func validateCiliumConfig(cilium *CiliumConfig) error {
 		return fmt.Errorf("cilium policyEnforcementMode \"%s\" not supported", cilium.PolicyEnforcementMode)
 	}
 
+	if cilium.EgressMasqueradeInterfaces == "" {
+		return nil
+	}
+
+	// TODO: add more checks for valid interface names
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -772,7 +772,8 @@ type CiliumConfig struct {
 	// PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.
 	PolicyEnforcementMode CiliumPolicyEnforcementMode `json:"policyEnforcementMode,omitempty"`
 
-	// EgressMasquaradeInterfaces determines which network interfaces are used for masquerading. Accepted values are valid interface names or interface prefix.
+	// EgressMasquaradeInterfaces determines which network interfaces are used for masquerading. Accepted values are a valid interface name or interface prefix.
+	// +optional
 	EgressMasqueradeInterfaces string `json:"egressMasqueradeInterfaces,omitempty"`
 
 	// SkipUpgrade indicicates that Cilium maintenance should be skipped during upgrades. This can

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -561,6 +561,10 @@ func (n *CiliumConfig) Equal(o *CiliumConfig) bool {
 		return false
 	}
 
+	if n.EgressMasqueradeInterfaces != o.EgressMasqueradeInterfaces {
+		return false
+	}
+
 	oSkipUpgradeIsFalse := o.SkipUpgrade == nil || !*o.SkipUpgrade
 	nSkipUpgradeIsFalse := n.SkipUpgrade == nil || !*n.SkipUpgrade
 
@@ -767,6 +771,9 @@ type CNIConfig struct {
 type CiliumConfig struct {
 	// PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.
 	PolicyEnforcementMode CiliumPolicyEnforcementMode `json:"policyEnforcementMode,omitempty"`
+
+	// EgressMasquaradeInterfaces determines which network interfaces are used for masquerading. Accepted values are valid interface names or interface prefix.
+	EgressMasqueradeInterfaces string `json:"egressMasqueradeInterfaces,omitempty"`
 
 	// SkipUpgrade indicicates that Cilium maintenance should be skipped during upgrades. This can
 	// be used when operators wish to self manage the Cilium installation.

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2640,6 +2640,26 @@ func TestCiliumConfigEquality(t *testing.T) {
 			},
 			Equal: false,
 		},
+		{
+			Name: "EqualEgressMasqueradeInterfaces",
+			A: &v1alpha1.CiliumConfig{
+				EgressMasqueradeInterfaces: "eth0",
+			},
+			B: &v1alpha1.CiliumConfig{
+				EgressMasqueradeInterfaces: "eth0",
+			},
+			Equal: true,
+		},
+		{
+			Name: "DiffEgressMasqueradeInterfaces",
+			A: &v1alpha1.CiliumConfig{
+				EgressMasqueradeInterfaces: "eth0",
+			},
+			B: &v1alpha1.CiliumConfig{
+				EgressMasqueradeInterfaces: "eth1",
+			},
+			Equal: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -223,6 +223,11 @@ func templateValues(spec *cluster.Spec) values {
 	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != "" {
 		val["policyEnforcementMode"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode
 	}
+
+	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces != "" {
+		val["egressMasqueradeInterfaces"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces
+	}
+
 	return val
 }
 

--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -41,7 +41,7 @@ func (c UpgradePlan) Needed() bool {
 	return c.VersionUpgradeNeeded() || c.ConfigUpdateNeeded()
 }
 
-// VersionUpgradeNeeded determines if a version upgrade is needed or notß
+// VersionUpgradeNeeded determines if a version upgrade is needed or not
 // Returns true if any of the installation components needs an upgrade.
 func (c UpgradePlan) VersionUpgradeNeeded() bool {
 	return c.DaemonSet.Needed() || c.Operator.Needed()
@@ -228,7 +228,7 @@ func configMapUpgradePlan(configMap *corev1.ConfigMap, clusterSpec *cluster.Spec
 
 	egressMasqueradeUpdate := ConfigComponentUpdatePlan{
 		Name:     EgressMasqueradeInterfacesComponentName,
-		NewValue: string(newEgressMasqueradeInterfaces),
+		NewValue: newEgressMasqueradeInterfaces,
 	}
 
 	if configMap == nil {
@@ -239,7 +239,7 @@ func configMapUpgradePlan(configMap *corev1.ConfigMap, clusterSpec *cluster.Spec
 			egressMasqueradeUpdate.UpdateReason = fmt.Sprintf("Egress masquerade interfaces changed: [%s] -> [%s]", egressMasqueradeUpdate.OldValue, egressMasqueradeUpdate.NewValue)
 		}
 	} else if egressMasqueradeUpdate.NewValue != "" {
-		egressMasqueradeUpdate.UpdateReason = "Egress masquerade interfaces is not present in config"
+		egressMasqueradeUpdate.UpdateReason = "Egress masquerade interfaces field is not present in config but is configured in cluster spec"
 	}
 
 	updatePlan.Components = append(updatePlan.Components, egressMasqueradeUpdate)

--- a/pkg/networking/cilium/upgrade_plan_test.go
+++ b/pkg/networking/cilium/upgrade_plan_test.go
@@ -26,7 +26,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			installation: &cilium.Installation{
 				DaemonSet: daemonSet("cilium:v1.0.0"),
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
@@ -51,6 +51,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue: "default",
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -59,7 +62,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			name: "daemon set not installed",
 			installation: &cilium.Installation{
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
@@ -84,6 +87,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue: "default",
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -93,7 +99,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			installation: &cilium.Installation{
 				DaemonSet: daemonSet("cilium:v1.0.0"),
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.1"
@@ -119,6 +125,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue: "default",
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -135,7 +144,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 					}
 				}),
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.1"
@@ -161,6 +170,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue: "default",
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -169,7 +181,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			name: "operator is not present",
 			installation: &cilium.Installation{
 				DaemonSet: daemonSet("cilium:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
@@ -194,6 +206,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue: "default",
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -205,7 +220,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 				Operator: deployment("cilium-operator:v1.0.0", func(d *appsv1.Deployment) {
 					d.Spec.Template.Spec.Containers = nil
 				}),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
@@ -230,6 +245,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue: "default",
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -239,7 +257,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			installation: &cilium.Installation{
 				DaemonSet: daemonSet("cilium:v1.0.0"),
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
@@ -264,6 +282,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							Name:     cilium.PolicyEnforcementComponentName,
 							OldValue: "default",
 							NewValue: "default",
+						},
+						{
+							Name: "EgressMasqueradeInterfaces",
 						},
 					},
 				},
@@ -298,6 +319,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							Name:     cilium.PolicyEnforcementComponentName,
 							NewValue: "default",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -307,7 +331,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			installation: &cilium.Installation{
 				DaemonSet: daemonSet("cilium:v1.0.0"),
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default"),
+				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
@@ -336,6 +360,9 @@ func TestBuildUpgradePlan(t *testing.T) {
 							NewValue:     "always",
 							UpdateReason: "Cilium enable-policy changed: [default] -> [always]",
 						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
 					},
 				},
 			},
@@ -345,7 +372,7 @@ func TestBuildUpgradePlan(t *testing.T) {
 			installation: &cilium.Installation{
 				DaemonSet: daemonSet("cilium:v1.0.0"),
 				Operator:  deployment("cilium-operator:v1.0.0"),
-				ConfigMap: ciliumConfigMap("default", func(cm *corev1.ConfigMap) {
+				ConfigMap: ciliumConfigMap("default", "", func(cm *corev1.ConfigMap) {
 					cm.Data = nil
 				}),
 			},
@@ -375,6 +402,52 @@ func TestBuildUpgradePlan(t *testing.T) {
 							OldValue:     "",
 							NewValue:     "always",
 							UpdateReason: "Cilium enable-policy field is not present in config",
+						},
+						{
+							Name: "EgressMasqueradeInterfaces",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "EgressMasqueradeInterfaces has changed",
+			installation: &cilium.Installation{
+				DaemonSet: daemonSet("cilium:v1.0.0"),
+				Operator:  deployment("cilium-operator:v1.0.0"),
+				ConfigMap: ciliumConfigMap("default", "old"),
+			},
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{
+						EgressMasqueradeInterfaces: "new",
+					},
+				}
+			}),
+			want: cilium.UpgradePlan{
+				DaemonSet: cilium.VersionedComponentUpgradePlan{
+					OldImage: "cilium:v1.0.0",
+					NewImage: "cilium:v1.0.0",
+				},
+				Operator: cilium.VersionedComponentUpgradePlan{
+					OldImage: "cilium-operator:v1.0.0",
+					NewImage: "cilium-operator:v1.0.0",
+				},
+				ConfigMap: cilium.ConfigUpdatePlan{
+					UpdateReason: "Egress masquerade interfaces changed: [old] -> [new]",
+					Components: []cilium.ConfigComponentUpdatePlan{
+						{
+							Name:     cilium.PolicyEnforcementComponentName,
+							OldValue: "default",
+							NewValue: "default",
+						},
+						{
+							Name:         cilium.EgressMasqueradeInterfacesComponentName,
+							OldValue:     "old",
+							NewValue:     "new",
+							UpdateReason: "Egress masquerade interfaces changed: [old] -> [new]",
 						},
 					},
 				},
@@ -442,7 +515,7 @@ func daemonSet(image string, opts ...dsOpt) *appsv1.DaemonSet {
 
 type cmOpt func(*corev1.ConfigMap)
 
-func ciliumConfigMap(enforcementMode string, opts ...cmOpt) *corev1.ConfigMap {
+func ciliumConfigMap(enforcementMode string, egressMasqueradeInterface string, opts ...cmOpt) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -453,7 +526,8 @@ func ciliumConfigMap(enforcementMode string, opts ...cmOpt) *corev1.ConfigMap {
 			Namespace: "kube-system",
 		},
 		Data: map[string]string{
-			cilium.PolicyEnforcementConfigMapKey: enforcementMode,
+			cilium.PolicyEnforcementConfigMapKey:    enforcementMode,
+			cilium.EgressMasqueradeInterfacesMapKey: egressMasqueradeInterface,
 		},
 	}
 

--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -171,11 +171,11 @@ func ciliumHelmChartValuesChanged(currentSpec, newSpec *cluster.Spec) bool {
 		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode {
 			return true
 		}
+		if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces {
+			return true
+		}
 	}
 	// we can add comparisons for more values here as we start accepting them from cluster spec
-	if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces {
-		return true
-	}
 
 	return false
 }

--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -173,6 +173,10 @@ func ciliumHelmChartValuesChanged(currentSpec, newSpec *cluster.Spec) bool {
 		}
 	}
 	// we can add comparisons for more values here as we start accepting them from cluster spec
+	if newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces != currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces {
+		return true
+	}
+
 	return false
 }
 

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -108,7 +108,6 @@ func TestUpgraderUpgradeSuccessValuesChanged(t *testing.T) {
 
 	// setting policy enforcement mode to something other than the "default" mode
 	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
-	// tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = "test"
 
 	// Templater and client and already tested individually so we only want to test the flow (order of calls)
 	gomock.InOrder(
@@ -161,6 +160,30 @@ func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCiliumConfigSpec(t *te
 	tt.currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: nil}
 	// setting policy enforcement mode to something other than the "default" mode
 	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
+
+	// Templater and client and already tested individually so we only want to test the flow (order of calls)
+	gomock.InOrder(
+		tt.expectTemplatePreFlight(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.client.EXPECT().WaitForPreflightDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForPreflightDeployment(tt.ctx, tt.cluster),
+		tt.client.EXPECT().Delete(tt.ctx, tt.cluster, tt.manifestPre),
+		tt.expectTemplateManifest(),
+		tt.client.EXPECT().Apply(tt.ctx, tt.cluster, tt.manifest),
+		tt.client.EXPECT().WaitForCiliumDaemonSet(tt.ctx, tt.cluster),
+		tt.client.EXPECT().WaitForCiliumDeployment(tt.ctx, tt.cluster),
+	)
+
+	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
+}
+
+func TestUpgraderUpgradeSuccessEgressMasqueradeInterfacesValueChanged(t *testing.T) {
+	tt := newUpgraderTest(t)
+	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+
+	// setting egress masquerade interfaces to something other than ""
+	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = "test"
 
 	// Templater and client and already tested individually so we only want to test the flow (order of calls)
 	gomock.InOrder(

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -108,6 +108,7 @@ func TestUpgraderUpgradeSuccessValuesChanged(t *testing.T) {
 
 	// setting policy enforcement mode to something other than the "default" mode
 	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
+	// tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = "test"
 
 	// Templater and client and already tested individually so we only want to test the flow (order of calls)
 	gomock.InOrder(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for configuring the egress-masquerade-interfaces option in Cilium CNI via eks-a cluster spec. This allows users to configure this setting at cluster create as well as upgrade the setting.

Users can configure this setting like so:

```yaml
  clusterNetwork:
    cniConfig:
      cilium:
        egressMasqueradeInterfaces: eth+
```
where `egressMasqueradeInterfaces` expects a string that is an interface name or an interface prefix.

For more context on `egressMasqueradeInterfaces`:
https://docs.cilium.io/en/v1.13/network/concepts/masquerading/#iptables-based

*Testing (if applicable):*
Checked the cilium config map to validate that the setting had been configured correctly, and validated that the setting could be changed via upgrades.

Also validated that setting this resulted in the correct behavior via:
1. Setting up hardware with two network interfaces.
2. Creating a cluster with one interface specified in `egressMasqueradeInterfaces`
3. Checking that the correct interface was specified on the cilium config map
4. `tcp dump` on the non-specified interface and validating that the IP that gets used when pinging `1.1.1.1` is non-masqueraded

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


