### PR TITLE
Fix side effects E2E tests

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -843,7 +843,7 @@ func TestDockerKubernetes126to127GithubFluxEnabledUpgradeFromLatestMinorRelease(
 	)
 }
 
-func TestDockerKubernetes126ManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+func TestDockerKubernetes126WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewDocker(t)
 	runTestManagementClusterUpgradeSideEffects(t, provider, "", v1alpha1.Kube126)
 }

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2288,7 +2288,7 @@ func TestVSphereKubernetes124UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes126ManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+func TestVSphereKubernetes126WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewVSphere(t)
 	runTestManagementClusterUpgradeSideEffects(t, provider, v1alpha1.Ubuntu, v1alpha1.Kube126)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2207,7 +2207,7 @@ func (e *ClusterE2ETest) CreateCloudStackCredentialsSecretFromEnvVar(name string
 
 	secretContent, err := yaml.Marshal(secret)
 	if err != nil {
-		e.T.Fatalf("error mashalling credentials secret : %v", err)
+		e.T.Fatalf("error marshalling credentials secret : %v", err)
 		return
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are setting OIDCConfig in the workload clusters in this test, so we need to set OIDC env vars in E2E infra for management cluster upgrade side effects tests by mentioning OIDC in test name

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

