### PR TITLE
Fix reconcile return for tink hardware failures with controller

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -355,10 +355,10 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 	// We need a new reader each time so that the catalogue gets recreated.
 	kubeReader := hardware.NewKubeReader(r.client)
 	if err := kubeReader.LoadHardware(ctx); err != nil {
-		log.Error(err, "Hardware validation failure")
+		log.Error(err, "Loading hardware failure")
 		failureMessage := err.Error()
 		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
-		return controller.ResultWithReturn(), nil
+		return controller.Result{}, err
 	}
 
 	var v tinkerbell.ClusterSpecValidator
@@ -411,7 +411,7 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 		failureMessage := fmt.Errorf("hardware validation failure: %v", err).Error()
 		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
 
-		return controller.ResultWithReturn(), nil
+		return controller.Result{}, err
 	}
 
 	return controller.Result{}, nil
@@ -428,7 +428,7 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 		failureMessage := err.Error()
 		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
 
-		return controller.ResultWithReturn(), nil
+		return controller.Result{}, err
 	}
 
 	for _, rm := range kubeReader.GetCatalogue().AllBMCs() {
@@ -437,7 +437,7 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 			failureMessage := err.Error()
 			clusterSpec.Cluster.Status.FailureMessage = &failureMessage
 
-			return controller.ResultWithReturn(), nil
+			return controller.Result{}, err
 		}
 	}
 

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -514,8 +514,8 @@ func TestReconcilerValidateHardwareCountNewClusterFail(t *testing.T) {
 
 	result, err := tt.reconciler().Reconcile(tt.ctx, logger, tt.cluster)
 
-	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
-	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
+	tt.Expect(err).ToNot(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}), "result should not stop reconciliation")
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met for selector '{\"type\":\"worker\"}': have 0, require 1"))
 	tt.cleanup()
 }
@@ -533,8 +533,8 @@ func TestReconcilerValidateHardwareCountRollingUpdateFail(t *testing.T) {
 	tt.Expect(err).NotTo(HaveOccurred())
 	result, err := tt.reconciler().ValidateHardware(tt.ctx, logger, scope)
 
-	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
-	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
+	tt.Expect(err).ToNot(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}), "result should not stop reconciliation")
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met for selector"))
 	tt.cleanup()
 }
@@ -553,8 +553,8 @@ func TestReconcilerValidateHardwareScalingUpdateFail(t *testing.T) {
 	tt.Expect(op).To(Equal(reconciler.NoChange))
 	result, err := tt.reconciler().ValidateHardware(tt.ctx, logger, scope)
 
-	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
-	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
+	tt.Expect(err).NotTo(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}), "result should stop reconciliation")
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met for selector '{\"type\":\"worker\"}': have 0, require 1"))
 	tt.cleanup()
 }
@@ -571,8 +571,8 @@ func TestReconcilerValidateHardwareNoHardware(t *testing.T) {
 
 	result, err := tt.reconciler().Reconcile(tt.ctx, logger, tt.cluster)
 
-	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
-	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
+	tt.Expect(err).NotTo(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}), "result should not stop reconciliation")
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met for selector '{\"type\":\"cp\"}': have 0, require 1"))
 	tt.cleanup()
 }
@@ -629,8 +629,8 @@ func TestReconcilerValidateRufioMachinesFail(t *testing.T) {
 
 	result, err := tt.reconciler().Reconcile(tt.ctx, logger, tt.cluster)
 
-	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
-	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
+	tt.Expect(err).ToNot(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}), "result should not stop reconciliation")
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("bmc connection failure"))
 	tt.cleanup()
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix reconcile return for tinkerbell hardware failures with controller. The controller was not reconciling for upgrades if changes were made to the hardware as they are not eksa objects.

*Testing (if applicable):*
- Manual testing using the controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

