### PR TITLE
Set skip ip annotation on cluster create for skip ip check flag

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -106,7 +106,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return err
 	}
 
-	createCLIConfig := buildCreateCliConfig(cc.skipIpCheck)
+	createCLIConfig := buildCreateCliConfig(cc)
 
 	clusterManagerTimeoutOpts, err := buildClusterManagerOpts(cc.timeoutOptions, clusterSpec.Cluster.Spec.DatacenterRef.Kind)
 	if err != nil {
@@ -135,7 +135,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 	}
 	defer close(ctx, deps)
 
-	_, err = deps.CreateClusterDefaulter.Run(ctx, clusterSpec)
+	clusterSpec, err = deps.CreateClusterDefaulter.Run(ctx, clusterSpec)
 	if err != nil {
 		return err
 	}

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -106,6 +106,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return err
 	}
 
+	createCLIConfig := buildCreateCliConfig(cc.skipIpCheck)
+
 	clusterManagerTimeoutOpts, err := buildClusterManagerOpts(cc.timeoutOptions, clusterSpec.Cluster.Spec.DatacenterRef.Kind)
 	if err != nil {
 		return fmt.Errorf("failed to build cluster manager opts: %v", err)
@@ -120,7 +122,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		WithWriter().
 		WithEksdInstaller().
 		WithPackageInstaller(clusterSpec, cc.installPackages, cc.managementKubeconfig).
-		WithValidatorClients()
+		WithValidatorClients().
+		WithCreateClusterDefaulter(createCLIConfig)
 
 	if cc.timeoutOptions.noTimeouts {
 		factory.WithNoTimeouts()
@@ -131,6 +134,11 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return err
 	}
 	defer close(ctx, deps)
+
+	_, err = deps.CreateClusterDefaulter.Run(ctx, clusterSpec)
+	if err != nil {
+		return err
+	}
 
 	createCluster := workflows.NewCreate(
 		deps.Bootstrapper,

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -162,6 +162,13 @@ func buildCliConfig(clusterSpec *cluster.Spec) *config.CliConfig {
 	return cliConfig
 }
 
+func buildCreateCliConfig(skipIPCheck bool) *config.CreateCliConfig {
+	createCliConfig := &config.CreateCliConfig{}
+	createCliConfig.SkipCPIPCheck = skipIPCheck
+
+	return createCliConfig
+}
+
 func getManagementCluster(clusterSpec *cluster.Spec) *types.Cluster {
 	if clusterSpec.ManagementCluster == nil {
 		return &types.Cluster{

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -162,9 +162,9 @@ func buildCliConfig(clusterSpec *cluster.Spec) *config.CliConfig {
 	return cliConfig
 }
 
-func buildCreateCliConfig(skipIPCheck bool) *config.CreateCliConfig {
-	createCliConfig := &config.CreateCliConfig{}
-	createCliConfig.SkipCPIPCheck = skipIPCheck
+func buildCreateCliConfig(clusterOptions *createClusterOptions) config.CreateClusterCLIConfig {
+	createCliConfig := config.CreateClusterCLIConfig{}
+	createCliConfig.SkipCPIPCheck = clusterOptions.skipIpCheck
 
 	return createCliConfig
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1167,17 +1167,12 @@ func (c *Cluster) DisableControlPlaneIPCheck() {
 	c.Annotations[skipIPCheckAnnotation] = "true"
 }
 
-// SkipControlPlaneIPCheck checks it the `skip-ip-check` annotation is set on the Cluster object.
-func (c *Cluster) SkipControlPlaneIPCheck() bool {
+// ControlPlaneIPCheckDisabled checks it the `skip-ip-check` annotation is set on the Cluster object.
+func (c *Cluster) ControlPlaneIPCheckDisabled() bool {
 	if s, ok := c.Annotations[skipIPCheckAnnotation]; ok {
 		return s == "true"
 	}
 	return false
-}
-
-// SkipIPCheckAnnotation returns the `skip-ip-check` annotation as a string.
-func (c *Cluster) SkipIPCheckAnnotation() string {
-	return skipIPCheckAnnotation
 }
 
 func (c *Cluster) ResourceType() string {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -33,6 +33,9 @@ const (
 	// etcdAnnotation can be applied to EKS-A machineconfig CR for etcd, to prevent controller from making changes to it.
 	etcdAnnotation = "anywhere.eks.amazonaws.com/etcd"
 
+	// skipIPCheckAnnotation skips the availability control plane IP validation during cluster creation. Use only if your network configuration is conflicting with the default port scan.
+	skipIPCheckAnnotation = "anywhere.eks.amazonaws.com/skip-ip-check"
+
 	// managementAnnotation points to the name of a management cluster
 	// cluster object.
 	managementAnnotation = "anywhere.eks.amazonaws.com/managed-by"
@@ -1154,6 +1157,27 @@ func (c *Cluster) PausedAnnotation() string {
 
 func (c *Cluster) ControlPlaneAnnotation() string {
 	return controlPlaneAnnotation
+}
+
+// DisableControlPlaneIPCheck sets the `skip-ip-check` annotation on the Cluster object.
+func (c *Cluster) DisableControlPlaneIPCheck() {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string, 1)
+	}
+	c.Annotations[skipIPCheckAnnotation] = "true"
+}
+
+// SkipControlPlaneIPCheck checks it the `skip-ip-check` annotation is set on the Cluster object.
+func (c *Cluster) SkipControlPlaneIPCheck() bool {
+	if s, ok := c.Annotations[skipIPCheckAnnotation]; ok {
+		return s == "true"
+	}
+	return false
+}
+
+// SkipIPCheckAnnotation returns the `skip-ip-check` annotation as a string.
+func (c *Cluster) SkipIPCheckAnnotation() string {
+	return skipIPCheckAnnotation
 }
 
 func (c *Cluster) ResourceType() string {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2811,3 +2811,59 @@ func TestClusterIsSingleNode(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterSetSkipIPCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    bool
+		cluster *v1alpha1.Cluster
+	}{
+		{
+			name:    "success",
+			want:    true,
+			cluster: &v1alpha1.Cluster{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cluster.DisableControlPlaneIPCheck()
+			got := tt.cluster.SkipControlPlaneIPCheck()
+
+			if got != tt.want {
+				t.Errorf("SetSkipIPCheck() %v = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCluster_IsSkipIPCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *v1alpha1.Cluster
+		want    bool
+	}{
+		{
+			name: "annotation exists",
+			want: true,
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.Annotations = map[string]string{
+					c.SkipIPCheckAnnotation(): "true",
+				}
+			}),
+		},
+		{
+			name: "annotation does not exist",
+			want: false,
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.Annotations = nil
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cluster.SkipControlPlaneIPCheck(); got != tt.want {
+				t.Errorf("Cluster.IsSkipIPCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2812,7 +2812,7 @@ func TestClusterIsSingleNode(t *testing.T) {
 	}
 }
 
-func TestClusterSetSkipIPCheck(t *testing.T) {
+func TestClusterDisableControlPlaneIPCheck(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    bool
@@ -2827,16 +2827,15 @@ func TestClusterSetSkipIPCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.cluster.DisableControlPlaneIPCheck()
-			got := tt.cluster.SkipControlPlaneIPCheck()
-
+			got := tt.cluster.ControlPlaneIPCheckDisabled()
 			if got != tt.want {
-				t.Errorf("SetSkipIPCheck() %v = %v, want %v", tt.name, got, tt.want)
+				t.Errorf("DisableControlPlaneIPCheck() %v = %v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestCluster_IsSkipIPCheck(t *testing.T) {
+func TestClusterControlPlaneIPCheckDisabled(t *testing.T) {
 	tests := []struct {
 		name    string
 		cluster *v1alpha1.Cluster
@@ -2846,9 +2845,7 @@ func TestCluster_IsSkipIPCheck(t *testing.T) {
 			name: "annotation exists",
 			want: true,
 			cluster: baseCluster(func(c *v1alpha1.Cluster) {
-				c.Annotations = map[string]string{
-					c.SkipIPCheckAnnotation(): "true",
-				}
+				c.DisableControlPlaneIPCheck()
 			}),
 		},
 		{
@@ -2861,8 +2858,8 @@ func TestCluster_IsSkipIPCheck(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.cluster.SkipControlPlaneIPCheck(); got != tt.want {
-				t.Errorf("Cluster.IsSkipIPCheck() = %v, want %v", got, tt.want)
+			if got := tt.cluster.ControlPlaneIPCheckDisabled(); got != tt.want {
+				t.Errorf("ControlPlaneIPCheckDisabled() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/cli/createclusterdefaulter.go
+++ b/pkg/cli/createclusterdefaulter.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/defaulting"
+)
+
+// CreateClusterDefaulter defines the cluster defaulter for create cluster command defaults.
+type CreateClusterDefaulter struct {
+	runner *defaulting.Runner[*cluster.Spec]
+}
+
+// Default is the type used for registering various default methods in the defaulting runner.
+type Default func(ctx context.Context, spec *cluster.Spec) (*cluster.Spec, error)
+
+// NewCreateClusterDefaulter to instantiate and register defaults.
+func NewCreateClusterDefaulter(skipIPCheck cluster.ControlPlaneIPCheckAnnotationDefaulter) CreateClusterDefaulter {
+	r := defaulting.NewRunner[*cluster.Spec]()
+	r.Register(
+		skipIPCheck.ControlPlaneIPCheckDefault,
+	)
+
+	return CreateClusterDefaulter{
+		runner: r,
+	}
+}
+
+// Run will run all the defaults registered to the Create Cluster Defaulter.
+func (v CreateClusterDefaulter) Run(ctx context.Context, spec *cluster.Spec) (*cluster.Spec, error) {
+	return v.runner.RunAll(ctx, spec)
+}

--- a/pkg/cli/createclusterdefaulter.go
+++ b/pkg/cli/createclusterdefaulter.go
@@ -12,9 +12,6 @@ type CreateClusterDefaulter struct {
 	runner *defaulting.Runner[*cluster.Spec]
 }
 
-// Default is the type used for registering various default methods in the defaulting runner.
-type Default func(ctx context.Context, spec *cluster.Spec) (*cluster.Spec, error)
-
 // NewCreateClusterDefaulter to instantiate and register defaults.
 func NewCreateClusterDefaulter(skipIPCheck cluster.ControlPlaneIPCheckAnnotationDefaulter) CreateClusterDefaulter {
 	r := defaulting.NewRunner[*cluster.Spec]()

--- a/pkg/cli/createclusterdefaulter_test.go
+++ b/pkg/cli/createclusterdefaulter_test.go
@@ -1,0 +1,26 @@
+package cli_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/cli"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/defaulting"
+)
+
+func TestNewCreateClusterDefaulter(t *testing.T) {
+	g := NewWithT(t)
+
+	skipIPCheck := cluster.NewControlPlaneIPCheckAnnotationDefaulter(false)
+
+	r := defaulting.NewRunner[*cluster.Spec]()
+	r.Register(
+		skipIPCheck.ControlPlaneIPCheckDefault,
+	)
+
+	got := cli.NewCreateClusterDefaulter(skipIPCheck)
+
+	g.Expect(got).NotTo(BeNil())
+}

--- a/pkg/cli/createclusterdefaulter_test.go
+++ b/pkg/cli/createclusterdefaulter_test.go
@@ -1,13 +1,18 @@
 package cli_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cli"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/defaulting"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestNewCreateClusterDefaulter(t *testing.T) {
@@ -23,4 +28,101 @@ func TestNewCreateClusterDefaulter(t *testing.T) {
 	got := cli.NewCreateClusterDefaulter(skipIPCheck)
 
 	g.Expect(got).NotTo(BeNil())
+}
+
+func TestRunWithoutSkipIPAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	clusterSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: baseCluster(),
+		},
+	}
+	skipIPCheck := cluster.NewControlPlaneIPCheckAnnotationDefaulter(false)
+
+	createClusterDefaulter := cli.NewCreateClusterDefaulter(skipIPCheck)
+	clusterSpec, err := createClusterDefaulter.Run(context.Background(), clusterSpec)
+
+	skipIPClusterAnnotation := clusterSpec.Config.Cluster.ControlPlaneIPCheckDisabled()
+
+	g.Expect(err).To(BeNil())
+	g.Expect(skipIPClusterAnnotation).To(BeFalse())
+}
+
+func TestRunWithSkipIPAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	clusterSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: baseCluster(),
+		},
+	}
+	skipIPCheck := cluster.NewControlPlaneIPCheckAnnotationDefaulter(true)
+
+	createClusterDefaulter := cli.NewCreateClusterDefaulter(skipIPCheck)
+	clusterSpec, err := createClusterDefaulter.Run(context.Background(), clusterSpec)
+
+	skipIPClusterAnnotation := clusterSpec.Config.Cluster.ControlPlaneIPCheckDisabled()
+
+	g.Expect(err).To(BeNil())
+	g.Expect(skipIPClusterAnnotation).To(BeTrue())
+}
+
+type clusterOpt func(c *anywherev1.Cluster)
+
+func baseCluster(opts ...clusterOpt) *anywherev1.Cluster {
+	c := &anywherev1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.ClusterKind,
+			APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mgmt",
+		},
+		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: anywherev1.Kube121,
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				Count: 3,
+				Endpoint: &anywherev1.Endpoint{
+					Host: "1.1.1.1",
+				},
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.VSphereMachineConfigKind,
+					Name: "eksa-unit-test",
+				},
+			},
+			BundlesRef: &anywherev1.BundlesRef{
+				Name:       "bundles-1",
+				Namespace:  constants.EksaSystemNamespace,
+				APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+			},
+			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{{
+				Name:  "md-0",
+				Count: ptr.Int(1),
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.VSphereMachineConfigKind,
+					Name: "eksa-unit-test",
+				},
+			}},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}},
+				Pods: anywherev1.Pods{
+					CidrBlocks: []string{"192.168.0.0/16"},
+				},
+				Services: anywherev1.Services{
+					CidrBlocks: []string{"10.96.0.0/12"},
+				},
+			},
+			DatacenterRef: anywherev1.Ref{
+				Kind: anywherev1.VSphereDatacenterKind,
+				Name: "eksa-unit-test",
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
 }

--- a/pkg/cli/doc.go
+++ b/pkg/cli/doc.go
@@ -1,5 +1,5 @@
 /*
 Package cli implements usecases logic that are designed to be run exclusively from the cli
-and need desambiguation. This is, the same or similar concept exists in an eks-a nontroller.
+and need disambiguation. This is, the same or similar concept exists in an eks-a controller.
 */
 package cli

--- a/pkg/cluster/defaults.go
+++ b/pkg/cluster/defaults.go
@@ -1,5 +1,30 @@
 package cluster
 
+import (
+	"context"
+)
+
 func SetConfigDefaults(c *Config) error {
 	return manager().SetDefaults(c)
+}
+
+// ControlPlaneIPCheckAnnotationDefaulter is the defaulter created to set the skip ip value.
+type ControlPlaneIPCheckAnnotationDefaulter struct {
+	skipCPIPCheck bool
+}
+
+// NewControlPlaneIPCheckAnnotationDefaulter allows to create a new ControlPlaneIPCheckAnnotationDefaulter.
+func NewControlPlaneIPCheckAnnotationDefaulter(skipIPCheck bool) ControlPlaneIPCheckAnnotationDefaulter {
+	return ControlPlaneIPCheckAnnotationDefaulter{
+		skipCPIPCheck: skipIPCheck,
+	}
+}
+
+// ControlPlaneIPCheckDefault sets the annotation for control plane skip ip check if the flag is set to true.
+func (d ControlPlaneIPCheckAnnotationDefaulter) ControlPlaneIPCheckDefault(ctx context.Context, spec *Spec) (*Spec, error) {
+	if d.skipCPIPCheck {
+		spec.Cluster.DisableControlPlaneIPCheck()
+	}
+
+	return spec, nil
 }

--- a/pkg/cluster/defaults_test.go
+++ b/pkg/cluster/defaults_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -8,6 +9,8 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestSetDefaultFluxConfigPath(t *testing.T) {
@@ -88,4 +91,104 @@ func TestSetConfigDefaults(t *testing.T) {
 	originalC := clusterConfigFromFile(t, "testdata/cluster_1_19.yaml")
 	g.Expect(cluster.SetConfigDefaults(c)).To(Succeed())
 	g.Expect(c).NotTo(Equal(originalC))
+}
+
+func TestNewControlPlaneIPCheckAnnotationDefaulterNoAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	newControlPlaneIPCheckAnnotationDefaulter := cluster.NewControlPlaneIPCheckAnnotationDefaulter(false)
+
+	c := baseCluster()
+
+	clusterSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: c,
+		},
+	}
+
+	updatedClusterSpec, err := newControlPlaneIPCheckAnnotationDefaulter.ControlPlaneIPCheckDefault(context.Background(), clusterSpec)
+
+	g.Expect(err).To(BeNil())
+	g.Expect(clusterSpec).To(Equal(updatedClusterSpec))
+}
+
+func TestNewControlPlaneIPCheckAnnotationDefaulterAddAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	newControlPlaneIPCheckAnnotationDefaulter := cluster.NewControlPlaneIPCheckAnnotationDefaulter(true)
+
+	c := baseCluster()
+
+	clusterSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: c,
+		},
+	}
+
+	oldCluster := clusterSpec.Config.Cluster.DeepCopy()
+	oldCluster.DisableControlPlaneIPCheck()
+
+	_, err := newControlPlaneIPCheckAnnotationDefaulter.ControlPlaneIPCheckDefault(context.Background(), clusterSpec)
+
+	g.Expect(err).To(BeNil())
+	g.Expect(oldCluster).To(Equal(clusterSpec.Config.Cluster))
+}
+
+type clusterOpt func(c *anywherev1.Cluster)
+
+func baseCluster(opts ...clusterOpt) *anywherev1.Cluster {
+	c := &anywherev1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.ClusterKind,
+			APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mgmt",
+		},
+		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: anywherev1.Kube121,
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				Count: 3,
+				Endpoint: &anywherev1.Endpoint{
+					Host: "1.1.1.1",
+				},
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.VSphereMachineConfigKind,
+					Name: "eksa-unit-test",
+				},
+			},
+			BundlesRef: &anywherev1.BundlesRef{
+				Name:       "bundles-1",
+				Namespace:  constants.EksaSystemNamespace,
+				APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+			},
+			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{{
+				Name:  "md-0",
+				Count: ptr.Int(1),
+				MachineGroupRef: &anywherev1.Ref{
+					Kind: anywherev1.VSphereMachineConfigKind,
+					Name: "eksa-unit-test",
+				},
+			}},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				CNIConfig: &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}},
+				Pods: anywherev1.Pods{
+					CidrBlocks: []string{"192.168.0.0/16"},
+				},
+				Services: anywherev1.Services{
+					CidrBlocks: []string{"10.96.0.0/12"},
+				},
+			},
+			DatacenterRef: anywherev1.Ref{
+				Kind: anywherev1.VSphereDatacenterKind,
+				Name: "eksa-unit-test",
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,7 @@ type CliConfig struct {
 	GitKnownHostsFile   string
 }
 
-// CreateCliConfig is the config we use for create specific configurations.
-type CreateCliConfig struct {
+// CreateClusterCLIConfig is the config we use for create cluster specific configurations.
+type CreateClusterCLIConfig struct {
 	SkipCPIPCheck bool
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,3 +17,8 @@ type CliConfig struct {
 	GitPrivateKeyFile   string
 	GitKnownHostsFile   string
 }
+
+// CreateCliConfig is the config we use for create specific configurations.
+type CreateCliConfig struct {
+	SkipCPIPCheck bool
+}

--- a/pkg/config/vsphereuser.go
+++ b/pkg/config/vsphereuser.go
@@ -15,10 +15,10 @@ const (
 )
 
 type VSphereUserConfig struct {
-	EksaVsphereUsername    string
-	EksaVspherePassword    string
-	EksaVsphereCPUsername  string
-	EksaVsphereCPPassword  string
+	EksaVsphereUsername   string
+	EksaVspherePassword   string
+	EksaVsphereCPUsername string
+	EksaVsphereCPPassword string
 }
 
 //go:embed static/globalPrivs.json

--- a/pkg/config/vsphereuser_test.go
+++ b/pkg/config/vsphereuser_test.go
@@ -10,10 +10,10 @@ func TestNewVsphereUserConfig(t *testing.T) {
 	wantUsername := "FOO"
 	wantPassword := "BAR"
 	wantEnv := map[string]string{
-		config.EksavSphereUsernameKey:    wantUsername,
-		config.EksavSpherePasswordKey:    wantPassword,
-		config.EksavSphereCPUsernameKey:  "",
-		config.EksavSphereCPPasswordKey:  "",
+		config.EksavSphereUsernameKey:   wantUsername,
+		config.EksavSpherePasswordKey:   wantPassword,
+		config.EksavSphereCPUsernameKey: "",
+		config.EksavSphereCPPasswordKey: "",
 	}
 	for k, v := range wantEnv {
 		t.Setenv(k, v)

--- a/pkg/defaulting/runner.go
+++ b/pkg/defaulting/runner.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Default is the logic for a default for a type O. It should return a value of O
-// wether it updates it or not. When there is an error, return the zero value of O
+// whether it updates it or not. When there is an error, return the zero value of O
 // and the error.
 type Default[O any] func(ctx context.Context, obj O) (O, error)
 

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -93,7 +93,7 @@ type Dependencies struct {
 	ManifestReader              *manifests.Reader
 	closers                     []types.Closer
 	CliConfig                   *cliconfig.CliConfig
-	CreateCliConfig             *cliconfig.CreateCliConfig
+	CreateCliConfig             *cliconfig.CreateClusterCLIConfig
 	PackageInstaller            interfaces.PackageInstaller
 	BundleRegistry              curatedpackages.BundleRegistry
 	PackageControllerClient     *curatedpackages.PackageControllerClient
@@ -1008,7 +1008,7 @@ func (f *Factory) WithCliConfig(cliConfig *cliconfig.CliConfig) *Factory {
 }
 
 // WithCreateClusterDefaulter builds a create cluster defaulter that builds defaulter dependencies specific to the create cluster command. The defaulter is then run once the factory is built in the create cluster command.
-func (f *Factory) WithCreateClusterDefaulter(createCliConfig *cliconfig.CreateCliConfig) *Factory {
+func (f *Factory) WithCreateClusterDefaulter(createCliConfig cliconfig.CreateClusterCLIConfig) *Factory {
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		controlPlaneIPCheckAnnotationDefaulter := cluster.NewControlPlaneIPCheckAnnotationDefaulter(createCliConfig.SkipCPIPCheck)
 

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/aws"
 	"github.com/aws/eks-anywhere/pkg/awsiamauth"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
+	"github.com/aws/eks-anywhere/pkg/cli"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
@@ -92,6 +93,7 @@ type Dependencies struct {
 	ManifestReader              *manifests.Reader
 	closers                     []types.Closer
 	CliConfig                   *cliconfig.CliConfig
+	CreateCliConfig             *cliconfig.CreateCliConfig
 	PackageInstaller            interfaces.PackageInstaller
 	BundleRegistry              curatedpackages.BundleRegistry
 	PackageControllerClient     *curatedpackages.PackageControllerClient
@@ -104,6 +106,7 @@ type Dependencies struct {
 	SnowValidator               *snow.Validator
 	IPValidator                 *validator.IPValidator
 	UnAuthKubectlClient         KubeClients
+	CreateClusterDefaulter      cli.CreateClusterDefaulter
 }
 
 // KubeClients defines super struct that exposes all behavior.
@@ -1001,6 +1004,21 @@ func (f *Factory) WithNoTimeouts() *Factory {
 // WithCliConfig builds a cli config.
 func (f *Factory) WithCliConfig(cliConfig *cliconfig.CliConfig) *Factory {
 	f.dependencies.CliConfig = cliConfig
+	return f
+}
+
+// WithCreateClusterDefaulter builds a create cluster defaulter that builds defaulter dependencies specific to the create cluster command. The defaulter is then run once the factory is built in the create cluster command.
+func (f *Factory) WithCreateClusterDefaulter(createCliConfig *cliconfig.CreateCliConfig) *Factory {
+	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
+		controlPlaneIPCheckAnnotationDefaulter := cluster.NewControlPlaneIPCheckAnnotationDefaulter(createCliConfig.SkipCPIPCheck)
+
+		createClusterDefaulter := cli.NewCreateClusterDefaulter(controlPlaneIPCheckAnnotationDefaulter)
+
+		f.dependencies.CreateClusterDefaulter = createClusterDefaulter
+
+		return nil
+	})
+
 	return f
 }
 

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -31,7 +31,7 @@ type factoryTest struct {
 	hardwareConfigFile    string
 	tinkerbellBootstrapIP string
 	cliConfig             config.CliConfig
-	createCLIConfig       config.CreateCliConfig
+	createCLIConfig       config.CreateClusterCLIConfig
 }
 
 type provider string
@@ -58,7 +58,7 @@ func newTest(t *testing.T, p provider) *factoryTest {
 		t.Fatalf("Not a valid provider: %v", p)
 	}
 
-	createCLIConfig := config.CreateCliConfig{
+	createCLIConfig := config.CreateClusterCLIConfig{
 		SkipCPIPCheck: false,
 	}
 
@@ -221,7 +221,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithIPValidator().
 		WithKubeProxyCLIUpgrader().
 		WithValidatorClients().
-		WithCreateClusterDefaulter(&tt.createCLIConfig).
+		WithCreateClusterDefaulter(tt.createCLIConfig).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -31,6 +31,7 @@ type factoryTest struct {
 	hardwareConfigFile    string
 	tinkerbellBootstrapIP string
 	cliConfig             config.CliConfig
+	createCLIConfig       config.CreateCliConfig
 }
 
 type provider string
@@ -57,11 +58,16 @@ func newTest(t *testing.T, p provider) *factoryTest {
 		t.Fatalf("Not a valid provider: %v", p)
 	}
 
+	createCLIConfig := config.CreateCliConfig{
+		SkipCPIPCheck: false,
+	}
+
 	return &factoryTest{
 		WithT:             NewGomegaWithT(t),
 		clusterConfigFile: clusterConfigFile,
 		clusterSpec:       test.NewFullClusterSpec(t, clusterConfigFile),
 		ctx:               context.Background(),
+		createCLIConfig:   createCLIConfig,
 	}
 }
 
@@ -215,6 +221,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithIPValidator().
 		WithKubeProxyCLIUpgrader().
 		WithValidatorClients().
+		WithCreateClusterDefaulter(&tt.createCLIConfig).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())

--- a/pkg/providers/validator/validate.go
+++ b/pkg/providers/validator/validate.go
@@ -37,7 +37,7 @@ func NewIPValidator(opts ...IPValidatorOpt) *IPValidator {
 // ValidateControlPlaneIPUniqueness checks whether or not the control plane endpoint defined
 // in the cluster spec is available.
 func (v *IPValidator) ValidateControlPlaneIPUniqueness(cluster *v1alpha1.Cluster) error {
-	if cluster.SkipControlPlaneIPCheck() {
+	if cluster.ControlPlaneIPCheckDisabled() {
 		return nil
 	}
 

--- a/pkg/providers/validator/validate.go
+++ b/pkg/providers/validator/validate.go
@@ -37,6 +37,10 @@ func NewIPValidator(opts ...IPValidatorOpt) *IPValidator {
 // ValidateControlPlaneIPUniqueness checks whether or not the control plane endpoint defined
 // in the cluster spec is available.
 func (v *IPValidator) ValidateControlPlaneIPUniqueness(cluster *v1alpha1.Cluster) error {
+	if cluster.SkipControlPlaneIPCheck() {
+		return nil
+	}
+
 	ip := cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
 	if networkutils.IsIPInUse(v.netClient, ip) {
 		return errors.Errorf("cluster controlPlaneConfiguration.Endpoint.Host <%s> is already in use, control plane IP must be unique", ip)

--- a/pkg/providers/validator/validate_test.go
+++ b/pkg/providers/validator/validate_test.go
@@ -31,3 +31,22 @@ func TestValidateControlPlaneIPUniqueness(t *testing.T) {
 
 	g.Expect(ipValidator.ValidateControlPlaneIPUniqueness(cluster)).To(Succeed())
 }
+
+func TestSkipValidateControlPlaneIPUniqueness(t *testing.T) {
+	g := NewWithT(t)
+	cluster := &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+			},
+		},
+	}
+	cluster.DisableControlPlaneIPCheck()
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockNetClient(ctrl)
+	ipValidator := validator.NewIPValidator(validator.CustomNetClient(client))
+
+	g.Expect(ipValidator.ValidateControlPlaneIPUniqueness(cluster)).To(BeNil())
+}

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -597,10 +597,10 @@ func createSecret() *corev1.Secret {
 			APIVersion: "v1",
 		},
 		Data: map[string][]byte{
-			"username":    []byte("user"),
-			"password":    []byte("pass"),
-			"usernameCP":  []byte("userCP"),
-			"passwordCP":  []byte("passCP"),
+			"username":   []byte("user"),
+			"password":   []byte("pass"),
+			"usernameCP": []byte("userCP"),
+			"passwordCP": []byte("passCP"),
 		},
 	}
 }

--- a/pkg/providers/vsphere/validator_test.go
+++ b/pkg/providers/vsphere/validator_test.go
@@ -202,10 +202,10 @@ func TestValidatorValidateVsphereCPUserPrivsError(t *testing.T) {
 	vsc := mocks.NewMockVSphereClient(ctrl)
 
 	wantEnv := map[string]string{
-		config.EksavSphereUsernameKey:    "foo",
-		config.EksavSpherePasswordKey:    "bar",
-		config.EksavSphereCPUsernameKey:  "foo2",
-		config.EksavSphereCPPasswordKey:  "bar2",
+		config.EksavSphereUsernameKey:   "foo",
+		config.EksavSpherePasswordKey:   "bar",
+		config.EksavSphereCPUsernameKey: "foo2",
+		config.EksavSphereCPPasswordKey: "bar2",
 	}
 	for k, v := range wantEnv {
 		t.Setenv(k, v)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set skip ip annotation on cluster create when skip ip check flag is passed to the CLI. This is done for future work where the CLI would be using the controller to create workload clusters and the control plane ip validation needs to be skipped by the controller.

*Testing (if applicable):*
- unit tests
- test manually on vsphere cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

