### PR TITLE
Handle special cases for Cilium upgrades when using API

### DIFF
--- a/pkg/controller/serverside/reconcile.go
+++ b/pkg/controller/serverside/reconcile.go
@@ -39,3 +39,13 @@ func ReconcileObject(ctx context.Context, c client.Client, obj client.Object) er
 
 	return nil
 }
+
+// UpdateObject updates the existing object during reconciliation.
+// This is intended for special use cases only as the preferred method to reconcile objects is server-side apply.
+func UpdateObject(ctx context.Context, c client.Client, obj client.Object) error {
+	if err := c.Update(ctx, obj, client.FieldOwner(fieldManager)); err != nil {
+		return errors.Wrapf(err, "failed to reconcile object %s, %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	}
+
+	return nil
+}

--- a/pkg/controller/serverside/reconcile_test.go
+++ b/pkg/controller/serverside/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/controller/serverside"
 )
 
@@ -119,6 +120,122 @@ spec:
 				).To(BeTrue(), "Object spec in cluster is not equal to expected object spec:\n Actual:\n%#v\n Expected:\n%#v", cluster.Spec, o.Spec)
 			}
 		})
+	}
+}
+
+func TestReconcileUpdateObject(t *testing.T) {
+	cluster1 := newCluster("cluster-1")
+
+	yaml := []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+spec:
+  controlPlaneEndpoint:
+    host: 1.1.1.1
+    port: 8081`)
+
+	initial := []*clusterapiv1.Cluster{
+		updatedCluster(cluster1, func(c capiCluster) {
+			c.Spec.ControlPlaneEndpoint.Port = 8080
+			c.Spec.ControlPlaneEndpoint.Host = "1.1.1.1"
+		}),
+	}
+
+	expected := []*clusterapiv1.Cluster{
+		updatedCluster(cluster1, func(c capiCluster) {
+			c.Spec.ControlPlaneEndpoint.Port = 8081
+			c.Spec.ControlPlaneEndpoint.Host = "1.1.1.1"
+		}),
+	}
+
+	c := env.Client()
+	reader := env.APIReader()
+	ctx := context.Background()
+
+	g := NewWithT(t)
+	ns := env.CreateNamespaceForTest(ctx, t)
+
+	for _, o := range initial {
+		o.SetNamespace(ns)
+
+		if err := c.Create(ctx, o); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	yaml = []byte(strings.ReplaceAll(string(yaml), "#namespace#", ns))
+
+	objs, err := clientutil.YamlToClientObjects(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objs[0].SetResourceVersion(initial[0].GetResourceVersion())
+	for _, o := range objs {
+		g.Expect(serverside.UpdateObject(ctx, c, o)).To(Succeed(), "Failed to reconcile with UpdateObject()")
+	}
+
+	for _, o := range expected {
+		key := client.ObjectKey{
+			Namespace: ns,
+			Name:      o.GetName(),
+		}
+
+		cluster := &clusterapiv1.Cluster{}
+
+		g.Expect(reader.Get(ctx, key, cluster)).To(Succeed(), "Failed getting obj from cluster")
+		g.Expect(
+			equality.Semantic.DeepDerivative(o.Spec, cluster.Spec),
+		).To(BeTrue(), "Object spec in cluster is not equal to expected object spec:\n Actual:\n%#v\n Expected:\n%#v", cluster.Spec, o.Spec)
+	}
+}
+
+func TestReconcileUpdateObjectError(t *testing.T) {
+	cluster1 := newCluster("cluster-1")
+
+	yaml := []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+spec:
+  controlPlaneEndpoint:
+    host: 1.1.1.1
+    port: 8081`)
+
+	initial := []*clusterapiv1.Cluster{
+		updatedCluster(cluster1, func(c capiCluster) {
+			c.Spec.ControlPlaneEndpoint.Port = 8080
+			c.Spec.ControlPlaneEndpoint.Host = "1.1.1.1"
+		}),
+	}
+
+	c := env.Client()
+	ctx := context.Background()
+
+	g := NewWithT(t)
+	ns := env.CreateNamespaceForTest(ctx, t)
+
+	for _, o := range initial {
+		o.SetNamespace(ns)
+
+		if err := c.Create(ctx, o); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	yaml = []byte(strings.ReplaceAll(string(yaml), "#namespace#", ns))
+
+	objs, err := clientutil.YamlToClientObjects(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, o := range objs {
+		err := serverside.UpdateObject(ctx, c, o)
+		g.Expect(err).To(MatchError(ContainSubstring("must be specified for an update")))
 	}
 }
 

--- a/pkg/networking/cilium/client.go
+++ b/pkg/networking/cilium/client.go
@@ -21,6 +21,8 @@ const (
 	// ConfigMapName is the default name for the Cilium ConfigMap
 	// containing Cilium's configuration.
 	ConfigMapName = "cilium-config"
+	// ServiceName is the default name for the Cilium Service installed in EKS-A clusters.
+	ServiceName = "cilium-agent"
 )
 
 // Client allows to interact with the Kubernetes API.

--- a/pkg/networking/cilium/reconciler/fetch.go
+++ b/pkg/networking/cilium/reconciler/fetch.go
@@ -22,12 +22,12 @@ func (p *preflightInstallation) installed() bool {
 }
 
 func getPreflightInstallation(ctx context.Context, client client.Client) (*preflightInstallation, error) {
-	ds, err := getPreflightDaemonSet(ctx, client)
+	ds, err := getDaemonSet(ctx, client, cilium.PreflightDaemonSetName)
 	if err != nil {
 		return nil, err
 	}
 
-	deployment, err := getPreflightDeployment(ctx, client)
+	deployment, err := getDeployment(ctx, client, cilium.PreflightDeploymentName)
 	if err != nil {
 		return nil, err
 	}
@@ -38,10 +38,10 @@ func getPreflightInstallation(ctx context.Context, client client.Client) (*prefl
 	}, nil
 }
 
-func getPreflightDeployment(ctx context.Context, client client.Client) (*appsv1.Deployment, error) {
+func getDeployment(ctx context.Context, client client.Client, name string) (*appsv1.Deployment, error) {
 	deployment := &appsv1.Deployment{}
 	key := types.NamespacedName{
-		Name:      cilium.PreflightDeploymentName,
+		Name:      name,
 		Namespace: constants.KubeSystemNamespace,
 	}
 	err := client.Get(ctx, key, deployment)
@@ -55,9 +55,9 @@ func getPreflightDeployment(ctx context.Context, client client.Client) (*appsv1.
 	return deployment, nil
 }
 
-func getPreflightDaemonSet(ctx context.Context, client client.Client) (*appsv1.DaemonSet, error) {
+func getDaemonSet(ctx context.Context, client client.Client, name string) (*appsv1.DaemonSet, error) {
 	ds := &appsv1.DaemonSet{}
-	key := types.NamespacedName{Name: cilium.PreflightDaemonSetName, Namespace: constants.KubeSystemNamespace}
+	key := types.NamespacedName{Name: name, Namespace: constants.KubeSystemNamespace}
 	err := client.Get(ctx, key, ds)
 	switch {
 	case apierrors.IsNotFound(err):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The new Cilium version changes the port number for `envoy-metrics` and `prometheus` but the field names remained the same. This caused "duplicate value" errors when upgrading to the new Cilium version using server-side apply because the merge key for these fields is the port number, not the name. See below:

`"err":"failed to reconcile object /v1, Kind=Service, kube-system/cilium-agent: Service \"cilium-agent\" is invalid: spec.ports[1].name: Duplicate value: \"envoy-metrics\"","errVerbose":"Service \"cilium-agent\" is invalid`

To alleviate this issue, we will use the client.Updatestrategy to update the object to be compatible with the new version of Cilium. We are only doing this for the Cilium Service, DaemonSet, and Deployment since those are the only objects affected. The rest of the objects in the Cilium upgrade manifest will continue to be applied using server-side apply.

*Testing (if applicable):*

Tested with Tilt


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

