### PR TITLE
Remove CSI related code from vSphere API E2E

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2786,7 +2786,7 @@ func TestVSphereUpgradeKubernetes123to124UbuntuWorkloadClusterAPI(t *testing.T) 
 	)
 }
 
-func TestVSphereCiliumDisableCSIUbuntuAPI(t *testing.T) {
+func TestVSphereCiliumUbuntuAPI(t *testing.T) {
 	vsphere := framework.NewVSphere(t)
 
 	managementCluster := framework.NewClusterE2ETest(
@@ -2825,10 +2825,8 @@ func TestVSphereCiliumDisableCSIUbuntuAPI(t *testing.T) {
 			api.ClusterToConfigFiller(
 				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
 			),
-			api.VSphereToConfigFiller(api.WithDisableCSI(true)),
 		)
 		wc.ApplyClusterManifest()
-		wc.DeleteWorkloadVsphereCSI()
 		wc.ValidateClusterState()
 		wc.DeleteClusterWithKubectl()
 		wc.ValidateClusterDelete()
@@ -2922,7 +2920,7 @@ func TestVSphereUpgradeWorkerNodeGroupsUbuntuGitHubFluxAPI(t *testing.T) {
 	)
 }
 
-func TestVSphereUpgradeKubernetesCiliumDisableCSIUbuntuGitHubFluxAPI(t *testing.T) {
+func TestVSphereUpgradeKubernetesCiliumUbuntuGitHubFluxAPI(t *testing.T) {
 	vsphere := framework.NewVSphere(t)
 
 	managementCluster := framework.NewClusterE2ETest(
@@ -2962,10 +2960,8 @@ func TestVSphereUpgradeKubernetesCiliumDisableCSIUbuntuGitHubFluxAPI(t *testing.
 			api.ClusterToConfigFiller(
 				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
 			),
-			api.VSphereToConfigFiller(api.WithDisableCSI(true)),
 			vsphere.WithUbuntu124(),
 		)
-		wc.DeleteWorkloadVsphereCSI()
 		wc.ValidateClusterState()
 		test.DeleteWorkloadClusterFromGit(wc)
 		wc.ValidateClusterDelete()

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 
@@ -17,11 +16,9 @@ import (
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/manifests/releases"
-	"github.com/aws/eks-anywhere/pkg/retrier"
 	anywheretypes "github.com/aws/eks-anywhere/pkg/types"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
-	"github.com/aws/eks-anywhere/test/framework/cluster/validations"
 )
 
 const (
@@ -731,12 +728,7 @@ func readVSphereConfig() (vsphereConfig, error) {
 
 // ClusterStateValidations returns a list of provider specific validations.
 func (v *VSphere) ClusterStateValidations() []clusterf.StateValidation {
-	return []clusterf.StateValidation{
-		clusterf.RetriableStateValidation(
-			retrier.NewWithMaxRetries(60, 5*time.Second),
-			validations.ValidateCSI,
-		),
-	}
+	return []clusterf.StateValidation{}
 }
 
 // ValidateNodesDiskGiB validates DiskGiB for all the machines.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CSI was removed but vSphere API e2e tests were not updated. 
This PR removes a validation that checks if the CSI driver is available and ready as well as removing attempts to delete CSI resources from a cluster.

*Testing (if applicable):*
vSphere API tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

