### PR TITLE
Remove vsphere-csi-driver project from bundle release

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -2831,6 +2831,7 @@ spec:
                               type: string
                           type: object
                         driver:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -2953,6 +2954,7 @@ spec:
                               type: string
                           type: object
                         syncer:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -2987,12 +2989,10 @@ spec:
                       - clusterAPIController
                       - clusterTemplate
                       - components
-                      - driver
                       - kubeProxy
                       - kubeVip
                       - manager
                       - metadata
-                      - syncer
                       - version
                       type: object
                   required:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -2999,6 +2999,7 @@ spec:
                               type: string
                           type: object
                         driver:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -3121,6 +3122,7 @@ spec:
                               type: string
                           type: object
                         syncer:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -3155,12 +3157,10 @@ spec:
                       - clusterAPIController
                       - clusterTemplate
                       - components
-                      - driver
                       - kubeProxy
                       - kubeVip
                       - manager
                       - metadata
-                      - syncer
                       - version
                       type: object
                   required:

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -193,8 +193,10 @@ type VSphereBundle struct {
 	KubeProxy            Image    `json:"kubeProxy"`
 	Manager              Image    `json:"manager"`
 	KubeVip              Image    `json:"kubeVip"`
-	Driver               Image    `json:"driver"`
-	Syncer               Image    `json:"syncer"`
+	// This field has been deprecated
+	Driver               Image    `json:"driver,omitempty"`
+	// This field has been deprecated
+	Syncer               Image    `json:"syncer,omitempty"`
 	Components           Manifest `json:"components"`
 	Metadata             Manifest `json:"metadata"`
 	ClusterTemplate      Manifest `json:"clusterTemplate"`

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -2831,6 +2831,7 @@ spec:
                               type: string
                           type: object
                         driver:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -2953,6 +2954,7 @@ spec:
                               type: string
                           type: object
                         syncer:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -2987,12 +2989,10 @@ spec:
                       - clusterAPIController
                       - clusterTemplate
                       - components
-                      - driver
                       - kubeProxy
                       - kubeVip
                       - manager
                       - metadata
-                      - syncer
                       - version
                       type: object
                   required:

--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -822,26 +822,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			"projectPath",
 		},
 	},
-	// Vsphere-csi-driver artifacts
-	{
-		ProjectName: "vsphere-csi-driver",
-		ProjectPath: "projects/kubernetes-sigs/vsphere-csi-driver",
-		Images: []*assettypes.Image{
-			{
-				RepoName:  "driver",
-				AssetName: "vsphere-csi-driver",
-			},
-			{
-				RepoName:  "syncer",
-				AssetName: "vsphere-csi-syncer",
-			},
-		},
-		ImageRepoPrefix: "kubernetes-sigs/vsphere-csi-driver/csi",
-		ImageTagOptions: []string{
-			"gitTag",
-			"projectPath",
-		},
-	},
 }
 
 func GetBundleReleaseAssetsConfigMap() []assettypes.AssetConfig {

--- a/release/pkg/bundles/vsphere.go
+++ b/release/pkg/bundles/vsphere.go
@@ -31,7 +31,6 @@ func GetVsphereBundle(r *releasetypes.ReleaseConfig, eksDReleaseChannel string, 
 		"cluster-api-provider-vsphere": r.BundleArtifactsTable["cluster-api-provider-vsphere"],
 		"kube-rbac-proxy":              r.BundleArtifactsTable["kube-rbac-proxy"],
 		"kube-vip":                     r.BundleArtifactsTable["kube-vip"],
-		"vsphere-csi-driver":           r.BundleArtifactsTable["vsphere-csi-driver"],
 	}
 	sortedComponentNames := bundleutils.SortArtifactsMap(vsphereBundleArtifacts)
 
@@ -114,8 +113,6 @@ func GetVsphereBundle(r *releasetypes.ReleaseConfig, eksDReleaseChannel string, 
 		KubeProxy:            bundleImageArtifacts["kube-rbac-proxy"],
 		Manager:              bundleImageArtifacts["cloud-provider-vsphere"],
 		KubeVip:              bundleImageArtifacts["kube-vip"],
-		Driver:               bundleImageArtifacts["vsphere-csi-driver"],
-		Syncer:               bundleImageArtifacts["vsphere-csi-syncer"],
 		Components:           bundleManifestArtifacts["infrastructure-components.yaml"],
 		ClusterTemplate:      bundleManifestArtifacts["cluster-template.yaml"],
 		Metadata:             bundleManifestArtifacts["metadata.yaml"],

--- a/release/pkg/operations/bundle_release_test.go
+++ b/release/pkg/operations/bundle_release_test.go
@@ -76,13 +76,13 @@ func TestGenerateBundleManifest(t *testing.T) {
 			cliMinVersion:       "v0.16.0",
 			cliMaxVersion:       "v0.16.0",
 		},
-		// {
-		// 	testName:            "Dev-release from release-0.15",
-		// 	buildRepoBranchName: "release-0.15",
-		// 	cliRepoBranchName:   "release-0.15",
-		// 	cliMinVersion:       "v0.15.0",
-		// 	cliMaxVersion:       "v0.15.0",
-		// },
+		{
+			testName:            "Dev-release from release-0.16",
+			buildRepoBranchName: "release-0.16",
+			cliRepoBranchName:   "release-0.16",
+			cliMinVersion:       "v0.16.0",
+			cliMaxVersion:       "v0.16.0",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -755,15 +755,7 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/cluster-template.yaml
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -793,15 +785,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.4-eks-d-1-23-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
+      syncer: {}
       version: v1.6.1+abcdef1
   - bootstrap:
       components:
@@ -1550,15 +1534,7 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/cluster-template.yaml
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -1588,15 +1564,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.4-eks-d-1-24-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
+      syncer: {}
       version: v1.6.1+abcdef1
   - bootstrap:
       components:
@@ -2318,15 +2286,7 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/cluster-template.yaml
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -2356,15 +2316,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.1-eks-d-1-25-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
+      syncer: {}
       version: v1.6.1+abcdef1
   - bootstrap:
       components:
@@ -3086,15 +3038,7 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/cluster-template.yaml
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -3124,15 +3068,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.26.0-eks-d-1-26-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
+      syncer: {}
       version: v1.6.1+abcdef1
   - bootstrap:
       components:
@@ -3854,15 +3790,7 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/cluster-template.yaml
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-build.1
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -3892,14 +3820,6 @@ spec:
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.26.0-eks-d-1-27-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.6.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-build.1
+      syncer: {}
       version: v1.6.1+abcdef1
 status: {}

--- a/release/pkg/test/testdata/release-0.16-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.16-bundle-release.yaml
@@ -4,13 +4,13 @@ metadata:
   creationTimestamp: "1970-01-01T00:00:00Z"
   name: bundles-1
 spec:
-  cliMaxVersion: v0.14.0
-  cliMinVersion: v0.14.0
+  cliMaxVersion: v0.16.0
+  cliMinVersion: v0.16.0
   number: 1
   versionsBundles:
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -19,7 +19,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -28,27 +28,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
+        imageDigest: sha256:a1f0161cb9f6d7b0e2f5b66ddb40cc70c6fddcba9bd2e62e3ff337f236300dfe
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
+        imageDigest: sha256:e0c844f682373faa43d5b5f006695cf4502b0a0747f617ff607591e09882e616
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2
       kubeadmBootstrap:
         arch:
         - amd64
@@ -57,7 +57,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-21-26-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-23-eks-a-v0.0.0-dev-release-0.16-build.1
     certManager:
       acmesolver:
         arch:
@@ -67,7 +67,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       cainjector:
         arch:
         - amd64
@@ -76,7 +76,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       controller:
         arch:
         - amd64
@@ -85,7 +85,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       ctl:
         arch:
         - amd64
@@ -94,10 +94,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cert-manager/manifests/v1.11.1/cert-manager.yaml
+      version: v1.11.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -106,32 +106,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
     cilium:
       cilium:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
+        imageDigest: sha256:41cc8d39ef9cc996f9ed2aee7e232b7cead7af7dbf58c7f2db78526485608800
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.11.15-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
+        imageDigest: sha256:d85e1b06b40dcce88b89d604d1c645f53deac381d909375b606d0adf9bc2955a
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.11.15-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cilium/manifests/cilium/v1.11.15-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
+        imageDigest: sha256:076a884143abe3342af64c258d7062005f09343764d40b8cc2cd37d8302f2c35
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.15-eksa.1
+      version: v1.11.15-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -141,9 +141,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc5-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -152,7 +152,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -161,13 +161,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
+      version: v0.4.9-rc5+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -176,7 +176,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -185,13 +185,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -200,7 +200,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -209,15 +209,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -226,7 +226,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -235,1624 +235,61 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     eksD:
       ami:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-21-26 release
-          name: bottlerocket-v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-23-23 release
+          name: bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-21/1-21-26/bottlerocket-v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-      channel: 1-21
-      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      crictl:
-        arch:
-        - amd64
-        description: cri-tools tarball for linux/amd64
-        name: cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-      etcdadm:
-        arch:
-        - amd64
-        description: etcdadm tarball for linux/amd64
-        name: etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-      gitCommit: 0123456789abcdef0123456789abcdef01234567
-      imagebuilder:
-        arch:
-        - amd64
-        description: image-builder tarball for linux/amd64
-        name: image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-      kindNode:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kind-node image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kind-node
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVersion: v1.21.14
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-21/kubernetes-1-21-eks-26.yaml
-      name: kubernetes-1-21-eks-26
-      ova:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Ova image for EKS-D 1-21-26 release
-          name: bottlerocket-v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-21/1-21-26/bottlerocket-v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
-      raw:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Raw image for EKS-D 1-21-26 release
-          name: bottlerocket-v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-21/1-21-26/bottlerocket-v1.21.14-eks-d-1-21-26-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-    eksa:
-      cliTools:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-cli-tools image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-cli-tools
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-cluster-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-cluster-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.15.2/eksa-components.yaml
-      diagnosticCollector:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-diagnostic-collector image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-diagnostic-collector
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
-    etcdadmBootstrap:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for etcdadm-bootstrap-provider image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: etcdadm-bootstrap-provider
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
-    etcdadmController:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for etcdadm-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: etcdadm-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
-    flux:
-      helmController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for helm-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: helm-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      kustomizeController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kustomize-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kustomize-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
-      notificationController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for notification-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: notification-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      sourceController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for source-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: source-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
-    haproxy:
-      image:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for haproxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: haproxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
-    kindnetd:
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
-    kubeVersion: "1.21"
-    nutanix:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-nutanix image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-nutanix
-        os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
-    packageController:
-      helmChart:
-        description: Helm chart for eks-anywhere-packages
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      packageController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-packages image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-packages
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      tokenRefresher:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for ecr-token-refresher image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: ecr-token-refresher
-        os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
-    snow:
-      bottlerocketBootstrapSnow:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for bottlerocket-bootstrap-snow image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: bottlerocket-bootstrap-snow
-        os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-21-26-eks-a-v0.0.0-dev-release-0.14-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-snow-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-snow-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.24-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/metadata.yaml
-      version: v0.1.24+abcdef1
-    tinkerbell:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-tinkerbell image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-tinkerbell
-        os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
-      envoy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for envoy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: envoy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
-      tinkerbellStack:
-        actions:
-          cexec:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for cexec image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: cexec
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          imageToDisk:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for image2disk image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: image2disk
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          kexec:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for kexec image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: kexec
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          ociToDisk:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for oci2disk image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: oci2disk
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          reboot:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for reboot image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: reboot
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          writeFile:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for writefile image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: writefile
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-        boots:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for boots image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
-        hegel:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for hegel image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
-        hook:
-          bootkit:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-bootkit image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-bootkit
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
-          docker:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-docker image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-docker
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
-          initramfs:
-            amd:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
-            arm:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
-          kernel:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-kernel image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-kernel
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
-          vmlinuz:
-            amd:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
-            arm:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
-        rufio:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for rufio image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
-        tink:
-          tinkController:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-controller image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
-          tinkServer:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-server image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
-          tinkWorker:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-worker image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
-        tinkerbellChart:
-          description: Helm chart for tinkerbell-chart
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
-    vSphere:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-vsphere image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-vsphere
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cloud-provider-vsphere image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cloud-provider-vsphere
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.21.3-eks-d-1-21-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
-  - bootstrap:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kubeadm-bootstrap-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kubeadm-bootstrap-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    bottlerocketHostContainers:
-      admin:
-        arch:
-        - amd64
-        description: Container image for bottlerocket-admin image
-        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
-        name: bottlerocket-admin
-        os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
-      control:
-        arch:
-        - amd64
-        description: Container image for bottlerocket-control image
-        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
-        name: bottlerocket-control
-        os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
-      kubeadmBootstrap:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for bottlerocket-bootstrap image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: bottlerocket-bootstrap
-        os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-22-21-eks-a-v0.0.0-dev-release-0.14-build.1
-    certManager:
-      acmesolver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-acmesolver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-acmesolver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      cainjector:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-cainjector image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-cainjector
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      ctl:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-ctl image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
-      webhook:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-webhook image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-webhook
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-    cilium:
-      cilium:
-        arch:
-        - amd64
-        description: Container image for cilium image
-        imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
-        name: cilium
-        os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
-      helmChart:
-        description: Helm chart for cilium-chart
-        imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
-        name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
-      operator:
-        arch:
-        - amd64
-        description: Container image for operator-generic image
-        imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
-        name: operator-generic
-        os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
-    cloudStack:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
-      kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
-    clusterAPI:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    controlPlane:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kubeadm-control-plane-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kubeadm-control-plane-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    docker:
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-docker image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-docker
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    eksD:
-      ami:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Ami image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-      channel: 1-22
-      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-      crictl:
-        arch:
-        - amd64
-        description: cri-tools tarball for linux/amd64
-        name: cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-      etcdadm:
-        arch:
-        - amd64
-        description: etcdadm tarball for linux/amd64
-        name: etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-      gitCommit: 0123456789abcdef0123456789abcdef01234567
-      imagebuilder:
-        arch:
-        - amd64
-        description: image-builder tarball for linux/amd64
-        name: image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-        os: linux
-        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
-      kindNode:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kind-node image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kind-node
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVersion: v1.22.17
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-22/kubernetes-1-22-eks-21.yaml
-      name: kubernetes-1-22-eks-21
-      ova:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Ova image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
-      raw:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Raw image for EKS-D 1-22-21 release
-          name: bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-22/1-22-21/bottlerocket-v1.22.17-eks-d-1-22-21-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-    eksa:
-      cliTools:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-cli-tools image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-cli-tools
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-cluster-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-cluster-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.15.2/eksa-components.yaml
-      diagnosticCollector:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-diagnostic-collector image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-diagnostic-collector
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
-    etcdadmBootstrap:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for etcdadm-bootstrap-provider image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: etcdadm-bootstrap-provider
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
-    etcdadmController:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for etcdadm-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: etcdadm-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
-    flux:
-      helmController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for helm-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: helm-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      kustomizeController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kustomize-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kustomize-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
-      notificationController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for notification-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: notification-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      sourceController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for source-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: source-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
-    haproxy:
-      image:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for haproxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: haproxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
-    kindnetd:
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
-    kubeVersion: "1.22"
-    nutanix:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-nutanix image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-nutanix
-        os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
-    packageController:
-      helmChart:
-        description: Helm chart for eks-anywhere-packages
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      packageController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for eks-anywhere-packages image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: eks-anywhere-packages
-        os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      tokenRefresher:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for ecr-token-refresher image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: ecr-token-refresher
-        os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
-    snow:
-      bottlerocketBootstrapSnow:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for bottlerocket-bootstrap-snow image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: bottlerocket-bootstrap-snow
-        os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-22-21-eks-a-v0.0.0-dev-release-0.14-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-snow-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-snow-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.24-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/metadata.yaml
-      version: v0.1.24+abcdef1
-    tinkerbell:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-tinkerbell image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-tinkerbell
-        os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
-      envoy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for envoy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: envoy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
-      tinkerbellStack:
-        actions:
-          cexec:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for cexec image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: cexec
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          imageToDisk:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for image2disk image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: image2disk
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          kexec:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for kexec image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: kexec
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          ociToDisk:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for oci2disk image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: oci2disk
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          reboot:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for reboot image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: reboot
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-          writeFile:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for writefile image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: writefile
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
-        boots:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for boots image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
-        hegel:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for hegel image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
-        hook:
-          bootkit:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-bootkit image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-bootkit
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
-          docker:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-docker image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-docker
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
-          initramfs:
-            amd:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
-            arm:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
-          kernel:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for hook-kernel image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: hook-kernel
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
-          vmlinuz:
-            amd:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
-            arm:
-              description: Tinkerbell operating system installation environment (osie)
-                component
-              name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
-        rufio:
-          arch:
-          - amd64
-          - arm64
-          description: Container image for rufio image
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
-          os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
-        tink:
-          tinkController:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-controller image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
-          tinkServer:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-server image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
-          tinkWorker:
-            arch:
-            - amd64
-            - arm64
-            description: Container image for tink-worker image
-            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
-            os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
-        tinkerbellChart:
-          description: Helm chart for tinkerbell-chart
-          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
-    vSphere:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-vsphere image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-vsphere
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cloud-provider-vsphere image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cloud-provider-vsphere
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.22.6-eks-d-1-22-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v1.3.1+abcdef1
-  - bootstrap:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kubeadm-bootstrap-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kubeadm-bootstrap-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    bottlerocketHostContainers:
-      admin:
-        arch:
-        - amd64
-        description: Container image for bottlerocket-admin image
-        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
-        name: bottlerocket-admin
-        os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
-      control:
-        arch:
-        - amd64
-        description: Container image for bottlerocket-control image
-        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
-        name: bottlerocket-control
-        os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
-      kubeadmBootstrap:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for bottlerocket-bootstrap image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: bottlerocket-bootstrap
-        os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-23-16-eks-a-v0.0.0-dev-release-0.14-build.1
-    certManager:
-      acmesolver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-acmesolver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-acmesolver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      cainjector:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-cainjector image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-cainjector
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      ctl:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-ctl image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
-      webhook:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cert-manager-webhook image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-webhook
-        os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
-    cilium:
-      cilium:
-        arch:
-        - amd64
-        description: Container image for cilium image
-        imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
-        name: cilium
-        os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
-      helmChart:
-        description: Helm chart for cilium-chart
-        imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
-        name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
-      operator:
-        arch:
-        - amd64
-        description: Container image for operator-generic image
-        imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
-        name: operator-generic
-        os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
-    cloudStack:
-      clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
-      kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
-    clusterAPI:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    controlPlane:
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
-      controller:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kubeadm-control-plane-controller image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kubeadm-control-plane-controller
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    docker:
-      clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
-      components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
-      kubeProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      manager:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-docker image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cluster-api-provider-docker
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
-      metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
-    eksD:
-      ami:
-        bottlerocket:
-          arch:
-          - amd64
-          description: Bottlerocket Ami image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
-          os: linux
-          osName: bottlerocket
-          sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-distro/ami/1-23/1-23-23/bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
       channel: 1-23
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      containerd:
+        arch:
+        - amd64
+        description: containerd tarball for linux/amd64
+        name: containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/containerd/v1.6.21/containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
         description: cri-tools tarball for linux/amd64
-        name: cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cri-tools/v1.26.1/cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
         description: etcdadm tarball for linux/amd64
-        name: etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm/f089d308442c18f487a52d09fd067ae9ac7cd8f2/etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
         - amd64
         description: image-builder tarball for linux/amd64
-        name: image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1861,32 +298,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVersion: v1.23.16
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-16.yaml
-      name: kubernetes-1-23-eks-16
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVersion: v1.23.17
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-23/kubernetes-1-23-eks-23.yaml
+      name: kubernetes-1-23-eks-23
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-23-23 release
+          name: bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-distro/ova/1-23/1-23-23/bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-23-16 release
-          name: bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-23-23 release
+          name: bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-23/1-23-16/bottlerocket-v1.23.16-eks-d-1-23-16-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-distro/raw/1-23/1-23-23/bottlerocket-v1.23.17-eks-d-1-23-23-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -1896,7 +333,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterController:
         arch:
         - amd64
@@ -1905,9 +342,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.15.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-anywhere/manifests/cluster-controller/v0.16.0/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -1916,11 +353,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.0.0-dev-release-0.16+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1929,7 +366,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.8-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1938,13 +375,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/metadata.yaml
+      version: v1.0.8+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1953,7 +390,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.7-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1962,10 +399,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/metadata.yaml
+      version: v1.0.7+abcdef1
     flux:
       helmController:
         arch:
@@ -1975,7 +412,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.33.0-eks-a-v0.0.0-dev-release-0.16-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1984,7 +421,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
       notificationController:
         arch:
         - amd64
@@ -1993,7 +430,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
       sourceController:
         arch:
         - amd64
@@ -2002,8 +439,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v2.0.0-rc.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2013,11 +450,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.18.0-eks-a-v0.0.0-dev-release-0.16-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/kind/manifests/kindnetd/v0.18.0/kindnetd.yaml
+      version: v0.18.0+abcdef1
     kubeVersion: "1.23"
     nutanix:
       clusterAPIController:
@@ -2028,11 +465,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2041,16 +478,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
+      version: v1.2.1+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
       packageController:
         arch:
         - amd64
@@ -2059,7 +496,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2068,8 +505,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.3.9+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2079,9 +516,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-16-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-23-23-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2090,7 +527,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -2099,10 +536,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.24-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.25-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/metadata.yaml
-      version: v0.1.24+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/metadata.yaml
+      version: v0.1.25+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2112,11 +549,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2125,7 +562,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -2134,9 +571,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2147,7 +584,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2156,7 +593,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           kexec:
             arch:
             - amd64
@@ -2165,7 +602,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2174,7 +611,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           reboot:
             arch:
             - amd64
@@ -2183,7 +620,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           writeFile:
             arch:
             - amd64
@@ -2192,7 +629,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
         boots:
           arch:
           - amd64
@@ -2201,7 +638,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-release-0.16-build.1
         hegel:
           arch:
           - amd64
@@ -2210,7 +647,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-release-0.16-build.1
         hook:
           bootkit:
             arch:
@@ -2220,7 +657,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           docker:
             arch:
             - amd64
@@ -2229,18 +666,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -2249,18 +686,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -2269,7 +706,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a6b208f19c9ee97fb9d9211cfdd26b971eac90ae-eks-a-v0.0.0-dev-release-0.16-build.1
         tink:
           tinkController:
             arch:
@@ -2279,7 +716,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
           tinkServer:
             arch:
             - amd64
@@ -2288,7 +725,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
           tinkWorker:
             arch:
             - amd64
@@ -2297,13 +734,13 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -2313,20 +750,12 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -2335,7 +764,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -2344,7 +773,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -2353,22 +782,14 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.1-eks-d-1-23-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.23.4-eks-d-1-23-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+      syncer: {}
       version: v1.3.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2377,7 +798,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2386,27 +807,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
+        imageDigest: sha256:a1f0161cb9f6d7b0e2f5b66ddb40cc70c6fddcba9bd2e62e3ff337f236300dfe
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
+        imageDigest: sha256:e0c844f682373faa43d5b5f006695cf4502b0a0747f617ff607591e09882e616
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2
       kubeadmBootstrap:
         arch:
         - amd64
@@ -2415,7 +836,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-11-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-24-18-eks-a-v0.0.0-dev-release-0.16-build.1
     certManager:
       acmesolver:
         arch:
@@ -2425,7 +846,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       cainjector:
         arch:
         - amd64
@@ -2434,7 +855,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       controller:
         arch:
         - amd64
@@ -2443,7 +864,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       ctl:
         arch:
         - amd64
@@ -2452,10 +873,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cert-manager/manifests/v1.11.1/cert-manager.yaml
+      version: v1.11.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -2464,32 +885,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
     cilium:
       cilium:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
+        imageDigest: sha256:41cc8d39ef9cc996f9ed2aee7e232b7cead7af7dbf58c7f2db78526485608800
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.11.15-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
+        imageDigest: sha256:d85e1b06b40dcce88b89d604d1c645f53deac381d909375b606d0adf9bc2955a
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.11.15-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cilium/manifests/cilium/v1.11.15-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
+        imageDigest: sha256:076a884143abe3342af64c258d7062005f09343764d40b8cc2cd37d8302f2c35
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.15-eksa.1
+      version: v1.11.15-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -2499,9 +920,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc5-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -2510,7 +931,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -2519,13 +940,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
+      version: v0.4.9-rc5+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -2534,7 +955,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2543,13 +964,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -2558,7 +979,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2567,15 +988,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2584,7 +1005,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -2593,52 +1014,61 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     eksD:
       ami:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ami image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Ami image for EKS-D 1-24-18 release
+          name: bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ami/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-distro/ami/1-24/1-24-18/bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
       channel: 1-24
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      containerd:
+        arch:
+        - amd64
+        description: containerd tarball for linux/amd64
+        name: containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/containerd/v1.6.21/containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
         description: cri-tools tarball for linux/amd64
-        name: cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cri-tools/v1.26.1/cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
         description: etcdadm tarball for linux/amd64
-        name: etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm/f089d308442c18f487a52d09fd067ae9ac7cd8f2/etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
         - amd64
         description: image-builder tarball for linux/amd64
-        name: image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2647,32 +1077,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVersion: v1.24.10
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-11.yaml
-      name: kubernetes-1-24-eks-11
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVersion: v1.24.13
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-18.yaml
+      name: kubernetes-1-24-eks-18
       ova:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Ova image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          description: Bottlerocket Ova image for EKS-D 1-24-18 release
+          name: bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.ova
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/ova/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.ova
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-distro/ova/1-24/1-24-18/bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.ova
       raw:
         bottlerocket:
           arch:
           - amd64
-          description: Bottlerocket Raw image for EKS-D 1-24-11 release
-          name: bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          description: Bottlerocket Raw image for EKS-D 1-24-18 release
+          name: bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
           os: linux
           osName: bottlerocket
           sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-distro/raw/1-24/1-24-11/bottlerocket-v1.24.10-eks-d-1-24-11-eks-a-v0.0.0-dev-release-0.14-build.0-amd64.img.gz
+          uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-distro/raw/1-24/1-24-18/bottlerocket-v1.24.13-eks-d-1-24-18-eks-a-v0.0.0-dev-release-0.16-build.0-amd64.img.gz
     eksa:
       cliTools:
         arch:
@@ -2682,7 +1112,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterController:
         arch:
         - amd64
@@ -2691,9 +1121,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.15.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-anywhere/manifests/cluster-controller/v0.16.0/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -2702,11 +1132,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.0.0-dev-release-0.16+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2715,7 +1145,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.8-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2724,13 +1154,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/metadata.yaml
+      version: v1.0.8+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2739,7 +1169,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.7-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2748,10 +1178,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/metadata.yaml
+      version: v1.0.7+abcdef1
     flux:
       helmController:
         arch:
@@ -2761,7 +1191,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.33.0-eks-a-v0.0.0-dev-release-0.16-build.1
       kustomizeController:
         arch:
         - amd64
@@ -2770,7 +1200,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
       notificationController:
         arch:
         - amd64
@@ -2779,7 +1209,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
       sourceController:
         arch:
         - amd64
@@ -2788,8 +1218,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v2.0.0-rc.3+abcdef1
     haproxy:
       image:
         arch:
@@ -2799,11 +1229,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.18.0-eks-a-v0.0.0-dev-release-0.16-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/kind/manifests/kindnetd/v0.18.0/kindnetd.yaml
+      version: v0.18.0+abcdef1
     kubeVersion: "1.24"
     nutanix:
       clusterAPIController:
@@ -2814,11 +1244,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2827,16 +1257,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
+      version: v1.2.1+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
       packageController:
         arch:
         - amd64
@@ -2845,7 +1275,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -2854,8 +1284,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.3.9+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -2865,9 +1295,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-11-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-24-18-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -2876,7 +1306,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -2885,10 +1315,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.24-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.25-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/metadata.yaml
-      version: v0.1.24+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/metadata.yaml
+      version: v0.1.25+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -2898,11 +1328,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2911,7 +1341,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -2920,9 +1350,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2933,7 +1363,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           imageToDisk:
             arch:
             - amd64
@@ -2942,7 +1372,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           kexec:
             arch:
             - amd64
@@ -2951,7 +1381,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           ociToDisk:
             arch:
             - amd64
@@ -2960,7 +1390,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           reboot:
             arch:
             - amd64
@@ -2969,7 +1399,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           writeFile:
             arch:
             - amd64
@@ -2978,7 +1408,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
         boots:
           arch:
           - amd64
@@ -2987,7 +1417,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-release-0.16-build.1
         hegel:
           arch:
           - amd64
@@ -2996,7 +1426,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-release-0.16-build.1
         hook:
           bootkit:
             arch:
@@ -3006,7 +1436,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           docker:
             arch:
             - amd64
@@ -3015,18 +1445,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -3035,18 +1465,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -3055,7 +1485,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a6b208f19c9ee97fb9d9211cfdd26b971eac90ae-eks-a-v0.0.0-dev-release-0.16-build.1
         tink:
           tinkController:
             arch:
@@ -3065,7 +1495,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
           tinkServer:
             arch:
             - amd64
@@ -3074,7 +1504,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3083,13 +1513,13 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -3099,20 +1529,12 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -3121,7 +1543,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -3130,7 +1552,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -3139,22 +1561,14 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.1-eks-d-1-24-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.4-eks-d-1-24-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
-      syncer:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-syncer image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+      syncer: {}
       version: v1.3.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3163,7 +1577,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3172,27 +1586,27 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     bottlerocketHostContainers:
       admin:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
+        imageDigest: sha256:a1f0161cb9f6d7b0e2f5b66ddb40cc70c6fddcba9bd2e62e3ff337f236300dfe
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.9.4
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
+        imageDigest: sha256:e0c844f682373faa43d5b5f006695cf4502b0a0747f617ff607591e09882e616
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.0
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2
       kubeadmBootstrap:
         arch:
         - amd64
@@ -3201,7 +1615,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-7-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-25-14-eks-a-v0.0.0-dev-release-0.16-build.1
     certManager:
       acmesolver:
         arch:
@@ -3211,7 +1625,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       cainjector:
         arch:
         - amd64
@@ -3220,7 +1634,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       controller:
         arch:
         - amd64
@@ -3229,7 +1643,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       ctl:
         arch:
         - amd64
@@ -3238,10 +1652,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-ctl
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cert-manager/manifests/v1.9.1/cert-manager.yaml
-      version: v1.9.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cert-manager/manifests/v1.11.1/cert-manager.yaml
+      version: v1.11.1+abcdef1
       webhook:
         arch:
         - amd64
@@ -3250,32 +1664,32 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.9.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
     cilium:
       cilium:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:197b3706173bffc9563f7211788dfd326a36d1ac99d04c42357f80b7143da0d7
+        imageDigest: sha256:41cc8d39ef9cc996f9ed2aee7e232b7cead7af7dbf58c7f2db78526485608800
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:v1.11.15-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:252241c7986b52a4bec31c50e31daf349374b730dcb8aaa6db3a2b1cb025ff7c
+        imageDigest: sha256:d85e1b06b40dcce88b89d604d1c645f53deac381d909375b606d0adf9bc2955a
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/cilium:1.11.15-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cilium/manifests/cilium/v1.11.10-eksa.2/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cilium/manifests/cilium/v1.11.15-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:ec2677f33c9aa9b6a8f600314c718a913eb1f0d0006a991f69ee0a775bb29e14
+        imageDigest: sha256:076a884143abe3342af64c258d7062005f09343764d40b8cc2cd37d8302f2c35
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.11.10-eksa.2
-      version: v1.11.10-eksa.2
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.15-eksa.1
+      version: v1.11.15-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -3285,9 +1699,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc5-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/infrastructure-components.yaml
       kubeRbacProxy:
         arch:
         - amd64
@@ -3296,7 +1710,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -3305,13 +1719,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc4/metadata.yaml
-      version: v0.4.9-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
+      version: v0.4.9-rc5+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -3320,7 +1734,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3329,13 +1743,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/cluster-api/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -3344,7 +1758,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3353,15 +1767,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/control-plane-kubeadm/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3370,7 +1784,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -3379,43 +1793,52 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api/manifests/infrastructure-docker/v1.2.0/metadata.yaml
-      version: v1.2.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
       channel: 1-25
       components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      containerd:
+        arch:
+        - amd64
+        description: containerd tarball for linux/amd64
+        name: containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/containerd/v1.6.21/containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
         description: cri-tools tarball for linux/amd64
-        name: cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cri-tools/v1.24.2/cri-tools-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cri-tools/v1.26.1/cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
         description: etcdadm tarball for linux/amd64
-        name: etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm/5b496a72af3d80d64a16a650c85ce9a5882bc014/etcdadm-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm/f089d308442c18f487a52d09fd067ae9ac7cd8f2/etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       gitCommit: 0123456789abcdef0123456789abcdef01234567
       imagebuilder:
         arch:
         - amd64
         description: image-builder tarball for linux/amd64
-        name: image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        name: image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.14-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -3424,10 +1847,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.6-eks-d-1-25-7-eks-a-v0.0.0-dev-release-0.14-build.1
-      kubeVersion: v1.25.6
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-7.yaml
-      name: kubernetes-1-25-eks-7
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.25.9-eks-d-1-25-14-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVersion: v1.25.9
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-25/kubernetes-1-25-eks-14.yaml
+      name: kubernetes-1-25-eks-14
       ova:
         bottlerocket: {}
       raw:
@@ -3441,7 +1864,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cli-tools
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterController:
         arch:
         - amd64
@@ -3450,9 +1873,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-cluster-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/eks-anywhere/manifests/cluster-controller/v0.15.2/eksa-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-anywhere/manifests/cluster-controller/v0.16.0/eksa-components.yaml
       diagnosticCollector:
         arch:
         - amd64
@@ -3461,11 +1884,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-diagnostic-collector
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.15.2-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.0.0-dev-release-0.14+build.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.0.0-dev-release-0.16+build.0+abcdef1
     etcdadmBootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3474,7 +1897,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-bootstrap-provider
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.5-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.8-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3483,13 +1906,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.5-rc4/metadata.yaml
-      version: v1.0.5-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/metadata.yaml
+      version: v1.0.8+abcdef1
     etcdadmController:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3498,7 +1921,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: etcdadm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.4-rc4-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.7-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3507,10 +1930,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.4-rc4/metadata.yaml
-      version: v1.0.4-rc4+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/metadata.yaml
+      version: v1.0.7+abcdef1
     flux:
       helmController:
         arch:
@@ -3520,7 +1943,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.22.2-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.33.0-eks-a-v0.0.0-dev-release-0.16-build.1
       kustomizeController:
         arch:
         - amd64
@@ -3529,7 +1952,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v0.26.3-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
       notificationController:
         arch:
         - amd64
@@ -3538,7 +1961,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v0.24.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
       sourceController:
         arch:
         - amd64
@@ -3547,8 +1970,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v0.25.9-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.31.3+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v2.0.0-rc.3+abcdef1
     haproxy:
       image:
         arch:
@@ -3558,11 +1981,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.17.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.18.0-eks-a-v0.0.0-dev-release-0.16-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/kind/manifests/kindnetd/v0.17.0/kindnetd.yaml
-      version: v0.17.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/kind/manifests/kindnetd/v0.18.0/kindnetd.yaml
+      version: v0.18.0+abcdef1
     kubeVersion: "1.25"
     nutanix:
       clusterAPIController:
@@ -3573,11 +1996,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.1.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3586,16 +2009,16 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.1.0/metadata.yaml
-      version: v1.1.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
+      version: v1.2.1+abcdef1
     packageController:
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
       packageController:
         arch:
         - amd64
@@ -3604,7 +2027,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: eks-anywhere-packages
         os: linux
-        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
       tokenRefresher:
         arch:
         - amd64
@@ -3613,8 +2036,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: ecr-token-refresher
         os: linux
-        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.2.30-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: v0.2.30+abcdef1
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.3.9+abcdef1
     snow:
       bottlerocketBootstrapSnow:
         arch:
@@ -3624,9 +2047,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-7-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-25-14-eks-a-v0.0.0-dev-release-0.16-build.1
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
       kubeVip:
         arch:
         - amd64
@@ -3635,7 +2058,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -3644,10 +2067,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-snow-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.24-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.25-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.24/metadata.yaml
-      version: v0.1.24+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/metadata.yaml
+      version: v0.1.25+abcdef1
     tinkerbell:
       clusterAPIController:
         arch:
@@ -3657,11 +2080,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:9e9c2a397288908f73a4f499ac00aaf96d15deb6-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -3670,7 +2093,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: envoy
         os: linux
-        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -3679,9 +2102,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/9e9c2a397288908f73a4f499ac00aaf96d15deb6/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -3692,7 +2115,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: cexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           imageToDisk:
             arch:
             - amd64
@@ -3701,7 +2124,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: image2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           kexec:
             arch:
             - amd64
@@ -3710,7 +2133,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: kexec
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           ociToDisk:
             arch:
             - amd64
@@ -3719,7 +2142,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: oci2disk
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           reboot:
             arch:
             - amd64
@@ -3728,7 +2151,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: reboot
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
           writeFile:
             arch:
             - amd64
@@ -3737,7 +2160,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: writefile
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
         boots:
           arch:
           - amd64
@@ -3746,7 +2169,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: boots
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:79b1d9acb65dfd0527b44800eddbdcf6b751c8d8-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-release-0.16-build.1
         hegel:
           arch:
           - amd64
@@ -3755,7 +2178,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: hegel
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-release-0.16-build.1
         hook:
           bootkit:
             arch:
@@ -3765,7 +2188,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-bootkit
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           docker:
             arch:
             - amd64
@@ -3774,18 +2197,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-docker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           initramfs:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: initramfs-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-aarch64
           kernel:
             arch:
             - amd64
@@ -3794,18 +2217,18 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: hook-kernel
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
           vmlinuz:
             amd:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-x86_64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-x86_64
             arm:
               description: Tinkerbell operating system installation environment (osie)
                 component
               name: vmlinuz-aarch64
-              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/hook/6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2/vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-aarch64
         rufio:
           arch:
           - amd64
@@ -3814,7 +2237,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: rufio
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-eks-a-v0.0.0-dev-release-0.14-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a6b208f19c9ee97fb9d9211cfdd26b971eac90ae-eks-a-v0.0.0-dev-release-0.16-build.1
         tink:
           tinkController:
             arch:
@@ -3824,7 +2247,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-controller
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
           tinkServer:
             arch:
             - amd64
@@ -3833,7 +2256,7 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-server
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
           tinkWorker:
             arch:
             - amd64
@@ -3842,13 +2265,13 @@ spec:
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
             name: tink-worker
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:19b68beab1a902846c10ee3422cafb4fd5c3307e-eks-a-v0.0.0-dev-release-0.14-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-chart
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.1.6-eks-a-v0.0.0-dev-release-0.14-build.1
-      version: 9e9c2a397288908f73a4f499ac00aaf96d15deb6+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.4.0+abcdef1
     vSphere:
       clusterAPIController:
         arch:
@@ -3858,20 +2281,12 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.16-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
-      driver:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for vsphere-csi-driver image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-driver
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/driver:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+      driver: {}
       kubeProxy:
         arch:
         - amd64
@@ -3880,7 +2295,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.13.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
       kubeVip:
         arch:
         - amd64
@@ -3889,7 +2304,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.5-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       manager:
         arch:
         - amd64
@@ -3898,17 +2313,1513 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.0-eks-d-1-25-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.1-eks-d-1-25-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.14-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
-      syncer:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+      syncer: {}
+      version: v1.3.1+abcdef1
+  - bootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/bootstrap-components.yaml
+      controller:
         arch:
         - amd64
         - arm64
-        description: Container image for vsphere-csi-syncer image
+        description: Container image for kubeadm-bootstrap-controller image
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: vsphere-csi-syncer
+        name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/vsphere-csi-driver/csi/syncer:v2.2.0-eks-a-v0.0.0-dev-release-0.14-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    bottlerocketHostContainers:
+      admin:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-admin image
+        imageDigest: sha256:a1f0161cb9f6d7b0e2f5b66ddb40cc70c6fddcba9bd2e62e3ff337f236300dfe
+        name: bottlerocket-admin
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1
+      control:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-control image
+        imageDigest: sha256:e0c844f682373faa43d5b5f006695cf4502b0a0747f617ff607591e09882e616
+        name: bottlerocket-control
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2
+      kubeadmBootstrap:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-26-10-eks-a-v0.0.0-dev-release-0.16-build.1
+    certManager:
+      acmesolver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-acmesolver image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-acmesolver
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      cainjector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-cainjector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-cainjector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      ctl:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cert-manager/manifests/v1.11.1/cert-manager.yaml
+      version: v1.11.1+abcdef1
+      webhook:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-webhook image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-webhook
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+    cilium:
+      cilium:
+        arch:
+        - amd64
+        description: Container image for cilium image
+        imageDigest: sha256:41cc8d39ef9cc996f9ed2aee7e232b7cead7af7dbf58c7f2db78526485608800
+        name: cilium
+        os: linux
+        uri: public.ecr.aws/isovalent/cilium:v1.11.15-eksa.1
+      helmChart:
+        description: Helm chart for cilium-chart
+        imageDigest: sha256:d85e1b06b40dcce88b89d604d1c645f53deac381d909375b606d0adf9bc2955a
+        name: cilium-chart
+        uri: public.ecr.aws/isovalent/cilium:1.11.15-eksa.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cilium/manifests/cilium/v1.11.15-eksa.1/cilium.yaml
+      operator:
+        arch:
+        - amd64
+        description: Container image for operator-generic image
+        imageDigest: sha256:076a884143abe3342af64c258d7062005f09343764d40b8cc2cd37d8302f2c35
+        name: operator-generic
+        os: linux
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.15-eksa.1
+      version: v1.11.15-eksa.1
+    cloudStack:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-cloudstack image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-cloudstack
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc5-eks-a-v0.0.0-dev-release-0.16-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/infrastructure-components.yaml
+      kubeRbacProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
+      version: v0.4.9-rc5+abcdef1
+    clusterAPI:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    controlPlane:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/control-plane-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-control-plane-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-control-plane-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    docker:
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/cluster-template-development.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/infrastructure-components-development.yaml
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-docker image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-docker
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    eksD:
+      ami:
+        bottlerocket: {}
+      channel: 1-26
+      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      containerd:
+        arch:
+        - amd64
+        description: containerd tarball for linux/amd64
+        name: containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/containerd/v1.6.21/containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cri-tools/v1.26.1/cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm/f089d308442c18f487a52d09fd067ae9ac7cd8f2/etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      kindNode:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kind-node image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kind-node
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.26.4-eks-d-1-26-10-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVersion: v1.26.4
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-26/kubernetes-1-26-eks-10.yaml
+      name: kubernetes-1-26-eks-10
+      ova:
+        bottlerocket: {}
+      raw:
+        bottlerocket: {}
+    eksa:
+      cliTools:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cli-tools image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cli-tools
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cluster-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cluster-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-anywhere/manifests/cluster-controller/v0.16.0/eksa-components.yaml
+      diagnosticCollector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-diagnostic-collector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-diagnostic-collector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.0.0-dev-release-0.16+build.0+abcdef1
+    etcdadmBootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-bootstrap-provider image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-bootstrap-provider
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.8-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/metadata.yaml
+      version: v1.0.8+abcdef1
+    etcdadmController:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.7-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/metadata.yaml
+      version: v1.0.7+abcdef1
+    flux:
+      helmController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for helm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: helm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.33.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      kustomizeController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kustomize-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kustomize-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      notificationController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for notification-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: notification-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      sourceController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for source-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: source-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v2.0.0-rc.3+abcdef1
+    haproxy:
+      image:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for haproxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: haproxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.18.0-eks-a-v0.0.0-dev-release-0.16-build.1
+    kindnetd:
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/kind/manifests/kindnetd/v0.18.0/kindnetd.yaml
+      version: v0.18.0+abcdef1
+    kubeVersion: "1.26"
+    nutanix:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-nutanix image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-nutanix
+        os: linux
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
+      version: v1.2.1+abcdef1
+    packageController:
+      helmChart:
+        description: Helm chart for eks-anywhere-packages
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      packageController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-packages image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.3.9+abcdef1
+    snow:
+      bottlerocketBootstrapSnow:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap-snow image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap-snow
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-26-10-eks-a-v0.0.0-dev-release-0.16-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-snow-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-snow-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.25-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/metadata.yaml
+      version: v0.1.25+abcdef1
+    tinkerbell:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-tinkerbell image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-tinkerbell
+        os: linux
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+      tinkerbellStack:
+        actions:
+          cexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for cexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: cexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          imageToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for image2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: image2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          kexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for kexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: kexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          ociToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for oci2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: oci2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          reboot:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for reboot image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: reboot
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          writeFile:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for writefile image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: writefile
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+        boots:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for boots image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: boots
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-release-0.16-build.1
+        hegel:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for hegel image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: hegel
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-release-0.16-build.1
+        hook:
+          bootkit:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-bootkit image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-bootkit
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
+          docker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-docker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-docker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
+          initramfs:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-aarch64
+          kernel:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-kernel image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-kernel
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
+          vmlinuz:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-aarch64
+        rufio:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for rufio image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: rufio
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a6b208f19c9ee97fb9d9211cfdd26b971eac90ae-eks-a-v0.0.0-dev-release-0.16-build.1
+        tink:
+          tinkController:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-controller image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-controller
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
+          tinkServer:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-server image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-server
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
+          tinkWorker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-worker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-worker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
+        tinkerbellChart:
+          description: Helm chart for tinkerbell-chart
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: tinkerbell-chart
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.4.0+abcdef1
+    vSphere:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+      driver: {}
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cloud-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cloud-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.26.0-eks-d-1-26-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+      syncer: {}
+      version: v1.3.1+abcdef1
+  - bootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-bootstrap-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-bootstrap-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    bottlerocketHostContainers:
+      admin:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-admin image
+        imageDigest: sha256:a1f0161cb9f6d7b0e2f5b66ddb40cc70c6fddcba9bd2e62e3ff337f236300dfe
+        name: bottlerocket-admin
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.1
+      control:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-control image
+        imageDigest: sha256:e0c844f682373faa43d5b5f006695cf4502b0a0747f617ff607591e09882e616
+        name: bottlerocket-control
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.2
+      kubeadmBootstrap:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-27-4-eks-a-v0.0.0-dev-release-0.16-build.1
+    certManager:
+      acmesolver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-acmesolver image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-acmesolver
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      cainjector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-cainjector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-cainjector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      ctl:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cert-manager/manifests/v1.11.1/cert-manager.yaml
+      version: v1.11.1+abcdef1
+      webhook:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-webhook image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cert-manager-webhook
+        os: linux
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.11.1-eks-a-v0.0.0-dev-release-0.16-build.1
+    cilium:
+      cilium:
+        arch:
+        - amd64
+        description: Container image for cilium image
+        imageDigest: sha256:41cc8d39ef9cc996f9ed2aee7e232b7cead7af7dbf58c7f2db78526485608800
+        name: cilium
+        os: linux
+        uri: public.ecr.aws/isovalent/cilium:v1.11.15-eksa.1
+      helmChart:
+        description: Helm chart for cilium-chart
+        imageDigest: sha256:d85e1b06b40dcce88b89d604d1c645f53deac381d909375b606d0adf9bc2955a
+        name: cilium-chart
+        uri: public.ecr.aws/isovalent/cilium:1.11.15-eksa.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cilium/manifests/cilium/v1.11.15-eksa.1/cilium.yaml
+      operator:
+        arch:
+        - amd64
+        description: Container image for operator-generic image
+        imageDigest: sha256:076a884143abe3342af64c258d7062005f09343764d40b8cc2cd37d8302f2c35
+        name: operator-generic
+        os: linux
+        uri: public.ecr.aws/isovalent/operator-generic:v1.11.15-eksa.1
+      version: v1.11.15-eksa.1
+    cloudStack:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-cloudstack image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-cloudstack
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc5-eks-a-v0.0.0-dev-release-0.16-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/infrastructure-components.yaml
+      kubeRbacProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
+      version: v0.4.9-rc5+abcdef1
+    clusterAPI:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    controlPlane:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/control-plane-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-control-plane-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kubeadm-control-plane-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/control-plane-kubeadm/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    docker:
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/cluster-template-development.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/infrastructure-components-development.yaml
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-docker image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-docker
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.4.2-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/infrastructure-docker/v1.4.2/metadata.yaml
+      version: v1.4.2+abcdef1
+    eksD:
+      ami:
+        bottlerocket: {}
+      channel: 1-27
+      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      containerd:
+        arch:
+        - amd64
+        description: containerd tarball for linux/amd64
+        name: containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/containerd/v1.6.21/containerd-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cri-tools/v1.26.1/cri-tools-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm/f089d308442c18f487a52d09fd067ae9ac7cd8f2/etcdadm-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      gitCommit: 0123456789abcdef0123456789abcdef01234567
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+        os: linux
+        sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/image-builder/0.1.2/image-builder-v0.0.0-dev-release-0.16-build.0-linux-amd64.tar.gz
+      kindNode:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kind-node image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kind-node
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.27.1-eks-d-1-27-4-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVersion: v1.27.1
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-27/kubernetes-1-27-eks-4.yaml
+      name: kubernetes-1-27-eks-4
+      ova:
+        bottlerocket: {}
+      raw:
+        bottlerocket: {}
+    eksa:
+      cliTools:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cli-tools image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cli-tools
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cli-tools:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cluster-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-cluster-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-cluster-controller:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/eks-anywhere/manifests/cluster-controller/v0.16.0/eksa-components.yaml
+      diagnosticCollector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-diagnostic-collector image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-diagnostic-collector
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.16.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.0.0-dev-release-0.16+build.0+abcdef1
+    etcdadmBootstrap:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-bootstrap-provider image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-bootstrap-provider
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-bootstrap-provider:v1.0.8-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.8/metadata.yaml
+      version: v1.0.8+abcdef1
+    etcdadmController:
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: etcdadm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/etcdadm-controller:v1.0.7-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.7/metadata.yaml
+      version: v1.0.7+abcdef1
+    flux:
+      helmController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for helm-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: helm-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v0.33.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      kustomizeController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kustomize-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kustomize-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      notificationController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for notification-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: notification-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      sourceController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for source-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: source-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.0.0-rc.3-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v2.0.0-rc.3+abcdef1
+    haproxy:
+      image:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for haproxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: haproxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.18.0-eks-a-v0.0.0-dev-release-0.16-build.1
+    kindnetd:
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/kind/manifests/kindnetd/v0.18.0/kindnetd.yaml
+      version: v0.18.0+abcdef1
+    kubeVersion: "1.27"
+    nutanix:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-nutanix image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-nutanix
+        os: linux
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cluster-api-provider-nutanix:v1.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
+      version: v1.2.1+abcdef1
+    packageController:
+      helmChart:
+        description: Helm chart for eks-anywhere-packages
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      packageController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-packages image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: eks-anywhere-packages
+        os: linux
+        uri: public.ecr.aws/release-container-registry/eks-anywhere-packages:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/release-container-registry/ecr-token-refresher:v0.3.9-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.3.9+abcdef1
+    snow:
+      bottlerocketBootstrapSnow:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap-snow image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: bottlerocket-bootstrap-snow
+        os: linux
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-27-4-eks-a-v0.0.0-dev-release-0.16-build.1
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-snow-controller image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-snow-controller
+        os: linux
+        uri: public.ecr.aws/release-container-registry/aws/cluster-api-provider-aws-snow/manager:v0.1.25-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.25/metadata.yaml
+      version: v0.1.25+abcdef1
+    tinkerbell:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-tinkerbell image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-tinkerbell
+        os: linux
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+      tinkerbellStack:
+        actions:
+          cexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for cexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: cexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/cexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          imageToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for image2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: image2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/image2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          kexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for kexec image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: kexec
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/kexec:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          ociToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for oci2disk image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: oci2disk
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/oci2disk:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          reboot:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for reboot image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: reboot
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/reboot:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+          writeFile:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for writefile image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: writefile
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hub/writefile:6c0f0d437bde2c836d90b000312c8b25fa1b65e1-eks-a-v0.0.0-dev-release-0.16-build.1
+        boots:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for boots image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: boots
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.8.1-eks-a-v0.0.0-dev-release-0.16-build.1
+        hegel:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for hegel image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: hegel
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.10.1-eks-a-v0.0.0-dev-release-0.16-build.1
+        hook:
+          bootkit:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-bootkit image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-bootkit
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-bootkit:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
+          docker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-docker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-docker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-docker:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
+          initramfs:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-aarch64
+          kernel:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-kernel image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: hook-kernel
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/hook-kernel:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.0.0-dev-release-0.16-build.1
+          vmlinuz:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-x86_64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-aarch64
+              uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-aarch64
+        rufio:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for rufio image
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: rufio
+          os: linux
+          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:a6b208f19c9ee97fb9d9211cfdd26b971eac90ae-eks-a-v0.0.0-dev-release-0.16-build.1
+        tink:
+          tinkController:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-controller image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-controller
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
+          tinkServer:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-server image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-server
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
+          tinkWorker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-worker image
+            imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+            name: tink-worker
+            os: linux
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.0.0-dev-release-0.16-build.1
+        tinkerbellChart:
+          description: Helm chart for tinkerbell-chart
+          imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          name: tinkerbell-chart
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-chart:0.2.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      version: v0.4.0+abcdef1
+    vSphere:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cluster-api-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.3.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      clusterTemplate:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/cluster-template.yaml
+      components:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/infrastructure-components.yaml
+      driver: {}
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.14.1-eks-a-v0.0.0-dev-release-0.16-build.1
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cloud-provider-vsphere image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: cloud-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.26.0-eks-d-1-27-eks-a-v0.0.0-dev-release-0.16-build.1
+      metadata:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.3.1/metadata.yaml
+      syncer: {}
       version: v1.3.1+abcdef1
 status: {}


### PR DESCRIPTION
Remove vsphere-csi-driver project from bundle release. This will be removed in the next iteration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

