### PR TITLE
preflight block kindnetd

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -560,7 +560,7 @@ func validateNetworking(clusterConfig *Cluster) error {
 	clusterNetwork := clusterConfig.Spec.ClusterNetwork
 	if clusterNetwork.CNI == Kindnetd || clusterNetwork.CNIConfig != nil && clusterNetwork.CNIConfig.Kindnetd != nil {
 		if clusterConfig.Spec.DatacenterRef.Kind != DockerDatacenterKind {
-			return errors.New("kindnetd not supported as production CNI. Please use Cilium as CNI for production clusters")
+			return errors.New("kindnetd is only supported on Docker provider for development and testing. For all other providers please use Cilium CNI")
 		}
 	}
 	if len(clusterNetwork.Pods.CidrBlocks) <= 0 {

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -558,7 +558,11 @@ func validateEtcdReplicas(clusterConfig *Cluster) error {
 
 func validateNetworking(clusterConfig *Cluster) error {
 	clusterNetwork := clusterConfig.Spec.ClusterNetwork
-
+	if clusterNetwork.CNI == Kindnetd || clusterNetwork.CNIConfig != nil && clusterNetwork.CNIConfig.Kindnetd != nil {
+		if clusterConfig.Spec.DatacenterRef.Kind != DockerDatacenterKind {
+			return errors.New("kindnetd not supported as production CNI. Please use Cilium as CNI for production clusters")
+		}
+	}
 	if len(clusterNetwork.Pods.CidrBlocks) <= 0 {
 		return errors.New("pods CIDR block not specified or empty")
 	}

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2245,6 +2245,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: fmt.Errorf("invalid format for cni plugin: both old and new formats used, use only the CNIConfig field"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2267,6 +2270,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: nil,
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2289,6 +2295,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: fmt.Errorf("cni not specified"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2311,6 +2320,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: nil,
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2336,6 +2348,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: fmt.Errorf("the size of pod subnet with mask 30 is smaller than or equal to the size of node subnet with mask 28"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2361,6 +2376,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: fmt.Errorf("pod subnet mask (6) and node-mask (28) difference is greater than 16"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2419,6 +2437,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: fmt.Errorf("invalid CIDR block format for Pods: {[1.2.3]}. Please specify a valid CIDR block for pod subnet"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2477,6 +2498,9 @@ func TestValidateNetworking(t *testing.T) {
 			wantErr: fmt.Errorf("invalid CIDR block for Services: {[1.2.3]}. Please specify a valid CIDR block for service subnet"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
 					ClusterNetwork: ClusterNetwork{
 						Pods: Pods{
 							CidrBlocks: []string{
@@ -2559,6 +2583,106 @@ func TestValidateNetworking(t *testing.T) {
 						},
 						CNI:       Cilium,
 						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			name:    "vsphere cluster uses cilium CNI",
+			wantErr: nil,
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/8",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       Cilium,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			name:    "vsphere cluster uses kindnetd CNI",
+			wantErr: fmt.Errorf("kindnetd not supported as production CNI. Please use Cilium as CNI for production clusters"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/8",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       Kindnetd,
+						CNIConfig: nil,
+					},
+				},
+			},
+		},
+		{
+			name:    "vsphere cluster uses kindnetd CNIConfig",
+			wantErr: fmt.Errorf("kindnetd not supported as production CNI. Please use Cilium as CNI for production clusters"),
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/8",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       "",
+						CNIConfig: &CNIConfig{Kindnetd: &KindnetdConfig{}},
+					},
+				},
+			},
+		},
+		{
+			name:    "docker cluster uses kindnetd CNIConfig",
+			wantErr: nil,
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: DockerDatacenterKind,
+					},
+					ClusterNetwork: ClusterNetwork{
+						Pods: Pods{
+							CidrBlocks: []string{
+								"1.2.3.4/8",
+							},
+						},
+						Services: Services{
+							CidrBlocks: []string{
+								"1.2.3.4/7",
+							},
+						},
+						CNI:       "",
+						CNIConfig: &CNIConfig{Kindnetd: &KindnetdConfig{}},
 					},
 				},
 			},

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -2614,7 +2614,7 @@ func TestValidateNetworking(t *testing.T) {
 		},
 		{
 			name:    "vsphere cluster uses kindnetd CNI",
-			wantErr: fmt.Errorf("kindnetd not supported as production CNI. Please use Cilium as CNI for production clusters"),
+			wantErr: fmt.Errorf("kindnetd is only supported on Docker provider for development and testing. For all other providers please use Cilium CNI"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
 					DatacenterRef: Ref{
@@ -2639,7 +2639,7 @@ func TestValidateNetworking(t *testing.T) {
 		},
 		{
 			name:    "vsphere cluster uses kindnetd CNIConfig",
-			wantErr: fmt.Errorf("kindnetd not supported as production CNI. Please use Cilium as CNI for production clusters"),
+			wantErr: fmt.Errorf("kindnetd is only supported on Docker provider for development and testing. For all other providers please use Cilium CNI"),
 			cluster: &Cluster{
 				Spec: ClusterSpec{
 					DatacenterRef: Ref{


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/6097

*Description of changes:*
don't support kindnetd except docker

*Testing (if applicable):*
unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

