### PR TITLE
Refactor machine health checks to use cluster and kubernetes.Object

### DIFF
--- a/pkg/clients/kubernetes/runtimeclient.go
+++ b/pkg/clients/kubernetes/runtimeclient.go
@@ -76,3 +76,13 @@ type restConfigurator func([]byte) (*rest.Config, error)
 func (c restConfigurator) Config(data []byte) (*rest.Config, error) {
 	return c(data)
 }
+
+// ObjectsToRuntimeObjects converts objects of another type to runtime.Object's.
+func ObjectsToRuntimeObjects[T runtime.Object](objs []T) []runtime.Object {
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		runtimeObjs = append(runtimeObjs, o)
+	}
+
+	return runtimeObjs
+}

--- a/pkg/clients/kubernetes/runtimeclient_test.go
+++ b/pkg/clients/kubernetes/runtimeclient_test.go
@@ -3,6 +3,7 @@ package kubernetes_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -67,4 +69,33 @@ func TestClientFactoryBuildClientFromKubeconfigNoFile(t *testing.T) {
 	f := kubernetes.ClientFactory{}
 	_, err := f.BuildClientFromKubeconfig("file-does-not-exist.txt")
 	g.Expect(err).To(MatchError(ContainSubstring("open file-does-not-exist.txt: no such file or directory")))
+}
+
+func TestObjectsToRuntimeObjects(t *testing.T) {
+	tests := []struct {
+		name string
+		objs []kubernetes.Object
+		want []runtime.Object
+	}{
+		{
+			name: "kubernetes to runtime object",
+			objs: []kubernetes.Object{
+				dockerCluster(),
+			},
+			want: []runtime.Object{
+				dockerCluster(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := kubernetes.ObjectsToRuntimeObjects(tt.objs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ObjectsToRuntimeObjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func dockerCluster() *dockerv1.DockerCluster {
+	return &dockerv1.DockerCluster{}
 }

--- a/pkg/clusterapi/machine_health_check.go
+++ b/pkg/clusterapi/machine_health_check.go
@@ -5,12 +5,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
@@ -53,9 +52,9 @@ func machineHealthCheck(clusterName string, unhealthyTimeout, nodeStartupTimeout
 }
 
 // MachineHealthCheckForControlPlane creates MachineHealthCheck resources for the control plane.
-func MachineHealthCheckForControlPlane(clusterSpec *cluster.Spec, unhealthyTimeout, nodeStartupTimeout time.Duration) *clusterv1.MachineHealthCheck {
-	mhc := machineHealthCheck(ClusterName(clusterSpec.Cluster), unhealthyTimeout, nodeStartupTimeout)
-	mhc.SetName(ControlPlaneMachineHealthCheckName(clusterSpec))
+func MachineHealthCheckForControlPlane(cluster *v1alpha1.Cluster, unhealthyTimeout, nodeStartupTimeout time.Duration) *clusterv1.MachineHealthCheck {
+	mhc := machineHealthCheck(ClusterName(cluster), unhealthyTimeout, nodeStartupTimeout)
+	mhc.SetName(ControlPlaneMachineHealthCheckName(cluster))
 	mhc.Spec.Selector.MatchLabels[clusterv1.MachineControlPlaneLabel] = ""
 	maxUnhealthy := intstr.Parse(maxUnhealthyControlPlane)
 	mhc.Spec.MaxUnhealthy = &maxUnhealthy
@@ -63,30 +62,30 @@ func MachineHealthCheckForControlPlane(clusterSpec *cluster.Spec, unhealthyTimeo
 }
 
 // MachineHealthCheckForWorkers creates MachineHealthCheck resources for the workers.
-func MachineHealthCheckForWorkers(clusterSpec *cluster.Spec, unhealthyTimeout, nodeStartupTimeout time.Duration) []*clusterv1.MachineHealthCheck {
-	m := make([]*clusterv1.MachineHealthCheck, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
-	for _, workerNodeGroupConfig := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		mhc := machineHealthCheckForWorker(clusterSpec, workerNodeGroupConfig, unhealthyTimeout, nodeStartupTimeout)
+func MachineHealthCheckForWorkers(cluster *v1alpha1.Cluster, unhealthyTimeout, nodeStartupTimeout time.Duration) []*clusterv1.MachineHealthCheck {
+	m := make([]*clusterv1.MachineHealthCheck, 0, len(cluster.Spec.WorkerNodeGroupConfigurations))
+	for _, workerNodeGroupConfig := range cluster.Spec.WorkerNodeGroupConfigurations {
+		mhc := machineHealthCheckForWorker(cluster, workerNodeGroupConfig, unhealthyTimeout, nodeStartupTimeout)
 		m = append(m, mhc)
 	}
 	return m
 }
 
-func machineHealthCheckForWorker(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, unhealthyTimeout, nodeStartupTimeout time.Duration) *clusterv1.MachineHealthCheck {
-	mhc := machineHealthCheck(ClusterName(clusterSpec.Cluster), unhealthyTimeout, nodeStartupTimeout)
-	mhc.SetName(WorkerMachineHealthCheckName(clusterSpec, workerNodeGroupConfig))
-	mhc.Spec.Selector.MatchLabels[clusterv1.MachineDeploymentNameLabel] = MachineDeploymentName(clusterSpec.Cluster, workerNodeGroupConfig)
+func machineHealthCheckForWorker(cluster *v1alpha1.Cluster, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, unhealthyTimeout, nodeStartupTimeout time.Duration) *clusterv1.MachineHealthCheck {
+	mhc := machineHealthCheck(ClusterName(cluster), unhealthyTimeout, nodeStartupTimeout)
+	mhc.SetName(WorkerMachineHealthCheckName(cluster, workerNodeGroupConfig))
+	mhc.Spec.Selector.MatchLabels[clusterv1.MachineDeploymentNameLabel] = MachineDeploymentName(cluster, workerNodeGroupConfig)
 	maxUnhealthy := intstr.Parse(maxUnhealthyWorker)
 	mhc.Spec.MaxUnhealthy = &maxUnhealthy
 	return mhc
 }
 
 // MachineHealthCheckObjects creates MachineHealthCheck resources for control plane and all the worker node groups.
-func MachineHealthCheckObjects(clusterSpec *cluster.Spec, unhealthyTimeout, nodeStartupTimeout time.Duration) []runtime.Object {
-	mhcWorkers := MachineHealthCheckForWorkers(clusterSpec, unhealthyTimeout, nodeStartupTimeout)
-	o := make([]runtime.Object, 0, len(mhcWorkers)+1)
+func MachineHealthCheckObjects(cluster *v1alpha1.Cluster, unhealthyTimeout, nodeStartupTimeout time.Duration) []kubernetes.Object {
+	mhcWorkers := MachineHealthCheckForWorkers(cluster, unhealthyTimeout, nodeStartupTimeout)
+	o := make([]kubernetes.Object, 0, len(mhcWorkers)+1)
 	for _, item := range mhcWorkers {
 		o = append(o, item)
 	}
-	return append(o, MachineHealthCheckForControlPlane(clusterSpec, unhealthyTimeout, nodeStartupTimeout))
+	return append(o, MachineHealthCheckForControlPlane(cluster, unhealthyTimeout, nodeStartupTimeout))
 }

--- a/pkg/clusterapi/machine_health_check_test.go
+++ b/pkg/clusterapi/machine_health_check_test.go
@@ -7,11 +7,11 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
@@ -21,7 +21,7 @@ func TestMachineHealthCheckForControlPlane(t *testing.T) {
 	for _, timeout := range timeouts {
 		tt := newApiBuilerTest(t)
 		want := expectedMachineHealthCheckForControlPlane(timeout)
-		got := clusterapi.MachineHealthCheckForControlPlane(tt.clusterSpec, timeout, timeout)
+		got := clusterapi.MachineHealthCheckForControlPlane(tt.clusterSpec.Cluster, timeout, timeout)
 		tt.Expect(got).To(BeComparableTo(want))
 	}
 }
@@ -68,7 +68,7 @@ func TestMachineHealthCheckForWorkers(t *testing.T) {
 		tt := newApiBuilerTest(t)
 		tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{*tt.workerNodeGroupConfig}
 		want := expectedMachineHealthCheckForWorkers(timeout)
-		got := clusterapi.MachineHealthCheckForWorkers(tt.clusterSpec, timeout, timeout)
+		got := clusterapi.MachineHealthCheckForWorkers(tt.clusterSpec.Cluster, timeout, timeout)
 		tt.Expect(got).To(Equal(want))
 	}
 }
@@ -116,9 +116,9 @@ func TestMachineHealthCheckObjects(t *testing.T) {
 	tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{*tt.workerNodeGroupConfig}
 	timeout := 5 * time.Minute
 
-	wantWN := clusterapi.MachineHealthCheckForWorkers(tt.clusterSpec, timeout, timeout)
-	wantCP := clusterapi.MachineHealthCheckForControlPlane(tt.clusterSpec, timeout, timeout)
+	wantWN := clusterapi.MachineHealthCheckForWorkers(tt.clusterSpec.Cluster, timeout, timeout)
+	wantCP := clusterapi.MachineHealthCheckForControlPlane(tt.clusterSpec.Cluster, timeout, timeout)
 
-	got := clusterapi.MachineHealthCheckObjects(tt.clusterSpec, timeout, timeout)
-	tt.Expect(got).To(Equal([]runtime.Object{wantWN[0], wantCP}))
+	got := clusterapi.MachineHealthCheckObjects(tt.clusterSpec.Cluster, timeout, timeout)
+	tt.Expect(got).To(Equal([]kubernetes.Object{wantWN[0], wantCP}))
 }

--- a/pkg/clusterapi/name.go
+++ b/pkg/clusterapi/name.go
@@ -111,12 +111,14 @@ func WorkerMachineTemplateName(clusterSpec *cluster.Spec, workerNodeGroupConfig 
 	return DefaultObjectName(fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfig.Name))
 }
 
-func ControlPlaneMachineHealthCheckName(clusterSpec *cluster.Spec) string {
-	return fmt.Sprintf("%s-kcp-unhealthy", KubeadmControlPlaneName(clusterSpec.Cluster))
+// ControlPlaneMachineHealthCheckName returns a name for a kcp machine health check.
+func ControlPlaneMachineHealthCheckName(cluster *v1alpha1.Cluster) string {
+	return fmt.Sprintf("%s-kcp-unhealthy", KubeadmControlPlaneName(cluster))
 }
 
-func WorkerMachineHealthCheckName(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
-	return fmt.Sprintf("%s-worker-unhealthy", MachineDeploymentName(clusterSpec.Cluster, workerNodeGroupConfig))
+// WorkerMachineHealthCheckName returns a name for a worker machine health check.
+func WorkerMachineHealthCheckName(cluster *v1alpha1.Cluster, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration) string {
+	return fmt.Sprintf("%s-worker-unhealthy", MachineDeploymentName(cluster, workerNodeGroupConfig))
 }
 
 // InitialTemplateNamesForWorkers returns the default initial names for workers machine templates and kubeadm config templates.

--- a/pkg/clusterapi/name_test.go
+++ b/pkg/clusterapi/name_test.go
@@ -241,7 +241,7 @@ func TestControlPlaneMachineHealthCheckName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
-			g.Expect(clusterapi.ControlPlaneMachineHealthCheckName(g.clusterSpec)).To(Equal(tt.want))
+			g.Expect(clusterapi.ControlPlaneMachineHealthCheckName(g.clusterSpec.Cluster)).To(Equal(tt.want))
 		})
 	}
 }
@@ -259,7 +259,7 @@ func TestWorkerMachineHealthCheckName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newApiBuilerTest(t)
-			g.Expect(clusterapi.WorkerMachineHealthCheckName(g.clusterSpec, *g.workerNodeGroupConfig)).To(Equal(tt.want))
+			g.Expect(clusterapi.WorkerMachineHealthCheckName(g.clusterSpec.Cluster, *g.workerNodeGroupConfig)).To(Equal(tt.want))
 		})
 	}
 }

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -775,7 +775,7 @@ func getProviderNamespaces(providerDeployments map[string][]string) []string {
 }
 
 func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster) error {
-	mhc, err := templater.ObjectsToYaml(clusterapi.MachineHealthCheckObjects(clusterSpec, c.unhealthyMachineTimeout, c.nodeStartupTimeout)...)
+	mhc, err := templater.ObjectsToYaml(kubernetes.ObjectsToRuntimeObjects(clusterapi.MachineHealthCheckObjects(clusterSpec.Cluster, c.unhealthyMachineTimeout, c.nodeStartupTimeout))...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor machine health checks to use cluster and kubernetes.Object. Also convert templater method that converts objects to yaml a generic method.

*Testing (if applicable):*
- unit tests
- manual tests

*Documentation added/planned (if applicable):*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

