### PR TITLE
Convert snow software version to integer and compare.

### DIFF
--- a/pkg/providers/snow/validator.go
+++ b/pkg/providers/snow/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -13,7 +14,7 @@ import (
 
 const (
 	defaultAwsSshKeyName       = "eksa-default"
-	snowballMinSoftwareVersion = "102"
+	snowballMinSoftwareVersion = 102
 	minimumVCPU                = 2
 )
 
@@ -193,8 +194,14 @@ func (v *Validator) ValidateDeviceSoftware(ctx context.Context, m *v1alpha1.Snow
 		if err != nil {
 			return fmt.Errorf("checking software version for device [%s]: %v", ip, err)
 		}
-		if version < snowballMinSoftwareVersion {
-			return fmt.Errorf("the software version installed [%s] on device [%s] is below the minimum supported version [%s]", version, ip, snowballMinSoftwareVersion)
+
+		versionInt, err := strconv.Atoi(version)
+		if err != nil {
+			return fmt.Errorf("checking software version for device [%s]: %v", ip, err)
+		}
+
+		if versionInt < snowballMinSoftwareVersion {
+			return fmt.Errorf("the software version installed [%s] on device [%s] is below the minimum supported version [%d]", version, ip, snowballMinSoftwareVersion)
 		}
 	}
 

--- a/pkg/providers/snow/validator_test.go
+++ b/pkg/providers/snow/validator_test.go
@@ -230,7 +230,7 @@ func TestValidateDeviceIsUnlockedNotFoundInClientMapError(t *testing.T) {
 
 func TestValidateDeviceSoftware(t *testing.T) {
 	g := newConfigManagerTest(t)
-	g.aws.EXPECT().SnowballDeviceSoftwareVersion(g.ctx).Return("102", nil).Times(2)
+	g.aws.EXPECT().SnowballDeviceSoftwareVersion(g.ctx).Return("1012", nil).Times(2)
 	err := g.validator.ValidateDeviceSoftware(g.ctx, g.machineConfig)
 	g.Expect(err).To(Succeed())
 }
@@ -260,4 +260,11 @@ func TestValidateDeviceSoftwareNotFoundInClientMapError(t *testing.T) {
 	g.machineConfig.Spec.Devices = []string{"device-not-exist"}
 	err := g.validator.ValidateDeviceSoftware(g.ctx, g.machineConfig)
 	g.Expect(err).To(MatchError(ContainSubstring("credentials not found for device")))
+}
+
+func TestValidateDeviceSoftwareConvertToIntegerError(t *testing.T) {
+	g := newConfigManagerTest(t)
+	g.aws.EXPECT().SnowballDeviceSoftwareVersion(g.ctx).Return("version", nil)
+	err := g.validator.ValidateDeviceSoftware(g.ctx, g.machineConfig)
+	g.Expect(err).To(MatchError(ContainSubstring("invalid syntax")))
 }


### PR DESCRIPTION
*Issue #, if available:*
The snow software version comparison used string, causing problem for Snowblade devices, which use version of 1012.
```
2023-06-23T23:04:00.510Z	V0	❌ Validation failed	{"validation": "snow Provider setup is valid", "error": "setting defaults and validate snow config: invalid cluster config: the software version installed [1012] on device [192.168.1.57] is below the minimum supported version [102]", "remediation": ""}
```

*Description of changes:*
Convert the software version to integer and compare

*Testing (if applicable):*
* make, all unit tests passed
* patched eksa and successfully created cluster on snowblade devices.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

