### PR TITLE
Set vsphere creds for CP and CSI

### DIFF
--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -88,6 +88,28 @@ func SetupEnvVars(ctx context.Context, vsphereDatacenter *anywherev1.VSphereData
 		return fmt.Errorf("failed setting env %s: %v", config.EksavSpherePasswordKey, err)
 	}
 
+	vsphereCPUsername := secret.Data["usernameCP"]
+	vsphereCPPassword := secret.Data["passwordCP"]
+
+	if err := os.Setenv(config.EksavSphereCPUsernameKey, string(vsphereCPUsername)); err != nil {
+		return fmt.Errorf("failed setting env %s: %v", config.EksavSphereCPUsernameKey, err)
+	}
+
+	if err := os.Setenv(config.EksavSphereCPPasswordKey, string(vsphereCPPassword)); err != nil {
+		return fmt.Errorf("failed setting env %s: %v", config.EksavSphereCPPasswordKey, err)
+	}
+
+	vsphereCSIUsername := secret.Data["usernameCSI"]
+	vsphereCSIPassword := secret.Data["passwordCSI"]
+
+	if err := os.Setenv(config.EksavSphereCSIUsernameKey, string(vsphereCSIUsername)); err != nil {
+		return fmt.Errorf("failed setting env %s: %v", config.EksavSphereCSIUsernameKey, err)
+	}
+
+	if err := os.Setenv(config.EksavSphereCSIPasswordKey, string(vsphereCSIPassword)); err != nil {
+		return fmt.Errorf("failed setting env %s: %v", config.EksavSphereCSIPasswordKey, err)
+	}
+
 	if err := vsphere.SetupEnvVars(vsphereDatacenter); err != nil {
 		return fmt.Errorf("failed setting env vars: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set vsphere creds for CP and CSI. These weren't being set in the reconciler previously.

The data in the secret looks like this
```
  password: UmlzaGx
  passwordCP: UmlzaGx
  passwordCSI: UmlzaGx
  username: W1hem9uLmNvbQ==
  usernameCP: W1hem9uLmNvbQ==
  usernameCSI: W1hem9uLmNvbQ==
```
*Testing (if applicable):*
- Using updated controller image and tested it out on vsphere clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

