### PR TITLE
External etcd support for Nutanix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,7 @@ mocks: ## Generate mocks
 	${MOCKGEN} -destination=pkg/aws/mocks/snowballdevice.go -package=mocks -source "pkg/aws/snowballdevice.go"
 	${MOCKGEN} -destination=pkg/providers/nutanix/mocks/client.go -package=mocks -source "pkg/providers/nutanix/client.go"
 	${MOCKGEN} -destination=pkg/providers/nutanix/mocks/validator.go -package=mocks -source "pkg/providers/nutanix/validator.go"
+	${MOCKGEN} -destination=pkg/providers/nutanix/mocks/kubectl.go -package=mocks -source "pkg/providers/nutanix/kubectl.go"
 	${MOCKGEN} -destination=pkg/providers/nutanix/mocks/roundtripper.go -package=mocks net/http RoundTripper
 	${MOCKGEN} -destination=pkg/providers/snow/mocks/aws.go -package=mocks -source "pkg/providers/snow/aws.go"
 	${MOCKGEN} -destination=pkg/providers/snow/mocks/defaults.go -package=mocks -source "pkg/providers/snow/defaults.go"

--- a/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generateclusterconfig.go
@@ -223,24 +223,37 @@ func generateClusterConfig(clusterName string) error {
 		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithClusterEndpoint())
 		clusterConfigOpts = append(clusterConfigOpts,
 			v1alpha1.ControlPlaneConfigCount(3),
+			v1alpha1.ExternalETCDConfigCount(3),
 			v1alpha1.WorkerNodeConfigCount(3),
 			v1alpha1.WorkerNodeConfigName(constants.DefaultWorkerNodeGroupName),
 		)
 
 		cpMachineConfig := v1alpha1.NewNutanixMachineConfigGenerate(providers.GetControlPlaneNodeName(clusterName))
+		etcdMachineConfig := v1alpha1.NewNutanixMachineConfigGenerate(providers.GetEtcdNodeName(clusterName))
+		workerMachineConfig := v1alpha1.NewNutanixMachineConfigGenerate(clusterName)
+
+		clusterConfigOpts = append(clusterConfigOpts,
+			v1alpha1.WithCPMachineGroupRef(cpMachineConfig),
+			v1alpha1.WithEtcdMachineGroupRef(etcdMachineConfig),
+			v1alpha1.WithWorkerMachineGroupRef(workerMachineConfig),
+		)
+
 		cpMcYaml, err := yaml.Marshal(cpMachineConfig)
 		if err != nil {
 			return fmt.Errorf("failed to generate cluster yaml: %v", err)
 		}
-		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithCPMachineGroupRef(cpMachineConfig))
 
-		workerMachineConfig := v1alpha1.NewNutanixMachineConfigGenerate(clusterName)
+		etcdMcYaml, err := yaml.Marshal(etcdMachineConfig)
+		if err != nil {
+			return fmt.Errorf("failed to generate cluster yaml: %v", err)
+		}
+
 		workerMcYaml, err := yaml.Marshal(workerMachineConfig)
 		if err != nil {
 			return fmt.Errorf("failed to generate cluster yaml: %v", err)
 		}
-		clusterConfigOpts = append(clusterConfigOpts, v1alpha1.WithWorkerMachineGroupRef(workerMachineConfig))
-		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml)
+
+		machineGroupYaml = append(machineGroupYaml, cpMcYaml, workerMcYaml, etcdMcYaml)
 	default:
 		return fmt.Errorf("not a valid provider")
 	}

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -43,6 +43,13 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: NutanixCluster
     name: "{{.clusterName}}"
+{{- if .externalEtcd }}
+  managedExternalEtcdRef:
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    kind: EtcdadmCluster
+    name: "{{.clusterName}}-etcd"
+    namespace: "{{.eksaSystemNamespace}}"
+{{- end }}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -352,6 +359,126 @@ spec:
 {{- range .additionalCategories}}
         - key:   "{{ .Key }}"
           value: "{{ .Value }}"
+{{- end }}
+{{- end }}
+{{- if .externalEtcd }}
+---
+kind: EtcdadmCluster
+apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "{{.clusterName}}-etcd"
+  namespace: "{{.eksaSystemNamespace}}"
+spec:
+  replicas: {{.externalEtcdReplicas}}
+  etcdadmConfigSpec:
+    etcdadmBuiltin: true
+    format: {{.format}}
+{{- if .etcdNtpServers }}
+    ntp:
+      enabled: true
+      servers: {{ range .etcdNtpServers }}
+      - {{ . }}
+      {{- end }}
+{{- end }}
+    cloudInitConfig:
+      version: {{.externalEtcdVersion}}
+      installDir: "/usr/bin"
+    preEtcdadmCommands:
+      - hostname "{{`{{ ds.meta_data.hostname }}`}}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
+      - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+{{- if .etcdCipherSuites }}
+    cipherSuites: {{.etcdCipherSuites}}
+{{- end }}
+    users:
+      - name: "{{.etcdSshUsername}}"
+        sshAuthorizedKeys:
+          - "{{.etcdSshAuthorizedKey}}"
+        sudo: ALL=(ALL) NOPASSWD:ALL
+{{- if .proxyConfig }}
+    proxy:
+      httpProxy: {{ .httpProxy }}
+      httpsProxy: {{ .httpsProxy }}
+      noProxy: {{ range .noProxy }}
+        - {{ . }}
+      {{- end }}
+{{- end }}
+{{- if .registryMirrorMap }}
+    registryMirror:
+      endpoint: {{ .publicMirror }}
+      {{- if .registryCACert }}
+      caCert: |
+{{ .registryCACert | indent 8 }}
+      {{- end }}
+{{- end }}
+{{- if .etcdCertBundles }}
+    certBundles:
+    {{- range .etcdCertBundles }}
+    - name: "{{ .Name }}"
+      data: |
+{{ .Data | indent 8 }}
+      {{- end }}
+{{- end}}
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixMachineTemplate
+    name: "{{.etcdTemplateName}}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "{{.etcdTemplateName}}"
+  namespace: "{{.eksaSystemNamespace}}"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://{{.clusterName}}-m1"
+      vcpusPerSocket: {{.etcdVCPUsPerSocket}}
+      vcpuSockets: {{.etcdVcpuSockets}}
+      memorySize: {{.etcdMemorySize}}
+      systemDiskSize: {{.etcdSystemDiskSize}}
+      image:
+{{- if (eq .etcdImageIDType "name") }}
+        type: name
+        name: "{{.etcdImageName}}"
+{{ else if (eq .etcdImageIDType "uuid") }}
+        type: uuid
+        uuid: "{{.etcdImageUUID}}"
+{{ end }}
+      cluster:
+{{- if (eq .etcdNutanixPEClusterIDType "name") }}
+        type: name
+        name: "{{.etcdNutanixPEClusterName}}"
+{{- else if (eq .etcdNutanixPEClusterIDType "uuid") }}
+        type: uuid
+        uuid: "{{.etcdNutanixPEClusterUUID}}"
+{{ end }}
+      subnet:
+{{- if (eq .etcdSubnetIDType "name") }}
+        - type: name
+          name: "{{.etcdSubnetName}}"
+{{- else if (eq .etcdSubnetIDType "uuid") }}
+        - type: uuid
+          uuid: "{{.etcdSubnetUUID}}"
+{{ end }}
+{{- if .etcdProjectIDType}}
+      project:
+{{- if (eq .etcdProjectIDType "name") }}
+        type: name
+        name: "{{.etcdProjectName}}"
+{{- else if (eq .etcdProjectIDType "uuid") }}
+        type: uuid
+        uuid: "{{.etcdProjectUUID}}"
+{{ end }}
+{{ end }}
+{{- if .etcdAdditionalCategories}}
+      additionalCategories:
+{{- range .etcdAdditionalCategories}}
+        - key:   "{{ .Key }}"
+          value: "{{ .Value }}"
+{{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/pkg/providers/nutanix/kubectl.go
+++ b/pkg/providers/nutanix/kubectl.go
@@ -3,6 +3,7 @@ package nutanix
 import (
 	"context"
 
+	etcdv1beta1 "github.com/aws/etcdadm-controller/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
@@ -17,10 +18,12 @@ type ProviderKubectlClient interface {
 	GetEksaCluster(ctx context.Context, cluster *types.Cluster, clusterName string) (*v1alpha1.Cluster, error)
 	GetEksaNutanixDatacenterConfig(ctx context.Context, nutanixDatacenterConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.NutanixDatacenterConfig, error)
 	GetEksaNutanixMachineConfig(ctx context.Context, nutanixMachineConfigName string, kubeconfigFile string, namespace string) (*v1alpha1.NutanixMachineConfig, error)
+	GetEtcdadmCluster(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*etcdv1beta1.EtcdadmCluster, error)
 	GetKubeadmControlPlane(ctx context.Context, cluster *types.Cluster, clusterName string, opts ...executables.KubectlOpt) (*kubeadmv1beta1.KubeadmControlPlane, error)
 	GetMachineDeployment(ctx context.Context, workerNodeGroupName string, opts ...executables.KubectlOpt) (*clusterv1.MachineDeployment, error)
 	SearchNutanixMachineConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.NutanixMachineConfig, error)
 	SearchNutanixDatacenterConfig(ctx context.Context, name string, kubeconfigFile string, namespace string) ([]*v1alpha1.NutanixDatacenterConfig, error)
 	DeleteEksaNutanixDatacenterConfig(ctx context.Context, nutanixDatacenterConfigName string, kubeconfigFile string, namespace string) error
 	DeleteEksaNutanixMachineConfig(ctx context.Context, nutanixMachineConfigName string, kubeconfigFile string, namespace string) error
+	UpdateAnnotation(ctx context.Context, resourceType, objectName string, annotations map[string]string, opts ...executables.KubectlOpt) error
 }

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -20,7 +20,9 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/common"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
+
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+	etcdv1beta1 "github.com/aws/etcdadm-controller/api/v1beta1"
 )
 
 //go:embed config/cp-template.yaml
@@ -394,6 +396,46 @@ func NeedsNewKubeadmConfigTemplate(newWorkerNodeGroup *v1alpha1.WorkerNodeGroupC
 		!v1alpha1.UsersSliceEqual(oldWorkerNodeNmc.Spec.Users, newWorkerNodeNmc.Spec.Users)
 }
 
+func needsNewEtcdTemplate(oldSpec, newSpec *cluster.Spec, oldNmc, newNmc *v1alpha1.NutanixMachineConfig) bool {
+	if oldSpec.Cluster.Spec.KubernetesVersion != newSpec.Cluster.Spec.KubernetesVersion {
+		return true
+	}
+	if oldSpec.Bundles.Spec.Number != newSpec.Bundles.Spec.Number {
+		return true
+	}
+
+	return AnyImmutableFieldChanged(oldNmc, newNmc)
+}
+
+func (p *Provider) getEtcdTemplateNameForCAPISpecUpgrade(ctx context.Context, eksaCluster *v1alpha1.Cluster, currentSpec, newClusterSpec *cluster.Spec, bootstrapCluster, workloadCluster *types.Cluster, ndc *v1alpha1.NutanixDatacenterConfig, clusterName string) (string, error) {
+	etcdMachineConfig := newClusterSpec.NutanixMachineConfigs[newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name]
+	etcdMachineVms, err := p.kubectlClient.GetEksaNutanixMachineConfig(ctx, eksaCluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, workloadCluster.KubeconfigFile, newClusterSpec.Cluster.Namespace)
+	if err != nil {
+		return "", err
+	}
+
+	if !needsNewEtcdTemplate(currentSpec, newClusterSpec, etcdMachineVms, etcdMachineConfig) {
+		etcdadmCluster, err := p.kubectlClient.GetEtcdadmCluster(ctx, workloadCluster, clusterName, executables.WithCluster(bootstrapCluster), executables.WithNamespace(constants.EksaSystemNamespace))
+		if err != nil {
+			return "", err
+		}
+		return etcdadmCluster.Spec.InfrastructureTemplate.Name, nil
+	} else {
+		/* During a cluster upgrade, etcd machines need to be upgraded first, so that the etcd machines with new spec get created and can be used by controlplane machines
+		   as etcd endpoints. KCP rollout should not start until then. As a temporary solution in the absence of static etcd endpoints, we annotate the etcd cluster as "upgrading",
+		   so that KCP checks this annotation and does not proceed if etcd cluster is upgrading. The etcdadm controller removes this annotation once the etcd upgrade is complete.
+		*/
+		err = p.kubectlClient.UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", clusterName),
+			map[string]string{etcdv1beta1.UpgradeInProgressAnnotation: "true"},
+			executables.WithCluster(bootstrapCluster),
+			executables.WithNamespace(constants.EksaSystemNamespace))
+		if err != nil {
+			return "", err
+		}
+		return common.EtcdMachineTemplateName(clusterName, p.templateBuilder.now), nil
+	}
+}
+
 func (p *Provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, newClusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	if err := p.UpdateSecrets(ctx, bootstrapCluster, newClusterSpec); err != nil {
 		return nil, nil, fmt.Errorf("updating Nutanix credentials: %v", err)
@@ -478,6 +520,13 @@ func (p *Provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 			workloadTemplateNames[workerNodeGroupConfiguration.Name] = workloadTemplateName
 		}
 		p.templateBuilder.workerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name] = p.machineConfigs[workerNodeGroupConfiguration.MachineGroupRef.Name].Spec
+	}
+
+	if newClusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
+		etcdTemplateName, err = p.getEtcdTemplateNameForCAPISpecUpgrade(ctx, eksaCluster, currentSpec, newClusterSpec, bootstrapCluster, workloadCluster, ndc, clusterName)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	cpOpt := func(values map[string]interface{}) {

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -202,6 +202,16 @@ func buildTemplateMapCP(
 		"subnetUUID":                   controlPlaneMachineSpec.Subnet.UUID,
 	}
 
+	if controlPlaneMachineSpec.Project != nil {
+		values["projectIDType"] = controlPlaneMachineSpec.Project.Type
+		values["projectName"] = controlPlaneMachineSpec.Project.Name
+		values["projectUUID"] = controlPlaneMachineSpec.Project.UUID
+	}
+
+	if len(controlPlaneMachineSpec.AdditionalCategories) > 0 {
+		values["additionalCategories"] = controlPlaneMachineSpec.AdditionalCategories
+	}
+
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
@@ -227,12 +237,30 @@ func buildTemplateMapCP(
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
-	}
+		values["etcdSshAuthorizedKey"] = etcdMachineSpec.Users[0].SshAuthorizedKeys[0]
+		values["etcdVCPUsPerSocket"] = etcdMachineSpec.VCPUsPerSocket
+		values["etcdVcpuSockets"] = etcdMachineSpec.VCPUSockets
+		values["etcdMemorySize"] = etcdMachineSpec.MemorySize.String()
+		values["etcdSystemDiskSize"] = etcdMachineSpec.SystemDiskSize.String()
+		values["etcdImageIDType"] = etcdMachineSpec.Image.Type
+		values["etcdImageName"] = etcdMachineSpec.Image.Name
+		values["etcdImageUUID"] = etcdMachineSpec.Image.UUID
+		values["etcdSubnetIDType"] = etcdMachineSpec.Subnet.Type
+		values["etcdSubnetName"] = etcdMachineSpec.Subnet.Name
+		values["etcdSubnetUUID"] = etcdMachineSpec.Subnet.UUID
+		values["etcdNutanixPEClusterIDType"] = etcdMachineSpec.Cluster.Type
+		values["etcdNutanixPEClusterName"] = etcdMachineSpec.Cluster.Name
+		values["etcdNutanixPEClusterUUID"] = etcdMachineSpec.Cluster.UUID
 
-	if controlPlaneMachineSpec.Project != nil {
-		values["projectIDType"] = controlPlaneMachineSpec.Project.Type
-		values["projectName"] = controlPlaneMachineSpec.Project.Name
-		values["projectUUID"] = controlPlaneMachineSpec.Project.UUID
+		if etcdMachineSpec.Project != nil {
+			values["etcdProjectIDType"] = etcdMachineSpec.Project.Type
+			values["etcdProjectName"] = etcdMachineSpec.Project.Name
+			values["etcdProjectUUID"] = etcdMachineSpec.Project.UUID
+		}
+
+		if len(etcdMachineSpec.AdditionalCategories) > 0 {
+			values["etcdAdditionalCategories"] = etcdMachineSpec.AdditionalCategories
+		}
 	}
 
 	if clusterSpec.AWSIamConfig != nil {
@@ -244,10 +272,6 @@ func buildTemplateMapCP(
 		values["httpProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpProxy
 		values["httpsProxy"] = clusterSpec.Cluster.Spec.ProxyConfiguration.HttpsProxy
 		values["noProxy"] = generateNoProxyList(clusterSpec)
-	}
-
-	if len(controlPlaneMachineSpec.AdditionalCategories) > 0 {
-		values["additionalCategories"] = controlPlaneMachineSpec.AdditionalCategories
 	}
 
 	return values, nil

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -31,6 +31,9 @@ var nutanixMachineConfigSpecWithProject string
 //go:embed testdata/machineConfig_additional_categories.yaml
 var nutanixMachineConfigSpecWithAdditionalCategories string
 
+//go:embed testdata/machineConfig_external_etcd.yaml
+var nutanixMachineConfigSpecExternalEtcd string
+
 func fakemarshal(v interface{}) ([]byte, error) {
 	return []byte{}, errors.New("marshalling failed")
 }
@@ -301,6 +304,46 @@ func TestNewNutanixTemplateBuilderAdditionalCategories(t *testing.T) {
 	assert.NotNil(t, workerSpec)
 
 	expectedWorkersSpec, err := os.ReadFile("testdata/expected_results_additional_categories_md.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedWorkersSpec, workerSpec)
+}
+
+func TestNewNutanixTemplateBuilderExternalEtcd(t *testing.T) {
+	t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+	t.Setenv(constants.EksaNutanixPasswordKey, "password")
+	creds := GetCredsFromEnv()
+
+	dcConf, _, _ := minimalNutanixConfigSpec(t)
+	machineConf := &anywherev1.NutanixMachineConfig{}
+	err := yaml.Unmarshal([]byte(nutanixMachineConfigSpecExternalEtcd), machineConf)
+	require.NoError(t, err)
+
+	workerConfs := map[string]anywherev1.NutanixMachineConfigSpec{
+		"eksa-unit-test": machineConf.Spec,
+	}
+	builder := NewNutanixTemplateBuilder(&dcConf.Spec, &machineConf.Spec, &machineConf.Spec, workerConfs, creds, time.Now)
+	assert.NotNil(t, builder)
+
+	buildSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-external-etcd.yaml")
+	cpSpec, err := builder.GenerateCAPISpecControlPlane(buildSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+
+	expectedControlPlaneSpec, err := os.ReadFile("testdata/expected_results_external_etcd.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedControlPlaneSpec, cpSpec)
+
+	workloadTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	kubeadmconfigTemplateNames := map[string]string{
+		"eksa-unit-test": "eksa-unit-test",
+	}
+	workerSpec, err := builder.GenerateCAPISpecWorkers(buildSpec, workloadTemplateNames, kubeadmconfigTemplateNames)
+	assert.NoError(t, err)
+	assert.NotNil(t, workerSpec)
+
+	expectedWorkersSpec, err := os.ReadFile("testdata/expected_results_external_etcd_md.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, expectedWorkersSpec, workerSpec)
 }

--- a/pkg/providers/nutanix/testdata/eksa-cluster-additional-categories.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-additional-categories.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-autoscaler.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-autoscaler.yaml
@@ -22,12 +22,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-external-etcd.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-external-etcd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kubernetesVersion: "1.19"
   controlPlaneConfiguration:
-    name: eksa-unit-test
+    name: eksa-unit-test-cp
     count: 3
     endpoint:
       host: test-ip
@@ -19,6 +19,12 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
+  externalEtcdConfiguration:
+    name: eksa-unit-test-etcd
+    count: 3
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test
@@ -30,9 +36,6 @@ spec:
     services:
       cidrBlocks:
         - 10.96.0.0/12
-  identityProviderRefs:
-    - kind: AWSIamConfig
-      name: aws-iam-auth-config
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: NutanixDatacenterConfig
@@ -70,18 +73,3 @@ spec:
     - name: "mySshUsername"
       sshAuthorizedKeys:
         - "mySshAuthorizedKey"
----
-apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-kind: AWSIamConfig
-metadata:
-  name: aws-iam-auth-config
-spec:
-  awsRegion: "us-east-1"
-  backendMode:
-    - "EKSConfigMap"
-  mapUsers:
-    - userARN: arn:aws:iam::861212534935:user/eksaiamauth
-      username: eksaiamauth
-      groups:
-        - "system:masters"
-  partition: "aws"

--- a/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-pc.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-pc.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-random-name.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-random-name.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-irsa.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-irsa.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-multiple-machineconfigs.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-multiple-machineconfigs.yaml
@@ -24,12 +24,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test-md-2
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-multiple-worker-md.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-multiple-worker-md.yaml
@@ -24,12 +24,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-no-credentialref.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-no-credentialref.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-node-taints-labels.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-node-taints-labels.yaml
@@ -33,12 +33,6 @@ spec:
       labels:
         key1-md: value1-md
         key2-md: value2-md
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-oidc.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-oidc.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-project.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-project.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-proxy.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-proxy.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster-registry-mirror.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-registry-mirror.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/eksa-cluster.json
+++ b/pkg/providers/nutanix/testdata/eksa-cluster.json
@@ -28,14 +28,6 @@
         }
       }
     ],
-    "externalEtcdConfiguration": {
-      "name": "eksa-unit-test",
-      "count": 3,
-      "machineGroupRef": {
-        "name": "eksa-unit-test",
-        "kind": "NutanixMachineConfig"
-      }
-    },
     "datacenterRef": {
       "kind": "NutanixDatacenterConfig",
       "name": "eksa-unit-test"

--- a/pkg/providers/nutanix/testdata/eksa-cluster.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster.yaml
@@ -19,12 +19,6 @@ spec:
       machineGroupRef:
         name: eksa-unit-test
         kind: NutanixMachineConfig
-  externalEtcdConfiguration:
-    name: eksa-unit-test
-    count: 3
-    machineGroupRef:
-      name: eksa-unit-test
-      kind: NutanixMachineConfig
   datacenterRef:
     kind: NutanixDatacenterConfig
     name: eksa-unit-test

--- a/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
@@ -66,11 +66,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -37,6 +37,11 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: NutanixCluster
     name: "eksa-unit-test"
+  managedExternalEtcdRef:
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    kind: EtcdadmCluster
+    name: "eksa-unit-test-etcd"
+    namespace: "eksa-system"
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -66,9 +71,11 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        local:
-          imageRepository: public.ecr.aws/eks-distro/etcd-io
-          imageTag: v3.4.14-eks-1-19-4
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
     files:
     - content: |
         apiVersion: v1
@@ -130,13 +137,6 @@ spec:
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
-    - content: |
-        [Service]
-        Environment="HTTP_PROXY=proxy.nutanix.com:8888"
-        Environment="HTTPS_PROXY=proxy.nutanix.com:8888"
-        Environment="NO_PROXY=192.168.0.0/16,10.96.0.0/12,noproxy1.nutanix.com,noproxy2.nutanix.com,noproxy3.nutanix.com,localhost,127.0.0.1,.svc,prism.nutanix.com,test-ip"
-      owner: root:root
-      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -161,8 +161,6 @@ spec:
         sshAuthorizedKeys:
           - "mySshAuthorizedKey"
     preKubeadmCommands:
-      - sudo systemctl daemon-reload
-      - sudo systemctl restart containerd
       - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
@@ -170,6 +168,60 @@ spec:
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
     useExperimentalRetryJoin: true
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "<no value>"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---
+kind: EtcdadmCluster
+apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "eksa-unit-test-etcd"
+  namespace: "eksa-system"
+spec:
+  replicas: 3
+  etcdadmConfigSpec:
+    etcdadmBuiltin: true
+    format: cloud-config
+    cloudInitConfig:
+      version: 3.4.14
+      installDir: "/usr/bin"
+    preEtcdadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    users:
+      - name: "mySshUsername"
+        sshAuthorizedKeys:
+          - "mySshAuthorizedKey"
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixMachineTemplate
+    name: "<no value>"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixMachineTemplate

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_md.yaml
@@ -1,0 +1,80 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+  name: "eksa-unit-test-eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  clusterName: "eksa-unit-test"
+  replicas: 4
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: "eksa-unit-test"
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: "eksa-unit-test"
+      clusterName: "eksa-unit-test"
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: NutanixMachineTemplate
+        name: "eksa-unit-test"
+      version: "v1.19.8-eks-1-19-4"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://eksa-unit-test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "eksa-unit-test"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      preKubeadmCommands:
+        - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            #cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      users:
+        - name: "mySshUsername"
+          lockPassword: false
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          sshAuthorizedKeys:
+            - "mySshAuthorizedKey"
+
+---

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -77,11 +77,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -68,11 +68,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -66,11 +66,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -69,11 +69,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -66,11 +66,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -66,11 +66,9 @@ spec:
         imageRepository: public.ecr.aws/eks-distro/coredns
         imageTag: v1.8.0-eks-1-19-4
       etcd:
-        external:
-          endpoints: []
-          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
-          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
-          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.4.14-eks-1-19-4
     files:
     - content: |
         apiVersion: v1

--- a/pkg/providers/nutanix/testdata/machineConfig_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/machineConfig_external_etcd.yaml
@@ -1,0 +1,24 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"


### PR DESCRIPTION
Description of changes:

### External etcd support for Nutanix
 
 - change Nutanix provider code
 - change cp-template
 - add new unit tests
 - change unit tests

Testing:
 - unit tests
 - manual test: install with external etcd
 - manual test: update external etcd cpu

```
$ eksctl anywhere create cluster -f ./eksa-ext-etcd-cluster.yaml --bundles-override ./bundle-release.yaml
Performing setup and validations
odd number of arguments passed as key-value pairs for logging	{"ignored key": "ext-etcd"}
ValidateClusterSpec for Nutanix datacenter
✅ Nutanix Provider setup is valid
✅ Validate OS is compatible with registry mirror configuration
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
Creating new bootstrap cluster
Provider specific pre-capi-install-setup on bootstrap cluster
Installing cluster-api providers on bootstrap cluster
Provider specific post-setup
Creating new workload cluster
Installing networking on workload cluster
Creating EKS-A namespace
Installing cluster-api providers on workload cluster
Installing EKS-A secrets on workload cluster
Installing resources on management cluster
Moving cluster management from bootstrap to workload cluster
Installing EKS-A custom components (CRD and controller) on workload cluster
Installing EKS-D components on workload cluster
Creating EKS-A CRDs instances on workload cluster
Installing GitOps Toolkit on workload cluster
GitOps field not specified, bootstrap flux skipped
Writing cluster config file
Deleting bootstrap cluster
🎉 Cluster created!
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
Enabling curated packages on the cluster
Installing helm chart on cluster	{"chart": "eks-anywhere-packages", "version": "0.0.0-2895f5c5498a1a546460382b5a685c12510698f2-release-0.16-helm"}

$ kubectl get nutanixmachines -n eksa-system
NAME                                                  ADDRESS         READY   PROVIDERID                                       NODEREF
ext-etcd-control-plane-template-1688665956667-7xr5b   10.40.142.52    true    nutanix://92b16775-eaa9-4cc4-9a09-735e675aae75   ext-etcd-4bjjt
ext-etcd-control-plane-template-1688665956667-zl95v   10.40.142.150   true    nutanix://7b27447e-aa3a-47a0-a6fc-5f3fed532dd6   ext-etcd-wgpsm
ext-etcd-control-plane-template-1688665956667-zw6hf   10.40.142.213   true    nutanix://4aa92d08-1318-4353-b006-e0bb923470c8   ext-etcd-bv9k7
ext-etcd-etcd-template-1688665956667-4g9qp            10.40.142.39    true    nutanix://3fae9129-dde2-4c42-ae79-bcd808101dcf
ext-etcd-etcd-template-1688665956667-5b6wx            10.40.142.49    true    nutanix://dc476ea1-47be-462c-9b81-af92cccf2e91
ext-etcd-etcd-template-1688665956667-sh8pd            10.40.142.211   true    nutanix://e98069c5-805e-4e2d-a37a-a3a524d5ba2d
ext-etcd-md-0-1688665956668-6mt5f                     10.40.142.243   true    nutanix://b4fc4af2-3def-417d-af8d-2b0481aaab51   ext-etcd-md-0-7494fb7767xbg698-7rtqr
ext-etcd-md-0-1688665956668-lsmpb                     10.40.142.118   true    nutanix://35dc9214-e303-4888-97c0-3009d685861d   ext-etcd-md-0-7494fb7767xbg698-6hgjp
ext-etcd-md-0-1688665956668-r6gxx                     10.40.142.72    true    nutanix://03949925-a4ec-449a-903b-33d0271a107c   ext-etcd-md-0-7494fb7767xbg698-5rdb7

$ kubectl get nodes
NAME                                   STATUS   ROLES           AGE   VERSION
ext-etcd-4bjjt                         Ready    control-plane   21m   v1.26.4-eks-597964d
ext-etcd-bv9k7                         Ready    control-plane   23m   v1.26.4-eks-597964d
ext-etcd-md-0-7494fb7767xbg698-5rdb7   Ready    <none>          24m   v1.26.4-eks-597964d
ext-etcd-md-0-7494fb7767xbg698-6hgjp   Ready    <none>          24m   v1.26.4-eks-597964d
ext-etcd-md-0-7494fb7767xbg698-7rtqr   Ready    <none>          24m   v1.26.4-eks-597964d
ext-etcd-wgpsm                         Ready    control-plane   25m   v1.26.4-eks-597964d
```

<img width="1418" alt="Screenshot 2023-07-06 at 20 26 03" src="https://github.com/aws/eks-anywhere/assets/506414/2eea9863-6e5f-4be0-8ba1-07550be7cc6e">

```
$ eksctl anywhere upgrade cluster -f ./eksa-ext-etcd-cluster.yaml --bundles-override ./bundle-release.yaml
Performing setup and validations
✅ Nutanix provider validation
✅ Validate OS is compatible with registry mirror configuration
✅ Validate certificate for registry mirror
✅ Control plane ready
✅ Worker nodes ready
✅ Nodes ready
✅ Cluster CRDs ready
✅ Cluster object present on workload cluster
✅ Upgrade cluster kubernetes version increment
✅ Validate authentication for git provider
✅ Validate immutable fields
✅ Validate pod disruption budgets
Ensuring etcd CAPI providers exist on management cluster before upgrade
Pausing EKS-A cluster controller reconcile
Pausing GitOps cluster resources reconcile
Upgrading core components
Creating bootstrap cluster
Provider specific pre-capi-install-setup on bootstrap cluster
Provider specific post-setup
Installing cluster-api providers on bootstrap cluster
Backing up workload cluster's management resources before moving to bootstrap cluster
Moving management cluster from workload to bootstrap cluster
Upgrading workload cluster
Moving cluster management from bootstrap to workload cluster
Updating EKS-A cluster resource
Resuming EKS-A controller reconcile
Updating Git Repo with new EKS-A cluster spec
GitOps field not specified, update git repo skipped
Forcing reconcile Git repo with latest commit
GitOps not configured, force reconcile flux git repo skipped
Resuming GitOps cluster resources kustomization
Writing cluster config file
🎉 Cluster upgraded!

$ kubectl get nutanixmachines -n eksa-system
NAME                                                  ADDRESS         READY   PROVIDERID                                       NODEREF
ext-etcd-control-plane-template-1688665956667-kjjtx   10.40.142.74    true    nutanix://adf3c55e-48e5-4520-98f9-b5f08aeb8ed4   ext-etcd-xcjjv
ext-etcd-control-plane-template-1688665956667-pgs5c   10.40.142.215   true    nutanix://ea7bdbaa-2fd3-4e4b-a471-96930625ed21   ext-etcd-vnkzh
ext-etcd-control-plane-template-1688665956667-z8cms   10.40.142.116   true    nutanix://52d7a93a-8924-4aa2-9549-0ab3d5105d91   ext-etcd-8h7lk
ext-etcd-etcd-template-1688668232852-hn269            10.40.142.109   true    nutanix://6ec0fe16-9910-481d-94b2-2f7bc34f4632
ext-etcd-etcd-template-1688668232852-q86xj            10.40.142.85    true    nutanix://b36ed857-9c75-4a65-8efd-f6b7f84d494e
ext-etcd-etcd-template-1688668232852-sr8mj            10.40.142.120   true    nutanix://08067bc8-4e20-44d8-bf56-a3c25871bea6
ext-etcd-md-0-1688665956668-6mt5f                     10.40.142.243   true    nutanix://b4fc4af2-3def-417d-af8d-2b0481aaab51   ext-etcd-md-0-7494fb7767xbg698-7rtqr
ext-etcd-md-0-1688665956668-lsmpb                     10.40.142.118   true    nutanix://35dc9214-e303-4888-97c0-3009d685861d   ext-etcd-md-0-7494fb7767xbg698-6hgjp
ext-etcd-md-0-1688665956668-r6gxx                     10.40.142.72    true    nutanix://03949925-a4ec-449a-903b-33d0271a107c   ext-etcd-md-0-7494fb7767xbg698-5rdb7

$ kubectl get nodes
NAME                                   STATUS   ROLES           AGE     VERSION
ext-etcd-8h7lk                         Ready    control-plane   11m     v1.26.4-eks-597964d
ext-etcd-md-0-7494fb7767xbg698-5rdb7   Ready    <none>          51m     v1.26.4-eks-597964d
ext-etcd-md-0-7494fb7767xbg698-6hgjp   Ready    <none>          51m     v1.26.4-eks-597964d
ext-etcd-md-0-7494fb7767xbg698-7rtqr   Ready    <none>          51m     v1.26.4-eks-597964d
ext-etcd-vnkzh                         Ready    control-plane   9m15s   v1.26.4-eks-597964d
ext-etcd-xcjjv                         Ready    control-plane   12m     v1.26.4-eks-597964d
```
<img width="1418" alt="Screenshot 2023-07-06 at 20 48 37" src="https://github.com/aws/eks-anywhere/assets/506414/60ee0e02-4c2b-42cb-9441-d011812a4e99">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
