### PR TITLE
Remove deprecated docs referencing cron-ecr-renew cronjob

### DIFF
--- a/docs/content/en/docs/packages/prereq.md
+++ b/docs/content/en/docs/packages/prereq.md
@@ -205,12 +205,6 @@ kubectl create secret -n eksa-packages generic aws-secret \
    --from-literal=REGION=${EKSA_AWS_REGION}
 ```
 
-If you recreate secrets, you can manually re-enable the cronjob and run the job to update the image pull secrets:
-```bash
-kubectl get cronjob -n eksa-packages cron-ecr-renew -o yaml | yq e '.spec.suspend |= false' - | kubectl apply -f -
-kubectl create job -n eksa-packages --from=cronjob/cron-ecr-renew run-it-now
-```
-
 ### Upgrade the packages controller
 
 Starting with EKS Anywhere v0.15.0 (packages controller v0.3.9+) the package controller will upgrade automatically according to the selected bundle. For any version prior to v0.3.X,

--- a/docs/content/en/docs/packages/troubleshoot.md
+++ b/docs/content/en/docs/packages/troubleshoot.md
@@ -119,19 +119,6 @@ kubectl delete secret -n eksa-packages aws-secret
 kubectl create secret -n eksa-packages generic aws-secret --from-literal=AWS_ACCESS_KEY_ID=${EKSA_AWS_ACCESS_KEY_ID} --from-literal=AWS_SECRET_ACCESS_KEY=${EKSA_AWS_SECRET_ACCESS_KEY}  --from-literal=REGION=${EKSA_AWS_REGION}
 ```
 
-If you recreate secrets, you can manually re-enable the cronjob and run the job to update the image pull secrets:
-```bash
-kubectl get cronjob -n eksa-packages cron-ecr-renew -o yaml | yq e '.spec.suspend |= false' - | kubectl apply -f -
-kubectl create job -n eksa-packages --from=cronjob/cron-ecr-renew run-it-now
-```
-
-### Warning: not able to trigger cron job
-```
-secret/aws-secret created
-Warning: not able to trigger cron job, please be aware this will prevent the package controller from installing curated packages.
-```
-This is most likely caused by an action to install curated packages in a cluster that is running `Kubernetes` at version `v1.20` or below. Note curated packages only support `Kubernetes` `v1.21` and above.
-
 ## Package on workload clusters
 
 Starting at `eksctl anywhere` version `v0.12.0`, packages on workload clusters are remotely managed by the management cluster. While interacting with the package resources by the following commands for a workload cluster, please make sure the kubeconfig is pointing to the **management cluster** that was used to create the workload cluster.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR removes associated docs for manually triggerring the` cron-ecr-renew` cronjob, which is only installed when BottleRocket semVersion is <= 1.13.1 according to [here](https://github.com/aws/eks-anywhere-packages/blob/cea344731eeded5b4b2b628f2752b199526cb4cd/charts/eks-anywhere-packages/templates/_helpers.tpl#L130C23-L130C23). In the [most recent minor version](https://github.com/aws/eks-anywhere-build-tooling/blob/release-0.16/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES) of EKS-A uses BR version >= 1.14.0. 
 
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

