### PR TITLE
Remove missing link to newer ubuntu version support doc

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -18,7 +18,7 @@ This will let you create a cluster in multiple providers for local development o
 ### Administrative machine prerequisites
 
 - Docker 20.x.x
-- Mac OS 10.15 / Ubuntu 20.04.2 LTS (See Note on newer Ubuntu versions)
+- Mac OS 10.15 / Ubuntu 20.04.2 LTS
 - 4 CPU cores
 - 16GB memory
 - 30GB free disk space


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://github.com/aws/eks-anywhere/pull/5592/files#diff-c5bfbb0cb70e1d5c90670d23997ef3e806e7aec7afef035050f9a3dfe2312e08 remove the notes but not reference to the notes.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

