### PR TITLE
Remove dependency on envtest from api package

### DIFF
--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook_test.go
@@ -1,13 +1,11 @@
 package v1alpha1_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/eks-anywhere/internal/test/envtest"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 )
@@ -94,12 +92,6 @@ func TestNutanixDatacenterConfigWebhooksValidateDelete(t *testing.T) {
 	g.Expect(dcConf.ValidateDelete()).To(Succeed())
 }
 
-func TestNutanixDatacenterConfigSetupWebhookWithManager(t *testing.T) {
-	g := NewWithT(t)
-	dcConf := nutanixDatacenterConfig()
-	g.Expect(dcConf.SetupWebhookWithManager(env.Manager())).To(Succeed())
-}
-
 func nutanixDatacenterConfig() *v1alpha1.NutanixDatacenterConfig {
 	return &v1alpha1.NutanixDatacenterConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -114,10 +106,4 @@ func nutanixDatacenterConfig() *v1alpha1.NutanixDatacenterConfig {
 			},
 		},
 	}
-}
-
-var env *envtest.Environment
-
-func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
 }

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
@@ -8,7 +8,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
@@ -318,13 +317,6 @@ func TestValidateUpdate_OldObjectNotMachineConfig(t *testing.T) {
 	newConfig := nutanixMachineConfig()
 	err := newConfig.ValidateUpdate(oldConfig)
 	g.Expect(err).To(HaveOccurred())
-}
-
-func TestNutanixMachineConfigSetupWebhookWithManager(t *testing.T) {
-	t.Setenv(features.FullLifecycleAPIEnvVar, "true")
-	g := NewWithT(t)
-	conf := nutanixMachineConfig()
-	g.Expect(conf.SetupWebhookWithManager(env.Manager())).To(Succeed())
 }
 
 func TestNutanixMachineConfigWebhooksValidateDelete(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
envtest was only being used to test the "setup with manager" method of some webhooks. There is no actual logic there, it's just boilerplate, so the benefit of unit testing it is minimal. However, adding envtest makes testing the package quite slower (from the milisecond range to 6s).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

