### PR TITLE
Added cgroups note for v01.5 and prior

### DIFF
--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -23,7 +23,7 @@ This allows you to try EKS Anywhere on your local machine or laptop before deplo
 * 16GB memory
 * 30GB free disk space
 * If you are using Ubuntu, use the Docker CE installation instructions to install Docker and not the Snap installation, as described here.
-* If you are using Ubuntu 21.10 or 22.04, you will need to switch from cgroups v2 to cgroups v1. For details, see Troubleshooting Guide.
+* For EKS Anywhere v0.15 and earlier, if you are using Ubuntu 21.10 or 22.04, you will need to switch from cgroups v2 to cgroups v1. For details, see [Troubleshooting Guide.]({{< relref "../../troubleshooting/troubleshooting.md#for-eks-anywhere-v015-and-earlier-cgroups-v2-is-not-supported-in-ubuntu-2110-and-2204" >}})
 * EKS Anywhere works with x86 and amd64 architectures. It currently will not work on computers with Apple Silicon or Arm based processors.
 
 ### Install EKS Anywhere CLI tools

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -23,20 +23,24 @@ See [Create cluster workflow]({{< relref "../overview" >}}) for an overview of t
 
 #### System and network requirements
 - Mac OS 10.15+ / Ubuntu 20.04.2 LTS or 22.04 LTS / RHEL or Rocky Linux 8.8+
+- [Docker 20.x.x](https://docs.docker.com/engine/install/)
+- [`curl`](https://everything.curl.dev/get)
+- [`yq`](https://github.com/mikefarah/yq/#install)
 - 4 CPU cores
 - 16GB memory
 - 30GB free disk space
 - Administrative machine must be on the same Layer 2 network as the cluster machines (Bare Metal provider only).
 
-#### Tools
-- [Docker 20.x.x](https://docs.docker.com/engine/install/)
-- [`curl`](https://everything.curl.dev/get)
-- [`yq`](https://github.com/mikefarah/yq/#install)
+Here are a few other things to keep in mind:
 
-{{% alert title="Note" color="primary" %}}
-- If you are using Ubuntu, use the Docker CE installation instructions to install Docker as described [here.](https://docs.docker.com/engine/install/ubuntu/) 
-- For EKS Anywhere Bare Metal, Docker Desktop is not supported.
-{{% /alert %}}
+* If you are using Ubuntu, use the Docker CE installation instructions to install Docker and not the Snap installation, as described [here.](https://docs.docker.com/engine/install/ubuntu/)
+
+* If you are using EKS Anywhere v0.15 or earlier and Ubuntu 21.10 or 22.04, you will need to switch from _cgroups v2_ to _cgroups v1_. For details, see [Troubleshooting Guide.]({{< relref "../../troubleshooting/troubleshooting.md#for-eks-anywhere-v015-and-earlier-cgroups-v2-is-not-supported-in-ubuntu-2110-and-2204" >}})
+
+* If you are using Docker Desktop, you need to know that:
+
+  * For EKS Anywhere Bare Metal, Docker Desktop is not supported
+  * For EKS Anywhere vSphere, if you are using EKS Anywhere v0.15 or earlier and Mac OS Docker Desktop 4.4.2 or newer `"deprecatedCgroupv1": true` must be set in `~/Library/Group\ Containers/group.com.docker/settings.json`.
 
 ### Install EKS Anywhere CLI tools
 
@@ -78,7 +82,7 @@ sudo mv ./eksctl-anywhere /usr/local/bin/
 ```
 
 Install the `kubectl` Kubernetes command line tool.
-This can be done by following the instructions [here](https://kubernetes.io/docs/tasks/tools/).
+This can be done by following the instructions [here](https://kubernetes.io/docs/tools/).
 
 Or you can install the latest kubectl directly with the following.
 

--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -49,12 +49,12 @@ Ensure you are running Docker 20.x.x for example:
 Docker version 20.10.6, build 370c289
 ```
 
-### Minimum requirements for docker version have not been met on Mac OS
+### Minimum requirements for Docker version have not been met on macOS
 ```
-Error: EKS Anywhere does not support Docker desktop versions between 4.3.0 and 4.4.1 on macOS
+Error: EKS Anywhere does not support Docker Desktop versions between 4.3.0 and 4.4.1 on macOS
 ```
 ```
-Error: EKS Anywhere requires Docker desktop to be configured to use CGroups v1. Please  set `deprecatedCgroupv1:true` in your `~/Library/Group\\ Containers/group.com.docker/settings.json` file
+Error: EKS Anywhere requires Docker Desktop to be configured to use CGroups v1. Please  set `deprecatedCgroupv1:true` in your `~/Library/Group\\ Containers/group.com.docker/settings.json` file
 ```
 Ensure you are running Docker Desktop 4.4.2 or newer and, if you are running EKS Anywhere v0.15 or earlier, have set `"deprecatedCgroupv1": true` in your settings.json file
 ```
@@ -68,7 +68,7 @@ Ensure you are running Docker Desktop 4.4.2 or newer and, if you are running EKS
 ```
 ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
 ```
-For EKS Anywhere v0.15 and earlier, it is recommended to use Ubuntu 20.04 for the Administrative Machine. This is because the EKS Anywhere Bootstrap cluster for those versions requires _cgroups v1_. Since Ubuntu 21.10 _cgroups v2_ is enabled by default. You can use Ubuntu 21.10 and 22.04 for the Administrative machine if you configure Ubuntu to use _cgroups v1_ instead.
+For EKS Anywhere v0.15 and earlier, if you are using Ubuntu it is recommended to use Ubuntu 20.04 for the Administrative Machine. This is because the EKS Anywhere Bootstrap cluster for those versions requires _cgroups v1_. Since Ubuntu 21.10 _cgroups v2_ is enabled by default. You can use Ubuntu 21.10 and 22.04 for the Administrative machine if you configure Ubuntu to use _cgroups v1_ instead. This is not an issue if you are using macOS for your Administrative machine.
 
 To verify cgroups version
 ```

--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -49,6 +49,47 @@ Ensure you are running Docker 20.x.x for example:
 Docker version 20.10.6, build 370c289
 ```
 
+### Minimum requirements for docker version have not been met on Mac OS
+```
+Error: EKS Anywhere does not support Docker desktop versions between 4.3.0 and 4.4.1 on macOS
+```
+```
+Error: EKS Anywhere requires Docker desktop to be configured to use CGroups v1. Please  set `deprecatedCgroupv1:true` in your `~/Library/Group\\ Containers/group.com.docker/settings.json` file
+```
+Ensure you are running Docker Desktop 4.4.2 or newer and have set `"deprecatedCgroupv1": true` in your settings.json file
+```
+% defaults read /Applications/Docker.app/Contents/Info.plist CFBundleShortVersionString
+4.42
+% docker info --format '{{json .CgroupVersion}}' 
+"1"
+```
+
+### For EKS Anywhere v0.15 and earlier, cgroups v2 is not supported in Ubuntu 21.10+ and 22.04
+```
+ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
+```
+For EKS Anywhere v0.15 and earlier, it is recommended to use Ubuntu 20.04 for the Administrative Machine. This is because the EKS Anywhere Bootstrap cluster for those versions requires _cgroups v1_. Since Ubuntu 21.10 _cgroups v2_ is enabled by default. You can use Ubuntu 21.10 and 22.04 for the Administrative machine if you configure Ubuntu to use _cgroups v1_ instead.
+
+To verify cgroups version
+```
+% docker info | grep Cgroup
+ Cgroup Driver: cgroupfs
+ Cgroup Version: 2
+```
+To use _cgroups v1_ you need to _sudo_ and edit _/etc/default/grub_ to set _GRUB_CMDLINE_LINUX_ to "systemd.unified_cgroup_hierarchy=0" and reboot.
+```
+%sudo <editor> /etc/default/grub
+GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"
+sudo update-grub
+sudo reboot now
+```
+Then verify you are using _cgroups v1_.
+```
+% docker info | grep Cgroup
+ Cgroup Driver: cgroupfs
+ Cgroup Version: 1
+```
+
 ### ECR access denied
 
 ```

--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -56,7 +56,7 @@ Error: EKS Anywhere does not support Docker desktop versions between 4.3.0 and 4
 ```
 Error: EKS Anywhere requires Docker desktop to be configured to use CGroups v1. Please  set `deprecatedCgroupv1:true` in your `~/Library/Group\\ Containers/group.com.docker/settings.json` file
 ```
-Ensure you are running Docker Desktop 4.4.2 or newer and have set `"deprecatedCgroupv1": true` in your settings.json file
+Ensure you are running Docker Desktop 4.4.2 or newer and, if you are running EKS Anywhere v0.15 or earlier, have set `"deprecatedCgroupv1": true` in your settings.json file
 ```
 % defaults read /Applications/Docker.app/Contents/Info.plist CFBundleShortVersionString
 4.42


### PR DESCRIPTION
*Description of changes:* The requirement to downgrade cgroups from v2 to v1 in some versions of Ubuntu was removed in EKS Anywhere v0.16. However, those running v0.15 or earlier still need to know about this issue. So this PR adds the notes and troubleshooting tip back in, noting that the issue only applies to v0.15 and earlier.
