### PR TITLE
Refactor WorkerNodeGroupConfiguration slice comparison

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -408,43 +407,49 @@ type WorkerNodeGroupConfiguration struct {
 	UpgradeRolloutStrategy *WorkerNodesUpgradeRolloutStrategy `json:"upgradeRolloutStrategy,omitempty"`
 }
 
-func generateWorkerNodeGroupKey(c WorkerNodeGroupConfiguration) (key string) {
-	key = c.Name
-	if c.MachineGroupRef != nil {
-		key += c.MachineGroupRef.Kind + c.MachineGroupRef.Name
+// Equal compares two WorkerNodeGroupConfigurations.
+func (w WorkerNodeGroupConfiguration) Equal(other WorkerNodeGroupConfiguration) bool {
+	return w.Name == other.Name &&
+		intPtrEqual(w.Count, other.Count) &&
+		w.AutoScalingConfiguration.Equal(other.AutoScalingConfiguration) &&
+		w.MachineGroupRef.Equal(other.MachineGroupRef) &&
+		TaintsSliceEqual(w.Taints, other.Taints) &&
+		MapEqual(w.Labels, other.Labels) &&
+		w.UpgradeRolloutStrategy.Equal(other.UpgradeRolloutStrategy)
+}
+
+func intPtrEqual(a, b *int) bool {
+	if a == b {
+		return true
 	}
-	if c.AutoScalingConfiguration != nil {
-		key += "autoscaling" + strconv.Itoa(c.AutoScalingConfiguration.MaxCount) + strconv.Itoa(c.AutoScalingConfiguration.MinCount)
+
+	if a == nil || b == nil {
+		return false
 	}
-	if c.Count == nil {
-		return "nil" + key
-	}
-	return strconv.Itoa(*c.Count) + key
+
+	return *a == *b
 }
 
 func WorkerNodeGroupConfigurationsSliceEqual(a, b []WorkerNodeGroupConfiguration) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	m := make(map[string]int, len(a))
-	for _, v := range a {
-		m[generateWorkerNodeGroupKey(v)]++
+
+	m := make(map[string]WorkerNodeGroupConfiguration, len(a))
+	for _, w := range a {
+		m[w.Name] = w
 	}
-	for _, v := range b {
-		k := generateWorkerNodeGroupKey(v)
-		if _, ok := m[k]; !ok {
+	for _, wb := range b {
+		wa, ok := m[wb.Name]
+		if !ok {
 			return false
 		}
-		m[k] -= 1
-		if m[k] == 0 {
-			delete(m, k)
+		if !wb.Equal(wa) {
+			return false
 		}
 	}
-	if len(m) != 0 {
-		return false
-	}
 
-	return WorkerNodeGroupConfigurationSliceTaintsEqual(a, b) && WorkerNodeGroupConfigurationsLabelsMapEqual(a, b)
+	return true
 }
 
 func WorkerNodeGroupConfigurationSliceTaintsEqual(a, b []WorkerNodeGroupConfiguration) bool {
@@ -1133,6 +1138,19 @@ type AutoScalingConfiguration struct {
 	MaxCount int `json:"maxCount,omitempty"`
 }
 
+// Equal compares two AutoScalingConfigurations.
+func (a *AutoScalingConfiguration) Equal(other *AutoScalingConfiguration) bool {
+	if a == other {
+		return true
+	}
+
+	if a == nil || other == nil {
+		return false
+	}
+
+	return a.MaxCount == other.MaxCount && a.MinCount == other.MinCount
+}
+
 // ControlPlaneUpgradeRolloutStrategy indicates rollout strategy for cluster.
 type ControlPlaneUpgradeRolloutStrategy struct {
 	Type          string                          `json:"type,omitempty"`
@@ -1148,6 +1166,19 @@ type ControlPlaneRollingUpdateParams struct {
 type WorkerNodesUpgradeRolloutStrategy struct {
 	Type          string                         `json:"type,omitempty"`
 	RollingUpdate WorkerNodesRollingUpdateParams `json:"rollingUpdate,omitempty"`
+}
+
+// Equal compares two WorkerNodesUpgradeRolloutStrategies.
+func (w *WorkerNodesUpgradeRolloutStrategy) Equal(other *WorkerNodesUpgradeRolloutStrategy) bool {
+	if w == other {
+		return true
+	}
+
+	if w == nil || other == nil {
+		return false
+	}
+
+	return w.Type == other.Type && w.RollingUpdate == other.RollingUpdate
 }
 
 // WorkerNodesRollingUpdateParams is API for rolling update strategy knobs.


### PR DESCRIPTION
*Description of changes:*
Since Name is now required, we can use is as the key for the comparison lookup and stop relying on "serialization" for the compare logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

