### PR TITLE
Apply insecure flag to oras copy

### DIFF
--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/helm"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/registrymirror"
+	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 // imagesCmd represents the images command.
@@ -49,7 +50,7 @@ func init() {
 	}
 	importImagesCmd.Flags().BoolVar(&importImagesCommand.includePackages, "include-packages", false, "Flag to indicate inclusion of curated packages in imported images")
 	importImagesCmd.Flag("include-packages").Deprecated = "use copy packages command"
-	importImagesCmd.Flags().BoolVar(&importImagesCommand.insecure, "insecure", false, "Flag to indicate skipping TLS verification while pushing helm charts")
+	importImagesCmd.Flags().BoolVar(&importImagesCommand.insecure, "insecure", false, "Flag to indicate skipping TLS verification while pushing helm charts and bundles")
 }
 
 var importImagesCommand = ImportImagesCommand{}
@@ -148,5 +149,5 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 		FileImporter:       oras.NewFileRegistryImporter(c.RegistryEndpoint, username, password, artifactsFolder),
 	}
 
-	return importArtifacts.Run(ctx)
+	return importArtifacts.Run(context.WithValue(ctx, types.InsecureRegistry, c.insecure))
 }

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/types"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -81,7 +82,7 @@ func PullLatestBundle(ctx context.Context, log logr.Logger, artifact string) ([]
 }
 
 func PushBundle(ctx context.Context, ref, fileName string, fileContent []byte) error {
-	registry, err := content.NewRegistry(content.RegistryOptions{})
+	registry, err := content.NewRegistry(content.RegistryOptions{Insecure: ctx.Value(types.InsecureRegistry).(bool)})
 	if err != nil {
 		return fmt.Errorf("creating registry: %w", err)
 	}

--- a/pkg/types/contextkey.go
+++ b/pkg/types/contextkey.go
@@ -1,0 +1,7 @@
+package types
+
+// EKSACliContextKey is defined to avoid conflict with other packages.
+type EKSACliContextKey string
+
+// InsecureRegistry can be used to bypass https registry certification check when push/pull images or artifacts.
+var InsecureRegistry = EKSACliContextKey("insecure-registry")


### PR DESCRIPTION
*Issue #, if available:* When `--insecure` is passed `eksctl-anywhere import images` command, curated packages yaml bundles cannot be pushed to registry mirror with self generated cert. The following error will show:

`x509: certificate signed by unknown authority`

*Description of changes:* Insecure flag is applied to oras

*Testing (if applicable):* Manual invoked eksctl-anywhere import images with and without insecure flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

