### PR TITLE
Update cluster autoscaler docs

### DIFF
--- a/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
+++ b/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
@@ -10,11 +10,6 @@ description: >
 If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
 Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}) in the event of a problem.
 
-  {{% alert title="Important" color="warning" %}}
-   * Starting at `eksctl anywhere` version `v0.12.0`, packages on workload clusters are remotely managed by the management cluster.
-   * While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster.
-   {{% /alert %}}
-
 ## Choose a Deployment Approach
 
 Each Cluster Autoscaler instance can target one cluster for autoscaling.
@@ -129,6 +124,12 @@ eksctl anywhere delete package --cluster <cluster-name> cluster-autoscaler
 ```
 
 ## Install Cluster Autoscaler in workload cluster
+
+  {{% alert title="Important" color="warning" %}}
+
+   While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster. The only exception is when you need to create a new namespace, the command `kubectl create <namespace>` should be executed with `kubeconfig` pointing to the workload cluster.
+   
+  {{% /alert %}}
 
 A few extra steps are required to install cluster autoscaler in a workload cluster instead of the management cluster.
 

--- a/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
+++ b/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
@@ -12,7 +12,7 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
 
   {{% alert title="Important" color="warning" %}}
    * Starting at `eksctl anywhere` version `v0.12.0`, packages on workload clusters are remotely managed by the management cluster.
-   * While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster. The only exception is the `kubectl create namespace` command below, which should be run with `kubeconfig` pointing to the workload cluster.
+   * While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster.
    {{% /alert %}}
 
 ## Choose a Deployment Approach
@@ -137,7 +137,7 @@ First, retrieve the management cluster's kubeconfig secret:
 kubectl -n eksa-system get secrets <management-cluster-name>-kubeconfig -o yaml > mgmt-secret.yaml
 ```
 
-Update the secret's namespace to the namespace in the workload cluster that you would like to deploy the cluster autoscaler to.
+Update the secret's namespace to the `targetNamespace`, the namespace in the workload cluster that you would like to deploy the cluster autoscaler to.
 Then, apply the secret to the workload cluster.
 ```yaml
 kubectl --kubeconfig /path/to/workload/kubeconfig apply -f mgmt-secret.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Clarified instructions to update management kubeconfig secret namespace to the `targetNamespace` of the cluster autoscaler


*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

