### PR TITLE
Add FailureReason to Cluster status

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -560,6 +560,10 @@ spec:
                 description: Descriptive message about a fatal problem while reconciling
                   a cluster
                 type: string
+              failureReason:
+                description: Machine readable value about a terminal problem while
+                  reconciling the cluster set at the same time as failureMessage
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed
                   by the controller.

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -354,7 +354,7 @@ func (r *ClusterReconciler) preClusterProviderReconcile(ctx context.Context, log
 	}
 	if cluster.IsManaged() {
 		if err := r.clusterValidator.ValidateManagementClusterName(ctx, log, cluster); err != nil {
-			cluster.SetFailure(err.Error(), anywherev1.ManagementClusterRefInvalidReason)
+			cluster.SetFailure(anywherev1.ManagementClusterRefInvalidReason, err.Error())
 			return controller.Result{}, err
 		}
 	}
@@ -486,7 +486,7 @@ func (r *ClusterReconciler) buildClusterConfig(ctx context.Context, clus *anywhe
 		var notFound apierrors.APIStatus
 		if apierrors.IsNotFound(err) && errors.As(err, &notFound) {
 			failureMessage := fmt.Sprintf("Dependent cluster objects don't exist: %s", notFound)
-			clus.SetFailure(failureMessage, anywherev1.MissingDependentObjectsReason)
+			clus.SetFailure(anywherev1.MissingDependentObjectsReason, failureMessage)
 		}
 		return nil, err
 	}
@@ -548,7 +548,7 @@ func (r *ClusterReconciler) setBundlesRef(ctx context.Context, clus *anywherev1.
 	if err := r.client.Get(ctx, types.NamespacedName{Name: clus.ManagedBy(), Namespace: clus.Namespace}, mgmtCluster); err != nil {
 		if apierrors.IsNotFound(err) {
 			failureMessage := fmt.Sprintf("Management cluster %s does not exist", clus.Spec.ManagementCluster.Name)
-			clus.SetFailure(failureMessage, anywherev1.ManagementClusterRefInvalidReason)
+			clus.SetFailure(anywherev1.ManagementClusterRefInvalidReason, failureMessage)
 		}
 		return err
 	}

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -934,6 +934,9 @@ func TestClusterReconcilerDeleteExistingCAPIClusterSuccess(t *testing.T) {
 	if apiCluster.Status.FailureMessage != nil {
 		t.Errorf("Expected failure message to be nil. FailureMessage:%s", *apiCluster.Status.FailureMessage)
 	}
+	if apiCluster.Status.FailureReason != nil {
+		t.Errorf("Expected failure message to be nil. FailureReason:%s", *apiCluster.Status.FailureReason)
+	}
 }
 
 func TestClusterReconcilerReconcileDeletePausedCluster(t *testing.T) {
@@ -1065,6 +1068,9 @@ func TestClusterReconcilerDeleteNoCAPIClusterSuccess(t *testing.T) {
 
 	if apiCluster.Status.FailureMessage != nil {
 		t.Errorf("Expected failure message to be nil. FailureMessage:%s", *apiCluster.Status.FailureMessage)
+	}
+	if apiCluster.Status.FailureReason != nil {
+		t.Errorf("Expected failure reason to be nil. FailureReason:%s", *apiCluster.Status.FailureReason)
 	}
 }
 

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1272,7 +1272,7 @@ func (c *Cluster) MachineConfigRefs() []Ref {
 }
 
 // SetFailure sets the failureMessage and failureReason of the Cluster status.
-func (c *Cluster) SetFailure(failureMessage string, failureReason FailureReasonType) {
+func (c *Cluster) SetFailure(failureReason FailureReasonType, failureMessage string) {
 	c.Status.FailureMessage = ptr.String(failureMessage)
 	c.Status.FailureReason = &failureReason
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/semver"
+	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 const (
@@ -835,11 +836,51 @@ var validCiliumPolicyEnforcementModes = map[CiliumPolicyEnforcementMode]bool{
 	CiliumPolicyModeNever:   true,
 }
 
+// FailureReasonType is a type for defining failure reasons.
+type FailureReasonType string
+
+// Reasons for the terminal failures while reconciling the Cluster object.
+const (
+	// MissingDependentObjectsReason reports that the Cluster is missing dependent objects.
+	MissingDependentObjectsReason FailureReasonType = "MissingDependentObjects"
+
+	// ManagementClusterRefInvalidReason reports that the Cluster management cluster reference is invalid. This
+	// can whether if it does not exist or the cluster referenced is not a management cluster.
+	ManagementClusterRefInvalidReason FailureReasonType = "ManagementClusterRefInvalid"
+
+	// ClusterInvalidReason reports that the Cluster spec validation has failed.
+	ClusterInvalidReason FailureReasonType = "ClusterInvalid"
+
+	// DatacenterConfigInvalidReason reports that the Cluster datacenterconfig validation has failed.
+	DatacenterConfigInvalidReason FailureReasonType = "DatacenterConfigInvalid"
+
+	// MachineConfigInvalidReason reports that the Cluster machineconfig validation has failed.
+	MachineConfigInvalidReason FailureReasonType = "MachineConfigInvalid"
+
+	// UnavailableControlPlaneIPReason reports that the Cluster controlPlaneIP is already in use.
+	UnavailableControlPlaneIPReason FailureReasonType = "UnavailableControlPlaneIP"
+)
+
+// Reasons for the terminal failures while reconciling the Cluster object specific for Tinkerbell.
+const (
+	// HardwareInvalidReason reports that the hardware validation has failed.
+	HardwareInvalidReason FailureReasonType = "HardwareInvalid"
+
+	// MachineInvalidReason reports that the baremetal machine validation has failed.
+	MachineInvalidReason FailureReasonType = "MachineInvalid"
+)
+
 // ClusterStatus defines the observed state of Cluster.
 type ClusterStatus struct {
 	// Descriptive message about a fatal problem while reconciling a cluster
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
+
+	// Machine readable value about a terminal problem while reconciling the cluster
+	// set at the same time as failureMessage
+	// +optional
+	FailureReason *FailureReasonType `json:"failureReason,omitempty"`
+
 	// EksdReleaseRef defines the properties of the EKS-D object on the cluster
 	EksdReleaseRef *EksdReleaseRef `json:"eksdReleaseRef,omitempty"`
 	// +optional
@@ -1228,6 +1269,18 @@ func (c *Cluster) MachineConfigRefs() []Ref {
 	}
 
 	return machineConfigRefMap.toSlice()
+}
+
+// SetFailure sets the failureMessage and failureReason of the Cluster status.
+func (c *Cluster) SetFailure(failureMessage string, failureReason FailureReasonType) {
+	c.Status.FailureMessage = ptr.String(failureMessage)
+	c.Status.FailureReason = &failureReason
+}
+
+// ClearFailure clears the failureMessage and failureReason of the Cluster status by setting them to nil.
+func (c *Cluster) ClearFailure() {
+	c.Status.FailureMessage = nil
+	c.Status.FailureReason = nil
 }
 
 type refSet map[Ref]struct{}

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2817,7 +2817,7 @@ func TestCluster_SetFailure(t *testing.T) {
 	wantFailureMessage := "invalid cluster"
 	wantFailureReason := v1alpha1.FailureReasonType("InvalidCluster")
 	cluster := &v1alpha1.Cluster{}
-	cluster.SetFailure(wantFailureMessage, wantFailureReason)
+	cluster.SetFailure(wantFailureReason, wantFailureMessage)
 	g.Expect(cluster.Status.FailureMessage).To(HaveValue(Equal(wantFailureMessage)))
 	g.Expect(cluster.Status.FailureReason).To(HaveValue(Equal(wantFailureReason)))
 }

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2812,6 +2812,32 @@ func TestClusterIsSingleNode(t *testing.T) {
 	}
 }
 
+func TestCluster_SetFailure(t *testing.T) {
+	g := NewWithT(t)
+	wantFailureMessage := "invalid cluster"
+	wantFailureReason := v1alpha1.FailureReasonType("InvalidCluster")
+	cluster := &v1alpha1.Cluster{}
+	cluster.SetFailure(wantFailureMessage, wantFailureReason)
+	g.Expect(cluster.Status.FailureMessage).To(HaveValue(Equal(wantFailureMessage)))
+	g.Expect(cluster.Status.FailureReason).To(HaveValue(Equal(wantFailureReason)))
+}
+
+func TestCluster_ClearFailure(t *testing.T) {
+	g := NewWithT(t)
+	failureMessage := "invalid cluster"
+	failureReason := v1alpha1.FailureReasonType("InvalidCluster")
+	cluster := &v1alpha1.Cluster{
+		Status: v1alpha1.ClusterStatus{
+			FailureMessage: &failureMessage,
+			FailureReason:  &failureReason,
+		},
+	}
+
+	cluster.ClearFailure()
+	g.Expect(cluster.Status.FailureMessage).To(BeNil())
+	g.Expect(cluster.Status.FailureReason).To(BeNil())
+}
+
 func TestClusterDisableControlPlaneIPCheck(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/controller/clusters/ipvalidator.go
+++ b/pkg/controller/clusters/ipvalidator.go
@@ -44,7 +44,7 @@ func (i *IPValidator) ValidateControlPlaneIP(ctx context.Context, log logr.Logge
 		return controller.Result{}, nil
 	}
 	if err := i.ipUniquenessValidator.ValidateControlPlaneIPUniqueness(spec.Cluster); err != nil {
-		spec.Cluster.SetFailure(err.Error(), anywherev1.UnavailableControlPlaneIPReason)
+		spec.Cluster.SetFailure(anywherev1.UnavailableControlPlaneIPReason, err.Error())
 		log.Error(err, "Unavailable control plane IP")
 		return controller.ResultWithReturn(), nil
 	}

--- a/pkg/controller/clusters/ipvalidator.go
+++ b/pkg/controller/clusters/ipvalidator.go
@@ -10,7 +10,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/controller"
-	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 // IPUniquenessValidator defines an interface for the methods to validate the control plane IP.
@@ -45,7 +44,7 @@ func (i *IPValidator) ValidateControlPlaneIP(ctx context.Context, log logr.Logge
 		return controller.Result{}, nil
 	}
 	if err := i.ipUniquenessValidator.ValidateControlPlaneIPUniqueness(spec.Cluster); err != nil {
-		spec.Cluster.Status.FailureMessage = ptr.String(err.Error())
+		spec.Cluster.SetFailure(err.Error(), anywherev1.UnavailableControlPlaneIPReason)
 		log.Error(err, "Unavailable control plane IP")
 		return controller.ResultWithReturn(), nil
 	}

--- a/pkg/controller/clusters/ipvalidator_test.go
+++ b/pkg/controller/clusters/ipvalidator_test.go
@@ -29,6 +29,7 @@ func TestValidateControlPlaneIPSuccess(t *testing.T) {
 	ipValidator := clusters.NewIPValidator(ipUniquenessValidator, client)
 	tt.Expect(ipValidator.ValidateControlPlaneIP(context.Background(), tt.logger, tt.spec)).To(Equal(controller.Result{}))
 	tt.Expect(tt.spec.Cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.spec.Cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestValidateControlPlaneIPUnavailable(t *testing.T) {
@@ -39,6 +40,7 @@ func TestValidateControlPlaneIPUnavailable(t *testing.T) {
 	ipValidator := clusters.NewIPValidator(ipUniquenessValidator, client)
 	tt.Expect(ipValidator.ValidateControlPlaneIP(context.Background(), tt.logger, tt.spec)).To(Equal(controller.ResultWithReturn()))
 	tt.Expect(tt.spec.Cluster.Status.FailureMessage).To(HaveValue(ContainSubstring("already in use")))
+	tt.Expect(tt.spec.Cluster.Status.FailureReason).To(HaveValue(Equal(anywherev1.UnavailableControlPlaneIPReason)))
 }
 
 func TestValidateControlPlaneIPCapiClusterExists(t *testing.T) {
@@ -51,6 +53,7 @@ func TestValidateControlPlaneIPCapiClusterExists(t *testing.T) {
 	ipValidator := clusters.NewIPValidator(ipUniquenessValidator, client)
 	tt.Expect(ipValidator.ValidateControlPlaneIP(context.Background(), tt.logger, tt.spec)).To(Equal(controller.Result{}))
 	tt.Expect(tt.spec.Cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.spec.Cluster.Status.FailureReason).To(BeNil())
 }
 
 type ipValidatorTest struct {

--- a/pkg/controller/clusters/validations.go
+++ b/pkg/controller/clusters/validations.go
@@ -16,7 +16,7 @@ import (
 // CleanupStatusAfterValidate removes errors from the cluster status. Intended to be used as a reconciler phase
 // after all validation phases have been executed.
 func CleanupStatusAfterValidate(_ context.Context, _ logr.Logger, spec *cluster.Spec) (controller.Result, error) {
-	spec.Cluster.Status.FailureMessage = nil
+	spec.Cluster.ClearFailure()
 	return controller.Result{}, nil
 }
 

--- a/pkg/controller/clusters/validations_test.go
+++ b/pkg/controller/clusters/validations_test.go
@@ -16,19 +16,19 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/controller"
 	"github.com/aws/eks-anywhere/pkg/controller/clusters"
-	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 func TestCleanupStatusAfterValidate(t *testing.T) {
 	g := NewWithT(t)
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Status.FailureMessage = ptr.String("invalid cluster")
+		s.Cluster.SetFailure("invalid cluster", "InvalidCluster")
 	})
 
 	g.Expect(
 		clusters.CleanupStatusAfterValidate(context.Background(), test.NewNullLogger(), spec),
 	).To(Equal(controller.Result{}))
 	g.Expect(spec.Cluster.Status.FailureMessage).To(BeNil())
+	g.Expect(spec.Cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestValidateManagementClusterNameSuccess(t *testing.T) {

--- a/pkg/controller/clusters/validations_test.go
+++ b/pkg/controller/clusters/validations_test.go
@@ -21,7 +21,7 @@ import (
 func TestCleanupStatusAfterValidate(t *testing.T) {
 	g := NewWithT(t)
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.SetFailure("invalid cluster", "InvalidCluster")
+		s.Cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 	})
 
 	g.Expect(

--- a/pkg/providers/cloudstack/reconciler/reconciler.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler.go
@@ -83,7 +83,7 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	}
 	if dataCenterConfig.Status.FailureMessage != nil {
 		failureMessage := fmt.Sprintf("Invalid %s CloudStackDatacenterConfig: %s", dataCenterConfig.Name, *dataCenterConfig.Status.FailureMessage)
-		spec.Cluster.SetFailure(failureMessage, anywherev1.DatacenterConfigInvalidReason)
+		spec.Cluster.SetFailure(anywherev1.DatacenterConfigInvalidReason, failureMessage)
 
 		log.Error(errors.New(*dataCenterConfig.Status.FailureMessage), "Invalid CloudStackDatacenterConfig", "datacenterConfig", klog.KObj(dataCenterConfig))
 	} else {
@@ -109,7 +109,7 @@ func (r *Reconciler) ValidateMachineConfig(ctx context.Context, log logr.Logger,
 	if err = validator.ValidateClusterMachineConfigs(ctx, spec); err != nil {
 		log.Error(err, "Invalid CloudStackMachineConfig")
 		failureMessage := err.Error()
-		spec.Cluster.SetFailure(failureMessage, anywherev1.MachineConfigInvalidReason)
+		spec.Cluster.SetFailure(anywherev1.MachineConfigInvalidReason, failureMessage)
 
 		return controller.ResultWithReturn(), nil
 	}

--- a/pkg/providers/cloudstack/reconciler/reconciler.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler.go
@@ -83,7 +83,8 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	}
 	if dataCenterConfig.Status.FailureMessage != nil {
 		failureMessage := fmt.Sprintf("Invalid %s CloudStackDatacenterConfig: %s", dataCenterConfig.Name, *dataCenterConfig.Status.FailureMessage)
-		spec.Cluster.Status.FailureMessage = &failureMessage
+		spec.Cluster.SetFailure(failureMessage, anywherev1.DatacenterConfigInvalidReason)
+
 		log.Error(errors.New(*dataCenterConfig.Status.FailureMessage), "Invalid CloudStackDatacenterConfig", "datacenterConfig", klog.KObj(dataCenterConfig))
 	} else {
 		log.Info("CloudStackDatacenterConfig hasn't been validated yet", klog.KObj(dataCenterConfig))
@@ -108,7 +109,8 @@ func (r *Reconciler) ValidateMachineConfig(ctx context.Context, log logr.Logger,
 	if err = validator.ValidateClusterMachineConfigs(ctx, spec); err != nil {
 		log.Error(err, "Invalid CloudStackMachineConfig")
 		failureMessage := err.Error()
-		spec.Cluster.Status.FailureMessage = &failureMessage
+		spec.Cluster.SetFailure(failureMessage, anywherev1.MachineConfigInvalidReason)
+
 		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -42,7 +42,7 @@ const (
 func TestReconcilerReconcileSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
-	tt.cluster.SetFailure("invalid cluster", anywherev1.FailureReasonType("InvalidCluster"))
+	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -42,7 +42,7 @@ const (
 func TestReconcilerReconcileSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
-	tt.cluster.Status.FailureMessage = ptr.String("invalid cluster")
+	tt.cluster.SetFailure("invalid cluster", anywherev1.FailureReasonType("InvalidCluster"))
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
@@ -78,6 +78,8 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	)
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestReconcilerValidateDatacenterConfigRequeue(t *testing.T) {
@@ -132,6 +134,7 @@ func TestReconcilerValidateMachineConfigInvalidSecret(t *testing.T) {
 	tt.Expect(err).To(MatchError(ContainSubstring("Secret \"global\" not found")))
 	tt.Expect(result).To(Equal(controller.Result{}))
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestReconcilerValidateMachineConfigGetValidatorFail(t *testing.T) {
@@ -150,6 +153,7 @@ func TestReconcilerValidateMachineConfigGetValidatorFail(t *testing.T) {
 	tt.Expect(err).To(MatchError(ContainSubstring(errMsg)))
 	tt.Expect(result).To(Equal(controller.Result{}))
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestReconcilerValidateMachineConfigFail(t *testing.T) {
@@ -171,6 +175,7 @@ func TestReconcilerValidateMachineConfigFail(t *testing.T) {
 	tt.Expect(err).To(BeNil())
 	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
 	tt.Expect(tt.cluster.Status.FailureMessage).To(HaveValue(ContainSubstring(errMsg)))
+	tt.Expect(tt.cluster.Status.FailureReason).To(HaveValue(Equal(anywherev1.MachineConfigInvalidReason)))
 }
 
 func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
@@ -201,6 +206,7 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.ResultWithRequeue(30 * time.Second)))
 }
 
@@ -220,6 +226,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -276,6 +283,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -351,6 +359,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -370,6 +379,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 
 	tt.Expect(err).To(MatchError(ContainSubstring("building client")))
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -387,6 +397,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.ShouldEventuallyExist(tt.ctx,
@@ -452,6 +463,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.ShouldEventuallyExist(tt.ctx,

--- a/pkg/providers/docker/reconciler/reconciler_test.go
+++ b/pkg/providers/docker/reconciler/reconciler_test.go
@@ -51,6 +51,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 
 	tt.Expect(tt.reconciler().Reconcile(tt.ctx, logger, tt.cluster)).To(Equal(controller.Result{}))
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 
 	tt.ShouldEventuallyExist(tt.ctx, capiCluster)
 	tt.ShouldEventuallyExist(tt.ctx,
@@ -139,6 +140,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.ShouldEventuallyExist(tt.ctx,
@@ -186,6 +188,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -204,6 +207,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 
 	tt.Expect(err).To(MatchError(ContainSubstring("building client")))
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -219,6 +223,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.ShouldEventuallyExist(tt.ctx,
@@ -287,6 +292,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -347,6 +353,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {

--- a/pkg/providers/nutanix/reconciler/reconciler.go
+++ b/pkg/providers/nutanix/reconciler/reconciler.go
@@ -178,7 +178,7 @@ func (r *Reconciler) ValidateClusterSpec(ctx context.Context, log logr.Logger, c
 	if err := r.validator.ValidateClusterSpec(ctx, clusterSpec, creds); err != nil {
 		log.Error(err, "Invalid cluster spec", "cluster", clusterSpec.Cluster.Name)
 		failureMessage := err.Error()
-		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.ClusterInvalidReason)
+		clusterSpec.Cluster.SetFailure(anywherev1.ClusterInvalidReason, failureMessage)
 		return controller.ResultWithReturn(), nil
 	}
 

--- a/pkg/providers/nutanix/reconciler/reconciler.go
+++ b/pkg/providers/nutanix/reconciler/reconciler.go
@@ -178,7 +178,7 @@ func (r *Reconciler) ValidateClusterSpec(ctx context.Context, log logr.Logger, c
 	if err := r.validator.ValidateClusterSpec(ctx, clusterSpec, creds); err != nil {
 		log.Error(err, "Invalid cluster spec", "cluster", clusterSpec.Cluster.Name)
 		failureMessage := err.Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.ClusterInvalidReason)
 		return controller.ResultWithReturn(), nil
 	}
 

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 		if !machineConfig.Status.SpecValid {
 			if machineConfig.Status.FailureMessage != nil {
 				failureMessage := fmt.Sprintf("Invalid %s SnowMachineConfig: %s", machineConfig.Name, *machineConfig.Status.FailureMessage)
-				clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+				clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineConfigInvalidReason)
 				log.Error(errors.New(*machineConfig.Status.FailureMessage), "Invalid SnowMachineConfig", "machineConfig", klog.KObj(machineConfig))
 			} else {
 				log.Info("SnowMachineConfig hasn't been validated yet", "machineConfig", klog.KObj(machineConfig))

--- a/pkg/providers/snow/reconciler/reconciler.go
+++ b/pkg/providers/snow/reconciler/reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 		if !machineConfig.Status.SpecValid {
 			if machineConfig.Status.FailureMessage != nil {
 				failureMessage := fmt.Sprintf("Invalid %s SnowMachineConfig: %s", machineConfig.Name, *machineConfig.Status.FailureMessage)
-				clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineConfigInvalidReason)
+				clusterSpec.Cluster.SetFailure(anywherev1.MachineConfigInvalidReason, failureMessage)
 				log.Error(errors.New(*machineConfig.Status.FailureMessage), "Invalid SnowMachineConfig", "machineConfig", klog.KObj(machineConfig))
 			} else {
 				log.Info("SnowMachineConfig hasn't been validated yet", "machineConfig", klog.KObj(machineConfig))

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -36,7 +36,7 @@ const (
 func TestReconcilerReconcileSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
-	tt.cluster.SetFailure("invalid cluster", anywherev1.FailureReasonType("InvalidCluster"))
+	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
 	})

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -36,7 +36,7 @@ const (
 func TestReconcilerReconcileSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
-	tt.cluster.Status.FailureMessage = ptr.String("invalid cluster")
+	tt.cluster.SetFailure("invalid cluster", anywherev1.FailureReasonType("InvalidCluster"))
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
 	})
@@ -57,9 +57,11 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
@@ -77,6 +79,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.ShouldEventuallyExist(tt.ctx,
@@ -130,6 +133,8 @@ func TestReconcilerValidateMachineConfigsInvalidWorkerMachineConfig(t *testing.T
 	tt.Expect(tt.cluster.Status.FailureMessage).ToNot(BeZero())
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("Invalid worker-machine-config SnowMachineConfig"))
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("Something wrong"))
+	tt.Expect(tt.cluster.Status.FailureReason).ToNot(BeZero())
+	tt.Expect(*tt.cluster.Status.FailureReason).To(HaveValue(Equal(anywherev1.MachineConfigInvalidReason)))
 }
 
 func TestReconcilerValidateMachineConfigsInvalidControlPlaneMachineConfig(t *testing.T) {
@@ -146,6 +151,8 @@ func TestReconcilerValidateMachineConfigsInvalidControlPlaneMachineConfig(t *tes
 	tt.Expect(tt.cluster.Status.FailureMessage).ToNot(BeZero())
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("Invalid cp-machine-config SnowMachineConfig"))
 	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("Something wrong"))
+	tt.Expect(tt.cluster.Status.FailureReason).ToNot(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(HaveValue(Equal(anywherev1.MachineConfigInvalidReason)))
 }
 
 func TestReconcilerValidateMachineConfigsMachineConfigNotValidated(t *testing.T) {
@@ -158,6 +165,7 @@ func TestReconcilerValidateMachineConfigsMachineConfigNotValidated(t *testing.T)
 	tt.Expect(err).To(BeNil(), "error should be nil to prevent requeue")
 	tt.Expect(result).To(Equal(controller.Result{Result: &reconcile.Result{}}), "result should stop reconciliation")
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeNil())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeNil())
 }
 
 func TestReconcilerReconcileWorkers(t *testing.T) {
@@ -172,6 +180,7 @@ func TestReconcilerReconcileWorkers(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -183,6 +192,7 @@ func TestReconcilerReconcileControlPlane(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 
 	tt.ShouldEventuallyExist(tt.ctx,
@@ -223,6 +233,7 @@ func TestReconcilerCheckControlPlaneReadyItIsReady(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -243,6 +254,7 @@ func TestReconcilerReconcileCNISuccess(t *testing.T) {
 
 	tt.Expect(err).NotTo(HaveOccurred())
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 
@@ -261,6 +273,7 @@ func TestReconcilerReconcileCNIErrorClientRegistry(t *testing.T) {
 
 	tt.Expect(err).To(MatchError(ContainSubstring("building client")))
 	tt.Expect(tt.cluster.Status.FailureMessage).To(BeZero())
+	tt.Expect(tt.cluster.Status.FailureReason).To(BeZero())
 	tt.Expect(result).To(Equal(controller.Result{}))
 }
 

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -132,7 +132,7 @@ func (r *Reconciler) ValidateClusterSpec(ctx context.Context, log logr.Logger, t
 	if err := clusterSpecValidator.Validate(tinkerbellClusterSpec); err != nil {
 		log.Error(err, "Invalid Tinkerbell Cluster spec")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.ClusterInvalidReason)
+		clusterSpec.Cluster.SetFailure(anywherev1.ClusterInvalidReason, failureMessage)
 		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil
@@ -279,7 +279,7 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	if err := r.validateTinkerbellIPMatch(ctx, tinkerbellScope.ClusterSpec); err != nil {
 		log.Error(err, "Invalid TinkerbellDatacenterConfig")
 		failureMessage := err.Error()
-		tinkerbellScope.ClusterSpec.Cluster.SetFailure(failureMessage, anywherev1.DatacenterConfigInvalidReason)
+		tinkerbellScope.ClusterSpec.Cluster.SetFailure(anywherev1.DatacenterConfigInvalidReason, failureMessage)
 		return controller.ResultWithReturn(), nil
 	}
 
@@ -357,7 +357,7 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 	if err := kubeReader.LoadHardware(ctx); err != nil {
 		log.Error(err, "Loading hardware failure")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.HardwareInvalidReason)
+		clusterSpec.Cluster.SetFailure(anywherev1.HardwareInvalidReason, failureMessage)
 
 		return controller.ResultWithReturn(), nil
 	}
@@ -410,7 +410,7 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 	if err := v.Validate(tinkClusterSpec); err != nil {
 		log.Error(err, "Hardware validation failure")
 		failureMessage := fmt.Errorf("hardware validation failure: %v", err).Error()
-		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.HardwareInvalidReason)
+		clusterSpec.Cluster.SetFailure(anywherev1.HardwareInvalidReason, failureMessage)
 
 		return controller.Result{}, err
 	}
@@ -427,7 +427,7 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 	if err := kubeReader.LoadRufioMachines(ctx); err != nil {
 		log.Error(err, "loading existing rufio machines from the cluster")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineInvalidReason)
+		clusterSpec.Cluster.SetFailure(anywherev1.MachineInvalidReason, failureMessage)
 
 		return controller.Result{}, err
 	}
@@ -436,7 +436,7 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 		if err := r.checkContactable(rm); err != nil {
 			log.Error(err, "rufio machine check failure")
 			failureMessage := err.Error()
-			clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineInvalidReason)
+			clusterSpec.Cluster.SetFailure(anywherev1.MachineInvalidReason, failureMessage)
 
 			return controller.Result{}, err
 		}

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -132,7 +132,7 @@ func (r *Reconciler) ValidateClusterSpec(ctx context.Context, log logr.Logger, t
 	if err := clusterSpecValidator.Validate(tinkerbellClusterSpec); err != nil {
 		log.Error(err, "Invalid Tinkerbell Cluster spec")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.ClusterInvalidReason)
 		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil
@@ -279,7 +279,7 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	if err := r.validateTinkerbellIPMatch(ctx, tinkerbellScope.ClusterSpec); err != nil {
 		log.Error(err, "Invalid TinkerbellDatacenterConfig")
 		failureMessage := err.Error()
-		tinkerbellScope.ClusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		tinkerbellScope.ClusterSpec.Cluster.SetFailure(failureMessage, anywherev1.DatacenterConfigInvalidReason)
 		return controller.ResultWithReturn(), nil
 	}
 
@@ -357,8 +357,9 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 	if err := kubeReader.LoadHardware(ctx); err != nil {
 		log.Error(err, "Loading hardware failure")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
-		return controller.Result{}, err
+		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.HardwareInvalidReason)
+
+		return controller.ResultWithReturn(), nil
 	}
 
 	var v tinkerbell.ClusterSpecValidator
@@ -409,7 +410,7 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 	if err := v.Validate(tinkClusterSpec); err != nil {
 		log.Error(err, "Hardware validation failure")
 		failureMessage := fmt.Errorf("hardware validation failure: %v", err).Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.HardwareInvalidReason)
 
 		return controller.Result{}, err
 	}
@@ -426,7 +427,7 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 	if err := kubeReader.LoadRufioMachines(ctx); err != nil {
 		log.Error(err, "loading existing rufio machines from the cluster")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineInvalidReason)
 
 		return controller.Result{}, err
 	}
@@ -435,7 +436,7 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 		if err := r.checkContactable(rm); err != nil {
 			log.Error(err, "rufio machine check failure")
 			failureMessage := err.Error()
-			clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+			clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineInvalidReason)
 
 			return controller.Result{}, err
 		}

--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -149,7 +149,8 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 	if !dataCenterConfig.Status.SpecValid {
 		if dataCenterConfig.Status.FailureMessage != nil {
 			failureMessage := fmt.Sprintf("Invalid %s VSphereDatacenterConfig: %s", dataCenterConfig.Name, *dataCenterConfig.Status.FailureMessage)
-			clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+
+			clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.DatacenterConfigInvalidReason)
 			log.Error(errors.New(*dataCenterConfig.Status.FailureMessage), "Invalid VSphereDatacenterConfig", "datacenterConfig", klog.KObj(dataCenterConfig))
 		} else {
 			log.Info("VSphereDatacenterConfig hasn't been validated yet", klog.KObj(dataCenterConfig))
@@ -176,7 +177,7 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 	if err := r.validator.ValidateClusterMachineConfigs(ctx, vsphereClusterSpec); err != nil {
 		log.Error(err, "Invalid VSphereMachineConfig")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.Status.FailureMessage = &failureMessage
+		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineConfigInvalidReason)
 		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil

--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -150,7 +150,7 @@ func (r *Reconciler) ValidateDatacenterConfig(ctx context.Context, log logr.Logg
 		if dataCenterConfig.Status.FailureMessage != nil {
 			failureMessage := fmt.Sprintf("Invalid %s VSphereDatacenterConfig: %s", dataCenterConfig.Name, *dataCenterConfig.Status.FailureMessage)
 
-			clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.DatacenterConfigInvalidReason)
+			clusterSpec.Cluster.SetFailure(anywherev1.DatacenterConfigInvalidReason, failureMessage)
 			log.Error(errors.New(*dataCenterConfig.Status.FailureMessage), "Invalid VSphereDatacenterConfig", "datacenterConfig", klog.KObj(dataCenterConfig))
 		} else {
 			log.Info("VSphereDatacenterConfig hasn't been validated yet", klog.KObj(dataCenterConfig))
@@ -177,7 +177,7 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 	if err := r.validator.ValidateClusterMachineConfigs(ctx, vsphereClusterSpec); err != nil {
 		log.Error(err, "Invalid VSphereMachineConfig")
 		failureMessage := err.Error()
-		clusterSpec.Cluster.SetFailure(failureMessage, anywherev1.MachineConfigInvalidReason)
+		clusterSpec.Cluster.SetFailure(anywherev1.MachineConfigInvalidReason, failureMessage)
 		return controller.ResultWithReturn(), nil
 	}
 	return controller.Result{}, nil

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -47,7 +47,7 @@ const (
 func TestReconcilerReconcileSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
-	tt.cluster.SetFailure("invalid cluster", anywherev1.FailureReasonType("InvalidCluster"))
+	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name


### PR DESCRIPTION
Issue #, if available:
#5628 

Description of changes:

Changes to the Cluster status as per the the proposal [here](https://github.com/aws/eks-anywhere/pull/6005):
- Added FailureReason

Testing (if applicable):
- Unit testing
- Manual testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.