### PR TITLE
Implement conditions in Cluster status

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -550,6 +550,11 @@ spec:
                 description: Descriptive message about a fatal problem while reconciling
                   a cluster
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller set everytime the status is updated.
+                format: int64
+                type: integer
               reconciledGeneration:
                 description: 'ReconciledGeneration represents the .metadata.generation
                   the last time the cluster was successfully reconciled. It is the

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -385,10 +385,10 @@ func (r *ClusterReconciler) postClusterProviderReconcile(ctx context.Context, lo
 
 func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) error {
 	// An EKS-A Cluster managed by the CLI is deleted after the cluster finalizer is removed, leaving the CAPI cluster behind. In this case, we do not want to update
-	// the status. If we do, patching will through a 404 NotFound error when trying to update the status of the already deleted
+	// the status. If we do, patching will throw a 404 NotFound error when trying to update the status of the already deleted
 	// Cluster object.
 	if !cluster.DeletionTimestamp.IsZero() && metav1.HasAnnotation(cluster.ObjectMeta, anywherev1.ManagedByCLIAnnotation) {
-		log.Info("Clusters is managed by CLI has been deleted but CAPI cluster may remain, skipping updating cluster status")
+		log.Info("Cluster managed by CLI has been deleted but CAPI cluster may remain, skipping updating cluster status")
 		return nil
 	}
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +37,7 @@ import (
 )
 
 const (
-	defaultRequeueTime = time.Minute
+	defaultRequeueTime = 10 * time.Second
 	// ClusterFinalizerName is the finalizer added to clusters to handle deletion.
 	ClusterFinalizerName = "clusters.anywhere.eks.amazonaws.com/finalizer"
 )
@@ -178,6 +180,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 }
 
 // Reconcile reconciles a cluster object.
+// nolint:gocyclo //TODO: Reduce high cycomatic complexity.
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters;snowmachineconfigs;snowippools;vspheredatacenterconfigs;vspheremachineconfigs;dockerdatacenterconfigs;tinkerbellmachineconfigs;tinkerbelldatacenterconfigs;cloudstackdatacenterconfigs;cloudstackmachineconfigs;nutanixdatacenterconfigs;nutanixmachineconfigs;bundles;awsiamconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=oidcconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=awsiamconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -192,7 +195,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 // +kubebuilder:rbac:groups="",namespace=eksa-system,resources=secrets,verbs=delete;
 // +kubebuilder:rbac:groups=tinkerbell.org,resources=hardware;hardware/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=bmc.tinkerbell.org,resources=machines;machines/status,verbs=get;list;watch
-func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
 	// Fetch the Cluster object
 	cluster := &anywherev1.Cluster{}
@@ -211,9 +214,32 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	}
 
 	defer func() {
-		// Always attempt to patch the object and status after each reconciliation.
-		if err := patchHelper.Patch(ctx, cluster); err != nil {
+		err := r.updateStatus(ctx, log, cluster)
+		if err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+
+		args := make([]string, 0, len(cluster.Status.Conditions))
+		for _, condition := range cluster.Status.Conditions {
+			args = append(args, fmt.Sprintf("%s=%s %s", condition.Type, condition.Status, condition.Reason))
+		}
+
+		log.Info("Current conditions", "conditions", strings.Join(args, ", "))
+
+		// Always attempt to patch the object and status after each reconciliation.
+		patchOpts := []patch.Option{}
+
+		// Patch ObservedGeneration only if the reconciliation completed without error
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchCluster(ctx, patchHelper, cluster, patchOpts...); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+
+		// Only requeue if we are not already re-queueing and the Cluster ready condition is false
+		if reterr == nil && !result.Requeue && result.RequeueAfter <= 0 && conditions.IsFalse(cluster, anywherev1.ReadyCondition) {
+			result = ctrl.Result{RequeueAfter: defaultRequeueTime}
 		}
 	}()
 
@@ -357,6 +383,101 @@ func (r *ClusterReconciler) postClusterProviderReconcile(ctx context.Context, lo
 	return controller.Result{}, nil
 }
 
+func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) error {
+	// An EKS-A Cluster managed by the CLI is deleted after the cluster finalizer is removed, leaving the CAPI cluster behind. In this case, we do not want to update
+	// the status. If we do, patching will through a 404 NotFound error when trying to update the status of the already deleted
+	// Cluster object.
+	if !cluster.DeletionTimestamp.IsZero() && metav1.HasAnnotation(cluster.ObjectMeta, anywherev1.ManagedByCLIAnnotation) {
+		log.Info("Clusters is managed by CLI has been deleted but CAPI cluster may remain, skipping updating cluster status")
+		return nil
+	}
+
+	// ObservedGeneration represents the last observed generation, and consequently represents that the current status is up to date.
+	// Then if observedGeneration is equal to generation AND the Cluster's "Ready" condition is "True", then we can skip another status update
+	if cluster.Status.ObservedGeneration == cluster.Generation && conditions.IsTrue(cluster, anywherev1.ReadyCondition) {
+		log.Info("Generation matches observedGeneration and the cluster is ready, skipping status update")
+		return nil
+	}
+
+	log.Info("Updating cluster status")
+	defer func() {
+		// Always update the readyCondition by summarizing the state of other conditions.
+		conditions.SetSummary(cluster,
+			conditions.WithConditions(
+				anywherev1.ControlPlaneReadyCondition,
+				anywherev1.WorkersReadyConditon,
+			),
+		)
+	}()
+
+	if err := r.updateControlPlaneStatus(ctx, log, cluster); err != nil {
+		return errors.Wrap(err, "updating controlplane status")
+	}
+
+	if err := r.updateWorkersStatus(ctx, log, cluster); err != nil {
+		return errors.Wrap(err, "updating workers status")
+	}
+
+	updateCNIStatus(log, cluster)
+
+	return nil
+}
+
+func (r *ClusterReconciler) updateControlPlaneStatus(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) error {
+	log.Info("Updating control plane status")
+	kcp, err := controller.GetKubeadmControlPlane(ctx, r.client, cluster)
+	if err != nil {
+		return errors.Wrapf(err, "getting kubeadmcontrolplane")
+	}
+
+	if err = clusters.UpdateControlPlaneInitializedCondition(cluster, kcp); err != nil {
+		return errors.Wrap(err, "updating control plane initialized condition")
+	}
+
+	if err = clusters.UpdateControlPlaneReadyCondition(cluster, kcp); err != nil {
+		return errors.Wrap(err, "updating control plane ready condition")
+	}
+
+	return nil
+}
+
+func (r *ClusterReconciler) updateWorkersStatus(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) error {
+	log.Info("Updating workers status")
+	machineDeployments, err := controller.GetMachineDeployments(ctx, r.client, cluster)
+	if err != nil {
+		return errors.Wrap(err, "getting machine deployments")
+	}
+
+	if err = clusters.UpdateWorkersReadyCondition(cluster, machineDeployments); err != nil {
+		return errors.Wrap(err, "updating workers ready condition")
+	}
+
+	return nil
+}
+
+func updateCNIStatus(log logr.Logger, cluster *anywherev1.Cluster) {
+	// Initialize DefaultCNIConfiguredCondition condition, so that it appears in the status sooner rather than later
+	// The CNI reconciler handles the rest of the logic for determining the condition and updating the status.
+	if conditions.Get(cluster, anywherev1.DefaultCNIConfiguredCondition) == nil {
+		log.Info("Initializing CNI status")
+
+		conditions.MarkFalse(
+			cluster,
+			anywherev1.DefaultCNIConfiguredCondition,
+			anywherev1.WaitingForDefaultCNIConfiguredReason,
+			clusterv1.ConditionSeverityInfo,
+			"Waiting for default CNI to be configured",
+		)
+	}
+
+	// TODO: Remove after self-managed clusters are created with the controller in the CLI
+	// Self managed clusters do not use the CNI reconciler, so this status would never get resolved.
+	if cluster.IsSelfManaged() {
+		log.Info("Updating CNI status")
+		clusters.UpdateSelfManagedClusterDefaultCNIConfiguredCondition(cluster)
+	}
+}
+
 func (r *ClusterReconciler) reconcileDelete(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) (ctrl.Result, error) {
 	if cluster.IsSelfManaged() {
 		return ctrl.Result{}, errors.New("deleting self-managed clusters is not supported")
@@ -443,6 +564,23 @@ func (r *ClusterReconciler) ensureClusterOwnerReferences(ctx context.Context, cl
 	}
 
 	return nil
+}
+
+func patchCluster(ctx context.Context, patchHelper *patch.Helper, cluster *anywherev1.Cluster, patchOpts ...patch.Option) error {
+	// Patch the object, ignoring conflicts on the conditions owned by this controller.
+	options := append([]patch.Option{
+		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
+			// TODO: Add each condition her that the controller should ignored conflicts for.
+			anywherev1.ReadyCondition,
+			anywherev1.ControlPlaneInitializedCondition,
+			anywherev1.ControlPlaneReadyCondition,
+			anywherev1.WorkersReadyConditon,
+			anywherev1.DefaultCNIConfiguredCondition,
+		}},
+	}, patchOpts...)
+
+	// Always attempt to patch the object and status after each reconciliation.
+	return patchHelper.Patch(ctx, cluster, options...)
 }
 
 // aggregatedGeneration computes the combined generation of the resources linked

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -314,7 +314,6 @@ func TestClusterReconcilerReconcileStatus(t *testing.T) {
 			},
 			wantErr: "",
 		},
-
 		{
 			testName: "not ready, control plane initialize",
 			kcpStatus: controlplanev1.KubeadmControlPlaneStatus{

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
@@ -165,4 +166,48 @@ func CAPICluster(opts ...CAPIClusterOpt) *clusterv1.Cluster {
 	}
 
 	return c
+}
+
+// KubeadmControlPlaneOpt represents an function where a kubeadmcontrolplane is passed as an argument.
+type KubeadmControlPlaneOpt func(kcp *controlplanev1.KubeadmControlPlane)
+
+// KubeadmControlPlane returns a kubeadm controlplane which can be configured by passing in opts arguments.
+func KubeadmControlPlane(opts ...KubeadmControlPlaneOpt) *controlplanev1.KubeadmControlPlane {
+	kcp := &controlplanev1.KubeadmControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmControlPlane",
+			APIVersion: controlplanev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(kcp)
+	}
+
+	return kcp
+}
+
+// MachineDeploymentOpt represents an function where a kubeadmcontrolplane is passed as an argument.
+type MachineDeploymentOpt func(md *clusterv1.MachineDeployment)
+
+// MachineDeployment returns a machinedeployment which can be configured by passing in opts arguments.
+func MachineDeployment(opts ...MachineDeploymentOpt) *clusterv1.MachineDeployment {
+	md := &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(md)
+	}
+
+	return md
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -830,6 +830,10 @@ type ClusterStatus struct {
 	// to its behavior if changed externally. Its meaning and implementation are
 	// subject to change in the future.
 	ChildrenReconciledGeneration int64 `json:"childrenReconciledGeneration,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the controller
+	// set everytime the status is updated.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type EksdReleaseRef struct {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -813,7 +813,7 @@ type ClusterStatus struct {
 	// EksdReleaseRef defines the properties of the EKS-D object on the cluster
 	EksdReleaseRef *EksdReleaseRef `json:"eksdReleaseRef,omitempty"`
 	// +optional
-	Conditions []clusterv1.Condition `json:"conditions,omitempty"`
+	Conditions []Condition `json:"conditions,omitempty"`
 
 	// ReconciledGeneration represents the .metadata.generation the last time the
 	// cluster was successfully reconciled. It is the latest generation observed
@@ -831,8 +831,7 @@ type ClusterStatus struct {
 	// subject to change in the future.
 	ChildrenReconciledGeneration int64 `json:"childrenReconciledGeneration,omitempty"`
 
-	// ObservedGeneration is the latest generation observed by the controller
-	// set everytime the status is updated.
+	// ObservedGeneration is the latest generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -1,0 +1,49 @@
+package v1alpha1
+
+// Conditions and condition Reasons for the Cluster object.
+const (
+	// ReadyCondition reports a summary of other conditions, indicating an overall operational
+	// state of the cluster.
+	ReadyCondition ConditionType = "Ready"
+
+	// PendingUpdateReason reports when an update has been scheduled but has yet to happen.
+	PendingUpdateReason = "PendingUpdate"
+
+	// ControlPlaneInitializedCondition reports that all the control plane nodes are
+	// in a fully ready and running state.
+	ControlPlaneReadyCondition = "ControlPlaneReady"
+
+	// ControlPlaneInitializedCondition reports that the first control plane instance has been initialized
+	// and so the control plane is available and an API server instance is ready for processing requests.
+	ControlPlaneInitializedCondition = "ControlPlaneInitialized"
+
+	// WaitingForControlPlaneInitializedReason used when cluster is waiting for control plane to be initialized.
+	WaitingForControlPlaneInitializedReason = "WaitingForControlPlaneInitialized"
+
+	// FirstControlPlaneUnavailableMessage used when waiting for the first control plane instance to become
+	// initialized and available.
+	FirstControlPlaneUnavailableMessage = "The first control plane instance is not available yet"
+
+	// WaitingForControlPlaneReadyReason used when cluster is waiting for control plane nodes to transition to a
+	// fully ready and running state.
+	WaitingForControlPlaneReadyReason = "WaitingForControlPlaneReady"
+
+	// WorkersReadyConditon used reports the status on the worker nodes and is true when the expected
+	// number of workers are in a fully ready and running state.
+	WorkersReadyConditon ConditionType = "WorkersReady"
+
+	// WaitingForWorkersReadyReason used when cluster is waiting for control plane nodes to transition to a
+	// fully ready and running state.
+	WaitingForWorkersReadyReason = "WaitingForWorkersReady"
+
+	// DefaultCNIConfiguredCondition reports the default cni cluster has been configured successfully.
+	DefaultCNIConfiguredCondition ConditionType = "DefaultCNIConfigured"
+
+	// WaitingForDefaultCNIConfiguredReason used when cluster is waiting default cni to be installed.
+	WaitingForDefaultCNIConfiguredReason = "WaitingForDefaultCNIConfigured"
+
+	// SkipUpgradesForDefaultCNIConfiguredReason used to indicate the custer has been configured to skip
+	// upgrades for the default cni. The default cni may still be installed, for example to successfully
+	// create a cluster.
+	SkipUpgradesForDefaultCNIConfiguredReason = "SkipUpgradesForDefaultCNIConfigured"
+)

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -11,11 +11,11 @@ const (
 
 	// ControlPlaneInitializedCondition reports that all the control plane nodes are
 	// in a fully ready and running state.
-	ControlPlaneReadyCondition = "ControlPlaneReady"
+	ControlPlaneReadyCondition ConditionType = "ControlPlaneReady"
 
 	// ControlPlaneInitializedCondition reports that the first control plane instance has been initialized
 	// and so the control plane is available and an API server instance is ready for processing requests.
-	ControlPlaneInitializedCondition = "ControlPlaneInitialized"
+	ControlPlaneInitializedCondition ConditionType = "ControlPlaneInitialized"
 
 	// WaitingForControlPlaneInitializedReason used when cluster is waiting for control plane to be initialized.
 	WaitingForControlPlaneInitializedReason = "WaitingForControlPlaneInitialized"

--- a/pkg/api/v1alpha1/condition_types.go
+++ b/pkg/api/v1alpha1/condition_types.go
@@ -1,0 +1,12 @@
+package v1alpha1
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+type (
+	// ConditionType is an alias for clusterv1.ConditionType.
+	ConditionType = clusterv1.ConditionType
+	// Condition is an alias for clusterv1.Condition.
+	Condition = clusterv1.Condition
+)

--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -91,3 +91,18 @@ func GetMachineDeployment(ctx context.Context, client client.Client, machineDepl
 	}
 	return machineDeployment, nil
 }
+
+// GetMachineDeployments reads all of cluster-api MachineDeployment for an eks-a cluster using a kube client.
+func GetMachineDeployments(ctx context.Context, c client.Client, cluster *anywherev1.Cluster) ([]clusterv1.MachineDeployment, error) {
+	machineDeployments := &clusterv1.MachineDeploymentList{}
+
+	err := c.List(ctx, machineDeployments, client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name}, client.InNamespace(constants.EksaSystemNamespace))
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return machineDeployments.Items, nil
+}

--- a/pkg/controller/clusterapi_test.go
+++ b/pkg/controller/clusterapi_test.go
@@ -106,6 +106,57 @@ func TestGetMachineDeploymentError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
 }
 
+func TestGetMachineDeploymentsSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	md1 := machineDeployment()
+	md1.Name = "md-1"
+
+	md1.Labels = map[string]string{
+		clusterv1.ClusterNameLabel: eksaCluster.Name,
+	}
+
+	md2 := md1.DeepCopy()
+	md2.Name = "md-2"
+
+	client := fake.NewClientBuilder().WithObjects(eksaCluster, md1, md2).Build()
+
+	g.Expect(controller.GetMachineDeployments(ctx, client, eksaCluster)).To(Equal([]clusterv1.MachineDeployment{*md1, *md2}))
+}
+
+func TestGetMachineDeploymentsMachineDeploymentsInDifferentClusters(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	machineDeployment1 := machineDeployment()
+	machineDeployment1.Name = "md-1"
+	machineDeployment1.Labels = map[string]string{
+		clusterv1.ClusterNameLabel: eksaCluster.Name,
+	}
+
+	machineDeployment2 := machineDeployment()
+	machineDeployment2.Name = "md-2"
+	machineDeployment2.Labels = map[string]string{
+		clusterv1.ClusterNameLabel: "other-cluster",
+	}
+
+	client := fake.NewClientBuilder().WithObjects(eksaCluster, machineDeployment1, machineDeployment2).Build()
+
+	g.Expect(controller.GetMachineDeployments(ctx, client, eksaCluster)).To(Equal([]clusterv1.MachineDeployment{*machineDeployment1}))
+}
+
+func TestGetMachineDeploymentsError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	eksaCluster := eksaCluster()
+	// This should make the client fail because CRDs are not registered
+	client := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	_, err := controller.GetMachineDeployments(ctx, client, eksaCluster)
+	g.Expect(err).To(MatchError(ContainSubstring("no kind is registered for the type")))
+}
+
 func TestGetCapiClusterObjectKey(t *testing.T) {
 	g := NewWithT(t)
 	eksaCluster := eksaCluster()

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -38,13 +38,13 @@ func UpdateControlPlaneInitializedCondition(cluster *anywherev1.Cluster, kcp *co
 		return nil
 	}
 
-	con, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneInitializedCondition, kcp, controlplanev1.AvailableCondition)
+	kcpCondition, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneInitializedCondition, kcp, controlplanev1.AvailableCondition)
 	if err != nil {
 		return err
 	}
 
-	if con != nil {
-		conditions.MarkFalse(cluster, anywherev1.ControlPlaneInitializedCondition, con.Reason, con.Severity, con.Message)
+	if kcpCondition != nil {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneInitializedCondition, kcpCondition.Reason, kcpCondition.Severity, kcpCondition.Message)
 		return nil
 	}
 
@@ -75,20 +75,19 @@ func UpdateControlPlaneReadyCondition(cluster *anywherev1.Cluster, kcp *controlp
 		return fmt.Errorf("expected reference to kubeadmcontrolplane, but got nil instead ")
 	}
 
-	statusUpToDate := kcp.Status.ObservedGeneration == kcp.ObjectMeta.Generation
 	// We make sure to check that the status is up to date before using it
+	statusUpToDate := kcp.Status.ObservedGeneration == kcp.ObjectMeta.Generation
 	if !statusUpToDate {
 		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.PendingUpdateReason, clusterv1.ConditionSeverityInfo, "")
 		return nil
 	}
 
-	con, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneReadyCondition, kcp, clusterv1.ReadyCondition)
+	kcpCondition, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneReadyCondition, kcp, clusterv1.ReadyCondition)
 	if err != nil {
 		return err
 	}
-
-	if con != nil {
-		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, con.Reason, con.Severity, con.Message)
+	if kcpCondition != nil {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, kcpCondition.Reason, kcpCondition.Severity, kcpCondition.Message)
 		return nil
 	}
 

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -1,0 +1,187 @@
+package clusters
+
+import (
+	"fmt"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func checkKubeadmControlPlaneError(cluster *anywherev1.Cluster, clusterConditionType anywherev1.ConditionType, kcp *controlplanev1.KubeadmControlPlane, kcpConditionType clusterv1.ConditionType) (*anywherev1.Condition, error) {
+	kcpCondition := conditions.Get(kcp, kcpConditionType)
+
+	if kcpCondition == nil {
+		return nil, fmt.Errorf("unable to read condition %s from kubeadmcontrolplane %s", kcpConditionType, kcp.Name)
+	}
+
+	// Surface any errors from the KubeadmControlPlane
+	if kcpCondition.Severity == clusterv1.ConditionSeverityError {
+		return conditions.FalseCondition(clusterConditionType, kcpCondition.Reason, kcpCondition.Severity, kcpCondition.Message), nil
+	}
+
+	return nil, nil
+}
+
+// UpdateControlPlaneInitializedCondition updates the ControlPlaneInitialized condition if it hasn't already been set.
+// This condition should be set only once.
+func UpdateControlPlaneInitializedCondition(cluster *anywherev1.Cluster, kcp *controlplanev1.KubeadmControlPlane) error {
+	// Return early if the ControlPlaneInitializedCondition is already "True"
+	if conditions.IsTrue(cluster, anywherev1.ControlPlaneInitializedCondition) {
+		return nil
+	}
+
+	if kcp == nil {
+		conditions.Set(cluster, waitingForCPInitializedCondition())
+		return nil
+	}
+
+	con, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneInitializedCondition, kcp, controlplanev1.AvailableCondition)
+	if err != nil {
+		return err
+	}
+
+	if con != nil {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneInitializedCondition, con.Reason, con.Severity, con.Message)
+		return nil
+	}
+
+	available := conditions.IsTrue(kcp, controlplanev1.AvailableCondition)
+	if !available {
+		conditions.Set(cluster, waitingForCPInitializedCondition())
+		return nil
+	}
+
+	conditions.MarkTrue(cluster, anywherev1.ControlPlaneInitializedCondition)
+	return nil
+}
+
+func waitingForCPInitializedCondition() *anywherev1.Condition {
+	return conditions.FalseCondition(anywherev1.ControlPlaneInitializedCondition, anywherev1.WaitingForControlPlaneInitializedReason, clusterv1.ConditionSeverityInfo, anywherev1.FirstControlPlaneUnavailableMessage)
+}
+
+// UpdateControlPlaneReadyCondition updates the ControlPlaneReady condition. It checks whether the KubeadmControlPlane is ready
+// and number of ready vs expected replicas are accounted for.
+func UpdateControlPlaneReadyCondition(cluster *anywherev1.Cluster, kcp *controlplanev1.KubeadmControlPlane) error {
+	initializedCondition := conditions.Get(cluster, anywherev1.ControlPlaneInitializedCondition)
+	if initializedCondition.Status != "True" {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, initializedCondition.Reason, initializedCondition.Severity, initializedCondition.Message)
+		return nil
+	}
+
+	if kcp == nil {
+		return fmt.Errorf("expected reference to kubeadmcontrolplane, but got nil instead ")
+	}
+
+	statusUpToDate := kcp.Status.ObservedGeneration == kcp.ObjectMeta.Generation
+	// We make sure to check that the status is up to date before using it
+	if !statusUpToDate {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.PendingUpdateReason, clusterv1.ConditionSeverityInfo, "")
+		return nil
+	}
+
+	con, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneReadyCondition, kcp, clusterv1.ReadyCondition)
+	if err != nil {
+		return err
+	}
+
+	if con != nil {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, con.Reason, con.Severity, con.Message)
+		return nil
+	}
+
+	// The control plane should be marked ready when the total number of nodes specified in the spec is
+	// equal to the ready amount in the cluster. We need to check this in two parts, since
+	// in the case of a rolling upgrade, there can be ready machines in the cluster with the old spec.
+
+	expected := cluster.Spec.ControlPlaneConfiguration.Count
+	readyReplicas := int(kcp.Status.ReadyReplicas)
+	updatedReplicas := int(kcp.Status.UpdatedReplicas)
+	totalReplicas := int(kcp.Status.Replicas)
+
+	// Get the number of outdated nodes, as long as there are some, we want to reflect that in the message
+	totalOutdated := totalReplicas - updatedReplicas
+	if totalOutdated > 0 {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.WaitingForControlPlaneReadyReason, clusterv1.ConditionSeverityInfo, "Control plane nodes not up-to-date yet, %d rolling (%d up to date)", expected, updatedReplicas)
+		return nil
+	}
+
+	// First, we compare the total number of readyReplicas to the expected number,
+	if readyReplicas != expected {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.WaitingForControlPlaneReadyReason, clusterv1.ConditionSeverityInfo, "Control plane nodes not ready yet, %d expected (%d ready)", expected, readyReplicas)
+		return nil
+	}
+
+	conditions.MarkTrue(cluster, anywherev1.ControlPlaneReadyCondition)
+	return nil
+}
+
+// UpdateWorkersReadyCondition checks the WorkersReadyConditon condition. It checks whether each MachineDeployment is ready
+// and number of ready vs expected replicas are accounted for.
+func UpdateWorkersReadyCondition(cluster *anywherev1.Cluster, machineDeployments []clusterv1.MachineDeployment) error {
+	expected := 0
+	for _, wng := range cluster.Spec.WorkerNodeGroupConfigurations {
+		expected += *wng.Count
+	}
+
+	// The workers condition should be marked ready when the total number of nodes specified in the spec is
+	// equal to the ready amount in the cluster and there are no lingering old nodes. We need to check this in
+	// two parts, since in the case of a rolling upgrade, there can be ready machines in the cluster with the old spec.
+
+	totalReady := 0
+	totalUpdatedReplicas := 0
+	totalReplicas := 0
+
+	for _, md := range machineDeployments {
+		// We make sure to check that the status is up to date before using it
+		statusUpToDate := md.Status.ObservedGeneration == md.ObjectMeta.Generation
+		if !statusUpToDate {
+			conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, anywherev1.PendingUpdateReason, clusterv1.ConditionSeverityInfo, "Waiting to update machine deployment %s", md.Name)
+			return nil
+		}
+
+		totalReady += int(md.Status.ReadyReplicas)
+		totalUpdatedReplicas += int(md.Status.UpdatedReplicas)
+		totalReplicas += int(md.Status.Replicas)
+	}
+
+	// First, get the number of outdated nodes, as long as there are some, we want to reflect that in the message
+	totalOutdated := totalReplicas - totalUpdatedReplicas
+	if totalOutdated > 0 {
+		conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, anywherev1.WaitingForWorkersReadyReason, clusterv1.ConditionSeverityInfo, "Worker nodes not up-to-date yet, %d rolling (%d up to date)", totalReplicas, totalUpdatedReplicas)
+		return nil
+	}
+
+	// Then, we compare the total number of readyReplicas to the expected number,
+	if totalReady != expected {
+		conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, anywherev1.WaitingForWorkersReadyReason, clusterv1.ConditionSeverityInfo, "Worker nodes not ready yet, %d expected (%d ready)", expected, totalReady)
+		return nil
+	}
+
+	conditions.MarkTrue(cluster, anywherev1.WorkersReadyConditon)
+	return nil
+}
+
+// UpdateSelfManagedClusterDefaultCNIConfiguredCondition is responsible for updating the DefaultCNIConfiguredCondition for self-managed clusters.
+// This is meant to be done in the CNI recondile, however, self-managed clusters do not use the it, so this status would never get resolved.
+func UpdateSelfManagedClusterDefaultCNIConfiguredCondition(cluster *anywherev1.Cluster) {
+	if !conditions.IsTrue(cluster, anywherev1.ControlPlaneReadyCondition) {
+		return
+	}
+
+	ciliumCfg := cluster.Spec.ClusterNetwork.CNIConfig.Cilium
+
+	// Though it may be installed initially to successfully create the cluster,
+	// if the CNI is configured to skip upgrades, we want to mark the condition as "False"
+	// as maintenance is not being performed by EKS-A.
+
+	// Otherwise, we can assume the CNI has been
+	// configured at this point after confirming the control plane is ready
+	if !ciliumCfg.IsManaged() {
+		conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, clusterv1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades")
+	} else {
+		conditions.MarkTrue(cluster, anywherev1.DefaultCNIConfiguredCondition)
+	}
+}

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -1,0 +1,650 @@
+package clusters_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	_ "github.com/aws/eks-anywhere/internal/test/envtest"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
+)
+
+func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name          string
+		kcp           *controlplanev1.KubeadmControlPlane
+		conditions    []anywherev1.Condition
+		wantCondition *anywherev1.Condition
+		wantErr       string
+	}{
+		{
+			name:       "kcp is nil",
+			kcp:        nil,
+			conditions: []anywherev1.Condition{},
+			wantCondition: &anywherev1.Condition{
+				Type:     "ControlPlaneInitialized",
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityInfo,
+				Reason:   anywherev1.WaitingForControlPlaneInitializedReason,
+				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+			},
+			wantErr: "",
+		},
+		{
+			name: "control plane already initialized",
+			kcp:  nil,
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.ControlPlaneInitializedCondition,
+				Status: "True",
+			},
+			wantErr: "",
+		},
+		{
+			name:          "kcp missing available condition ",
+			kcp:           test.KubeadmControlPlane(),
+			wantCondition: nil,
+			wantErr:       "unable to read condition",
+		},
+		{
+			name: "kcp available condition with error",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:     controlplanev1.AvailableCondition,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityError,
+						Reason:   "TestReason",
+						Message:  "test message",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneInitializedCondition,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityError,
+				Reason:   "TestReason",
+				Message:  "test message",
+			},
+			wantErr: "",
+		},
+		{
+			name: "kcp  available condtion false",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = clusterv1.Conditions{
+					{
+						Type:   controlplanev1.AvailableCondition,
+						Status: "False",
+					},
+				}
+			}),
+			conditions: []anywherev1.Condition{},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneInitializedCondition,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityInfo,
+				Reason:   anywherev1.WaitingForControlPlaneInitializedReason,
+				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+			},
+			wantErr: "",
+		},
+		{
+			name: "kcp available condition true",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = clusterv1.Conditions{
+					{
+						Type:   controlplanev1.AvailableCondition,
+						Status: "True",
+					},
+				}
+			}),
+			conditions: []anywherev1.Condition{},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.ControlPlaneInitializedCondition,
+				Status: "True",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := test.NewClusterSpec().Cluster
+			cluster.Status.Conditions = tt.conditions
+
+			err := clusters.UpdateControlPlaneInitializedCondition(cluster, tt.kcp)
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).To(BeNil())
+
+				condition := conditions.Get(cluster, anywherev1.ControlPlaneInitializedCondition)
+				g.Expect(condition).ToNot(BeNil())
+
+				condition.LastTransitionTime = v1.Time{}
+				g.Expect(condition).To(Equal(tt.wantCondition))
+			}
+		})
+	}
+}
+
+func TestUpdateControlPlaneReadyCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name          string
+		kcp           *controlplanev1.KubeadmControlPlane
+		spec          *cluster.Spec
+		wantCondition *anywherev1.Condition
+		wantErr       string
+	}{
+		{
+			name: "control plane not initialized",
+			kcp:  &controlplanev1.KubeadmControlPlane{},
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:     anywherev1.ControlPlaneInitializedCondition,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityInfo,
+						Reason:   anywherev1.WaitingForControlPlaneInitializedReason,
+						Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityInfo,
+				Reason:   anywherev1.WaitingForControlPlaneInitializedReason,
+				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+			},
+			wantErr: "",
+		},
+		{
+			name: "control plane initialized but kcp nil",
+			kcp:  nil,
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: nil,
+			wantErr:       "expected reference to kubeadmcontrolplane, but got nil instead",
+		},
+		{
+			name: "control plane pending update",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Generation = 1
+				kcp.Status.ObservedGeneration = 2
+			}),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Status:   "False",
+				Reason:   anywherev1.PendingUpdateReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+			},
+			wantErr: "",
+		},
+		{
+			name: "kcp missing ready condition",
+			kcp:  test.KubeadmControlPlane(),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: nil,
+			wantErr:       "unable to read condition",
+		},
+		{
+			name: "kcp ready condition with error",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:     clusterv1.ReadyCondition,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityError,
+						Reason:   "TestReason",
+						Message:  "test message",
+					},
+				}
+			}),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityError,
+				Reason:   "TestReason",
+				Message:  "test message",
+			},
+			wantErr: "",
+		},
+		{
+			name: "control plane replicas out of date",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Replicas = 3
+				kcp.Status.UpdatedReplicas = 1
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:     clusterv1.ReadyCondition,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityInfo,
+					},
+				}
+			}),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Status:   "False",
+				Reason:   anywherev1.WaitingForControlPlaneReadyReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Control plane nodes not up-to-date yet",
+			},
+			wantErr: "",
+		},
+		{
+			name: "control plane not ready yet",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.ReadyReplicas = 1
+				kcp.Status.UpdatedReplicas = 3
+				kcp.Status.Replicas = 3
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:     clusterv1.ReadyCondition,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityInfo,
+					},
+				}
+			}),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Status:   "False",
+				Reason:   anywherev1.WaitingForControlPlaneReadyReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Control plane nodes not ready yet",
+			},
+			wantErr: "",
+		},
+		{
+			name: "control plane all ready",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.ReadyReplicas = 3
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:   clusterv1.ReadyCondition,
+						Status: "True",
+					},
+				}
+			}),
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneInitializedCondition,
+						Status: "True",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.ControlPlaneReadyCondition,
+				Status: "True",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := tt.spec.Cluster
+			err := clusters.UpdateControlPlaneReadyCondition(cluster, tt.kcp)
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).To(BeNil())
+
+				condition := conditions.Get(cluster, anywherev1.ControlPlaneReadyCondition)
+				g.Expect(condition).ToNot(BeNil())
+
+				message := condition.Message
+				wantMessage := tt.wantCondition.Message
+
+				// Ignoring these fields for comparison sake, they're not too important for testing
+				condition.Message = ""
+				condition.LastTransitionTime = v1.Time{}
+				tt.wantCondition.Message = ""
+
+				g.Expect(condition).To(Equal(tt.wantCondition))
+				g.Expect(message).To(ContainSubstring(wantMessage))
+			}
+		})
+	}
+}
+
+func TestUpdateWorkersReadyCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name               string
+		spec               *cluster.Spec
+		machineDeployments []clusterv1.MachineDeployment
+		wantCondition      *anywherev1.Condition
+		wantErr            string
+	}{
+		{
+			name: "workers pending update",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Count: ptr.Int(1),
+					},
+					{
+						Count: ptr.Int(1),
+					},
+				}
+			}),
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Generation = 1
+					md.Status.ObservedGeneration = 0
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Generation = 1
+					md.Status.ObservedGeneration = 1
+				}),
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.PendingUpdateReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+			},
+		},
+		{
+			name: "workers not ready yet",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Count: ptr.Int(1),
+					},
+					{
+						Count: ptr.Int(2),
+					},
+				}
+			}),
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Status.ReadyReplicas = 1
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Status.ReadyReplicas = 0
+				}),
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.WaitingForWorkersReadyReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Worker nodes not ready yet",
+			},
+		},
+		{
+			name: "worker out of date ",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Count: ptr.Int(1),
+					},
+					{
+						Count: ptr.Int(2),
+					},
+				}
+			}),
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Status.UpdatedReplicas = 1
+					md.Status.Replicas = 1
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Status.Replicas = 3
+					md.Status.UpdatedReplicas = 1
+				}),
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.WaitingForWorkersReadyReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Worker nodes not up-to-date yet",
+			},
+		},
+		{
+			name: "workers ready",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						Count: ptr.Int(1),
+					},
+					{
+						Count: ptr.Int(2),
+					},
+				}
+			}),
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Status.ReadyReplicas = 1
+					md.Status.UpdatedReplicas = 1
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.Status.ReadyReplicas = 2
+					md.Status.UpdatedReplicas = 2
+				}),
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.WorkersReadyConditon,
+				Status: "True",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := tt.spec.Cluster
+			err := clusters.UpdateWorkersReadyCondition(cluster, tt.machineDeployments)
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				condition := conditions.Get(cluster, anywherev1.WorkersReadyConditon)
+				g.Expect(condition).ToNot(BeNil())
+
+				message := condition.Message
+				wantMessage := tt.wantCondition.Message
+
+				// Ignoring these fields for comparison sake, they're not too important for testing
+				condition.Message = ""
+				condition.LastTransitionTime = v1.Time{}
+				tt.wantCondition.Message = ""
+
+				g.Expect(err).To(BeNil())
+				g.Expect(condition).To(Equal(tt.wantCondition))
+				g.Expect(message).To(ContainSubstring(wantMessage))
+			}
+		})
+	}
+}
+
+func TestUpdateSelfManagedClusterDefaultCNIConfiguredCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name                    string
+		spec                    *cluster.Spec
+		wantCondition           *anywherev1.Condition
+		checkLastTransitionTime bool
+		wantErr                 string
+	}{
+		{
+			name: "no condition updates",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.ClusterNetwork = anywherev1.ClusterNetwork{
+					CNIConfig: &anywherev1.CNIConfig{
+						Cilium: &anywherev1.CiliumConfig{},
+					},
+				}
+
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneReadyCondition,
+						Status: "False",
+					},
+					{
+						Type:               anywherev1.DefaultCNIConfiguredCondition,
+						Reason:             anywherev1.WaitingForDefaultCNIConfiguredReason,
+						Status:             "False",
+						LastTransitionTime: v1.Time{},
+						Severity:           clusterv1.ConditionSeverityInfo,
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:               anywherev1.DefaultCNIConfiguredCondition,
+				Reason:             anywherev1.WaitingForDefaultCNIConfiguredReason,
+				Status:             "False",
+				LastTransitionTime: v1.Time{},
+				Severity:           clusterv1.ConditionSeverityInfo,
+			},
+			checkLastTransitionTime: true,
+		},
+		{
+			name: "cilium is unmanaged",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.ClusterNetwork = anywherev1.ClusterNetwork{
+					CNIConfig: &anywherev1.CNIConfig{
+						Cilium: &anywherev1.CiliumConfig{
+							SkipUpgrade: ptr.Bool(true),
+						},
+					},
+				}
+
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneReadyCondition,
+						Status: "True",
+					},
+					{
+						Type:     anywherev1.DefaultCNIConfiguredCondition,
+						Reason:   anywherev1.WaitingForDefaultCNIConfiguredReason,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityInfo,
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.DefaultCNIConfiguredCondition,
+				Reason:   anywherev1.SkipUpgradesForDefaultCNIConfiguredReason,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityWarning,
+			},
+		},
+		{
+			name: "cilium is managed",
+			spec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Spec.ClusterNetwork = anywherev1.ClusterNetwork{
+					CNIConfig: &anywherev1.CNIConfig{
+						Cilium: &anywherev1.CiliumConfig{},
+					},
+				}
+
+				s.Cluster.Status.Conditions = []anywherev1.Condition{
+					{
+						Type:   anywherev1.ControlPlaneReadyCondition,
+						Status: "True",
+					},
+					{
+						Type:     anywherev1.DefaultCNIConfiguredCondition,
+						Reason:   anywherev1.WaitingForDefaultCNIConfiguredReason,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityInfo,
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.DefaultCNIConfiguredCondition,
+				Status: "True",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := tt.spec.Cluster
+			clusters.UpdateSelfManagedClusterDefaultCNIConfiguredCondition(cluster)
+			condition := conditions.Get(cluster, anywherev1.DefaultCNIConfiguredCondition)
+			g.Expect(condition).ToNot(BeNil())
+
+			// Ignoring these fields for comparison sake, they're not too important for testing
+			condition.Message = ""
+
+			if !tt.checkLastTransitionTime {
+				condition.LastTransitionTime = v1.Time{}
+			}
+			g.Expect(condition).To(Equal(tt.wantCondition))
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
#5628 

*Description of changes:*
This PR  implement the Cluster status as per the proposal [here](https://github.com/aws/eks-anywhere/pull/6005).

Changes to the cluster.status
- Added `Conditions`: `ControlPlaneInitialized`, `DefaultCNIConfigured`, `ControlPlaneReady`, `WorkersReady`, `Ready`
- Added `ObservedGeneration` field


*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

