### PR TITLE
Add DefaultCNI field to Cluster status

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -532,6 +532,19 @@ spec:
                   - type
                   type: object
                 type: array
+              defaultCNI:
+                description: information on the EKS Anywhere CNI configured
+                properties:
+                  name:
+                    description: Name of the default CNI
+                    type: string
+                  status:
+                    description: Applied, Not Applied
+                    type: string
+                  version:
+                    description: Empty if not applied or no version can be inferred.
+                    type: string
+                type: object
               eksdReleaseRef:
                 description: EksdReleaseRef defines the properties of the EKS-D object
                   on the cluster

--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -538,8 +538,8 @@ spec:
                   name:
                     description: Name of the default CNI
                     type: string
-                  status:
-                    description: Applied, Not Applied
+                  state:
+                    description: State reports the current state of the default CNI.
                     type: string
                   version:
                     description: Empty if not applied or no version can be inferred.

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -411,7 +411,9 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 		return errors.Wrap(err, "updating status for workers")
 	}
 
-	clusters.UpdateClusterStatusForCNI(ctx, cluster)
+	if err := clusters.UpdateClusterStatusForCNI(ctx, r.client, cluster); err != nil {
+		return errors.Wrap(err, "updating status for cni")
+	}
 
 	// Always update the readyCondition by summarizing the state of other conditions.
 	conditions.SetSummary(cluster,

--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -105,7 +105,8 @@ func (f *Factory) WithClusterReconciler(capiProviders []clusterctlv1.Provider, o
 	f.withTracker().
 		WithProviderClusterReconcilerRegistry(capiProviders).
 		withAWSIamConfigReconciler().
-		withPackageControllerClient()
+		withPackageControllerClient().
+		withCNIReconciler()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.reconcilers.ClusterReconciler != nil {
@@ -118,6 +119,7 @@ func (f *Factory) WithClusterReconciler(capiProviders []clusterctlv1.Provider, o
 			f.awsIamConfigReconciler,
 			clusters.NewClusterValidator(f.manager.GetClient()),
 			f.packageControllerClient,
+			f.cniReconciler,
 			opts...,
 		)
 

--- a/controllers/mocks/cluster_controller.go
+++ b/controllers/mocks/cluster_controller.go
@@ -229,3 +229,40 @@ func (mr *MockClusterValidatorMockRecorder) ValidateManagementClusterName(ctx, l
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateManagementClusterName", reflect.TypeOf((*MockClusterValidator)(nil).ValidateManagementClusterName), ctx, log, cluster)
 }
+
+// MockClusterCNIReconciler is a mock of ClusterCNIReconciler interface.
+type MockClusterCNIReconciler struct {
+	ctrl     *gomock.Controller
+	recorder *MockClusterCNIReconcilerMockRecorder
+}
+
+// MockClusterCNIReconcilerMockRecorder is the mock recorder for MockClusterCNIReconciler.
+type MockClusterCNIReconcilerMockRecorder struct {
+	mock *MockClusterCNIReconciler
+}
+
+// NewMockClusterCNIReconciler creates a new mock instance.
+func NewMockClusterCNIReconciler(ctrl *gomock.Controller) *MockClusterCNIReconciler {
+	mock := &MockClusterCNIReconciler{ctrl: ctrl}
+	mock.recorder = &MockClusterCNIReconcilerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClusterCNIReconciler) EXPECT() *MockClusterCNIReconcilerMockRecorder {
+	return m.recorder
+}
+
+// UpdateClusterStatusForCNI mocks base method.
+func (m *MockClusterCNIReconciler) UpdateClusterStatusForCNI(ctx context.Context, client client.Client, cluster *v1alpha1.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterStatusForCNI", ctx, client, cluster)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterStatusForCNI indicates an expected call of UpdateClusterStatusForCNI.
+func (mr *MockClusterCNIReconcilerMockRecorder) UpdateClusterStatusForCNI(ctx, client, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterStatusForCNI", reflect.TypeOf((*MockClusterCNIReconciler)(nil).UpdateClusterStatusForCNI), ctx, client, cluster)
+}

--- a/designs/cluster-status.md
+++ b/designs/cluster-status.md
@@ -178,8 +178,8 @@ type ClusterCNI struct {
     // +optional
     Version string`json:"version,omitempty"`
     
-    // Applied, Not Applied
-    Status string`json:"status,omitempty"`
+   	// State reports the current state of the default CNI.
+    state string`json:"state,omitempty"`
 }
 ```
 

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -893,7 +893,7 @@ type ClusterCNI struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
-	// Applied, Not Applied
+	// Status reports the current state of the default CNI.
 	Status ClusterCNIStatus `json:"status,omitempty"`
 }
 

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -870,18 +870,18 @@ const (
 	MachineInvalidReason FailureReasonType = "MachineInvalid"
 )
 
-// ClusterCNIStatus is a type for defining statuses for Cluster default cni.
-type ClusterCNIStatus string
+// ClusterCNIState is a type for defining statuses for Cluster default cni.
+type ClusterCNIState string
 
 const (
 	// ClusterCNIInitializing reports that the default CNI is initializing.
-	ClusterCNIInitializing ClusterCNIStatus = "initializing"
+	ClusterCNIInitializing ClusterCNIState = "initializing"
 
 	// ClusterCNIInstalled reports that the default CNI has been installed.
-	ClusterCNIInstalled ClusterCNIStatus = "installed"
+	ClusterCNIInstalled ClusterCNIState = "installed"
 
 	// ClusterCNIUpdating reports that the default CNI is updating.
-	ClusterCNIUpdating ClusterCNIStatus = "updating"
+	ClusterCNIUpdating ClusterCNIState = "updating"
 )
 
 // ClusterCNI represents a CNI cluster component.
@@ -893,8 +893,8 @@ type ClusterCNI struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
-	// Status reports the current state of the default CNI.
-	Status ClusterCNIStatus `json:"status,omitempty"`
+	// State reports the current state of the default CNI.
+	State ClusterCNIState `json:"state,omitempty"`
 }
 
 // ClusterStatus defines the observed state of Cluster.

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -870,6 +870,33 @@ const (
 	MachineInvalidReason FailureReasonType = "MachineInvalid"
 )
 
+// ClusterCNIStatus is a type for defining statuses for Cluster default cni.
+type ClusterCNIStatus string
+
+const (
+	// ClusterCNIInitializing reports that the default CNI is initializing.
+	ClusterCNIInitializing ClusterCNIStatus = "initializing"
+
+	// ClusterCNIInstalled reports that the default CNI has been installed.
+	ClusterCNIInstalled ClusterCNIStatus = "installed"
+
+	// ClusterCNIUpdating reports that the default CNI is updating.
+	ClusterCNIUpdating ClusterCNIStatus = "updating"
+)
+
+// ClusterCNI represents a CNI cluster component.
+type ClusterCNI struct {
+	// Name of the default CNI
+	Name string `json:"name,omitempty"`
+
+	// Empty if not applied or no version can be inferred.
+	// +optional
+	Version string `json:"version,omitempty"`
+
+	// Applied, Not Applied
+	Status ClusterCNIStatus `json:"status,omitempty"`
+}
+
 // ClusterStatus defines the observed state of Cluster.
 type ClusterStatus struct {
 	// Descriptive message about a fatal problem while reconciling a cluster
@@ -883,6 +910,11 @@ type ClusterStatus struct {
 
 	// EksdReleaseRef defines the properties of the EKS-D object on the cluster
 	EksdReleaseRef *EksdReleaseRef `json:"eksdReleaseRef,omitempty"`
+
+	// information on the EKS Anywhere CNI configured
+	// +optional
+	DefaultCNI *ClusterCNI `json:"defaultCNI,omitempty"`
+
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
 

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -11,7 +11,6 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/controller"
-	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 )
 
 // UpdateClusterStatusForControlPlane checks the current state of the Cluster's control plane and updates the
@@ -37,45 +36,6 @@ func UpdateClusterStatusForWorkers(ctx context.Context, client client.Client, cl
 	}
 
 	updateWorkersReadyCondition(cluster, machineDeployments)
-	return nil
-}
-
-// UpdateClusterStatusForCNI updates the Cluster status for the default cni before the control plane is ready. The CNI reconciler
-// handles the rest of the logic for determining the condition and updating the status based on the current state of the cluster.
-func UpdateClusterStatusForCNI(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
-	if !conditions.IsTrue(cluster, anywherev1.ControlPlaneReadyCondition) {
-		conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.ControlPlaneNotReadyReason, clusterv1.ConditionSeverityInfo, "")
-		SetClusterDefaultCNI(cluster, anywherev1.ClusterCNIInitializing, "")
-		return nil
-	}
-
-	// Self managed clusters do not use the CNI reconciler, so this status would never get resolved.
-	// TODO: Remove after self-managed clusters are created with the controller in the CLI
-	if cluster.IsSelfManaged() {
-		ciliumCfg := cluster.Spec.ClusterNetwork.CNIConfig.Cilium
-		// Though it may be installed initially to successfully create the cluster,
-		// if the CNI is configured to skip upgrades, we mark the condition as "False"
-		if !ciliumCfg.IsManaged() {
-			conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, clusterv1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades")
-			cluster.Status.DefaultCNI = nil
-			return nil
-		}
-
-		installation, err := cilium.GetInstallation(ctx, client)
-		if err != nil {
-			return err
-		}
-
-		version, err := installation.Version()
-		if err != nil {
-			dsImage := installation.DaemonSet.Spec.Template.Spec.Containers[0].Image
-			return errors.Wrapf(err, "installed cilium DS has an invalid version tag: %s", dsImage)
-		}
-		// Otherwise, since the control plane is fully ready we can assume the CNI has been configured.
-		conditions.MarkTrue(cluster, anywherev1.DefaultCNIConfiguredCondition)
-		SetClusterDefaultCNI(cluster, anywherev1.ClusterCNIInstalled, version)
-	}
-
 	return nil
 }
 
@@ -225,13 +185,4 @@ func updateWorkersReadyCondition(cluster *anywherev1.Cluster, machineDeployments
 // controlPlaneInitializationInProgressCondition returns a new "False" condition for the ControlPlaneInitializationInProgress reason.
 func controlPlaneInitializationInProgressCondition() *anywherev1.Condition {
 	return conditions.FalseCondition(anywherev1.ControlPlaneInitializedCondition, anywherev1.ControlPlaneInitializationInProgressReason, clusterv1.ConditionSeverityInfo, "The first control plane instance is not available yet")
-}
-
-// SetClusterDefaultCNI sets the DefaultCNI for the Cluster status.
-func SetClusterDefaultCNI(cluster *anywherev1.Cluster, status anywherev1.ClusterCNIStatus, version string) {
-	cluster.Status.DefaultCNI = &anywherev1.ClusterCNI{
-		Name:    "cilium",
-		Version: version,
-		Status:  status,
-	}
 }

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -2,9 +2,13 @@ package clusters_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -18,10 +22,54 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller/clusters"
+	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
 const controlPlaneInitalizationInProgressReason = "The first control plane instance is not available yet"
+
+func ciliumDaemonSet(name string, image string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "cilium",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "cilium",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  name,
+							Image: image,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func defaultCNI(status anywherev1.ClusterCNIStatus, version string) *anywherev1.ClusterCNI {
+	return &anywherev1.ClusterCNI{
+		Name:    "cilium",
+		Version: version,
+		Status:  status,
+	}
+}
 
 func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 	g := NewWithT(t)
@@ -692,22 +740,20 @@ func TestUpdateClusterStatusForCNI(t *testing.T) {
 	g := NewWithT(t)
 
 	tests := []struct {
-		name          string
-		spec          *cluster.Spec
-		conditions    []anywherev1.Condition
-		wantCondition *anywherev1.Condition
-		skipUpgrade   *bool
-		wantErr       string
+		name           string
+		conditions     []anywherev1.Condition
+		wantDefaultCNI *anywherev1.ClusterCNI
+		wantCondition  *anywherev1.Condition
 	}{
 		{
-			name:        "control plane is not ready",
-			skipUpgrade: ptr.Bool(false),
+			name: "control plane is not ready",
 			conditions: []anywherev1.Condition{
 				{
 					Type:   anywherev1.ControlPlaneReadyCondition,
 					Status: "False",
 				},
 			},
+			wantDefaultCNI: defaultCNI(anywherev1.ClusterCNIInitializing, ""),
 			wantCondition: &anywherev1.Condition{
 				Type:     anywherev1.DefaultCNIConfiguredCondition,
 				Reason:   anywherev1.ControlPlaneNotReadyReason,
@@ -716,34 +762,137 @@ func TestUpdateClusterStatusForCNI(t *testing.T) {
 			},
 		},
 		{
-			name:        "cilium is unmanaged",
-			skipUpgrade: ptr.Bool(true),
+			name: "control plane ready",
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneReadyCondition,
+					Status: "True",
+				},
+				{
+					Type:     anywherev1.DefaultCNIConfiguredCondition,
+					Reason:   anywherev1.ControlPlaneNotReadyReason,
+					Status:   "False",
+					Severity: clusterv1.ConditionSeverityInfo,
+				},
+			},
+			wantDefaultCNI: nil,
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.DefaultCNIConfiguredCondition,
+				Reason:   anywherev1.ControlPlaneNotReadyReason,
+				Status:   "False",
+				Severity: clusterv1.ConditionSeverityInfo,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			spec := test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Name = "test-cluster"
+				s.Cluster.Spec.ManagementCluster = anywherev1.ManagementCluster{Name: "management-cluster"}
+				s.Cluster.Status.Conditions = tt.conditions
+			})
+
+			client := fake.NewClientBuilder().Build()
+
+			err := clusters.UpdateClusterStatusForCNI(ctx, client, spec.Cluster)
+			g.Expect(err).To(BeNil())
+
+			if tt.wantCondition != nil {
+				condition := conditions.Get(spec.Cluster, tt.wantCondition.Type)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Type).To(Equal(tt.wantCondition.Type))
+				g.Expect(condition.Severity).To(Equal(tt.wantCondition.Severity))
+				g.Expect(condition.Status).To(Equal(tt.wantCondition.Status))
+				g.Expect(condition.Reason).To(Equal(tt.wantCondition.Reason))
+				g.Expect(condition.Message).To(ContainSubstring(tt.wantCondition.Message))
+			}
+		})
+	}
+}
+
+func TestUpdateClusterStatusForCNISelfManagedCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	ciliumVersion := "v1.10.1-eksa-1"
+	ciliumImage := fmt.Sprintf("cilium:%s", ciliumVersion)
+
+	tests := []struct {
+		name            string
+		conditions      []anywherev1.Condition
+		ciliumDaemonSet *appsv1.DaemonSet
+		wantDefaultCNI  *anywherev1.ClusterCNI
+		wantCondition   *anywherev1.Condition
+		skipUpgrade     *bool
+		wantErr         string
+	}{
+		{
+			name:            "cilium is unmanaged",
+			skipUpgrade:     ptr.Bool(true),
+			ciliumDaemonSet: ciliumDaemonSet(cilium.DaemonSetName, ciliumImage),
 			conditions: []anywherev1.Condition{
 				{
 					Type:   anywherev1.ControlPlaneReadyCondition,
 					Status: "True",
 				},
 			},
+			wantDefaultCNI: nil,
 			wantCondition: &anywherev1.Condition{
 				Type:     anywherev1.DefaultCNIConfiguredCondition,
 				Reason:   anywherev1.SkipUpgradesForDefaultCNIConfiguredReason,
 				Status:   "False",
 				Severity: clusterv1.ConditionSeverityWarning,
 			},
+			wantErr: "",
 		},
 		{
-			name:        "cilium is managed",
-			skipUpgrade: ptr.Bool(false),
+			name:            "cilium is managed",
+			skipUpgrade:     ptr.Bool(false),
+			ciliumDaemonSet: ciliumDaemonSet(cilium.DaemonSetName, ciliumImage),
 			conditions: []anywherev1.Condition{
 				{
 					Type:   anywherev1.ControlPlaneReadyCondition,
 					Status: "True",
 				},
 			},
+			wantDefaultCNI: defaultCNI(anywherev1.ClusterCNIInstalled, ciliumVersion),
 			wantCondition: &anywherev1.Condition{
 				Type:   anywherev1.DefaultCNIConfiguredCondition,
 				Status: "True",
 			},
+			wantErr: "",
+		},
+		{
+			name:            "cilium is managed",
+			skipUpgrade:     ptr.Bool(false),
+			ciliumDaemonSet: ciliumDaemonSet(cilium.DaemonSetName, ciliumImage),
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneReadyCondition,
+					Status: "True",
+				},
+			},
+			wantDefaultCNI: defaultCNI(anywherev1.ClusterCNIInstalled, ciliumVersion),
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.DefaultCNIConfiguredCondition,
+				Status: "True",
+			},
+			wantErr: "",
+		},
+		{
+			name:            "cilium is managed, version cilium installed version",
+			skipUpgrade:     ptr.Bool(false),
+			ciliumDaemonSet: ciliumDaemonSet(cilium.DaemonSetName, "cilium:eksa-invalid-version"),
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneReadyCondition,
+					Status: "True",
+				},
+			},
+			wantDefaultCNI: defaultCNI(anywherev1.ClusterCNIInstalled, ciliumVersion),
+			wantCondition:  nil,
+			wantErr:        "installed cilium DS has an invalid version tag",
 		},
 	}
 
@@ -764,9 +913,14 @@ func TestUpdateClusterStatusForCNI(t *testing.T) {
 				s.Cluster.Status.Conditions = tt.conditions
 			})
 
-			clusters.UpdateClusterStatusForCNI(ctx, spec.Cluster)
+			client := fake.NewClientBuilder().WithRuntimeObjects(tt.ciliumDaemonSet).Build()
 
-			if tt.wantCondition != nil {
+			err := clusters.UpdateClusterStatusForCNI(ctx, client, spec.Cluster)
+
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).To(BeNil())
 				condition := conditions.Get(spec.Cluster, tt.wantCondition.Type)
 				g.Expect(condition).ToNot(BeNil())
 				g.Expect(condition.Type).To(Equal(tt.wantCondition.Type))

--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -36,12 +36,17 @@ func (i Installation) Version() (string, error) {
 
 	dsImage := i.DaemonSet.Spec.Template.Spec.Containers[0].Image
 	_, dsImageTag := oci.Split(dsImage)
-	version, err := semver.New(dsImageTag)
+	semVer, err := semver.New(dsImageTag)
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("v%d.%d.%d-%s", version.Major, version.Minor, version.Patch, version.Prerelease), nil
+	version := fmt.Sprintf("v%d.%d.%d", semVer.Major, semVer.Minor, semVer.Patch)
+	if semVer.Prerelease != "" {
+		version = fmt.Sprintf("%s-%s", version, semVer.Prerelease)
+	}
+
+	return version, nil
 }
 
 // Installed determines if all EKS-A Embedded Cilium components are present. It identifies

--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -2,7 +2,6 @@ package cilium
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -12,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/aws/eks-anywhere/pkg/utils/oci"
 )
 
@@ -29,24 +27,14 @@ type Installation struct {
 }
 
 // Version returns the version of the cilium Installation.
-func (i Installation) Version() (string, error) {
+func (i Installation) Version() string {
 	if i.DaemonSet == nil {
-		return "", nil
+		return ""
 	}
 
 	dsImage := i.DaemonSet.Spec.Template.Spec.Containers[0].Image
 	_, dsImageTag := oci.Split(dsImage)
-	semVer, err := semver.New(dsImageTag)
-	if err != nil {
-		return "", err
-	}
-
-	version := fmt.Sprintf("v%d.%d.%d", semVer.Major, semVer.Minor, semVer.Patch)
-	if semVer.Prerelease != "" {
-		version = fmt.Sprintf("%s-%s", version, semVer.Prerelease)
-	}
-
-	return version, nil
+	return dsImageTag
 }
 
 // Installed determines if all EKS-A Embedded Cilium components are present. It identifies

--- a/pkg/networking/cilium/installation_test.go
+++ b/pkg/networking/cilium/installation_test.go
@@ -79,3 +79,36 @@ func TestInstallationInstalled(t *testing.T) {
 		})
 	}
 }
+
+func TestInstallationVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		installation cilium.Installation
+		want         string
+	}{
+		{
+			name: "installed",
+			installation: cilium.Installation{
+				DaemonSet: &appsv1.DaemonSet{
+					Spec: appsv1.DaemonSetSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{Image: "public.ecr.aws/isovalent/cilium:v1.11.15-eksa.1"},
+								},
+							},
+						},
+					},
+				},
+				Operator: &appsv1.Deployment{},
+			},
+			want: "v1.11.15-eksa.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.installation.Version()).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/networking/cilium/installation_test.go
+++ b/pkg/networking/cilium/installation_test.go
@@ -85,7 +85,6 @@ func TestInstallationVersion(t *testing.T) {
 		name         string
 		installation cilium.Installation
 		want         string
-		wantErr      string
 	}{
 		{
 			name: "no cilium daemon set, no version",
@@ -93,8 +92,7 @@ func TestInstallationVersion(t *testing.T) {
 				DaemonSet: nil,
 				Operator:  &appsv1.Deployment{},
 			},
-			want:    "",
-			wantErr: "",
+			want: "",
 		},
 		{
 			name: "repository, cilium and version",
@@ -112,8 +110,7 @@ func TestInstallationVersion(t *testing.T) {
 				},
 				Operator: &appsv1.Deployment{},
 			},
-			want:    "v1.11.15-eksa.1",
-			wantErr: "",
+			want: "v1.11.15-eksa.1",
 		},
 		{
 			name: "cilium and version",
@@ -131,8 +128,7 @@ func TestInstallationVersion(t *testing.T) {
 				},
 				Operator: &appsv1.Deployment{},
 			},
-			want:    "v1.11.15-eksa.1",
-			wantErr: "",
+			want: "v1.11.15-eksa.1",
 		},
 		{
 			name: "cilium and version only, no pre-release",
@@ -150,8 +146,7 @@ func TestInstallationVersion(t *testing.T) {
 				},
 				Operator: &appsv1.Deployment{},
 			},
-			want:    "v1.11.15",
-			wantErr: "",
+			want: "v1.11.15",
 		},
 		{
 			name: "invalid semver",
@@ -169,20 +164,14 @@ func TestInstallationVersion(t *testing.T) {
 				},
 				Operator: &appsv1.Deployment{},
 			},
-			want:    "",
-			wantErr: "invalid major version in semver",
+			want: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			version, err := tt.installation.Version()
-			if tt.wantErr != "" {
-				g.Expect(err).To(MatchError(ContainSubstring("")))
-			} else {
-				g.Expect(err).To(BeNil())
-				g.Expect(version).To(Equal(tt.want))
-			}
+			version := tt.installation.Version()
+			g.Expect(version).To(Equal(tt.want))
 		})
 	}
 }

--- a/pkg/networking/cilium/reconciler/reconciler.go
+++ b/pkg/networking/cilium/reconciler/reconciler.go
@@ -105,7 +105,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, logger logr.Logger, client c
 
 		version, err := installation.Version()
 		if err != nil {
-			return controller.Result{}, err
+			dsImage := installation.DaemonSet.Spec.Template.Spec.Containers[0].Image
+			return controller.Result{}, errors.Wrapf(err, "installed cilium DS has an invalid version tag: %s", dsImage)
 		}
 
 		clusters.SetClusterDefaultCNI(spec.Cluster, anywherev1.ClusterCNIInstalled, version)

--- a/pkg/networking/cilium/reconciler/reconciler_test.go
+++ b/pkg/networking/cilium/reconciler/reconciler_test.go
@@ -46,7 +46,8 @@ func TestReconcilerReconcileInstall(t *testing.T) {
 	tt.expectDaemonSetSemanticallyEqual(ds)
 	tt.expectOperatorSemanticallyEqual(operator)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIInstalled)))
 }
 
 func TestReconcilerReconcileInstallErrorGeneratingManifest(t *testing.T) {
@@ -79,7 +80,8 @@ func TestReconcilerReconcileAlreadyUpToDate(t *testing.T) {
 	tt.expectDaemonSetSemanticallyEqual(ds)
 	tt.expectOperatorSemanticallyEqual(operator)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIInstalled)))
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflight(t *testing.T) {
@@ -104,7 +106,8 @@ func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflight(t *testing.T) {
 	tt.expectDSToNotExist(preflightDS.Name, preflightDS.Namespace)
 	tt.expectDeploymentToNotExist(preflightDeployment.Name, preflightDeployment.Namespace)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIInstalled)))
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorFromTemplater(t *testing.T) {
@@ -160,7 +163,8 @@ func TestReconcilerReconcileUpgradeButCiliumDaemonSetNotReady(t *testing.T) {
 	)
 
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIUpdating)))
 }
 
 func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDaemonSetNotAvailable(t *testing.T) {
@@ -182,7 +186,8 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDaemonSetNotAvailab
 		Equal(controller.ResultWithRequeue(10 * time.Second)),
 	)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIUpdating)))
 }
 
 func TestReconcilerReconcileUpgradeErrorGeneratingPreflight(t *testing.T) {
@@ -225,7 +230,8 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDeploymentNotAvaila
 		Equal(controller.ResultWithRequeue(10 * time.Second)),
 	)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIUpdating)))
 }
 
 func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightNotReady(t *testing.T) {
@@ -248,7 +254,8 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightNotReady(t *testing
 		Equal(controller.ResultWithRequeue(10 * time.Second)),
 	)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIUpdating)))
 }
 
 func TestReconcilerReconcileUpgradePreflightDaemonSetNotReady(t *testing.T) {
@@ -268,7 +275,8 @@ func TestReconcilerReconcileUpgradePreflightDaemonSetNotReady(t *testing.T) {
 		Equal(controller.ResultWithRequeue(10 * time.Second)),
 	)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIUpdating)))
 }
 
 func TestReconcilerReconcileUpgradePreflightDeploymentSetNotReady(t *testing.T) {
@@ -290,7 +298,8 @@ func TestReconcilerReconcileUpgradePreflightDeploymentSetNotReady(t *testing.T) 
 		Equal(controller.ResultWithRequeue(10 * time.Second)),
 	)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.DefaultCNIUpgradeInProgressReason, v1beta1.ConditionSeverityInfo, "Cilium version upgrade needed"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIUpdating)))
 }
 
 func TestReconcilerReconcileUpgradeInvalidCiliumInstalledVersion(t *testing.T) {
@@ -407,7 +416,8 @@ func TestReconcilerReconcileUpgradePreflightReady(t *testing.T) {
 	tt.Expect(tt.reconciler.Reconcile(tt.ctx, test.NewNullLogger(), tt.client, tt.spec)).To(
 		Equal(controller.Result{}),
 	)
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIInstalled)))
 }
 
 func TestReconcilerReconcileUpdateConfigConfigMapEnablePolicyChange(t *testing.T) {
@@ -436,7 +446,8 @@ func TestReconcilerReconcileUpdateConfigConfigMapEnablePolicyChange(t *testing.T
 	tt.Expect(tt.reconciler.Reconcile(tt.ctx, test.NewNullLogger(), tt.client, tt.spec)).To(
 		Equal(controller.Result{}),
 	)
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIInstalled)))
 }
 
 func TestReconcilerReconcileSkipUpgradeWithoutCiliumInstalled(t *testing.T) {
@@ -463,7 +474,8 @@ func TestReconcilerReconcileSkipUpgradeWithoutCiliumInstalled(t *testing.T) {
 	tt.expectDaemonSetSemanticallyEqual(ds)
 	tt.expectOperatorSemanticallyEqual(operator)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("True", "", "", ""))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(Equal(defaultCNI(anywherev1.ClusterCNIInstalled)))
 }
 
 func TestReconcilerReconcileSkipUpgradeWithCiliumInstalled(t *testing.T) {
@@ -486,7 +498,8 @@ func TestReconcilerReconcileSkipUpgradeWithCiliumInstalled(t *testing.T) {
 	tt.expectDaemonSetSemanticallyEqual(ds)
 	tt.expectOperatorSemanticallyEqual(operator)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, v1beta1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, v1beta1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(BeNil())
 }
 
 func TestReconcilerReconcileSkipUpgradeWithAnnotationWithoutCilium(t *testing.T) {
@@ -506,7 +519,8 @@ func TestReconcilerReconcileSkipUpgradeWithAnnotationWithoutCilium(t *testing.T)
 		Equal(controller.Result{}),
 	)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, v1beta1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, v1beta1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(BeNil())
 }
 
 func TestReconcilerReconcileSkipUpgradeWithAnnotationWithCilium(t *testing.T) {
@@ -538,7 +552,8 @@ func TestReconcilerReconcileSkipUpgradeWithAnnotationWithCilium(t *testing.T) {
 	tt.expectDaemonSetSemanticallyEqual(ds)
 	tt.expectOperatorSemanticallyEqual(operator)
 	tt.expectCiliumInstalledAnnotation()
-	tt.expectDefaultCNIConfigured(defaultCNIConfiguredCondition("False", anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, v1beta1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades"))
+	tt.expectDefaultCNIConfiguredCondition(defaultCNIConfiguredCondition("False", anywherev1.SkipUpgradesForDefaultCNIConfiguredReason, v1beta1.ConditionSeverityWarning, "Configured to skip default Cilium CNI upgrades"))
+	tt.Expect(tt.spec.Cluster.Status.DefaultCNI).To(BeNil())
 }
 
 type reconcileTest struct {
@@ -708,7 +723,7 @@ func (tt *reconcileTest) expectOperatorSemanticallyEqual(wantOperator *appsv1.De
 	)
 }
 
-func (tt *reconcileTest) expectDefaultCNIConfigured(wantCondition *anywherev1.Condition) {
+func (tt *reconcileTest) expectDefaultCNIConfiguredCondition(wantCondition *anywherev1.Condition) {
 	tt.t.Helper()
 	condition := conditions.Get(tt.spec.Cluster, anywherev1.DefaultCNIConfiguredCondition)
 	tt.Expect(condition).ToNot(BeNil(), "missing defaultcniconfigured condition")
@@ -741,6 +756,14 @@ func buildManifest(g *WithT, objs ...client.Object) []byte {
 	}
 
 	return templater.AppendYamlResources(manifests...)
+}
+
+func defaultCNI(status anywherev1.ClusterCNIStatus) *anywherev1.ClusterCNI {
+	return &anywherev1.ClusterCNI{
+		Name:    "cilium",
+		Version: "v1.10.1-eksa-1",
+		Status:  status,
+	}
 }
 
 func ciliumDaemonSet() *appsv1.DaemonSet {

--- a/pkg/networking/reconciler/mocks/reconcilers.go
+++ b/pkg/networking/reconciler/mocks/reconcilers.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	cluster "github.com/aws/eks-anywhere/pkg/cluster"
 	controller "github.com/aws/eks-anywhere/pkg/controller"
 	logr "github.com/go-logr/logr"
@@ -51,4 +52,18 @@ func (m *MockCiliumReconciler) Reconcile(ctx context.Context, logger logr.Logger
 func (mr *MockCiliumReconcilerMockRecorder) Reconcile(ctx, logger, client, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockCiliumReconciler)(nil).Reconcile), ctx, logger, client, spec)
+}
+
+// UpdateClusterStatusForCNI mocks base method.
+func (m *MockCiliumReconciler) UpdateClusterStatusForCNI(ctx context.Context, client client.Client, cluster *v1alpha1.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterStatusForCNI", ctx, client, cluster)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterStatusForCNI indicates an expected call of UpdateClusterStatusForCNI.
+func (mr *MockCiliumReconcilerMockRecorder) UpdateClusterStatusForCNI(ctx, client, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterStatusForCNI", reflect.TypeOf((*MockCiliumReconciler)(nil).UpdateClusterStatusForCNI), ctx, client, cluster)
 }

--- a/pkg/networking/reconciler/reconciler.go
+++ b/pkg/networking/reconciler/reconciler.go
@@ -7,12 +7,14 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/controller"
 )
 
 type CiliumReconciler interface {
 	Reconcile(ctx context.Context, logger logr.Logger, client client.Client, spec *cluster.Spec) (controller.Result, error)
+	UpdateClusterStatusForCNI(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error
 }
 
 type Reconciler struct {
@@ -35,4 +37,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, logger logr.Logger, client c
 	} else {
 		return controller.Result{}, errors.New("unsupported CNI, only Cilium is supported at this time")
 	}
+}
+
+// UpdateClusterStatusForCNI updates the Cluster status for the default cni before the control plane is ready. The CNI reconciler
+// handles the rest of the logic for determining the condition and updating the status based on the current state of the cluster.
+func (r *Reconciler) UpdateClusterStatusForCNI(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
+	if cluster.Spec.ClusterNetwork.CNIConfig.Cilium != nil {
+		return r.ciliumReconciler.UpdateClusterStatusForCNI(ctx, client, cluster)
+	}
+
+	return errors.New("unsupported CNI, only Cilium is supported at this time")
 }


### PR DESCRIPTION
Issue #, if available:
 #5628 

Description of changes:
Changes to the Cluster status as per the the proposal [here](https://github.com/aws/eks-anywhere/pull/6005):
- Added DefaultCNI field

It also includes a fix for the `DefaultCNIConfigured` condition, where when a workload cluster control plane is upgraded, it is marked "False" with the `ControlPlaneNotReady`. It is not re-evaluated after the control plane becomes ready, as the controller stops reconciling before then. So, this PR addresses the issue by removing the condition update's dependency on `ControlPlaneReady`. We only need to change this status when there is a. change in the state of the CNI detected.

Testing (if applicable):
- Unit testing
- Manual testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

