### PR TITLE
Add WorkersReady condition to cluster status

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -404,7 +404,11 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 	log.Info("Updating cluster status")
 
 	if err := clusters.UpdateClusterStatusForControlPlane(ctx, r.client, cluster); err != nil {
-		return errors.Wrap(err, "updating controlplane status")
+		return errors.Wrap(err, "updating status for control plane")
+	}
+
+	if err := clusters.UpdateClusterStatusForWorkers(ctx, r.client, cluster); err != nil {
+		return errors.Wrap(err, "updating status for workers")
 	}
 
 	// Always update the readyCondition by summarizing the state of other conditions.

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -74,6 +74,20 @@ func testKubeadmControlPlaneFromCluster(cluster *anywherev1.Cluster) *controlpla
 	})
 }
 
+func machineDeploymentsFromCluster(cluster *anywherev1.Cluster) []clusterv1.MachineDeployment {
+	return []clusterv1.MachineDeployment{
+		*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+			md.ObjectMeta.Name = "md-0"
+			md.ObjectMeta.Labels = map[string]string{
+				clusterv1.ClusterNameLabel: cluster.Name,
+			}
+			md.Status.Replicas = 1
+			md.Status.ReadyReplicas = 1
+			md.Status.UpdatedReplicas = 1
+		}),
+	}
+}
+
 func newVsphereClusterReconcilerTest(t *testing.T, objs ...runtime.Object) *vsphereClusterReconcilerTest {
 	ctrl := gomock.NewController(t)
 	govcClient := vspheremocks.NewMockProviderGovcClient(ctrl)
@@ -248,17 +262,23 @@ func TestClusterReconcilerReconcileGenerations(t *testing.T) {
 				awsIAM.Generation = tt.awsIAMGeneration
 			}
 
+			kcp := testKubeadmControlPlaneFromCluster(config.Cluster)
+			machineDeployments := machineDeploymentsFromCluster(config.Cluster)
+
 			g := NewWithT(t)
 			ctx := context.Background()
 
-			objs := make([]runtime.Object, 0, 7)
+			objs := make([]runtime.Object, 0, 8)
 			objs = append(objs, config.Cluster, bundles)
 			for _, o := range config.ChildObjects() {
 				objs = append(objs, o)
 			}
 
-			kcp := testKubeadmControlPlaneFromCluster(config.Cluster)
 			objs = append(objs, kcp)
+
+			for _, obj := range machineDeployments {
+				objs = append(objs, obj.DeepCopy())
+			}
 
 			client := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 			mockCtrl := gomock.NewController(t)
@@ -347,15 +367,19 @@ func TestClusterReconcilerReconcilePausedCluster(t *testing.T) {
 	cluster := vsphereCluster()
 	cluster.SetManagedBy(managementCluster.Name)
 	capiCluster := newCAPICluster(cluster.Name, cluster.Namespace)
+	kcp := testKubeadmControlPlaneFromCluster(cluster)
+	machineDeployments := machineDeploymentsFromCluster(cluster)
+
+	objs := make([]runtime.Object, 0, 5)
+	objs = append(objs, managementCluster, cluster, capiCluster, kcp)
+	for _, md := range machineDeployments {
+		objs = append(objs, md.DeepCopy())
+	}
 
 	// Mark as paused
 	cluster.PauseReconcile()
 
-	kcp := testKubeadmControlPlaneFromCluster(cluster)
-
-	c := fake.NewClientBuilder().WithRuntimeObjects(
-		managementCluster, cluster, capiCluster, kcp,
-	).Build()
+	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	ctrl := gomock.NewController(t)
 	providerReconciler := mocks.NewMockProviderClusterReconciler(ctrl)
@@ -499,6 +523,13 @@ func TestClusterReconcilerReconcileDeletePausedCluster(t *testing.T) {
 	controllerutil.AddFinalizer(cluster, controllers.ClusterFinalizerName)
 	capiCluster := newCAPICluster(cluster.Name, cluster.Namespace)
 	kcp := testKubeadmControlPlaneFromCluster(cluster)
+	machineDeployments := machineDeploymentsFromCluster(cluster)
+
+	objs := make([]runtime.Object, 0, 5)
+	objs = append(objs, managementCluster, cluster, capiCluster, kcp)
+	for _, md := range machineDeployments {
+		objs = append(objs, md.DeepCopy())
+	}
 
 	// Mark cluster for deletion
 	now := metav1.Now()
@@ -510,9 +541,7 @@ func TestClusterReconcilerReconcileDeletePausedCluster(t *testing.T) {
 	controller := gomock.NewController(t)
 	iam := mocks.NewMockAWSIamConfigReconciler(controller)
 	clusterValidator := mocks.NewMockClusterValidator(controller)
-	c := fake.NewClientBuilder().WithRuntimeObjects(
-		managementCluster, cluster, capiCluster, kcp,
-	).Build()
+	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	r := controllers.NewClusterReconciler(c, newRegistryForDummyProviderReconciler(), iam, clusterValidator, nil)
 	g.Expect(r.Reconcile(ctx, clusterRequest(cluster))).To(Equal(reconcile.Result{}))

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -268,7 +268,7 @@ func TestClusterReconcilerReconcileGenerations(t *testing.T) {
 			g := NewWithT(t)
 			ctx := context.Background()
 
-			objs := make([]runtime.Object, 0, 8)
+			objs := make([]runtime.Object, 0, 7+len(machineDeployments))
 			objs = append(objs, config.Cluster, bundles)
 			for _, o := range config.ChildObjects() {
 				objs = append(objs, o)

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -209,5 +209,5 @@ func MachineDeployment(opts ...MachineDeploymentOpt) *clusterv1.MachineDeploymen
 		opt(md)
 	}
 
-	return md
+	return md.DeepCopy()
 }

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -209,5 +209,5 @@ func MachineDeployment(opts ...MachineDeploymentOpt) *clusterv1.MachineDeploymen
 		opt(md)
 	}
 
-	return md.DeepCopy()
+	return md
 }

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -21,6 +21,9 @@ const (
 	// ControlPlaneInitializationInProgressReason reports that the control plane initilization is in progress.
 	ControlPlaneInitializationInProgressReason = "ControlPlaneInitializationInProgress"
 
+	// ControlPlaneNotInitializedReason reports that the control plane is not initialized.
+	ControlPlaneNotInitializedReason = "ControlPlaneNotInitialized"
+
 	// WorkersReadyConditon reports the status on the worker nodes, indicating all those worker nodes
 	// are the right version and are ready, not including the old nodes.
 	WorkersReadyConditon ConditionType = "WorkersReady"

--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -91,3 +91,18 @@ func GetMachineDeployment(ctx context.Context, client client.Client, machineDepl
 	}
 	return machineDeployment, nil
 }
+
+// GetMachineDeployments reads all of cluster-api MachineDeployment for an eks-a cluster using a kube client.
+func GetMachineDeployments(ctx context.Context, c client.Client, cluster *anywherev1.Cluster) ([]clusterv1.MachineDeployment, error) {
+	machineDeployments := &clusterv1.MachineDeploymentList{}
+
+	err := c.List(ctx, machineDeployments, client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name}, client.InNamespace(constants.EksaSystemNamespace))
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return machineDeployments.Items, nil
+}

--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -97,10 +97,6 @@ func GetMachineDeployments(ctx context.Context, c client.Client, cluster *anywhe
 	machineDeployments := &clusterv1.MachineDeploymentList{}
 
 	err := c.List(ctx, machineDeployments, client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name}, client.InNamespace(constants.EksaSystemNamespace))
-	if apierrors.IsNotFound(err) {
-		return nil, nil
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -127,13 +127,9 @@ func updateControlPlaneInitializedCondition(cluster *anywherev1.Cluster, kcp *co
 func updateWorkersReadyCondition(cluster *anywherev1.Cluster, machineDeployments []clusterv1.MachineDeployment) {
 	initializedCondition := conditions.Get(cluster, anywherev1.ControlPlaneInitializedCondition)
 	if initializedCondition.Status != "True" {
-		conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, initializedCondition.Reason, initializedCondition.Severity, initializedCondition.Message)
+		conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, anywherev1.ControlPlaneNotInitializedReason, clusterv1.ConditionSeverityInfo, "")
 		return
 	}
-
-	// TODO: Here we should update the status based on the DefaultCNIConfigured condition. When it's false and skipUpgrades
-	// is not enabled for the CNI, WorkersReady should be marked false with the corresponding reason from the
-	// DefaultCNIConfigured condition.
 
 	totalExpected := 0
 	for _, wng := range cluster.Spec.WorkerNodeGroupConfigurations {
@@ -149,7 +145,7 @@ func updateWorkersReadyCondition(cluster *anywherev1.Cluster, machineDeployments
 	for _, md := range machineDeployments {
 		// We make sure to check that the status is up to date before using the information from the machine deployment status.
 		if md.Status.ObservedGeneration != md.ObjectMeta.Generation {
-			conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, anywherev1.OutdatedInformationReason, clusterv1.ConditionSeverityInfo, "worker node group %s status not up to date yet", md.Name)
+			conditions.MarkFalse(cluster, anywherev1.WorkersReadyConditon, anywherev1.OutdatedInformationReason, clusterv1.ConditionSeverityInfo, "Worker node group %s status not up to date yet", md.Name)
 			return
 		}
 

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -348,7 +348,7 @@ func TestUpdateWorkersReadyCondition(t *testing.T) {
 		wantErr                       string
 	}{
 		{
-			name:                          "workers not ready, control plane not initialized yet",
+			name:                          "workers not ready, control plane not initialized",
 			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{},
 			machineDeployments:            []clusterv1.MachineDeployment{},
 			conditions: []anywherev1.Condition{
@@ -363,7 +363,7 @@ func TestUpdateWorkersReadyCondition(t *testing.T) {
 			wantCondition: &anywherev1.Condition{
 				Type:     anywherev1.WorkersReadyConditon,
 				Status:   "False",
-				Reason:   anywherev1.ControlPlaneInitializationInProgressReason,
+				Reason:   anywherev1.ControlPlaneNotInitializedReason,
 				Severity: clusterv1.ConditionSeverityInfo,
 			},
 		},

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -17,6 +17,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 const controlPlaneInitalizationInProgressReason = "The first control plane instance is not available yet"
@@ -242,7 +243,7 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 			},
 		},
 		{
-			name: "control plane nodes provisioning in progress",
+			name: "control plane nodes not ready yet",
 			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
 				kcp.Status.Replicas = 3
 				kcp.Status.ReadyReplicas = 2
@@ -319,6 +320,359 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 			client = fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 			err := clusters.UpdateClusterStatusForControlPlane(ctx, client, cluster)
+			g.Expect(err).To(BeNil())
+
+			condition := conditions.Get(cluster, tt.wantCondition.Type)
+			g.Expect(condition).ToNot(BeNil())
+
+			g.Expect(condition.Type).To(Equal(tt.wantCondition.Type))
+			g.Expect(condition.Severity).To(Equal(tt.wantCondition.Severity))
+			g.Expect(condition.Status).To(Equal(tt.wantCondition.Status))
+			g.Expect(condition.Reason).To(Equal(tt.wantCondition.Reason))
+			g.Expect(condition.Message).To(ContainSubstring(tt.wantCondition.Message))
+		})
+	}
+}
+
+func TestUpdateWorkersReadyCondition(t *testing.T) {
+	cluster := test.NewClusterSpec().Cluster
+	clusterName := "test-cluster"
+	g := NewWithT(t)
+
+	tests := []struct {
+		name                          string
+		machineDeployments            []clusterv1.MachineDeployment
+		workerNodeGroupConfigurations []anywherev1.WorkerNodeGroupConfiguration
+		conditions                    []anywherev1.Condition
+		wantCondition                 *anywherev1.Condition
+		wantErr                       string
+	}{
+		{
+			name:                          "workers not ready, control plane not initialized yet",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{},
+			machineDeployments:            []clusterv1.MachineDeployment{},
+			conditions: []anywherev1.Condition{
+				{
+					Type:     anywherev1.ControlPlaneInitializedCondition,
+					Status:   "False",
+					Severity: clusterv1.ConditionSeverityInfo,
+					Reason:   anywherev1.ControlPlaneInitializationInProgressReason,
+					Message:  controlPlaneInitalizationInProgressReason,
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.ControlPlaneInitializationInProgressReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+			},
+		},
+		{
+			name: "workers not ready, outdated information, one group",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(1),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Generation = 1
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.ObservedGeneration = 0
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.OutdatedInformationReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+			},
+		},
+		{
+			name: "workers not ready, outdated information, two groups",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(1),
+				},
+				{
+					Count: ptr.Int(1),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Generation = 1
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.ObservedGeneration = 0
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-1"
+					md.ObjectMeta.Generation = 1
+					md.Status.ObservedGeneration = 1
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.OutdatedInformationReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+			},
+		},
+		{
+			name: "workers not ready, nodes not up to date ",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(1),
+				},
+				{
+					Count: ptr.Int(2),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 1
+					md.Status.ReadyReplicas = 1
+					md.Status.UpdatedReplicas = 1
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-1"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 2
+					md.Status.ReadyReplicas = 2
+					md.Status.UpdatedReplicas = 1
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.RollingUpgradeInProgress,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Worker nodes not up-to-date yet",
+			},
+		},
+		{
+			name: "workers not ready, scaling up",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(1),
+				},
+				{
+					Count: ptr.Int(2),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 0
+					md.Status.ReadyReplicas = 0
+					md.Status.UpdatedReplicas = 0
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-1"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 2
+					md.Status.ReadyReplicas = 2
+					md.Status.UpdatedReplicas = 2
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.ScalingUpReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Scaling up worker nodes",
+			},
+		},
+		{
+			name: "workers not ready, scaling down",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(2),
+				},
+				{
+					Count: ptr.Int(1),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 2
+					md.Status.ReadyReplicas = 2
+					md.Status.UpdatedReplicas = 2
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-1"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 2
+					md.Status.ReadyReplicas = 2
+					md.Status.UpdatedReplicas = 2
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.ScalingDownReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Scaling down worker nodes",
+			},
+		},
+		{
+			name: "workers not ready, nodes not ready yet",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(1),
+				},
+				{
+					Count: ptr.Int(2),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.ReadyReplicas = 1
+					md.Status.Replicas = 1
+					md.Status.UpdatedReplicas = 1
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-1"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.ReadyReplicas = 0
+					md.Status.Replicas = 2
+					md.Status.UpdatedReplicas = 2
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.WorkersReadyConditon,
+				Status:   "False",
+				Reason:   anywherev1.NodesNotReadyReason,
+				Severity: clusterv1.ConditionSeverityInfo,
+				Message:  "Worker nodes not ready yet",
+			},
+		},
+
+		{
+			name: "workers ready",
+			workerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Count: ptr.Int(1),
+				},
+				{
+					Count: ptr.Int(2),
+				},
+			},
+			machineDeployments: []clusterv1.MachineDeployment{
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-0"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 1
+					md.Status.ReadyReplicas = 1
+					md.Status.UpdatedReplicas = 1
+				}),
+				*test.MachineDeployment(func(md *clusterv1.MachineDeployment) {
+					md.ObjectMeta.Name = "md-1"
+					md.ObjectMeta.Labels = map[string]string{
+						clusterv1.ClusterNameLabel: clusterName,
+					}
+					md.Status.Replicas = 2
+					md.Status.ReadyReplicas = 2
+					md.Status.UpdatedReplicas = 2
+				}),
+			},
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.WorkersReadyConditon,
+				Status: "True",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cluster.Name = clusterName
+			cluster.Namespace = constants.EksaSystemNamespace
+			cluster.Spec.WorkerNodeGroupConfigurations = tt.workerNodeGroupConfigurations
+			cluster.Status.Conditions = tt.conditions
+
+			objs := []runtime.Object{}
+
+			var client client.Client
+			for _, md := range tt.machineDeployments {
+				objs = append(objs, md.DeepCopy())
+			}
+
+			client = fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+
+			err := clusters.UpdateClusterStatusForWorkers(ctx, client, cluster)
 			g.Expect(err).To(BeNil())
 
 			condition := conditions.Get(cluster, tt.wantCondition.Type)


### PR DESCRIPTION
Issue #, if available:
#5628 

Description of changes:
Changes to the Cluster status as per the the proposal [here](https://github.com/aws/eks-anywhere/pull/6005):
- WorkersReady condition

Testing (if applicable):

- Unit testing
- Manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

