### PR TITLE
Validate APIVersion is set when parsing EKSA config yaml

### DIFF
--- a/pkg/cluster/config_manager.go
+++ b/pkg/cluster/config_manager.go
@@ -135,6 +135,10 @@ func (c *ConfigManager) unmarshal(yamlManifest []byte) (*parsed, error) {
 			continue
 		}
 
+		if k.APIVersion == "" {
+			return nil, fmt.Errorf("apiVersion not set for kind: %s", k.Kind)
+		}
+
 		var obj APIObject
 
 		if k.Kind == anywherev1.ClusterKind {

--- a/pkg/cluster/config_manager.go
+++ b/pkg/cluster/config_manager.go
@@ -136,7 +136,7 @@ func (c *ConfigManager) unmarshal(yamlManifest []byte) (*parsed, error) {
 		}
 
 		if k.APIVersion == "" {
-			return nil, fmt.Errorf("apiVersion not set for kind: %s", k.Kind)
+			return nil, fmt.Errorf("apiVersion not set for Kind: %s", k.Kind)
 		}
 
 		var obj APIObject

--- a/pkg/cluster/config_manager_test.go
+++ b/pkg/cluster/config_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
@@ -145,6 +146,84 @@ kind: MysteryCRD
 
 	c := cluster.NewConfigManager()
 	g.Expect(c.Parse([]byte(manifest))).To(Equal(wantConfig))
+}
+
+func TestConfigManagerMissingAPIVersion(t *testing.T) {
+	g := NewWithT(t)
+	c := cluster.NewConfigManager()
+	g.Expect(c.RegisterMapping(anywherev1.DockerDatacenterKind, func() cluster.APIObject {
+		return &anywherev1.DockerDatacenterConfig{}
+	})).To(Succeed())
+	c.RegisterProcessors(func(c *cluster.Config, ol cluster.ObjectLookup) {
+		d := ol.GetFromRef(c.Cluster.APIVersion, c.Cluster.Spec.DatacenterRef)
+		c.DockerDatacenter = d.(*anywherev1.DockerDatacenterConfig)
+	})
+
+	wantCluster := &anywherev1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       anywherev1.ClusterKind,
+			APIVersion: anywherev1.SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "m-docker",
+		},
+		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: "1.21",
+			ManagementCluster: anywherev1.ManagementCluster{
+				Name: "m-docker",
+			},
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				Count: 1,
+			},
+			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+				{
+					Name:  "workers-1",
+					Count: ptr.Int(1),
+				},
+			},
+			DatacenterRef: anywherev1.Ref{
+				Kind: anywherev1.DockerDatacenterKind,
+				Name: "m-docker",
+			},
+			ClusterNetwork: anywherev1.ClusterNetwork{
+				Pods: anywherev1.Pods{
+					CidrBlocks: []string{"192.168.0.0/16"},
+				},
+				Services: anywherev1.Services{
+					CidrBlocks: []string{"10.96.0.0/12"},
+				},
+				CNI: "cilium",
+			},
+			IdentityProviderRefs: []anywherev1.Ref{
+				{
+					Kind: anywherev1.OIDCConfigKind,
+					Name: "eksa-unit-test",
+				},
+				{
+					Kind: anywherev1.AWSIamConfigKind,
+					Name: "eksa-unit-test",
+				},
+			},
+			GitOpsRef: &anywherev1.Ref{
+				Kind: anywherev1.FluxConfigKind,
+				Name: "eksa-unit-test",
+			},
+		},
+	}
+	wantDockerDatacenter := &anywherev1.DockerDatacenterConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind: anywherev1.DockerDatacenterKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "m-docker",
+		},
+	}
+
+	yamlManifest, err := templater.ObjectsToYaml(wantCluster, wantDockerDatacenter)
+	g.Expect(err).To(BeNil())
+
+	_, err = c.Parse(yamlManifest)
+	g.Expect(err).To(MatchError(ContainSubstring("apiVersion not set for kind")))
 }
 
 func TestConfigManagerSetDefaultsSuccess(t *testing.T) {

--- a/pkg/cluster/config_manager_test.go
+++ b/pkg/cluster/config_manager_test.go
@@ -223,7 +223,7 @@ func TestConfigManagerMissingAPIVersion(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	_, err = c.Parse(yamlManifest)
-	g.Expect(err).To(MatchError(ContainSubstring("apiVersion not set for kind")))
+	g.Expect(err).To(MatchError(ContainSubstring("apiVersion not set for Kind")))
 }
 
 func TestConfigManagerSetDefaultsSuccess(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
#6096 

*Description of changes:*
The config yaml is parsed by the [ConfigManager](https://github.com/aws/eks-anywhere/blob/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/pkg/cluster/config_manager.g) at the beginning of cluster creation/upgrade and added to an [ObjectLookup](https://github.com/aws/eks-anywhere/blob/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/pkg/cluster/config_manager.go#L156) that maps the objects with keys in the form of `<apiVersion><kind><name>`, and if the APIVersion field is empty then the resulting key would be `<kind><name>`.

Later on, it is attempted to be retrieved by dedicated object processors in a [ConfigManagerEntry](https://github.com/aws/eks-anywhere/blob/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/pkg/cluster/vsphere.go#L9). E.g. [processVSphereDatacenter](https://github.com/aws/eks-anywhere/blob/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/pkg/cluster/vsphere.go#L73) used for the vSphere `ConfigManagerEntry`, where the [objects.GetFromRef](https://github.com/aws/eks-anywhere/blob/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/pkg/cluster/vsphere.go#L75C20-L75C20) lookup operation uses the `Cluster.APIVersion` field to build the key `<apiVersion><kind><name>`  and fetch the object being referenced by the Cluster from the object map. However, as mentioned before, when APIVersion is empty that key is not created during parsing the config so it does not exist at this point and the processor fails to retrieve the object. Ultimately, it is assigned nil for example in the case of a `VSphereDatacenter` without an `APIVersion` field.

Given that the APIVersion field is required, we should validate that this field exists for all objects after parsing before continuing.

This PR adds a validation to ensure the API version is set on cluster objects in the config yaml file. 

Testing (if applicable):

- Unit testing
- Manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

