### PR TITLE
adding bootstrap backup for upgrade failure

### DIFF
--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -118,6 +118,17 @@ func NewWriter(t *testing.T) (dir string, writer filewriter.FileWriter) {
 	return dir, writer
 }
 
+// NewDirectory creates new test directory with cleanup.
+func NewDirectory(t *testing.T) (dir string) {
+	dir, err := os.MkdirTemp(".", SanitizePath(t.Name())+"-")
+	if err != nil {
+		t.Fatalf("error setting up folder for test: %v", err)
+	}
+
+	t.Cleanup(cleanupDir(t, dir))
+	return dir
+}
+
 func cleanupDir(t *testing.T, dir string) func() {
 	return func() {
 		if !t.Failed() {

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -224,6 +225,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
+		setup        func(*testing.T, *clusterctlTest)
 		wantMoveArgs []interface{}
 	}{
 		{
@@ -232,21 +234,46 @@ func TestClusterctlBackupManagement(t *testing.T) {
 				Name:           clusterName,
 				KubeconfigFile: "cluster.kubeconfig",
 			},
-			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+			},
 		},
 		{
 			testName: "no kubeconfig file",
 			cluster: &types.Cluster{
 				Name: clusterName,
 			},
-			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace}...)
+			},
+		},
+		{
+			testName: "existing backup",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
+				createTestDirectory(t, existingPath)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			tc := newClusterctlTest(t)
-			tc.e.EXPECT().Execute(tc.ctx, tt.wantMoveArgs...)
+			tc.writer, _ = tc.writer.WithDir(clusterName)
+			tc.clusterctl = executables.NewClusterctl(tc.e, tc.writer, files.NewReader())
+
+			tt.setup(t, tc)
 
 			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err != nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
@@ -257,18 +284,55 @@ func TestClusterctlBackupManagement(t *testing.T) {
 
 func TestClusterctlBackupManagementFailed(t *testing.T) {
 	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
-	tt := newClusterctlTest(t)
+	clusterName := "cluster"
 
-	cluster := &types.Cluster{
-		Name:           "cluster",
-		KubeconfigFile: "cluster.kubeconfig",
+	tests := []struct {
+		testName     string
+		cluster      *types.Cluster
+		setup        func(*testing.T, *clusterctlTest)
+		wantMoveArgs []interface{}
+	}{
+		{
+			testName: "backup failed",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+			},
+		},
+		{
+			testName: "temp backup failed",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
+				createTestDirectory(t, existingPath)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+			},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			tc := newClusterctlTest(t)
+			tc.writer, _ = tc.writer.WithDir(clusterName)
+			tc.clusterctl = executables.NewClusterctl(tc.e, tc.writer, files.NewReader())
 
-	wantMoveArgs := []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}
+			tt.setup(t, tc)
 
-	tt.e.EXPECT().Execute(tt.ctx, wantMoveArgs...).Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
-	if err := tt.clusterctl.BackupManagement(tt.ctx, cluster, managementClusterState); err == nil {
-		t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err == nil {
+				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+			}
+		})
 	}
 }
 
@@ -425,9 +489,64 @@ func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).NotTo(Succeed())
 }
 
+func TestReplacePath(t *testing.T) {
+	oldpath := "oldDir"
+	newpath := "newDir"
+
+	tests := []struct {
+		testName    string
+		directories []string
+		wantErr     error
+	}{
+		{
+			testName:    "replace success",
+			directories: []string{"oldDir", "newDir"},
+			wantErr:     nil,
+		},
+		{
+			testName:    "fail temp path",
+			directories: []string{"oldDir", "newDir", "newDir_temp"},
+			wantErr:     errors.New("renaming new path to temp"),
+		},
+		{
+			testName:    "fail old path",
+			directories: []string{"newDir"},
+			wantErr:     errors.New("renaming old path"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			testpath := test.NewDirectory(t)
+
+			for _, dir := range tt.directories {
+				createTestDirectory(t, filepath.Join(testpath, dir))
+			}
+
+			err := executables.ReplacePath(filepath.Join(testpath, oldpath), filepath.Join(testpath, newpath))
+			if tt.wantErr != nil {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr.Error())))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}
+
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {
 	s.VersionsBundle = versionBundle
 })
+
+func createTestDirectory(t *testing.T, dirpath string) {
+	err := os.MkdirAll(dirpath, os.ModePerm)
+	if err != nil {
+		t.Fatalf("Could not create directory: %s", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(dirpath)
+	})
+}
 
 var versionBundle = &cluster.VersionsBundle{
 	KubeDistro: &cluster.KubeDistro{

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -527,6 +527,11 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	err := commandContext.ClusterManager.UpgradeCluster(ctx, commandContext.ManagementCluster, commandContext.WorkloadCluster, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
+		logger.Info("Backing up management components from bootstrap cluster")
+		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.BootstrapCluster, commandContext.ManagementClusterStateDir)
+		if err != nil {
+			logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
+		}
 		return &CollectDiagnosticsTask{}
 	}
 

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -292,9 +292,15 @@ func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	)
 }
 
-func (c *upgradeTestSetup) expectBackupManagementToBootstrapFailed() {
+func (c *upgradeTestSetup) expectBackupManagementFromCluster(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath),
+	)
+}
+
+func (c *upgradeTestSetup) expectBackupManagementFromClusterFailed(cluster *types.Cluster) {
+	gomock.InOrder(
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
 	)
 }
 
@@ -620,6 +626,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test.expectMoveManagementToBootstrap()
 	test.expectPrepareUpgradeWorkload(test.bootstrapCluster, test.workloadCluster)
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
+	test.expectBackupManagementFromClusterFailed(test.bootstrapCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()
@@ -643,7 +650,7 @@ func TestUpgradeRunFailedBackupManagementUpgrade(t *testing.T) {
 	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
 	test.expectPauseGitOpsReconcile(test.workloadCluster)
 	test.expectCreateBootstrap()
-	test.expectBackupManagementToBootstrapFailed()
+	test.expectBackupManagementFromClusterFailed(test.managementCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()
@@ -722,6 +729,7 @@ func TestUpgradeWithCheckpointSecondRunSuccess(t *testing.T) {
 	test.expectMoveManagementToBootstrap()
 	test.expectPrepareUpgradeWorkload(test.bootstrapCluster, test.workloadCluster)
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
+	test.expectBackupManagementFromCluster(test.bootstrapCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/eks-anywhere-internal/issues/1429

*Description of changes:*
In the event of an upgrade failure, take a backup of management components on bootstrap cluster to ensure latest backup is closest to cluster state.

Modified `BackupManagement` to not immediately overwrite existing backups unless `clusterctl move` succeeds. This is to prevent partial backups in the event of an error in `clusterctl move`

*Testing (if applicable):*
Unit tests and manually run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

