### PR TITLE
Add node healthy check post create cluster

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -497,7 +497,7 @@ func (c *ClusterManager) getWorkloadClusterKubeconfig(ctx context.Context, clust
 func (c *ClusterManager) RunPostCreateWorkloadCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	logger.V(3).Info("Waiting for controlplane and worker machines to be ready")
 	labels := []string{clusterv1.MachineControlPlaneNameLabel, clusterv1.MachineDeploymentNameLabel}
-	return c.waitForNodesReady(ctx, managementCluster, workloadCluster.Name, labels, types.WithNodeRef())
+	return c.waitForNodesReady(ctx, managementCluster, workloadCluster.Name, labels, types.WithNodeRef(), types.WithNodeHealthy())
 }
 
 func (c *ClusterManager) DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After creating the workload cluster (with the bootstrap cluster as the management cluster), we do a node ready check. However, it is a little misleading. Currently, it only checks for the `NodeRef` on the CAPI machine so the log will report the node as ready, even if the node is unhealthy for some reason e.g. when the cilium installation on the cluster fails.

Therefore, this PR adds the node is healthy check in addition to the existing nodeRef check and we'd be able to track down issues where failures happen at this point faster. 

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

