### PR TITLE
Remove vsphere-csi-driver artifacts from images list

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -100,11 +100,9 @@ func (vb *VersionsBundle) CloudStackImages() []Image {
 func (vb *VersionsBundle) VsphereImages() []Image {
 	return []Image{
 		vb.VSphere.ClusterAPIController,
-		vb.VSphere.Driver,
 		vb.VSphere.KubeProxy,
 		vb.VSphere.KubeVip,
 		vb.VSphere.Manager,
-		vb.VSphere.Syncer,
 	}
 }
 


### PR DESCRIPTION
These are being removed in #5659 but this is just a quick fix for the download/import tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

