### PR TITLE
Simplify release artifact preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,9 +380,9 @@ update-golden-files:
 	make -C release update-bundle-golden-files
 	scripts/golden_create_pr.sh
 
-.PHONY: generate-checksums
-generate-checksums:
-	scripts/generate_checksum.sh
+.PHONY: prepare-release-artifacts
+prepare-release-artifacts:
+	scripts/prepare_release_artifacts.sh
 
 .PHONY: update-brew-formula
 update-brew-formula:


### PR DESCRIPTION
Release artifact preparation is a manual task that requires downloading binaries and generating checksum files. This change simplifies the process by downloading all binaries and generating the checksums in a single Make target.

The result of the `prepare-release-artifacts` target is a directory, `release-artifacts` containing checksum files and tarballs. Additionally, this PR patches checksum generation to include arm64 binaries.

Example:

```
eks-anywhere > make prepare-release-artifacts                                                       
Using standard BUNDLE_MANIFEST_URL ... and RELEASE_MANIFEST_URL ...                              
scripts/prepare_release_artifacts.sh                                                                
Building checksum files...                                                                          
Downloading release binaries...                                                                     
Release artifacts can be found in release-artifacts. 
 
eks-anywhere > ls -1 release-artifacts/
eksctl-anywhere-v0.16.2-darwin-amd64.tar.gz
eksctl-anywhere-v0.16.2-darwin-arm64.tar.gz
eksctl-anywhere-v0.16.2-linux-amd64.tar.gz
eksctl-anywhere-v0.16.2-linux-arm64.tar.gz
eksctl-anywhere-v0.16.2-sha256sums.txt
eksctl-anywhere-v0.16.2-sha512sums.txt

eks-anywhere > cat release-artifacts/eksctl-anywhere-v0.16.2-sha256sums.txt 
fc4bce850f2b9d480caf6877b5ff11022800a85f0e1059760312d36f505681d7 eksctl-anywhere-v0.16.2-linux-amd64.tar.gz
06104e71fd5177d6a712f98e651bd4f0e58fe234b8539a4b0c7cdefbcc2a1791 eksctl-anywhere-v0.16.2-darwin-amd64.tar.gz
14337e129b6bd87ae941dc09656513365eb2f455fff03dce6f7a2d96e2f2ffb2 eksctl-anywhere-v0.16.2-linux-arm64.tar.gz
83a00ade9f4dd5da55dc15853de927518e9e014bcdb83c756abd1e273fd9d344 eksctl-anywhere-v0.16.2-darwin-arm64.tar.gz
```

