### PR TITLE
Add observedGeneration and ControlPlaneInitialized condition to ClusterStatus

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -550,6 +550,11 @@ spec:
                 description: Descriptive message about a fatal problem while reconciling
                   a cluster
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               reconciledGeneration:
                 description: 'ReconciledGeneration represents the .metadata.generation
                   the last time the cluster was successfully reconciled. It is the

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -393,7 +393,7 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 
 	log.Info("Updating cluster status")
 
-	if err := r.updateControlPlaneStatus(ctx, log, cluster); err != nil {
+	if err := clusters.UpdateControlPlaneStatus(ctx, r.client, cluster); err != nil {
 		return errors.Wrap(err, "updating controlplane status")
 	}
 
@@ -405,18 +405,6 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 			anywherev1.WorkersReadyConditon,
 		),
 	)
-
-	return nil
-}
-
-func (r *ClusterReconciler) updateControlPlaneStatus(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) error {
-	log.Info("Updating control plane status")
-	kcp, err := controller.GetKubeadmControlPlane(ctx, r.client, cluster)
-	if err != nil {
-		return errors.Wrapf(err, "getting kubeadmcontrolplane")
-	}
-
-	clusters.UpdateControlPlaneInitializedCondition(cluster, kcp)
 
 	return nil
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -223,7 +223,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		patchOpts := []patch.Option{}
 
 		// We want the observedGeneration to indicate, that the status shown is up-to-date given the desired spec of the same generation.
-		// However, if there is an error while updating the status, we may a partial status update, In this case,
+		// However, if there is an error while updating the status, we may get a partial status update, In this case,
 		// a partially updated status is not considered up to date, so we should not update the observedGeneration
 
 		// Patch ObservedGeneration only if the reconciliation completed without error
@@ -393,7 +393,7 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 
 	log.Info("Updating cluster status")
 
-	if err := clusters.UpdateControlPlaneStatus(ctx, r.client, cluster); err != nil {
+	if err := clusters.UpdateClusterStatusForControlPlane(ctx, r.client, cluster); err != nil {
 		return errors.Wrap(err, "updating controlplane status")
 	}
 

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -101,9 +102,17 @@ func TestClusterReconcilerReconcileSelfManagedCluster(t *testing.T) {
 			BundlesRef: &anywherev1.BundlesRef{
 				Name: "my-bundles-ref",
 			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
+			},
 		},
 		Status: anywherev1.ClusterStatus{
 			ReconciledGeneration: 1,
+			Conditions: []anywherev1.Condition{
+				*conditions.TrueCondition(anywherev1.ReadyCondition),
+			},
 		},
 	}
 
@@ -196,6 +205,7 @@ func TestClusterReconcilerReconcileGenerations(t *testing.T) {
 			config, bundles := baseTestVsphereCluster()
 
 			config.Cluster.Generation = tt.clusterGeneration
+			config.Cluster.Status.ObservedGeneration = tt.clusterGeneration
 			config.Cluster.Status.ReconciledGeneration = tt.reconciledGeneration
 			config.Cluster.Status.ReconciledGeneration = tt.reconciledGeneration
 			config.Cluster.Status.ChildrenReconciledGeneration = tt.childReconciledGeneration
@@ -271,9 +281,17 @@ func TestClusterReconcilerReconcileSelfManagedClusterWithExperimentalUpgrades(t 
 			BundlesRef: &anywherev1.BundlesRef{
 				Name: "my-bundles-ref",
 			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
+			},
 		},
 		Status: anywherev1.ClusterStatus{
 			ReconciledGeneration: 1,
+			Conditions: []anywherev1.Condition{
+				*conditions.TrueCondition(anywherev1.ReadyCondition),
+			},
 		},
 	}
 
@@ -341,6 +359,11 @@ func TestClusterReconcilerReconcileDeletedSelfManagedCluster(t *testing.T) {
 			BundlesRef: &anywherev1.BundlesRef{
 				Name: "my-bundles-ref",
 			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
+			},
 		},
 		Status: anywherev1.ClusterStatus{
 			ReconciledGeneration: 1,
@@ -370,6 +393,11 @@ func TestClusterReconcilerReconcileSelfManagedClusterRegAuthFailNoSecret(t *test
 		Spec: anywherev1.ClusterSpec{
 			BundlesRef: &anywherev1.BundlesRef{
 				Name: "my-bundles-ref",
+			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
 			},
 			RegistryMirrorConfiguration: &anywherev1.RegistryMirrorConfiguration{
 				Authenticate: true,
@@ -571,6 +599,11 @@ func TestClusterReconcilerSkipDontInstallPackagesOnSelfManaged(t *testing.T) {
 				Name:      "my-bundles-ref",
 				Namespace: "my-namespace",
 			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
+			},
 			ManagementCluster: anywherev1.ManagementCluster{
 				Name: "",
 			},
@@ -608,6 +641,11 @@ func TestClusterReconcilerDontDeletePackagesOnSelfManaged(t *testing.T) {
 			BundlesRef: &anywherev1.BundlesRef{
 				Name:      "my-bundles-ref",
 				Namespace: "my-namespace",
+			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
 			},
 			ManagementCluster: anywherev1.ManagementCluster{
 				Name: "",
@@ -649,6 +687,11 @@ func TestClusterReconcilerPackagesDeletion(s *testing.T) {
 				BundlesRef: &anywherev1.BundlesRef{
 					Name:      "my-bundles-ref",
 					Namespace: "my-namespace",
+				},
+				ClusterNetwork: anywherev1.ClusterNetwork{
+					CNIConfig: &anywherev1.CNIConfig{
+						Cilium: &anywherev1.CiliumConfig{},
+					},
 				},
 				ManagementCluster: anywherev1.ManagementCluster{
 					Name: "my-management-cluster",
@@ -695,6 +738,11 @@ func TestClusterReconcilerPackagesInstall(s *testing.T) {
 				BundlesRef: &anywherev1.BundlesRef{
 					Name:      "my-bundles-ref",
 					Namespace: "my-namespace",
+				},
+				ClusterNetwork: anywherev1.ClusterNetwork{
+					CNIConfig: &anywherev1.CNIConfig{
+						Cilium: &anywherev1.CiliumConfig{},
+					},
 				},
 				ManagementCluster: anywherev1.ManagementCluster{
 					Name: "my-management-cluster",
@@ -902,6 +950,11 @@ func vsphereCluster() *anywherev1.Cluster {
 			Namespace: namespace,
 		},
 		Spec: anywherev1.ClusterSpec{
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{
+					Cilium: &anywherev1.CiliumConfig{},
+				},
+			},
 			DatacenterRef: anywherev1.Ref{
 				Kind: "VSphereDatacenterConfig",
 				Name: "datacenter",
@@ -931,6 +984,9 @@ func vsphereCluster() *anywherev1.Cluster {
 		},
 		Status: anywherev1.ClusterStatus{
 			ReconciledGeneration: 1,
+			Conditions: []anywherev1.Condition{
+				*conditions.TrueCondition(anywherev1.ReadyCondition),
+			},
 		},
 	}
 }

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -189,3 +189,25 @@ func KubeadmControlPlane(opts ...KubeadmControlPlaneOpt) *controlplanev1.Kubeadm
 
 	return kcp
 }
+
+// MachineDeploymentOpt represents an function where a kubeadmcontrolplane is passed as an argument.
+type MachineDeploymentOpt func(md *clusterv1.MachineDeployment)
+
+// MachineDeployment returns a machinedeployment which can be configured by passing in opts arguments.
+func MachineDeployment(opts ...MachineDeploymentOpt) *clusterv1.MachineDeployment {
+	md := &clusterv1.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(md)
+	}
+
+	return md
+}

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
@@ -165,4 +166,26 @@ func CAPICluster(opts ...CAPIClusterOpt) *clusterv1.Cluster {
 	}
 
 	return c
+}
+
+// KubeadmControlPlaneOpt represents an function where a kubeadmcontrolplane is passed as an argument.
+type KubeadmControlPlaneOpt func(kcp *controlplanev1.KubeadmControlPlane)
+
+// KubeadmControlPlane returns a kubeadm controlplane which can be configured by passing in opts arguments.
+func KubeadmControlPlane(opts ...KubeadmControlPlaneOpt) *controlplanev1.KubeadmControlPlane {
+	kcp := &controlplanev1.KubeadmControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmControlPlane",
+			APIVersion: controlplanev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.EksaSystemNamespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(kcp)
+	}
+
+	return kcp
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -813,7 +813,7 @@ type ClusterStatus struct {
 	// EksdReleaseRef defines the properties of the EKS-D object on the cluster
 	EksdReleaseRef *EksdReleaseRef `json:"eksdReleaseRef,omitempty"`
 	// +optional
-	Conditions []clusterv1.Condition `json:"conditions,omitempty"`
+	Conditions []Condition `json:"conditions,omitempty"`
 
 	// ReconciledGeneration represents the .metadata.generation the last time the
 	// cluster was successfully reconciled. It is the latest generation observed
@@ -830,6 +830,9 @@ type ClusterStatus struct {
 	// to its behavior if changed externally. Its meaning and implementation are
 	// subject to change in the future.
 	ChildrenReconciledGeneration int64 `json:"childrenReconciledGeneration,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type EksdReleaseRef struct {

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -1,0 +1,49 @@
+package v1alpha1
+
+// Conditions and condition Reasons for the Cluster object.
+const (
+	// ReadyCondition reports a summary of other conditions, indicating an overall operational
+	// state of the cluster.
+	ReadyCondition ConditionType = "Ready"
+
+	// PendingUpdateReason reports when an update has been scheduled but has yet to happen.
+	PendingUpdateReason = "PendingUpdate"
+
+	// ControlPlaneInitializedCondition reports that all the control plane nodes are
+	// in a fully ready and running state.
+	ControlPlaneReadyCondition ConditionType = "ControlPlaneReady"
+
+	// ControlPlaneInitializedCondition reports that the first control plane instance has been initialized
+	// and so the control plane is available and an API server instance is ready for processing requests.
+	ControlPlaneInitializedCondition ConditionType = "ControlPlaneInitialized"
+
+	// WaitingForControlPlaneInitializedReason used when cluster is waiting for control plane to be initialized.
+	WaitingForControlPlaneInitializedReason = "WaitingForControlPlaneInitialized"
+
+	// FirstControlPlaneUnavailableMessage used when waiting for the first control plane instance to become
+	// initialized and available.
+	FirstControlPlaneUnavailableMessage = "The first control plane instance is not available yet"
+
+	// WaitingForControlPlaneReadyReason used when cluster is waiting for control plane nodes to transition to a
+	// fully ready and running state.
+	WaitingForControlPlaneReadyReason = "WaitingForControlPlaneReady"
+
+	// WorkersReadyConditon used reports the status on the worker nodes and is true when the expected
+	// number of workers are in a fully ready and running state.
+	WorkersReadyConditon ConditionType = "WorkersReady"
+
+	// WaitingForWorkersReadyReason used when cluster is waiting for control plane nodes to transition to a
+	// fully ready and running state.
+	WaitingForWorkersReadyReason = "WaitingForWorkersReady"
+
+	// DefaultCNIConfiguredCondition reports the default cni cluster has been configured successfully.
+	DefaultCNIConfiguredCondition ConditionType = "DefaultCNIConfigured"
+
+	// WaitingForDefaultCNIConfiguredReason used when cluster is waiting default cni to be installed.
+	WaitingForDefaultCNIConfiguredReason = "WaitingForDefaultCNIConfigured"
+
+	// SkipUpgradesForDefaultCNIConfiguredReason used to indicate the custer has been configured to skip
+	// upgrades for the default cni. The default cni may still be installed, for example to successfully
+	// create a cluster.
+	SkipUpgradesForDefaultCNIConfiguredReason = "SkipUpgradesForDefaultCNIConfigured"
+)

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -1,32 +1,28 @@
 package v1alpha1
 
-// Conditions and condition Reasons for the Cluster object.
+// Conditions, condition reasons, and messages for the Cluster object.
 const (
 	// ReadyCondition reports a summary of other conditions, indicating an overall operational
 	// state of the cluster: all control plane and worker nodes are the right version,
-	// all nodes are ready not including old nodes.
+	// all nodes are ready, not including old nodes.
 	ReadyCondition ConditionType = "Ready"
 
 	// OutdatedInformationReason reports the system is waiting for stale cluster information to be refreshed.
 	OutdatedInformationReason = "OutdatedInformation"
 
-	// ControlPlaneInitializedCondition reports that all the control plane nodes are
-	// in a fully ready and running state.
+	// ControlPlaneReadyCondition reports the status on the control plane nodes, indicating all those control plane
+	// nodes are the right version and are ready, not including the old nodes.
 	ControlPlaneReadyCondition ConditionType = "ControlPlaneReady"
 
 	// ControlPlaneInitializedCondition reports that the first control plane instance has been initialized
 	// and so the control plane is available and an API server instance is ready for processing requests.
 	ControlPlaneInitializedCondition ConditionType = "ControlPlaneInitialized"
 
-	// ControlPlaneInitializationInProgressReason used when cluster the control plane initilization is in progress.
+	// ControlPlaneInitializationInProgressReason reports that the control plane initilization is in progress.
 	ControlPlaneInitializationInProgressReason = "ControlPlaneInitializationInProgress"
 
-	// FirstControlPlaneUnavailableMessage used when waiting for the first control plane instance to become
-	// initialized and available.
-	FirstControlPlaneUnavailableMessage = "The first control plane instance is not available yet"
-
-	// WorkersReadyConditon used reports the status on the worker nodes and is true when the expected
-	// number of workers are in a fully ready and running state.
+	// WorkersReadyConditon reports the status on the worker nodes, indicating all those worker nodes
+	// are the right version and are ready, not including the old nodes.
 	WorkersReadyConditon ConditionType = "WorkersReady"
 
 	// DefaultCNIConfiguredCondition reports the default cni cluster has been configured successfully.

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -3,11 +3,12 @@ package v1alpha1
 // Conditions and condition Reasons for the Cluster object.
 const (
 	// ReadyCondition reports a summary of other conditions, indicating an overall operational
-	// state of the cluster.
+	// state of the cluster: all control plane and worker nodes are the right version,
+	// all nodes are ready not including old nodes.
 	ReadyCondition ConditionType = "Ready"
 
-	// PendingUpdateReason reports when an update has been scheduled but has yet to happen.
-	PendingUpdateReason = "PendingUpdate"
+	// OutdatedInformationReason reports the system is waiting for stale cluster information to be refreshed.
+	OutdatedInformationReason = "OutdatedInformation"
 
 	// ControlPlaneInitializedCondition reports that all the control plane nodes are
 	// in a fully ready and running state.
@@ -17,33 +18,17 @@ const (
 	// and so the control plane is available and an API server instance is ready for processing requests.
 	ControlPlaneInitializedCondition ConditionType = "ControlPlaneInitialized"
 
-	// WaitingForControlPlaneInitializedReason used when cluster is waiting for control plane to be initialized.
-	WaitingForControlPlaneInitializedReason = "WaitingForControlPlaneInitialized"
+	// ControlPlaneInitializationInProgressReason used when cluster the control plane initilization is in progress.
+	ControlPlaneInitializationInProgressReason = "ControlPlaneInitializationInProgress"
 
 	// FirstControlPlaneUnavailableMessage used when waiting for the first control plane instance to become
 	// initialized and available.
 	FirstControlPlaneUnavailableMessage = "The first control plane instance is not available yet"
 
-	// WaitingForControlPlaneReadyReason used when cluster is waiting for control plane nodes to transition to a
-	// fully ready and running state.
-	WaitingForControlPlaneReadyReason = "WaitingForControlPlaneReady"
-
 	// WorkersReadyConditon used reports the status on the worker nodes and is true when the expected
 	// number of workers are in a fully ready and running state.
 	WorkersReadyConditon ConditionType = "WorkersReady"
 
-	// WaitingForWorkersReadyReason used when cluster is waiting for control plane nodes to transition to a
-	// fully ready and running state.
-	WaitingForWorkersReadyReason = "WaitingForWorkersReady"
-
 	// DefaultCNIConfiguredCondition reports the default cni cluster has been configured successfully.
 	DefaultCNIConfiguredCondition ConditionType = "DefaultCNIConfigured"
-
-	// WaitingForDefaultCNIConfiguredReason used when cluster is waiting default cni to be installed.
-	WaitingForDefaultCNIConfiguredReason = "WaitingForDefaultCNIConfigured"
-
-	// SkipUpgradesForDefaultCNIConfiguredReason used to indicate the custer has been configured to skip
-	// upgrades for the default cni. The default cni may still be installed, for example to successfully
-	// create a cluster.
-	SkipUpgradesForDefaultCNIConfiguredReason = "SkipUpgradesForDefaultCNIConfigured"
 )

--- a/pkg/api/v1alpha1/condition_types.go
+++ b/pkg/api/v1alpha1/condition_types.go
@@ -1,0 +1,12 @@
+package v1alpha1
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+type (
+	// ConditionType is an alias for clusterv1.ConditionType.
+	ConditionType = clusterv1.ConditionType
+	// Condition is an alias for clusterv1.Condition.
+	Condition = clusterv1.Condition
+)

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -1,0 +1,63 @@
+package clusters
+
+import (
+	"fmt"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// UpdateControlPlaneInitializedCondition updates the ControlPlaneInitialized condition if it hasn't already been set.
+// This condition should be set only once.
+func UpdateControlPlaneInitializedCondition(cluster *anywherev1.Cluster, kcp *controlplanev1.KubeadmControlPlane) error {
+	// Return early if the ControlPlaneInitializedCondition is already "True"
+	if conditions.IsTrue(cluster, anywherev1.ControlPlaneInitializedCondition) {
+		return nil
+	}
+
+	if kcp == nil {
+		conditions.Set(cluster, waitingForCPInitializedCondition())
+		return nil
+	}
+
+	kcpCondition, err := checkKubeadmControlPlaneError(cluster, anywherev1.ControlPlaneInitializedCondition, kcp, controlplanev1.AvailableCondition)
+	if err != nil {
+		return err
+	}
+
+	if kcpCondition != nil {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneInitializedCondition, kcpCondition.Reason, kcpCondition.Severity, kcpCondition.Message)
+		return nil
+	}
+
+	available := conditions.IsTrue(kcp, controlplanev1.AvailableCondition)
+	if !available {
+		conditions.Set(cluster, waitingForCPInitializedCondition())
+		return nil
+	}
+
+	conditions.MarkTrue(cluster, anywherev1.ControlPlaneInitializedCondition)
+	return nil
+}
+
+func waitingForCPInitializedCondition() *anywherev1.Condition {
+	return conditions.FalseCondition(anywherev1.ControlPlaneInitializedCondition, anywherev1.WaitingForControlPlaneInitializedReason, clusterv1.ConditionSeverityInfo, anywherev1.FirstControlPlaneUnavailableMessage)
+}
+
+func checkKubeadmControlPlaneError(cluster *anywherev1.Cluster, clusterConditionType anywherev1.ConditionType, kcp *controlplanev1.KubeadmControlPlane, kcpConditionType clusterv1.ConditionType) (*anywherev1.Condition, error) {
+	kcpCondition := conditions.Get(kcp, kcpConditionType)
+
+	if kcpCondition == nil {
+		return nil, fmt.Errorf("unable to read condition %s from kubeadmcontrolplane %s", kcpConditionType, kcp.Name)
+	}
+
+	// Surface any errors from the KubeadmControlPlane
+	if kcpCondition.Severity == clusterv1.ConditionSeverityError {
+		return conditions.FalseCondition(clusterConditionType, kcpCondition.Reason, kcpCondition.Severity, kcpCondition.Message), nil
+	}
+
+	return nil, nil
+}

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -10,7 +11,6 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/controller"
-	"github.com/pkg/errors"
 )
 
 // UpdateControlPlaneStatus checks the current state of the Cluster's control plane and updates the

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -146,7 +146,8 @@ func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
 
 			client = fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
-			clusters.UpdateControlPlaneStatus(ctx, client, cluster)
+			err := clusters.UpdateControlPlaneStatus(ctx, client, cluster)
+			g.Expect(err).To(BeNil())
 
 			condition := conditions.Get(cluster, anywherev1.ControlPlaneInitializedCondition)
 			g.Expect(condition).ToNot(BeNil())

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -1,0 +1,143 @@
+package clusters_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	_ "github.com/aws/eks-anywhere/internal/test/envtest"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+)
+
+func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name          string
+		kcp           *controlplanev1.KubeadmControlPlane
+		conditions    []anywherev1.Condition
+		wantCondition *anywherev1.Condition
+		wantErr       string
+	}{
+		{
+			name:       "kcp is nil",
+			kcp:        nil,
+			conditions: []anywherev1.Condition{},
+			wantCondition: &anywherev1.Condition{
+				Type:     "ControlPlaneInitialized",
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityInfo,
+				Reason:   anywherev1.WaitingForControlPlaneInitializedReason,
+				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+			},
+			wantErr: "",
+		},
+		{
+			name: "control plane already initialized",
+			kcp:  nil,
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.ControlPlaneInitializedCondition,
+				Status: "True",
+			},
+			wantErr: "",
+		},
+		{
+			name:          "kcp missing available condition ",
+			kcp:           test.KubeadmControlPlane(),
+			wantCondition: nil,
+			wantErr:       "unable to read condition",
+		},
+		{
+			name: "kcp available condition with error",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:     controlplanev1.AvailableCondition,
+						Status:   "False",
+						Severity: clusterv1.ConditionSeverityError,
+						Reason:   "TestReason",
+						Message:  "test message",
+					},
+				}
+			}),
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneInitializedCondition,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityError,
+				Reason:   "TestReason",
+				Message:  "test message",
+			},
+			wantErr: "",
+		},
+		{
+			name: "kcp  available condtion false",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = clusterv1.Conditions{
+					{
+						Type:   controlplanev1.AvailableCondition,
+						Status: "False",
+					},
+				}
+			}),
+			conditions: []anywherev1.Condition{},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneInitializedCondition,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityInfo,
+				Reason:   anywherev1.WaitingForControlPlaneInitializedReason,
+				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+			},
+			wantErr: "",
+		},
+		{
+			name: "kcp available condition true",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Conditions = clusterv1.Conditions{
+					{
+						Type:   controlplanev1.AvailableCondition,
+						Status: "True",
+					},
+				}
+			}),
+			conditions: []anywherev1.Condition{},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.ControlPlaneInitializedCondition,
+				Status: "True",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := test.NewClusterSpec().Cluster
+			cluster.Status.Conditions = tt.conditions
+
+			err := clusters.UpdateControlPlaneInitializedCondition(cluster, tt.kcp)
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).To(BeNil())
+
+				condition := conditions.Get(cluster, anywherev1.ControlPlaneInitializedCondition)
+				g.Expect(condition).ToNot(BeNil())
+
+				condition.LastTransitionTime = v1.Time{}
+				g.Expect(condition).To(Equal(tt.wantCondition))
+			}
+		})
+	}
+}

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -38,7 +38,7 @@ func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
 				Status:   "False",
 				Severity: clusterv1.ConditionSeverityInfo,
 				Reason:   anywherev1.ControlPlaneInitializationInProgressReason,
-				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+				Message:  "The first control plane instance is not available yet",
 			},
 		},
 		{
@@ -70,27 +70,6 @@ func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
 			},
 		},
 		{
-			name: "kcp not available, condition error",
-			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-				kcp.Status.Conditions = []clusterv1.Condition{
-					{
-						Type:     controlplanev1.AvailableCondition,
-						Status:   "False",
-						Severity: clusterv1.ConditionSeverityError,
-						Reason:   "TestReason",
-						Message:  "test message",
-					},
-				}
-			}),
-			wantCondition: &anywherev1.Condition{
-				Type:     anywherev1.ControlPlaneInitializedCondition,
-				Status:   "False",
-				Severity: clusterv1.ConditionSeverityError,
-				Reason:   "TestReason",
-				Message:  "test message",
-			},
-		},
-		{
 			name: "kcp not availabe yet",
 			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
 				kcp.Status.Conditions = clusterv1.Conditions{
@@ -106,7 +85,7 @@ func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
 				Status:   "False",
 				Severity: clusterv1.ConditionSeverityInfo,
 				Reason:   anywherev1.ControlPlaneInitializationInProgressReason,
-				Message:  anywherev1.FirstControlPlaneUnavailableMessage,
+				Message:  "The first control plane instance is not available yet",
 			},
 		},
 		{
@@ -146,7 +125,7 @@ func TestUpdateControlPlaneInitializedCondition(t *testing.T) {
 
 			client = fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
-			err := clusters.UpdateControlPlaneStatus(ctx, client, cluster)
+			err := clusters.UpdateClusterStatusForControlPlane(ctx, client, cluster)
 			g.Expect(err).To(BeNil())
 
 			condition := conditions.Get(cluster, anywherev1.ControlPlaneInitializedCondition)


### PR DESCRIPTION
*Issue #, if available:*
#5628 

*Description of changes:*
Changes to the Cluster status as per the [proposal](https://github.com/aws/eks-anywhere/pull/6005). Added:
- Added ObservedGeneration field
- ControlPlaneInitialized condition

*Testing (if applicable):*
- Unit testing
- Manual testing
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

