### PR TITLE
Modular k8s upgrade BuildSpec

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deprecated_importimages.go
+++ b/cmd/eksctl-anywhere/cmd/deprecated_importimages.go
@@ -76,7 +76,7 @@ func importImages(ctx context.Context, clusterSpecPath string) error {
 
 	de := executables.BuildDockerExecutable()
 
-	bundle := clusterSpec.VersionsBundle
+	bundle := clusterSpec.ControlPlaneVersionsBundle()
 	executableBuilder, closer, err := executables.InitInDockerExecutablesBuilder(ctx, bundle.Eksa.CliTools.VersionedImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)

--- a/cmd/eksctl-anywhere/cmd/listovas.go
+++ b/cmd/eksctl-anywhere/cmd/listovas.go
@@ -65,8 +65,18 @@ func listOvas(context context.Context, clusterSpecPath, bundlesOverride string) 
 		return err
 	}
 
-	bundle := clusterSpec.VersionsBundle
+	for _, version := range clusterSpec.Cluster.KubernetesVersions() {
+		bundle := clusterSpec.VersionsBundle(version)
+		err := printOvas(bundle)
+		if err != nil {
+			return err
+		}
+	}
 
+	return nil
+}
+
+func printOvas(bundle *cluster.VersionsBundle) error {
 	titler := cases.Title(language.English)
 	for _, ova := range bundle.Ovas() {
 		if strings.Contains(ova.URI, string(eksav1alpha1.Bottlerocket)) {
@@ -85,7 +95,6 @@ func listOvas(context context.Context, clusterSpecPath, bundlesOverride string) 
 		}
 		fmt.Println(yamlIndent(2, string(yamlOutput)))
 	}
-
 	return nil
 }
 

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -103,7 +103,11 @@ func (c clusterOptions) mountDirs() []string {
 }
 
 func readClusterSpec(clusterConfigPath string, cliVersion version.Info, opts ...cluster.FileSpecBuilderOpt) (*cluster.Spec, error) {
-	b := cluster.NewFileSpecBuilder(files.NewReader(), cliVersion, opts...)
+	b := cluster.NewFileSpecBuilder(
+		files.NewReader(files.WithEKSAUserAgent("cli", cliVersion.GitVersion)),
+		cliVersion,
+		opts...,
+	)
 	return b.Build(clusterConfigPath)
 }
 

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -38,14 +38,17 @@ func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
 				Name: "fluxTestCluster",
 			},
 			Spec: v1alpha1.ClusterSpec{
+				KubernetesVersion:             "1.19",
 				WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{{}},
 				EksaVersion:                   &version,
 			},
 		},
 	}
-	s.VersionsBundle = &cluster.VersionsBundle{
-		VersionsBundle: &releasev1alpha1.VersionsBundle{},
-		KubeDistro:     &cluster.KubeDistro{},
+	s.VersionsBundles = map[v1alpha1.KubernetesVersion]*cluster.VersionsBundle{
+		v1alpha1.Kube119: {
+			VersionsBundle: &releasev1alpha1.VersionsBundle{},
+			KubeDistro:     &cluster.KubeDistro{},
+		},
 	}
 	s.Bundles = &releasev1alpha1.Bundles{}
 	s.EKSARelease = EKSARelease()
@@ -83,7 +86,7 @@ func NewClusterSpecForConfig(tb testing.TB, config *cluster.Config) *cluster.Spe
 	spec, err := cluster.NewSpec(
 		config,
 		Bundles(tb),
-		EksdRelease(),
+		EksdReleases(),
 		EKSARelease(),
 	)
 	if err != nil {

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -10,6 +10,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -53,8 +54,48 @@ func EKSARelease() *releasev1.EKSARelease {
 	}
 }
 
+// EksdReleases returns a test release slice for unit testing.
+func EksdReleases() []eksdv1.Release {
+	return []eksdv1.Release{
+		*EksdRelease("1-19"),
+		*EksdRelease("1-22"),
+		*EksdRelease("1-24"),
+	}
+}
+
+// VersionsBundlesMap returns a test VersionsBundle map for unit testing.
+func VersionsBundlesMap() map[anywherev1.KubernetesVersion]*cluster.VersionsBundle {
+	return map[anywherev1.KubernetesVersion]*cluster.VersionsBundle{
+		anywherev1.Kube118: VersionBundle(),
+		anywherev1.Kube119: VersionBundle(),
+		anywherev1.Kube120: VersionBundle(),
+		anywherev1.Kube121: VersionBundle(),
+		anywherev1.Kube122: VersionBundle(),
+		anywherev1.Kube123: VersionBundle(),
+		anywherev1.Kube124: VersionBundle(),
+	}
+}
+
+// VersionBundle returns a test VersionsBundle struct for unit testing.
+func VersionBundle() *cluster.VersionsBundle {
+	return &cluster.VersionsBundle{
+		VersionsBundle: &releasev1.VersionsBundle{
+			Eksa: releasev1.EksaBundle{
+				DiagnosticCollector: releasev1.Image{
+					URI: "public.ecr.aws/eks-anywhere/diagnostic-collector:v0.9.1-eks-a-10",
+				},
+			},
+		},
+		KubeDistro: &cluster.KubeDistro{
+			AwsIamAuthImage: releasev1.Image{
+				URI: "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-11",
+			},
+		},
+	}
+}
+
 // EksdRelease returns a test release struct for unit testing.
-func EksdRelease() *eksdv1.Release {
+func EksdRelease(channel string) *eksdv1.Release {
 	return &eksdv1.Release{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Release",
@@ -65,7 +106,8 @@ func EksdRelease() *eksdv1.Release {
 			Namespace: "eksa-system",
 		},
 		Spec: eksdv1.ReleaseSpec{
-			Number: 1,
+			Number:  1,
+			Channel: channel,
 		},
 		Status: eksdv1.ReleaseStatus{
 			Components: []eksdv1.Component{
@@ -139,7 +181,7 @@ func Bundle() *releasev1.Bundles {
 					KubeVersion: "1.19",
 					EksD: releasev1.EksDRelease{
 						Name:           "test",
-						EksDReleaseUrl: "testdata/release.yaml",
+						EksDReleaseUrl: "embed:///testdata/release.yaml",
 						KubeVersion:    "1.19",
 					},
 					CertManager:                releasev1.CertManagerBundle{},
@@ -161,7 +203,7 @@ func Bundle() *releasev1.Bundles {
 					KubeVersion: "1.22",
 					EksD: releasev1.EksDRelease{
 						Name:           "test",
-						EksDReleaseUrl: "testdata/release.yaml",
+						EksDReleaseUrl: "embed:///testdata/release.yaml",
 						KubeVersion:    "1.22",
 					},
 					CertManager:                releasev1.CertManagerBundle{},
@@ -171,6 +213,32 @@ func Bundle() *releasev1.Bundles {
 					VSphere:                    releasev1.VSphereBundle{},
 					Docker:                     releasev1.DockerBundle{},
 					Eksa:                       releasev1.EksaBundle{},
+					Cilium:                     releasev1.CiliumBundle{},
+					Kindnetd:                   releasev1.KindnetdBundle{},
+					Flux:                       releasev1.FluxBundle{},
+					BottleRocketHostContainers: releasev1.BottlerocketHostContainersBundle{},
+					ExternalEtcdBootstrap:      releasev1.EtcdadmBootstrapBundle{},
+					ExternalEtcdController:     releasev1.EtcdadmControllerBundle{},
+					Tinkerbell:                 releasev1.TinkerbellBundle{},
+				},
+				{
+					KubeVersion: "1.24",
+					EksD: releasev1.EksDRelease{
+						Name:           "test",
+						EksDReleaseUrl: "embed:///testdata/release.yaml",
+						KubeVersion:    "1.22",
+					},
+					CertManager:  releasev1.CertManagerBundle{},
+					ClusterAPI:   releasev1.CoreClusterAPI{},
+					Bootstrap:    releasev1.KubeadmBootstrapBundle{},
+					ControlPlane: releasev1.KubeadmControlPlaneBundle{},
+					VSphere:      releasev1.VSphereBundle{},
+					Docker:       releasev1.DockerBundle{},
+					Eksa: releasev1.EksaBundle{
+						DiagnosticCollector: releasev1.Image{
+							URI: "public.ecr.aws/eks-anywhere/diagnostic-collector:v0.9.1-eks-a-10",
+						},
+					},
 					Cilium:                     releasev1.CiliumBundle{},
 					Kindnetd:                   releasev1.KindnetdBundle{},
 					Flux:                       releasev1.FluxBundle{},

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1348,6 +1348,25 @@ func (c *Cluster) ClearFailure() {
 	c.Status.FailureReason = nil
 }
 
+// KubernetesVersions returns a set of all unique k8s versions specified in the cluster
+// for both CP and workers.
+func (c *Cluster) KubernetesVersions() []KubernetesVersion {
+	versionsSet := map[string]struct{}{}
+	versions := make([]KubernetesVersion, 0, 1)
+
+	versionsSet[string(c.Spec.KubernetesVersion)] = struct{}{}
+	versions = append(versions, c.Spec.KubernetesVersion)
+	for _, w := range c.Spec.WorkerNodeGroupConfigurations {
+		if w.KubernetesVersion != nil {
+			if _, ok := versionsSet[string(*w.KubernetesVersion)]; !ok {
+				versions = append(versions, *w.KubernetesVersion)
+			}
+		}
+	}
+
+	return versions
+}
+
 type refSet map[Ref]struct{}
 
 func (r refSet) addIfNotNil(ref *Ref) bool {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -3079,3 +3079,14 @@ func TestWorkerNodeGroupConfigurationKubeVersionUnchanged(t *testing.T) {
 		})
 	}
 }
+
+func TestKubernetesVersions(t *testing.T) {
+	g := NewWithT(t)
+	cluster := baseCluster()
+	kube120 := v1alpha1.KubernetesVersion("1.20")
+	wng := cluster.Spec.WorkerNodeGroupConfigurations[0].DeepCopy()
+	cluster.Spec.WorkerNodeGroupConfigurations[0].KubernetesVersion = &kube120
+	cluster.Spec.WorkerNodeGroupConfigurations = append(cluster.Spec.WorkerNodeGroupConfigurations, *wng)
+	expected := []v1alpha1.KubernetesVersion{v1alpha1.Kube121, v1alpha1.Kube120}
+	g.Expect(cluster.KubernetesVersions()).To(Equal(expected))
+}

--- a/pkg/awsiamauth/installer_test.go
+++ b/pkg/awsiamauth/installer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	filewritermock "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
-	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 func TestInstallAWSIAMAuth(t *testing.T) {
@@ -57,20 +56,7 @@ func TestInstallAWSIAMAuth(t *testing.T) {
 				},
 			},
 		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &releasev1.VersionsBundle{
-				Eksa: releasev1.EksaBundle{
-					DiagnosticCollector: releasev1.Image{
-						URI: "public.ecr.aws/eks-anywhere/diagnostic-collector:v0.9.1-eks-a-10",
-					},
-				},
-			},
-			KubeDistro: &cluster.KubeDistro{
-				AwsIamAuthImage: releasev1.Image{
-					URI: "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-11",
-				},
-			},
-		},
+		VersionsBundles: test.VersionsBundlesMap(),
 		AWSIamConfig: &v1alpha1.AWSIamConfig{
 			Spec: v1alpha1.AWSIamConfigSpec{
 				AWSRegion:   "test-region",
@@ -163,20 +149,7 @@ func TestInstallAWSIAMAuthErrors(t *testing.T) {
 						},
 					},
 				},
-				VersionsBundle: &cluster.VersionsBundle{
-					VersionsBundle: &releasev1.VersionsBundle{
-						Eksa: releasev1.EksaBundle{
-							DiagnosticCollector: releasev1.Image{
-								URI: "public.ecr.aws/eks-anywhere/diagnostic-collector:v0.9.1-eks-a-10",
-							},
-						},
-					},
-					KubeDistro: &cluster.KubeDistro{
-						AwsIamAuthImage: releasev1.Image{
-							URI: "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-11",
-						},
-					},
-				},
+				VersionsBundles: test.VersionsBundlesMap(),
 				AWSIamConfig: &v1alpha1.AWSIamConfig{
 					Spec: v1alpha1.AWSIamConfigSpec{
 						AWSRegion:   "test-region",
@@ -320,20 +293,7 @@ func TestUpgradeAWSIAMAuth(t *testing.T) {
 				},
 			},
 		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &releasev1.VersionsBundle{
-				Eksa: releasev1.EksaBundle{
-					DiagnosticCollector: releasev1.Image{
-						URI: "public.ecr.aws/eks-anywhere/diagnostic-collector:v0.9.1-eks-a-10",
-					},
-				},
-			},
-			KubeDistro: &cluster.KubeDistro{
-				AwsIamAuthImage: releasev1.Image{
-					URI: "public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.5.2-eks-1-18-11",
-				},
-			},
-		},
+		VersionsBundles: test.VersionsBundlesMap(),
 		AWSIamConfig: &v1alpha1.AWSIamConfig{
 			Spec: v1alpha1.AWSIamConfigSpec{
 				AWSRegion:   "test-region",

--- a/pkg/awsiamauth/reconciler/reconciler_test.go
+++ b/pkg/awsiamauth/reconciler/reconciler_test.go
@@ -173,7 +173,7 @@ func TestReconcileCAPIClusterNotFound(t *testing.T) {
 	remoteClientRegistry := reconcilermocks.NewMockRemoteClientRegistry(ctrl)
 
 	bundle := test.Bundle()
-	eksdRelease := test.EksdRelease()
+	eksdRelease := test.EksdRelease("1-22")
 	eksaRelease := test.EKSARelease()
 	objs := []runtime.Object{bundle, eksaRelease, eksdRelease}
 	cb := fake.NewClientBuilder()
@@ -215,7 +215,7 @@ func TestReconcileRemoteGetClientError(t *testing.T) {
 	remoteClientRegistry := reconcilermocks.NewMockRemoteClientRegistry(ctrl)
 
 	bundle := test.Bundle()
-	eksdRelease := test.EksdRelease()
+	eksdRelease := test.EksdRelease("1-22")
 	eksaRelease := test.EKSARelease()
 	version := test.DevEksaVersion()
 	cluster := &anywherev1.Cluster{
@@ -269,7 +269,7 @@ func TestReconcileConfigMapNotFoundApplyError(t *testing.T) {
 
 	bundle := test.Bundle()
 	eksaRelease := test.EKSARelease()
-	eksdRelease := test.EksdRelease()
+	eksdRelease := test.EksdRelease("1-22")
 	version := test.DevEksaVersion()
 	cluster := &anywherev1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/awsiamauth/template.go
+++ b/pkg/awsiamauth/template.go
@@ -38,9 +38,11 @@ func (t *TemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, clusterID 
 		clusterIDValue = clusterID.String()
 	}
 
+	bundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	data := map[string]interface{}{
-		"image":              clusterSpec.VersionsBundle.KubeDistro.AwsIamAuthImage.VersionedImage(),
-		"initContainerImage": clusterSpec.VersionsBundle.Eksa.DiagnosticCollector.VersionedImage(),
+		"image":              bundle.KubeDistro.AwsIamAuthImage.VersionedImage(),
+		"initContainerImage": bundle.Eksa.DiagnosticCollector.VersionedImage(),
 		"awsRegion":          clusterSpec.AWSIamConfig.Spec.AWSRegion,
 		"clusterID":          clusterIDValue,
 		"backendMode":        strings.Join(clusterSpec.AWSIamConfig.Spec.BackendMode, ","),

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -54,8 +54,6 @@ func TestBootstrapperCreateBootstrapClusterFailureOnCreateNamespaceIfNotPresentF
 	kubeconfigFile := "c.kubeconfig"
 	clusterName := "cluster-name"
 	clusterSpec, _ := given(t, clusterName, kubeconfigFile)
-	clusterSpec.VersionsBundle.KubeVersion = "1.20"
-	clusterSpec.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
 
 	ctx := context.Background()
 	b, client := newBootstrapper(t)
@@ -302,8 +300,8 @@ func newBootstrapper(t *testing.T) (*bootstrapper.Bootstrapper, *mocks.MockClust
 func given(t *testing.T, clusterName, kubeconfig string) (clusterSpec *cluster.Spec, wantCluster *types.Cluster) {
 	return test.NewClusterSpec(func(s *cluster.Spec) {
 			s.Cluster.Name = clusterName
-			s.VersionsBundle.KubeVersion = "1.19"
-			s.VersionsBundle.KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
+			s.VersionsBundles["1.19"].KubeVersion = "1.19"
+			s.VersionsBundles["1.19"].KubeDistro.CoreDNS.Tag = "v1.8.3-eks-1-20-1"
 		}), &types.Cluster{
 			Name:           clusterName,
 			KubeconfigFile: kubeconfig,

--- a/pkg/cluster/builder_test.go
+++ b/pkg/cluster/builder_test.go
@@ -41,6 +41,12 @@ func TestFileSpecBuilderBuildError(t *testing.T) {
 			releaseURL:        "testdata/release_bundle_missing_eksd.yaml",
 			cliVersion:        "v0.0.1",
 		},
+		{
+			testName:          "Worker EkdD Release",
+			clusterConfigFile: "testdata/cluster_worker_k8s.yaml",
+			releaseURL:        "testdata/simple_release.yaml",
+			cliVersion:        "v0.0.1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/cluster/config_manager_test.go
+++ b/pkg/cluster/config_manager_test.go
@@ -25,6 +25,7 @@ func TestConfigManagerParseSuccess(t *testing.T) {
 		c.DockerDatacenter = d.(*anywherev1.DockerDatacenterConfig)
 	})
 
+	kubeVersion := anywherev1.KubernetesVersion("1.20")
 	yamlManifest := []byte(test.ReadFile(t, "testdata/docker_cluster_oidc_awsiam_flux.yaml"))
 	wantCluster := &anywherev1.Cluster{
 		TypeMeta: metav1.TypeMeta{
@@ -44,8 +45,9 @@ func TestConfigManagerParseSuccess(t *testing.T) {
 			},
 			WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 				{
-					Name:  "workers-1",
-					Count: ptr.Int(1),
+					Name:              "workers-1",
+					Count:             ptr.Int(1),
+					KubernetesVersion: &kubeVersion,
 				},
 			},
 			DatacenterRef: anywherev1.Ref{

--- a/pkg/cluster/parse_test.go
+++ b/pkg/cluster/parse_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
+	kube120 := anywherev1.KubernetesVersion("1.20")
+	kube119 := anywherev1.KubernetesVersion("1.19")
 	tests := []struct {
 		name                         string
 		yamlManifest                 []byte
@@ -50,8 +52,18 @@ func TestParseConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
-							Name:  "workers-1",
-							Count: ptr.Int(1),
+							Name:              "workers-1",
+							KubernetesVersion: &kube119,
+							Count:             ptr.Int(1),
+							MachineGroupRef: &anywherev1.Ref{
+								Kind: "VSphereMachineConfig",
+								Name: "eksa-unit-test",
+							},
+						},
+						{
+							Name:              "workers-2",
+							KubernetesVersion: &kube120,
+							Count:             ptr.Int(1),
 							MachineGroupRef: &anywherev1.Ref{
 								Kind: "VSphereMachineConfig",
 								Name: "eksa-unit-test",
@@ -400,8 +412,9 @@ func TestParseConfig(t *testing.T) {
 					},
 					WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 						{
-							Name:  "workers-1",
-							Count: ptr.Int(1),
+							Name:              "workers-1",
+							KubernetesVersion: &kube120,
+							Count:             ptr.Int(1),
 						},
 					},
 					DatacenterRef: anywherev1.Ref{

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -14,32 +14,38 @@ import (
 type Spec struct {
 	*Config
 	Bundles           *v1alpha1.Bundles
-	VersionsBundle    *VersionsBundle
-	eksdRelease       *eksdv1alpha1.Release
 	OIDCConfig        *eksav1alpha1.OIDCConfig
 	AWSIamConfig      *eksav1alpha1.AWSIamConfig
 	ManagementCluster *types.Cluster // TODO(g-gaston): cleanup, this doesn't belong here
 	EKSARelease       *v1alpha1.EKSARelease
+	VersionsBundles   map[eksav1alpha1.KubernetesVersion]*VersionsBundle
 }
 
 func (s *Spec) DeepCopy() *Spec {
 	return &Spec{
-		Config:       s.Config.DeepCopy(),
-		OIDCConfig:   s.OIDCConfig.DeepCopy(),
-		AWSIamConfig: s.AWSIamConfig.DeepCopy(),
-		VersionsBundle: &VersionsBundle{
-			VersionsBundle: s.VersionsBundle.VersionsBundle.DeepCopy(),
-			KubeDistro:     s.VersionsBundle.KubeDistro.deepCopy(),
-		},
-		eksdRelease: s.eksdRelease.DeepCopy(),
-		Bundles:     s.Bundles.DeepCopy(),
-		EKSARelease: s.EKSARelease.DeepCopy(),
+		Config:          s.Config.DeepCopy(),
+		OIDCConfig:      s.OIDCConfig.DeepCopy(),
+		AWSIamConfig:    s.AWSIamConfig.DeepCopy(),
+		Bundles:         s.Bundles.DeepCopy(),
+		VersionsBundles: deepCopyVersionsBundles(s.VersionsBundles),
+		EKSARelease:     s.EKSARelease.DeepCopy(),
 	}
 }
 
 type VersionsBundle struct {
 	*v1alpha1.VersionsBundle
 	KubeDistro *KubeDistro
+}
+
+func deepCopyVersionsBundles(v map[eksav1alpha1.KubernetesVersion]*VersionsBundle) map[eksav1alpha1.KubernetesVersion]*VersionsBundle {
+	m := make(map[eksav1alpha1.KubernetesVersion]*VersionsBundle, len(v))
+	for key, val := range v {
+		m[key] = &VersionsBundle{
+			VersionsBundle: val.VersionsBundle.DeepCopy(),
+			KubeDistro:     val.KubeDistro.deepCopy(),
+		}
+	}
+	return m
 }
 
 // EKSD represents an eks-d release.
@@ -49,6 +55,11 @@ type EKSD struct {
 	// Number is the monotonically increasing number that distinguishes the different eks-d releases
 	// for the same Kubernetes minor version (channel).
 	Number int
+}
+
+func (k *KubeDistro) deepCopy() *KubeDistro {
+	k2 := *k
+	return &k2
 }
 
 type KubeDistro struct {
@@ -67,36 +78,22 @@ type KubeDistro struct {
 	KubeProxy           v1alpha1.Image
 }
 
-func (k *KubeDistro) deepCopy() *KubeDistro {
-	k2 := *k
-	return &k2
-}
-
 type VersionedRepository struct {
 	Repository, Tag string
 }
 
 // NewSpec builds a new [Spec].
-func NewSpec(config *Config, bundles *v1alpha1.Bundles, eksdRelease *eksdv1alpha1.Release, eksaRelease *v1alpha1.EKSARelease) (*Spec, error) {
+func NewSpec(config *Config, bundles *v1alpha1.Bundles, eksdReleases []eksdv1alpha1.Release, eksaRelease *v1alpha1.EKSARelease) (*Spec, error) {
 	s := &Spec{}
-
-	versionsBundle, err := GetVersionsBundle(config.Cluster, bundles)
-	if err != nil {
-		return nil, err
-	}
-
-	kubeDistro, err := buildKubeDistro(eksdRelease)
-	if err != nil {
-		return nil, err
-	}
 
 	s.Bundles = bundles
 	s.Config = config
-	s.VersionsBundle = &VersionsBundle{
-		VersionsBundle: versionsBundle,
-		KubeDistro:     kubeDistro,
+
+	vb, err := getAllVersionsBundles(s.Cluster, bundles, eksdReleases)
+	if err != nil {
+		return nil, err
 	}
-	s.eksdRelease = eksdRelease
+	s.VersionsBundles = vb
 	s.EKSARelease = eksaRelease
 
 	// Get first aws iam config if it exists
@@ -116,16 +113,72 @@ func NewSpec(config *Config, bundles *v1alpha1.Bundles, eksdRelease *eksdv1alpha
 	return s, nil
 }
 
-func (s *Spec) KubeDistroImages() []v1alpha1.Image {
-	images := []v1alpha1.Image{}
-	for _, component := range s.eksdRelease.Status.Components {
-		for _, asset := range component.Assets {
-			if asset.Image != nil {
-				images = append(images, v1alpha1.Image{URI: asset.Image.URI})
-			}
-		}
+func getAllVersionsBundles(cluster *eksav1alpha1.Cluster, bundles *v1alpha1.Bundles, eksdReleases []eksdv1alpha1.Release) (map[eksav1alpha1.KubernetesVersion]*VersionsBundle, error) {
+	if len(eksdReleases) < 1 {
+		return nil, fmt.Errorf("no eksd releases were found")
 	}
-	return images
+
+	m := make(map[eksav1alpha1.KubernetesVersion]*VersionsBundle, len(eksdReleases))
+
+	for _, eksd := range eksdReleases {
+		channel := strings.Replace(eksd.Spec.Channel, "-", ".", 1)
+		version := eksav1alpha1.KubernetesVersion(channel)
+
+		if _, ok := m[version]; ok {
+			continue
+		}
+
+		versionBundle, err := getVersionBundles(version, bundles, &eksd)
+		if err != nil {
+			return nil, err
+		}
+
+		m[version] = versionBundle
+	}
+
+	return m, nil
+}
+
+func getVersionBundles(version eksav1alpha1.KubernetesVersion, b *v1alpha1.Bundles, eksdRelease *eksdv1alpha1.Release) (*VersionsBundle, error) {
+	v, err := GetVersionsBundle(version, b)
+	if err != nil {
+		return nil, err
+	}
+
+	kd, err := buildKubeDistro(eksdRelease)
+	if err != nil {
+		return nil, err
+	}
+
+	vb := &VersionsBundle{
+		VersionsBundle: v,
+		KubeDistro:     kd,
+	}
+
+	return vb, nil
+}
+
+// VersionsBundle returns a VersionsBundle if one exists for the provided kubernetes version and nil otherwise.
+func (s *Spec) VersionsBundle(version eksav1alpha1.KubernetesVersion) *VersionsBundle {
+	vb, ok := s.VersionsBundles[version]
+	if !ok {
+		return nil
+	}
+
+	return vb
+}
+
+// ControlPlaneVersionsBundle returns a VersionsBundle for the top level kubernetes version.
+func (s *Spec) ControlPlaneVersionsBundle() *VersionsBundle {
+	return s.VersionsBundle(s.Cluster.Spec.KubernetesVersion)
+}
+
+// WorkerNodeGroupVersionsBundle returns a VersionsBundle for the Worker Node's kubernetes version.
+func (s *Spec) WorkerNodeGroupVersionsBundle(w eksav1alpha1.WorkerNodeGroupConfiguration) *VersionsBundle {
+	if w.KubernetesVersion != nil {
+		return s.VersionsBundle(*w.KubernetesVersion)
+	}
+	return s.ControlPlaneVersionsBundle()
 }
 
 func buildKubeDistro(eksd *eksdv1alpha1.Release) (*KubeDistro, error) {
@@ -196,26 +249,6 @@ func kubeDistroRepository(image *eksdv1alpha1.AssetImage) (repo, tag string) {
 	}
 
 	return i.Image()[:lastInd], i.Tag()
-}
-
-func (vb *VersionsBundle) KubeDistroImages() []v1alpha1.Image {
-	var images []v1alpha1.Image
-	images = append(images, vb.KubeDistro.EtcdImage)
-	images = append(images, vb.KubeDistro.ExternalAttacher)
-	images = append(images, vb.KubeDistro.ExternalProvisioner)
-	images = append(images, vb.KubeDistro.LivenessProbe)
-	images = append(images, vb.KubeDistro.NodeDriverRegistrar)
-	images = append(images, vb.KubeDistro.Pause)
-
-	return images
-}
-
-func (vb *VersionsBundle) Images() []v1alpha1.Image {
-	var images []v1alpha1.Image
-	images = append(images, vb.VersionsBundle.Images()...)
-	images = append(images, vb.KubeDistroImages()...)
-
-	return images
 }
 
 func (vb *VersionsBundle) Ovas() []v1alpha1.Archive {

--- a/pkg/cluster/spec_test.go
+++ b/pkg/cluster/spec_test.go
@@ -25,7 +25,7 @@ func TestNewSpecError(t *testing.T) {
 		name        string
 		config      *cluster.Config
 		bundles     *releasev1.Bundles
-		eksdRelease *eksdv1.Release
+		eksdRelease []eksdv1.Release
 		error       string
 	}{
 		{
@@ -43,11 +43,17 @@ func TestNewSpecError(t *testing.T) {
 					Number: 2,
 				},
 			},
-			eksdRelease: &eksdv1.Release{},
-			error:       "kubernetes version 1.24 is not supported by bundles manifest 2",
+			eksdRelease: []eksdv1.Release{
+				{
+					Spec: eksdv1.ReleaseSpec{
+						Channel: "1-24",
+					},
+				},
+			},
+			error: "kubernetes version 1.24 is not supported by bundles manifest 2",
 		},
 		{
-			name: "invalid eks-d release",
+			name: "empty eksd releases",
 			config: &cluster.Config{
 				Cluster: &anywherev1.Cluster{
 					Spec: anywherev1.ClusterSpec{
@@ -56,18 +62,8 @@ func TestNewSpecError(t *testing.T) {
 					},
 				},
 			},
-			bundles: &releasev1.Bundles{
-				Spec: releasev1.BundlesSpec{
-					Number: 2,
-					VersionsBundles: []releasev1.VersionsBundle{
-						{
-							KubeVersion: "1.24",
-						},
-					},
-				},
-			},
-			eksdRelease: &eksdv1.Release{},
-			error:       "is no present in eksd release",
+			eksdRelease: []eksdv1.Release{},
+			error:       "no eksd releases were found",
 		},
 	}
 
@@ -84,11 +80,17 @@ func TestNewSpecError(t *testing.T) {
 func TestNewSpecValid(t *testing.T) {
 	g := NewWithT(t)
 	version := test.DevEksaVersion()
+	kube119 := anywherev1.KubernetesVersion("1.19")
 	config := &cluster.Config{
 		Cluster: &anywherev1.Cluster{
 			Spec: anywherev1.ClusterSpec{
-				KubernetesVersion: anywherev1.Kube124,
-				EksaVersion:       &version,
+				KubernetesVersion: kube119,
+				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						KubernetesVersion: &kube119,
+					},
+				},
+				EksaVersion: &version,
 			},
 		},
 		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
@@ -103,14 +105,16 @@ func TestNewSpecValid(t *testing.T) {
 			Number: 2,
 			VersionsBundles: []releasev1.VersionsBundle{
 				{
-					KubeVersion: "1.24",
+					KubeVersion: "1.19",
 				},
 			},
 		},
 	}
-	eksdRelease := readEksdRelease(t, "testdata/eksd_valid.yaml")
+	eksd := []eksdv1.Release{
+		*test.EksdRelease("1-19"),
+	}
 
-	spec, err := cluster.NewSpec(config, bundles, eksdRelease, test.EKSARelease())
+	spec, err := cluster.NewSpec(config, bundles, eksd, test.EKSARelease())
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(spec.AWSIamConfig).NotTo(BeNil())
 	g.Expect(spec.OIDCConfig).NotTo(BeNil())
@@ -125,7 +129,9 @@ func TestSpecDeepCopy(t *testing.T) {
 
 	g.Expect(err).To(Succeed())
 	bundles := test.Bundles(t)
-	eksd := test.EksdRelease()
+	eksd := []eksdv1.Release{
+		*test.EksdRelease("1-19"),
+	}
 	spec, err := cluster.NewSpec(config, bundles, eksd, test.EKSARelease())
 	g.Expect(err).To(Succeed())
 
@@ -199,18 +205,226 @@ func TestBundlesRefDefaulter(t *testing.T) {
 }
 
 func validateSpecFromSimpleBundle(t *testing.T, gotSpec *cluster.Spec) {
-	validateVersionedRepo(t, gotSpec.VersionsBundle.KubeDistro.Kubernetes, "public.ecr.aws/eks-distro/kubernetes", "v1.19.8-eks-1-19-4")
-	validateVersionedRepo(t, gotSpec.VersionsBundle.KubeDistro.CoreDNS, "public.ecr.aws/eks-distro/coredns", "v1.8.0-eks-1-19-4")
-	validateVersionedRepo(t, gotSpec.VersionsBundle.KubeDistro.Etcd, "public.ecr.aws/eks-distro/etcd-io", "v3.4.14-eks-1-19-4")
-	validateImageURI(t, gotSpec.VersionsBundle.KubeDistro.NodeDriverRegistrar, "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-19-4")
-	validateImageURI(t, gotSpec.VersionsBundle.KubeDistro.LivenessProbe, "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4")
-	validateImageURI(t, gotSpec.VersionsBundle.KubeDistro.ExternalAttacher, "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-19-4")
-	validateImageURI(t, gotSpec.VersionsBundle.KubeDistro.ExternalProvisioner, "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-19-4")
-	validateImageURI(t, gotSpec.VersionsBundle.KubeDistro.EtcdImage, "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-19-4")
-	validateImageURI(t, gotSpec.VersionsBundle.KubeDistro.KubeProxy, "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.19.8-eks-1-19-4")
-	if gotSpec.VersionsBundle.KubeDistro.EtcdVersion != "3.4.14" {
-		t.Errorf("GetNewSpec() = Spec: Invalid etcd version, got %s, want 3.4.14", gotSpec.VersionsBundle.KubeDistro.EtcdVersion)
+	VersionsBundle := gotSpec.ControlPlaneVersionsBundle()
+	validateVersionedRepo(t, VersionsBundle.KubeDistro.Kubernetes, "public.ecr.aws/eks-distro/kubernetes", "v1.19.8-eks-1-19-4")
+	validateVersionedRepo(t, VersionsBundle.KubeDistro.CoreDNS, "public.ecr.aws/eks-distro/coredns", "v1.8.0-eks-1-19-4")
+	validateVersionedRepo(t, VersionsBundle.KubeDistro.Etcd, "public.ecr.aws/eks-distro/etcd-io", "v3.4.14-eks-1-19-4")
+	validateImageURI(t, VersionsBundle.KubeDistro.NodeDriverRegistrar, "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-19-4")
+	validateImageURI(t, VersionsBundle.KubeDistro.LivenessProbe, "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-19-4")
+	validateImageURI(t, VersionsBundle.KubeDistro.ExternalAttacher, "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v3.1.0-eks-1-19-4")
+	validateImageURI(t, VersionsBundle.KubeDistro.ExternalProvisioner, "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-19-4")
+	validateImageURI(t, VersionsBundle.KubeDistro.EtcdImage, "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-19-4")
+	validateImageURI(t, VersionsBundle.KubeDistro.KubeProxy, "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.19.8-eks-1-19-4")
+	if VersionsBundle.KubeDistro.EtcdVersion != "3.4.14" {
+		t.Errorf("GetNewSpec() = Spec: Invalid etcd version, got %s, want 3.4.14", VersionsBundle.KubeDistro.EtcdVersion)
 	}
+}
+
+func TestGetVersionsBundleWorkerError(t *testing.T) {
+	g := NewWithT(t)
+	kube123 := anywherev1.KubernetesVersion("1.23")
+	config := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			Spec: anywherev1.ClusterSpec{
+				KubernetesVersion: anywherev1.Kube124,
+				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						KubernetesVersion: &kube123,
+					},
+				},
+			},
+		},
+		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
+			"myconfig": {},
+		},
+		AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{
+			"myconfig": {},
+		},
+	}
+	bundles := &releasev1.Bundles{
+		Spec: releasev1.BundlesSpec{
+			Number: 2,
+			VersionsBundles: []releasev1.VersionsBundle{
+				{
+					KubeVersion: "1.24",
+				},
+			},
+		},
+	}
+	eksd := test.EksdReleases()
+	er := test.EKSARelease()
+
+	_, err := cluster.NewSpec(config, bundles, eksd, er)
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestGetVersionsBundleNotFound(t *testing.T) {
+	g := NewWithT(t)
+	config := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			Spec: anywherev1.ClusterSpec{
+				KubernetesVersion: anywherev1.Kube124,
+			},
+		},
+		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
+			"myconfig": {},
+		},
+		AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{
+			"myconfig": {},
+		},
+	}
+	bundles := &releasev1.Bundles{
+		Spec: releasev1.BundlesSpec{
+			Number: 2,
+			VersionsBundles: []releasev1.VersionsBundle{
+				{
+					KubeVersion: "1.24",
+				},
+			},
+		},
+	}
+	eksd := []eksdv1.Release{
+		*test.EksdRelease("1-24"),
+	}
+	er := test.EKSARelease()
+
+	spec, err := cluster.NewSpec(config, bundles, eksd, er)
+	g.Expect(err).To(Succeed())
+	vb := spec.VersionsBundle("1.22")
+	g.Expect(vb).To(BeNil())
+}
+
+func TestGetVersionsBundlesErrorEksdEmpty(t *testing.T) {
+	g := NewWithT(t)
+	kube123 := anywherev1.KubernetesVersion("1.23")
+	config := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			Spec: anywherev1.ClusterSpec{
+				KubernetesVersion: anywherev1.Kube124,
+				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						KubernetesVersion: &kube123,
+					},
+				},
+			},
+		},
+		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
+			"myconfig": {},
+		},
+		AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{
+			"myconfig": {},
+		},
+	}
+	bundles := &releasev1.Bundles{
+		Spec: releasev1.BundlesSpec{
+			Number: 2,
+			VersionsBundles: []releasev1.VersionsBundle{
+				{
+					KubeVersion: "1.24",
+				},
+			},
+		},
+	}
+
+	_, err := cluster.NewSpec(config, bundles, []eksdv1.Release{}, test.EKSARelease())
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestWorkerNodeGroupVersionsBundle(t *testing.T) {
+	g := NewWithT(t)
+	kube123 := anywherev1.KubernetesVersion("1.23")
+	config := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			Spec: anywherev1.ClusterSpec{
+				KubernetesVersion: anywherev1.Kube124,
+				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						KubernetesVersion: &kube123,
+					},
+				},
+			},
+		},
+		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
+			"myconfig": {},
+		},
+		AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{
+			"myconfig": {},
+		},
+	}
+	bundles := &releasev1.Bundles{
+		Spec: releasev1.BundlesSpec{
+			Number: 2,
+			VersionsBundles: []releasev1.VersionsBundle{
+				{
+					KubeVersion: "1.23",
+				},
+			},
+		},
+	}
+
+	spec, err := cluster.NewSpec(config, bundles, []eksdv1.Release{*test.EksdRelease("1-23")}, test.EKSARelease())
+	g.Expect(err).To(BeNil())
+	versionsBundle := spec.WorkerNodeGroupVersionsBundle(spec.Cluster.Spec.WorkerNodeGroupConfigurations[0])
+	g.Expect(versionsBundle).ToNot(BeNil())
+}
+
+func TestGetVersionsBundlesErrorInvalidEksd(t *testing.T) {
+	g := NewWithT(t)
+	kube123 := anywherev1.KubernetesVersion("1.23")
+	config := &cluster.Config{
+		Cluster: &anywherev1.Cluster{
+			Spec: anywherev1.ClusterSpec{
+				KubernetesVersion: anywherev1.Kube124,
+				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
+					{
+						KubernetesVersion: &kube123,
+					},
+				},
+			},
+		},
+		OIDCConfigs: map[string]*anywherev1.OIDCConfig{
+			"myconfig": {},
+		},
+		AWSIAMConfigs: map[string]*anywherev1.AWSIamConfig{
+			"myconfig": {},
+		},
+	}
+	bundles := &releasev1.Bundles{
+		Spec: releasev1.BundlesSpec{
+			Number: 2,
+			VersionsBundles: []releasev1.VersionsBundle{
+				{
+					KubeVersion: "1.24",
+				},
+			},
+		},
+	}
+	eksd := []eksdv1.Release{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Release",
+				APIVersion: "distro.eks.amazonaws.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "eksa-system",
+			},
+			Spec: eksdv1.ReleaseSpec{
+				Number:  1,
+				Channel: "1-24",
+			},
+			Status: eksdv1.ReleaseStatus{
+				Components: []eksdv1.Component{
+					{
+						Assets: nil,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := cluster.NewSpec(config, bundles, eksd, test.EKSARelease())
+	g.Expect(err).ToNot(BeNil())
 }
 
 func validateImageURI(t *testing.T, gotImage releasev1.Image, wantURI string) {

--- a/pkg/cluster/testdata/cluster_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_1_19.yaml
@@ -24,6 +24,13 @@ spec:
   kubernetesVersion: "1.19"
   workerNodeGroupConfigurations:
     - name: workers-1
+      kubernetesVersion: "1.19"
+      count: 1
+      machineGroupRef:
+        kind: VSphereMachineConfig
+        name: eksa-unit-test
+    - name: workers-2
+      kubernetesVersion: "1.20"
       count: 1
       machineGroupRef:
         kind: VSphereMachineConfig

--- a/pkg/cluster/testdata/cluster_worker_k8s.yaml
+++ b/pkg/cluster/testdata/cluster_worker_k8s.yaml
@@ -1,0 +1,75 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: "myHostIp"
+    machineGroupRef:
+      kind: VSphereMachineConfig
+      name: eksa-unit-test-cp
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - name: workers-1
+      kubernetesVersion: "1.21"
+      count: 1
+      machineGroupRef:
+        kind: VSphereMachineConfig
+        name: eksa-unit-test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "/myDatacenter/network-1"
+  server: "myServer"
+  insecure: false
+  thumbprint: "myTlsThumbprint"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test-cp
+spec:
+  datastore: "myDatastore"
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  resourcePool: "myResourcePool"
+  users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datastore: "myDatastore"
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  resourcePool: "myResourcePool"
+  users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---

--- a/pkg/cluster/testdata/cluster_worker_node_k8s.yaml
+++ b/pkg/cluster/testdata/cluster_worker_node_k8s.yaml
@@ -1,0 +1,89 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 1
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: TinkerbellMachineConfig
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: test
+  externalEtcdConfiguration:
+    count: 1
+    machineGroupRef:
+      name: test-cp
+      kind: TinkerbellMachineConfig
+  kubernetesVersion: "1.19"
+  managementCluster:
+    name: test
+  workerNodeGroupConfigurations:
+    - count: 1
+      kubernetesVersion: "1.18"
+      machineGroupRef:
+        name: test-md
+        kind: TinkerbellMachineConfig
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: test
+spec:
+  tinkerbellIP: "1.2.3.4"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: tink-test
+  users:
+    - name: tink-user
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellTemplateConfig
+metadata:
+  name: tink-test
+spec:
+  template:
+    global_timeout: 6000
+    id: ""
+    name: tink-test
+    tasks:
+      - actions:
+          - environment:
+              COMPRESSED: "true"
+              DEST_DISK: /dev/sda
+              IMG_URL: ""
+            image: image2disk:v1.0.0
+            name: stream-image
+            timeout: 360
+        name: tink-test
+        volumes:
+          - /dev:/dev
+          - /dev/console:/dev/console
+          - /lib/firmware:/lib/firmware:ro
+        worker: "{{.device_1}}"
+    version: "0.1"

--- a/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
+++ b/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
@@ -21,6 +21,7 @@ spec:
     name: m-docker
   workerNodeGroupConfigurations:
   - name: workers-1
+    kubernetesVersion: "1.20"
     count: 1
   identityProviderRefs:
   - kind: OIDCConfig

--- a/pkg/cluster/testdata/simple_bundle.yaml
+++ b/pkg/cluster/testdata/simple_bundle.yaml
@@ -18,3 +18,14 @@ spec:
           uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node:v1.19.8-eks-d-1-19-4-eks-a-0.0.1.build.38
         kubeVersion: v1.19.8
         manifestUrl: "testdata/eksd_valid.yaml"
+    - kubeVersion: "1.20"
+      eksD:
+        channel: 1-20
+        gitCommit: 3e8cd38b0e561c0d6484bc7cd5b4590db6152d88
+        kindNode:
+          extraField: "fake field to test non strict unmarshalling"
+          description: kind/node container image
+          name: kind/node
+          uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node:v1.20.8-eks-d-1-19-4-eks-a-0.0.1.build.38
+        kubeVersion: v1.20.8
+        manifestUrl: "testdata/eksd_valid.yaml"

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -101,37 +101,39 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 			},
 		}
 
-		s.VersionsBundle = &cluster.VersionsBundle{
-			KubeDistro: &cluster.KubeDistro{
-				Kubernetes: cluster.VersionedRepository{
-					Repository: "public.ecr.aws/eks-distro/kubernetes",
-					Tag:        "v1.21.5-eks-1-21-9",
-				},
-				CoreDNS: cluster.VersionedRepository{
-					Repository: "public.ecr.aws/eks-distro/coredns",
-					Tag:        "v1.8.4-eks-1-21-9",
-				},
-				Etcd: cluster.VersionedRepository{
-					Repository: "public.ecr.aws/eks-distro/etcd-io",
-					Tag:        "v3.4.16-eks-1-21-9",
-				},
-				EtcdImage: v1alpha1.Image{
-					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
-				},
-				Pause: v1alpha1.Image{
-					URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
-				},
-			},
-			VersionsBundle: &v1alpha1.VersionsBundle{
-				BottleRocketHostContainers: v1alpha1.BottlerocketHostContainersBundle{
-					Admin: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+		s.VersionsBundles = map[anywherev1.KubernetesVersion]*cluster.VersionsBundle{
+			"1.21": {
+				KubeDistro: &cluster.KubeDistro{
+					Kubernetes: cluster.VersionedRepository{
+						Repository: "public.ecr.aws/eks-distro/kubernetes",
+						Tag:        "v1.21.5-eks-1-21-9",
 					},
-					Control: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+					CoreDNS: cluster.VersionedRepository{
+						Repository: "public.ecr.aws/eks-distro/coredns",
+						Tag:        "v1.8.4-eks-1-21-9",
 					},
-					KubeadmBootstrap: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+					Etcd: cluster.VersionedRepository{
+						Repository: "public.ecr.aws/eks-distro/etcd-io",
+						Tag:        "v3.4.16-eks-1-21-9",
+					},
+					EtcdImage: v1alpha1.Image{
+						URI: "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
+					},
+					Pause: v1alpha1.Image{
+						URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+					},
+				},
+				VersionsBundle: &v1alpha1.VersionsBundle{
+					BottleRocketHostContainers: v1alpha1.BottlerocketHostContainersBundle{
+						Admin: v1alpha1.Image{
+							URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+						},
+						Control: v1alpha1.Image{
+							URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+						},
+						KubeadmBootstrap: v1alpha1.Image{
+							URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+						},
 					},
 				},
 			},
@@ -478,7 +480,6 @@ func wantMachineDeployment() *clusterv1.MachineDeployment {
 func TestMachineDeployment(t *testing.T) {
 	tt := newApiBuilerTest(t)
 	got := clusterapi.MachineDeployment(tt.clusterSpec, *tt.workerNodeGroupConfig, tt.kubeadmConfigTemplate, tt.providerMachineTemplate)
-
 	tt.Expect(got).To(BeComparableTo(wantMachineDeployment()))
 }
 

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -77,7 +77,10 @@ func TestSetBottlerocketInKubeadmControlPlane(t *testing.T) {
 	)
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.CertificatesDir = "/var/lib/kubeadm/pki"
 
-	clusterapi.SetBottlerocketInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+
+	clusterapi.SetBottlerocketInKubeadmControlPlane(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -88,7 +91,10 @@ func TestSetBottlerocketAdminContainerImageInKubeadmControlPlane(t *testing.T) {
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = adminContainer
 	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = adminContainer
 
-	clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+
+	clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -99,7 +105,10 @@ func TestSetBottlerocketControlContainerImageInKubeadmControlPlane(t *testing.T)
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = controlContainer
 	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = controlContainer
 
-	clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+
+	clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -111,7 +120,10 @@ func TestSetBottlerocketInKubeadmConfigTemplate(t *testing.T) {
 	want.Spec.Template.Spec.JoinConfiguration.BottlerocketBootstrap = bootstrap
 	want.Spec.Template.Spec.JoinConfiguration.Pause = pause
 
-	clusterapi.SetBottlerocketInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+
+	clusterapi.SetBottlerocketInKubeadmConfigTemplate(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -121,7 +133,10 @@ func TestSetBottlerocketAdminContainerImageInKubeadmConfigTemplate(t *testing.T)
 	want := got.DeepCopy()
 	want.Spec.Template.Spec.JoinConfiguration.BottlerocketAdmin = adminContainer
 
-	clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+
+	clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -131,7 +146,10 @@ func TestSetBottlerocketControlContainerImageInKubeadmConfigTemplate(t *testing.
 	want := got.DeepCopy()
 	want.Spec.Template.Spec.JoinConfiguration.BottlerocketControl = controlContainer
 
-	clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+
+	clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -145,7 +163,9 @@ func TestSetBottlerocketInEtcdCluster(t *testing.T) {
 		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
 		PauseImage:     "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
 	}
-	clusterapi.SetBottlerocketInEtcdCluster(got, g.clusterSpec.VersionsBundle)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+	clusterapi.SetBottlerocketInEtcdCluster(got, bundle)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -159,7 +179,9 @@ func TestSetBottlerocketAdminContainerImageInEtcdCluster(t *testing.T) {
 	}
 	want := got.DeepCopy()
 	want.Spec.EtcdadmConfigSpec.BottlerocketConfig.AdminImage = "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1"
-	clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(got, g.clusterSpec.VersionsBundle.BottleRocketHostContainers.Admin)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+	clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(got, bundle.BottleRocketHostContainers.Admin)
 	g.Expect(got).To(Equal(want))
 }
 
@@ -173,7 +195,9 @@ func TestSetBottlerocketControlContainerImageInEtcdCluster(t *testing.T) {
 	}
 	want := got.DeepCopy()
 	want.Spec.EtcdadmConfigSpec.BottlerocketConfig.ControlImage = "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1"
-	clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(got, g.clusterSpec.VersionsBundle.BottleRocketHostContainers.Control)
+	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	g.Expect(bundle).ToNot(BeNil())
+	clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(got, bundle.BottleRocketHostContainers.Control)
 	g.Expect(got).To(Equal(want))
 }
 

--- a/pkg/clusterapi/installer_test.go
+++ b/pkg/clusterapi/installer_test.go
@@ -34,8 +34,8 @@ func newInstallerTest(t *testing.T) installerTest {
 
 	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Bundles.Spec.Number = 1
-		s.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.1.0"
-		s.VersionsBundle.ExternalEtcdController.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].ExternalEtcdBootstrap.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].ExternalEtcdController.Version = "v0.1.0"
 	})
 
 	return installerTest{

--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -75,63 +75,66 @@ func capiChangeDiff(currentSpec, newSpec *cluster.Spec, provider providers.Provi
 	changeDiff := &CAPIChangeDiff{}
 	componentChanged := false
 
-	if currentSpec.VersionsBundle.CertManager.Version != newSpec.VersionsBundle.CertManager.Version {
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+
+	if currentVersionsBundle.CertManager.Version != newVersionsBundle.CertManager.Version {
 		changeDiff.CertManager = &types.ComponentChangeDiff{
 			ComponentName: "cert-manager",
-			NewVersion:    newSpec.VersionsBundle.CertManager.Version,
-			OldVersion:    currentSpec.VersionsBundle.CertManager.Version,
+			NewVersion:    newVersionsBundle.CertManager.Version,
+			OldVersion:    currentVersionsBundle.CertManager.Version,
 		}
 		logger.V(1).Info("Cert-manager change diff", "oldVersion", changeDiff.CertManager.OldVersion, "newVersion", changeDiff.CertManager.NewVersion)
 		componentChanged = true
 	}
 
-	if currentSpec.VersionsBundle.ClusterAPI.Version != newSpec.VersionsBundle.ClusterAPI.Version {
+	if currentVersionsBundle.ClusterAPI.Version != newVersionsBundle.ClusterAPI.Version {
 		changeDiff.Core = &types.ComponentChangeDiff{
 			ComponentName: "cluster-api",
-			NewVersion:    newSpec.VersionsBundle.ClusterAPI.Version,
-			OldVersion:    currentSpec.VersionsBundle.ClusterAPI.Version,
+			NewVersion:    newVersionsBundle.ClusterAPI.Version,
+			OldVersion:    currentVersionsBundle.ClusterAPI.Version,
 		}
 		logger.V(1).Info("CAPI Core change diff", "oldVersion", changeDiff.Core.OldVersion, "newVersion", changeDiff.Core.NewVersion)
 		componentChanged = true
 	}
 
-	if currentSpec.VersionsBundle.ControlPlane.Version != newSpec.VersionsBundle.ControlPlane.Version {
+	if currentVersionsBundle.ControlPlane.Version != newVersionsBundle.ControlPlane.Version {
 		changeDiff.ControlPlane = &types.ComponentChangeDiff{
 			ComponentName: "kubeadm",
-			NewVersion:    newSpec.VersionsBundle.ControlPlane.Version,
-			OldVersion:    currentSpec.VersionsBundle.ControlPlane.Version,
+			NewVersion:    newVersionsBundle.ControlPlane.Version,
+			OldVersion:    currentVersionsBundle.ControlPlane.Version,
 		}
 		logger.V(1).Info("CAPI Control Plane provider change diff", "oldVersion", changeDiff.ControlPlane.OldVersion, "newVersion", changeDiff.ControlPlane.NewVersion)
 		componentChanged = true
 	}
 
-	if currentSpec.VersionsBundle.Bootstrap.Version != newSpec.VersionsBundle.Bootstrap.Version {
+	if currentVersionsBundle.Bootstrap.Version != newVersionsBundle.Bootstrap.Version {
 		componentChangeDiff := types.ComponentChangeDiff{
 			ComponentName: "kubeadm",
-			NewVersion:    newSpec.VersionsBundle.Bootstrap.Version,
-			OldVersion:    currentSpec.VersionsBundle.Bootstrap.Version,
+			NewVersion:    newVersionsBundle.Bootstrap.Version,
+			OldVersion:    currentVersionsBundle.Bootstrap.Version,
 		}
 		changeDiff.BootstrapProviders = append(changeDiff.BootstrapProviders, componentChangeDiff)
 		logger.V(1).Info("CAPI Kubeadm Bootstrap Provider change diff", "oldVersion", componentChangeDiff.OldVersion, "newVersion", componentChangeDiff.NewVersion)
 		componentChanged = true
 	}
 
-	if currentSpec.VersionsBundle.ExternalEtcdBootstrap.Version != newSpec.VersionsBundle.ExternalEtcdBootstrap.Version {
+	if currentVersionsBundle.ExternalEtcdBootstrap.Version != newVersionsBundle.ExternalEtcdBootstrap.Version {
 		componentChangeDiff := types.ComponentChangeDiff{
 			ComponentName: "etcdadm-bootstrap",
-			NewVersion:    newSpec.VersionsBundle.ExternalEtcdBootstrap.Version,
-			OldVersion:    currentSpec.VersionsBundle.ExternalEtcdBootstrap.Version,
+			NewVersion:    newVersionsBundle.ExternalEtcdBootstrap.Version,
+			OldVersion:    currentVersionsBundle.ExternalEtcdBootstrap.Version,
 		}
 		changeDiff.BootstrapProviders = append(changeDiff.BootstrapProviders, componentChangeDiff)
 		logger.V(1).Info("CAPI Etcdadm Bootstrap Provider change diff", "oldVersion", componentChangeDiff.OldVersion, "newVersion", componentChangeDiff.NewVersion)
 		componentChanged = true
 	}
 
-	if currentSpec.VersionsBundle.ExternalEtcdController.Version != newSpec.VersionsBundle.ExternalEtcdController.Version {
+	if currentVersionsBundle.ExternalEtcdController.Version != newVersionsBundle.ExternalEtcdController.Version {
 		componentChangeDiff := types.ComponentChangeDiff{
 			ComponentName: "etcdadm-controller",
-			NewVersion:    newSpec.VersionsBundle.ExternalEtcdController.Version,
-			OldVersion:    currentSpec.VersionsBundle.ExternalEtcdController.Version,
+			NewVersion:    newVersionsBundle.ExternalEtcdController.Version,
+			OldVersion:    currentVersionsBundle.ExternalEtcdController.Version,
 		}
 		changeDiff.BootstrapProviders = append(changeDiff.BootstrapProviders, componentChangeDiff)
 		logger.V(1).Info("CAPI Etcdadm Controller Provider change diff", "oldVersion", componentChangeDiff.OldVersion, "newVersion", componentChangeDiff.NewVersion)

--- a/pkg/clusterapi/upgrader_test.go
+++ b/pkg/clusterapi/upgrader_test.go
@@ -37,12 +37,12 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 
 	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Bundles.Spec.Number = 1
-		s.VersionsBundle.CertManager.Version = "v0.1.0"
-		s.VersionsBundle.ClusterAPI.Version = "v0.1.0"
-		s.VersionsBundle.ControlPlane.Version = "v0.1.0"
-		s.VersionsBundle.Bootstrap.Version = "v0.1.0"
-		s.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.1.0"
-		s.VersionsBundle.ExternalEtcdController.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].CertManager.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].ClusterAPI.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].ControlPlane.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].Bootstrap.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].ExternalEtcdBootstrap.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].ExternalEtcdController.Version = "v0.1.0"
 	})
 
 	return &upgraderTest{
@@ -98,7 +98,7 @@ func TestUpgraderUpgradeProviderChanges(t *testing.T) {
 
 func TestUpgraderUpgradeCoreChanges(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.VersionsBundle.ClusterAPI.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ClusterAPI.Version = "v0.2.0"
 	changeDiff := &clusterapi.CAPIChangeDiff{
 		Core: &types.ComponentChangeDiff{
 			ComponentName: "cluster-api",
@@ -119,12 +119,12 @@ func TestUpgraderUpgradeCoreChanges(t *testing.T) {
 
 func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.VersionsBundle.CertManager.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ClusterAPI.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ControlPlane.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.Bootstrap.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ExternalEtcdController.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].CertManager.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ClusterAPI.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ControlPlane.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].Bootstrap.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ExternalEtcdBootstrap.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ExternalEtcdController.Version = "v0.2.0"
 	changeDiff := &clusterapi.CAPIChangeDiff{
 		CertManager: &types.ComponentChangeDiff{
 			ComponentName: "cert-manager",
@@ -176,12 +176,12 @@ func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 func TestUpgraderUpgradeEverythingChangesExternalEtcd(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.newSpec.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{}
-	tt.newSpec.VersionsBundle.CertManager.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ClusterAPI.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ControlPlane.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.Bootstrap.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ExternalEtcdBootstrap.Version = "v0.2.0"
-	tt.newSpec.VersionsBundle.ExternalEtcdController.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].CertManager.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ClusterAPI.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ControlPlane.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].Bootstrap.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ExternalEtcdBootstrap.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].ExternalEtcdController.Version = "v0.2.0"
 	changeDiff := &clusterapi.CAPIChangeDiff{
 		CertManager: &types.ComponentChangeDiff{
 			ComponentName: "cert-manager",

--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -85,7 +85,7 @@ func (i *EKSAInstaller) Install(ctx context.Context, log logr.Logger, cluster *t
 
 // Upgrade re-installs the eksa components in a cluster if the VersionBundle defined in the
 // new spec has a different eks-a components version. Workload clusters are ignored.
-func (i *EKSAInstaller) Upgrade(ctx context.Context, log logr.Logger, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
+func (i *EKSAInstaller) Upgrade(ctx context.Context, log logr.Logger, c *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
 	log.V(1).Info("Checking for EKS-A components upgrade")
 	if !newSpec.Cluster.IsSelfManaged() {
 		log.V(1).Info("Skipping EKS-A components upgrade, not a self-managed cluster")
@@ -97,9 +97,11 @@ func (i *EKSAInstaller) Upgrade(ctx context.Context, log logr.Logger, cluster *t
 		return nil, nil
 	}
 	log.V(1).Info("Starting EKS-A components upgrade")
-	oldVersion := currentSpec.VersionsBundle.Eksa.Version
-	newVersion := newSpec.VersionsBundle.Eksa.Version
-	if err := i.Install(ctx, log, cluster, newSpec); err != nil {
+	oldVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	oldVersion := oldVersionsBundle.Eksa.Version
+	newVersion := newVersionsBundle.Eksa.Version
+	if err := i.Install(ctx, log, c, newSpec); err != nil {
 		return nil, fmt.Errorf("upgrading EKS-A components from version %v to version %v: %v", oldVersion, newVersion, err)
 	}
 
@@ -176,7 +178,8 @@ func fullLifeCycleControllerForProvider(cluster *anywherev1.Cluster) bool {
 }
 
 func (g *EKSAComponentGenerator) parseEKSAComponentsSpec(spec *cluster.Spec) (*eksaComponents, error) {
-	componentsManifest, err := bundles.ReadManifest(g.reader, spec.VersionsBundle.Eksa.Components)
+	bundle := spec.ControlPlaneVersionsBundle()
+	componentsManifest, err := bundles.ReadManifest(g.reader, bundle.Eksa.Components)
 	if err != nil {
 		return nil, fmt.Errorf("loading manifest for eksa components: %v", err)
 	}
@@ -223,13 +226,16 @@ func (c *eksaComponents) BuildFromParsed(lookup yamlutil.ObjectLookup) error {
 
 // EksaChangeDiff computes the version diff in eksa components between two specs.
 func EksaChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
-	if currentSpec.VersionsBundle.Eksa.Version != newSpec.VersionsBundle.Eksa.Version {
+	oldVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+
+	if oldVersionsBundle.Eksa.Version != newVersionsBundle.Eksa.Version {
 		return &types.ChangeDiff{
 			ComponentReports: []types.ComponentChangeDiff{
 				{
 					ComponentName: "EKS-A",
-					NewVersion:    newSpec.VersionsBundle.Eksa.Version,
-					OldVersion:    currentSpec.VersionsBundle.Eksa.Version,
+					NewVersion:    newVersionsBundle.Eksa.Version,
+					OldVersion:    oldVersionsBundle.Eksa.Version,
 				},
 			},
 		}

--- a/pkg/clustermanager/kube_proxy_test.go
+++ b/pkg/clustermanager/kube_proxy_test.go
@@ -59,9 +59,10 @@ func newPrepareKubeProxyTest() *prepareKubeProxyTest {
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = "my-cluster-test"
 		s.Cluster.Spec.KubernetesVersion = anywherev1.Kube123
-		s.VersionsBundle.KubeDistro.EKSD.Channel = "1.23"
-		s.VersionsBundle.KubeDistro.EKSD.Number = 18
-		s.VersionsBundle.KubeDistro.KubeProxy.URI = "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.23.16-eks-1-23-18"
+		s.VersionsBundles["1.23"] = test.VersionBundle()
+		s.VersionsBundles["1.23"].KubeDistro.EKSD.Channel = "1.23"
+		s.VersionsBundles["1.23"].KubeDistro.EKSD.Number = 18
+		s.VersionsBundles["1.23"].KubeDistro.KubeProxy.URI = "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.23.16-eks-1-23-18"
 	})
 	tt.kcp = &controlplanev1.KubeadmControlPlane{
 		TypeMeta: metav1.TypeMeta{
@@ -298,9 +299,9 @@ func TestKubeProxyUpgraderPrepareForUpgradeAlreadyUsingNewKubeProxy(t *testing.T
 func TestKubeProxyUpgraderPrepareForUpgradeNewSpecHasOldKubeProxy(t *testing.T) {
 	g := NewWithT(t)
 	tt := newPrepareKubeProxyTest()
-	tt.spec.VersionsBundle.KubeDistro.EKSD.Channel = "1.23"
-	tt.spec.VersionsBundle.KubeDistro.EKSD.Number = 16
-	tt.spec.VersionsBundle.KubeDistro.KubeProxy.URI = "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.23.16-eks-1-23-16"
+	tt.spec.VersionsBundles["1.23"].KubeDistro.EKSD.Channel = "1.23"
+	tt.spec.VersionsBundles["1.23"].KubeDistro.EKSD.Number = 16
+	tt.spec.VersionsBundles["1.23"].KubeDistro.KubeProxy.URI = "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.23.16-eks-1-23-16"
 	tt.kcp.Spec.Version = "1.23.16-eks-1-23-15"
 	tt.kubeProxy.Spec.Template.Spec.Containers[0].Image = "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.23.16-eks-1-23-15"
 	tt.initClients(t)

--- a/pkg/clustermarshaller/clustermarshaller_test.go
+++ b/pkg/clustermarshaller/clustermarshaller_test.go
@@ -21,6 +21,7 @@ func TestWriteClusterConfigWithOIDCAndGitOps(t *testing.T) {
 		s.Cluster.TypeMeta.Kind = v1alpha1.ClusterKind
 		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
 		s.Cluster.Name = "mycluster"
+		s.Cluster.Spec.KubernetesVersion = ""
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 			Count: 3,
 		}
@@ -129,6 +130,7 @@ func TestWriteClusterConfigWithFluxAndGitOpsConfigs(t *testing.T) {
 		s.Cluster.TypeMeta.Kind = v1alpha1.ClusterKind
 		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
 		s.Cluster.Name = "mycluster"
+		s.Cluster.Spec.KubernetesVersion = ""
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 			Count: 3,
 		}
@@ -235,6 +237,7 @@ func TestWriteClusterConfigWithFluxConfig(t *testing.T) {
 		s.Cluster.TypeMeta.Kind = v1alpha1.ClusterKind
 		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
 		s.Cluster.Name = "mycluster"
+		s.Cluster.Spec.KubernetesVersion = ""
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 			Count: 3,
 		}

--- a/pkg/curatedpackages/curatedpackages.go
+++ b/pkg/curatedpackages/curatedpackages.go
@@ -47,7 +47,7 @@ func GetVersionBundle(reader Reader, eksaVersion string, spec *v1alpha1.Cluster)
 	if err != nil {
 		return nil, err
 	}
-	versionsBundle, err := cluster.GetVersionsBundle(spec, b)
+	versionsBundle, err := cluster.GetVersionsBundle(spec.Spec.KubernetesVersion, b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -487,7 +487,7 @@ func (pc *PackageControllerClient) getBundleFromCluster(ctx context.Context, cli
 		return nil, err
 	}
 
-	verBundle, err := cluster.GetVersionsBundle(clusterObj, bundles)
+	verBundle, err := cluster.GetVersionsBundle(clusterObj.Spec.KubernetesVersion, bundles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages/mocks"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type packageInstallerTest struct {
@@ -40,16 +39,6 @@ func newPackageInstallerTest(t *testing.T) *packageInstallerTest {
 			Cluster: &anywherev1.Cluster{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "test-cluster",
-				},
-			},
-		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &v1alpha1.VersionsBundle{
-				PackageController: v1alpha1.PackageBundle{
-					HelmChart: v1alpha1.Image{
-						URI:  "test_registry/test/eks-anywhere-packages:v1",
-						Name: "test_chart",
-					},
 				},
 			},
 		},

--- a/pkg/defaulting/example_test.go
+++ b/pkg/defaulting/example_test.go
@@ -31,6 +31,7 @@ func ExampleRunner_RunAll() {
 
 	ctx := context.Background()
 	spec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster.Spec.KubernetesVersion = "1.24"
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 5
 	})
 	updatedSpec, agg := r.RunAll(ctx, *spec)

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -127,13 +127,14 @@ func (d *Dependencies) Close(ctx context.Context) error {
 }
 
 func ForSpec(ctx context.Context, clusterSpec *cluster.Spec) *Factory {
-	eksaToolsImage := clusterSpec.VersionsBundle.Eksa.CliTools
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	eksaToolsImage := versionsBundle.Eksa.CliTools
 	return NewFactory().
 		UseExecutableImage(eksaToolsImage.VersionedImage()).
 		WithRegistryMirror(registrymirror.FromCluster(clusterSpec.Cluster)).
 		UseProxyConfiguration(clusterSpec.Cluster.ProxyConfiguration()).
 		WithWriterFolder(clusterSpec.Cluster.Name).
-		WithDiagnosticCollectorImage(clusterSpec.VersionsBundle.Eksa.DiagnosticCollector.VersionedImage())
+		WithDiagnosticCollectorImage(versionsBundle.Eksa.DiagnosticCollector.VersionedImage())
 }
 
 // Factory helps initialization.
@@ -1228,12 +1229,16 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec, kubeConfig str
 		if err != nil {
 			return err
 		}
+		bundle := spec.ControlPlaneVersionsBundle()
+		if bundle == nil {
+			return fmt.Errorf("could not find VersionsBundle")
+		}
 		f.dependencies.PackageControllerClient = curatedpackages.NewPackageControllerClient(
 			f.dependencies.Helm,
 			f.dependencies.Kubectl,
 			spec.Cluster.Name,
 			mgmtKubeConfig,
-			&spec.VersionsBundle.PackageController.HelmChart,
+			&bundle.PackageController.HelmChart,
 			f.registryMirror,
 			curatedpackages.WithEksaAccessKeyId(eksaAccessKeyID),
 			curatedpackages.WithEksaSecretAccessKey(eksaSecretKey),

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -300,14 +300,19 @@ func TestFactoryBuildWithPackageInstaller(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "test-cluster",
 				},
+				Spec: anywherev1.ClusterSpec{
+					KubernetesVersion: "1.19",
+				},
 			},
 		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &v1alpha1.VersionsBundle{
-				PackageController: v1alpha1.PackageBundle{
-					HelmChart: v1alpha1.Image{
-						URI:  "test_registry/test/eks-anywhere-packages:v1",
-						Name: "test_chart",
+		VersionsBundles: map[anywherev1.KubernetesVersion]*cluster.VersionsBundle{
+			"1.19": {
+				VersionsBundle: &v1alpha1.VersionsBundle{
+					PackageController: v1alpha1.PackageBundle{
+						HelmChart: v1alpha1.Image{
+							URI:  "test_registry/test/eks-anywhere-packages:v1",
+							Name: "test_chart",
+						},
 					},
 				},
 			},
@@ -359,15 +364,18 @@ func TestFactoryBuildWithPackageControllerClientNoProxy(t *testing.T) {
 					ManagementCluster: anywherev1.ManagementCluster{
 						Name: "mgmt-1",
 					},
+					KubernetesVersion: "1.19",
 				},
 			},
 		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &v1alpha1.VersionsBundle{
-				PackageController: v1alpha1.PackageBundle{
-					HelmChart: v1alpha1.Image{
-						URI:  "test_registry/test/eks-anywhere-packages:v1",
-						Name: "test_chart",
+		VersionsBundles: map[anywherev1.KubernetesVersion]*cluster.VersionsBundle{
+			"1.19": {
+				VersionsBundle: &v1alpha1.VersionsBundle{
+					PackageController: v1alpha1.PackageBundle{
+						HelmChart: v1alpha1.Image{
+							URI:  "test_registry/test/eks-anywhere-packages:v1",
+							Name: "test_chart",
+						},
 					},
 				},
 			},
@@ -399,15 +407,18 @@ func TestFactoryBuildWithPackageControllerClientProxy(t *testing.T) {
 						HttpsProxy: "1.1.1.1",
 						NoProxy:    []string{"1.1.1.1"},
 					},
+					KubernetesVersion: "1.19",
 				},
 			},
 		},
-		VersionsBundle: &cluster.VersionsBundle{
-			VersionsBundle: &v1alpha1.VersionsBundle{
-				PackageController: v1alpha1.PackageBundle{
-					HelmChart: v1alpha1.Image{
-						URI:  "test_registry/test/eks-anywhere-packages:v1",
-						Name: "test_chart",
+		VersionsBundles: map[anywherev1.KubernetesVersion]*cluster.VersionsBundle{
+			"1.19": {
+				VersionsBundle: &v1alpha1.VersionsBundle{
+					PackageController: v1alpha1.PackageBundle{
+						HelmChart: v1alpha1.Image{
+							URI:  "test_registry/test/eks-anywhere-packages:v1",
+							Name: "test_chart",
+						},
 					},
 				},
 			},

--- a/pkg/eksd/installer_test.go
+++ b/pkg/eksd/installer_test.go
@@ -37,7 +37,7 @@ func newInstallerTest(t *testing.T) *installerTest {
 	client := mocks.NewMockEksdInstallerClient(ctrl)
 	reader := m.NewMockReader(ctrl)
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.EksD.Name = "eks-d-1"
+		s.VersionsBundles["1.19"].EksD.Name = "eks-d-1"
 	})
 
 	return &installerTest{

--- a/pkg/eksd/upgrader.go
+++ b/pkg/eksd/upgrader.go
@@ -38,14 +38,16 @@ func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentS
 }
 
 func EksdChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
-	if currentSpec.VersionsBundle.EksD.Name != newSpec.VersionsBundle.EksD.Name {
-		logger.V(1).Info("EKS-D change diff ", "oldVersion ", currentSpec.VersionsBundle.EksD.Name, "newVersion ", newSpec.VersionsBundle.EksD.Name)
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if currentVersionsBundle.EksD.Name != newVersionsBundle.EksD.Name {
+		logger.V(1).Info("EKS-D change diff ", "oldVersion ", currentVersionsBundle.EksD.Name, "newVersion ", newVersionsBundle.EksD.Name)
 		return &types.ChangeDiff{
 			ComponentReports: []types.ComponentChangeDiff{
 				{
 					ComponentName: "EKS-D",
-					NewVersion:    newSpec.VersionsBundle.EksD.Name,
-					OldVersion:    currentSpec.VersionsBundle.EksD.Name,
+					NewVersion:    newVersionsBundle.EksD.Name,
+					OldVersion:    currentVersionsBundle.EksD.Name,
 				},
 			},
 		}

--- a/pkg/eksd/upgrader_test.go
+++ b/pkg/eksd/upgrader_test.go
@@ -34,7 +34,7 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 	client := mocks.NewMockEksdInstallerClient(ctrl)
 	reader := m.NewMockReader(ctrl)
 	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.EksD.Name = "eks-d-1"
+		s.VersionsBundles["1.19"].EksD.Name = "eks-d-1"
 	})
 
 	return &upgraderTest{
@@ -68,7 +68,7 @@ func TestEksdUpgradeNoChanges(t *testing.T) {
 func TestEksdUpgradeSuccess(t *testing.T) {
 	tt := newUpgraderTest(t)
 
-	tt.newSpec.VersionsBundle.EksD.Name = "eks-d-2"
+	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "eks-d-2"
 	tt.newSpec.Bundles = bundle()
 
 	wantDiff := &types.ChangeDiff{
@@ -89,7 +89,7 @@ func TestEksdUpgradeSuccess(t *testing.T) {
 func TestUpgraderEksdUpgradeInstallError(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.eksdUpgrader.SetRetrier(retrier.NewWithMaxRetries(1, 0))
-	tt.newSpec.VersionsBundle.EksD.Name = "eks-d-2"
+	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "eks-d-2"
 	tt.newSpec.Bundles = bundle()
 	tt.newSpec.Bundles.Spec.VersionsBundles[0].EksD.Components = ""
 	tt.newSpec.Bundles.Spec.VersionsBundles[1].EksD.Components = ""

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -64,7 +64,7 @@ func imageRepository(image v1alpha1.Image) string {
 // used by cluster api to install components.
 // See: https://cluster-api.sigs.k8s.io/clusterctl/configuration.html
 func (c *Clusterctl) buildOverridesLayer(clusterSpec *cluster.Spec, clusterName string, provider providers.Provider) error {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 
 	// Adding cluster name to path temporarily following suggestion.
 	//
@@ -77,44 +77,44 @@ func (c *Clusterctl) buildOverridesLayer(clusterSpec *cluster.Spec, clusterName 
 
 	infraBundles := []types.InfrastructureBundle{
 		{
-			FolderName: filepath.Join("cert-manager", bundle.CertManager.Version),
+			FolderName: filepath.Join("cert-manager", versionsBundle.CertManager.Version),
 			Manifests: []v1alpha1.Manifest{
-				bundle.CertManager.Manifest,
+				versionsBundle.CertManager.Manifest,
 			},
 		},
 		{
-			FolderName: filepath.Join("bootstrap-kubeadm", bundle.Bootstrap.Version),
+			FolderName: filepath.Join("bootstrap-kubeadm", versionsBundle.Bootstrap.Version),
 			Manifests: []v1alpha1.Manifest{
-				bundle.Bootstrap.Components,
-				bundle.Bootstrap.Metadata,
+				versionsBundle.Bootstrap.Components,
+				versionsBundle.Bootstrap.Metadata,
 			},
 		},
 		{
-			FolderName: filepath.Join("cluster-api", bundle.ClusterAPI.Version),
+			FolderName: filepath.Join("cluster-api", versionsBundle.ClusterAPI.Version),
 			Manifests: []v1alpha1.Manifest{
-				bundle.ClusterAPI.Components,
-				bundle.ClusterAPI.Metadata,
+				versionsBundle.ClusterAPI.Components,
+				versionsBundle.ClusterAPI.Metadata,
 			},
 		},
 		{
-			FolderName: filepath.Join("control-plane-kubeadm", bundle.ControlPlane.Version),
+			FolderName: filepath.Join("control-plane-kubeadm", versionsBundle.ControlPlane.Version),
 			Manifests: []v1alpha1.Manifest{
-				bundle.ControlPlane.Components,
-				bundle.ControlPlane.Metadata,
+				versionsBundle.ControlPlane.Components,
+				versionsBundle.ControlPlane.Metadata,
 			},
 		},
 		{
-			FolderName: filepath.Join("bootstrap-etcdadm-bootstrap", bundle.ExternalEtcdBootstrap.Version),
+			FolderName: filepath.Join("bootstrap-etcdadm-bootstrap", versionsBundle.ExternalEtcdBootstrap.Version),
 			Manifests: []v1alpha1.Manifest{
-				bundle.ExternalEtcdBootstrap.Components,
-				bundle.ExternalEtcdBootstrap.Metadata,
+				versionsBundle.ExternalEtcdBootstrap.Components,
+				versionsBundle.ExternalEtcdBootstrap.Metadata,
 			},
 		},
 		{
-			FolderName: filepath.Join("bootstrap-etcdadm-controller", bundle.ExternalEtcdController.Version),
+			FolderName: filepath.Join("bootstrap-etcdadm-controller", versionsBundle.ExternalEtcdController.Version),
 			Manifests: []v1alpha1.Manifest{
-				bundle.ExternalEtcdController.Components,
-				bundle.ExternalEtcdController.Metadata,
+				versionsBundle.ExternalEtcdController.Components,
+				versionsBundle.ExternalEtcdController.Metadata,
 			},
 		},
 	}
@@ -265,7 +265,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluste
 
 func (c *Clusterctl) buildConfig(clusterSpec *cluster.Spec, clusterName string, provider providers.Provider) (*clusterctlConfiguration, error) {
 	t := templater.New(c.writer)
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 
 	path, err := os.Getwd()
 	if err != nil {
@@ -273,58 +273,58 @@ func (c *Clusterctl) buildConfig(clusterSpec *cluster.Spec, clusterName string, 
 	}
 
 	data := map[string]string{
-		"CertManagerInjectorRepository":                   imageRepository(bundle.CertManager.Cainjector),
-		"CertManagerInjectorTag":                          bundle.CertManager.Cainjector.Tag(),
-		"CertManagerControllerRepository":                 imageRepository(bundle.CertManager.Controller),
-		"CertManagerControllerTag":                        bundle.CertManager.Controller.Tag(),
-		"CertManagerWebhookRepository":                    imageRepository(bundle.CertManager.Webhook),
-		"CertManagerWebhookTag":                           bundle.CertManager.Webhook.Tag(),
-		"CertManagerVersion":                              bundle.CertManager.Version,
-		"ClusterApiControllerRepository":                  imageRepository(bundle.ClusterAPI.Controller),
-		"ClusterApiControllerTag":                         bundle.ClusterAPI.Controller.Tag(),
-		"ClusterApiKubeRbacProxyRepository":               imageRepository(bundle.ClusterAPI.KubeProxy),
-		"ClusterApiKubeRbacProxyTag":                      bundle.ClusterAPI.KubeProxy.Tag(),
-		"KubeadmBootstrapControllerRepository":            imageRepository(bundle.Bootstrap.Controller),
-		"KubeadmBootstrapControllerTag":                   bundle.Bootstrap.Controller.Tag(),
-		"KubeadmBootstrapKubeRbacProxyRepository":         imageRepository(bundle.Bootstrap.KubeProxy),
-		"KubeadmBootstrapKubeRbacProxyTag":                bundle.Bootstrap.KubeProxy.Tag(),
-		"KubeadmControlPlaneControllerRepository":         imageRepository(bundle.ControlPlane.Controller),
-		"KubeadmControlPlaneControllerTag":                bundle.ControlPlane.Controller.Tag(),
-		"KubeadmControlPlaneKubeRbacProxyRepository":      imageRepository(bundle.ControlPlane.KubeProxy),
-		"KubeadmControlPlaneKubeRbacProxyTag":             bundle.ControlPlane.KubeProxy.Tag(),
-		"ClusterApiVSphereControllerRepository":           imageRepository(bundle.VSphere.ClusterAPIController),
-		"ClusterApiVSphereControllerTag":                  bundle.VSphere.ClusterAPIController.Tag(),
-		"ClusterApiNutanixControllerRepository":           imageRepository(bundle.Nutanix.ClusterAPIController),
-		"ClusterApiNutanixControllerTag":                  bundle.Nutanix.ClusterAPIController.Tag(),
-		"ClusterApiCloudStackManagerRepository":           imageRepository(bundle.CloudStack.ClusterAPIController),
-		"ClusterApiCloudStackManagerTag":                  bundle.CloudStack.ClusterAPIController.Tag(),
-		"ClusterApiCloudStackKubeRbacProxyRepository":     imageRepository(bundle.CloudStack.KubeRbacProxy),
-		"ClusterApiCloudStackKubeRbacProxyTag":            bundle.CloudStack.KubeRbacProxy.Tag(),
-		"ClusterApiVSphereKubeRbacProxyRepository":        imageRepository(bundle.VSphere.KubeProxy),
-		"ClusterApiVSphereKubeRbacProxyTag":               bundle.VSphere.KubeProxy.Tag(),
-		"DockerKubeRbacProxyRepository":                   imageRepository(bundle.Docker.KubeProxy),
-		"DockerKubeRbacProxyTag":                          bundle.Docker.KubeProxy.Tag(),
-		"DockerManagerRepository":                         imageRepository(bundle.Docker.Manager),
-		"DockerManagerTag":                                bundle.Docker.Manager.Tag(),
-		"EtcdadmBootstrapProviderRepository":              imageRepository(bundle.ExternalEtcdBootstrap.Controller),
-		"EtcdadmBootstrapProviderTag":                     bundle.ExternalEtcdBootstrap.Controller.Tag(),
-		"EtcdadmBootstrapProviderKubeRbacProxyRepository": imageRepository(bundle.ExternalEtcdBootstrap.KubeProxy),
-		"EtcdadmBootstrapProviderKubeRbacProxyTag":        bundle.ExternalEtcdBootstrap.KubeProxy.Tag(),
-		"EtcdadmControllerRepository":                     imageRepository(bundle.ExternalEtcdController.Controller),
-		"EtcdadmControllerTag":                            bundle.ExternalEtcdController.Controller.Tag(),
-		"EtcdadmControllerKubeRbacProxyRepository":        imageRepository(bundle.ExternalEtcdController.KubeProxy),
-		"EtcdadmControllerKubeRbacProxyTag":               bundle.ExternalEtcdController.KubeProxy.Tag(),
-		"DockerProviderVersion":                           bundle.Docker.Version,
-		"VSphereProviderVersion":                          bundle.VSphere.Version,
-		"CloudStackProviderVersion":                       bundle.CloudStack.Version,
-		"SnowProviderVersion":                             bundle.Snow.Version,
-		"TinkerbellProviderVersion":                       bundle.Tinkerbell.Version,
-		"NutanixProviderVersion":                          bundle.Nutanix.Version,
-		"ClusterApiProviderVersion":                       bundle.ClusterAPI.Version,
-		"KubeadmControlPlaneProviderVersion":              bundle.ControlPlane.Version,
-		"KubeadmBootstrapProviderVersion":                 bundle.Bootstrap.Version,
-		"EtcdadmBootstrapProviderVersion":                 bundle.ExternalEtcdBootstrap.Version,
-		"EtcdadmControllerProviderVersion":                bundle.ExternalEtcdController.Version,
+		"CertManagerInjectorRepository":                   imageRepository(versionsBundle.CertManager.Cainjector),
+		"CertManagerInjectorTag":                          versionsBundle.CertManager.Cainjector.Tag(),
+		"CertManagerControllerRepository":                 imageRepository(versionsBundle.CertManager.Controller),
+		"CertManagerControllerTag":                        versionsBundle.CertManager.Controller.Tag(),
+		"CertManagerWebhookRepository":                    imageRepository(versionsBundle.CertManager.Webhook),
+		"CertManagerWebhookTag":                           versionsBundle.CertManager.Webhook.Tag(),
+		"CertManagerVersion":                              versionsBundle.CertManager.Version,
+		"ClusterApiControllerRepository":                  imageRepository(versionsBundle.ClusterAPI.Controller),
+		"ClusterApiControllerTag":                         versionsBundle.ClusterAPI.Controller.Tag(),
+		"ClusterApiKubeRbacProxyRepository":               imageRepository(versionsBundle.ClusterAPI.KubeProxy),
+		"ClusterApiKubeRbacProxyTag":                      versionsBundle.ClusterAPI.KubeProxy.Tag(),
+		"KubeadmBootstrapControllerRepository":            imageRepository(versionsBundle.Bootstrap.Controller),
+		"KubeadmBootstrapControllerTag":                   versionsBundle.Bootstrap.Controller.Tag(),
+		"KubeadmBootstrapKubeRbacProxyRepository":         imageRepository(versionsBundle.Bootstrap.KubeProxy),
+		"KubeadmBootstrapKubeRbacProxyTag":                versionsBundle.Bootstrap.KubeProxy.Tag(),
+		"KubeadmControlPlaneControllerRepository":         imageRepository(versionsBundle.ControlPlane.Controller),
+		"KubeadmControlPlaneControllerTag":                versionsBundle.ControlPlane.Controller.Tag(),
+		"KubeadmControlPlaneKubeRbacProxyRepository":      imageRepository(versionsBundle.ControlPlane.KubeProxy),
+		"KubeadmControlPlaneKubeRbacProxyTag":             versionsBundle.ControlPlane.KubeProxy.Tag(),
+		"ClusterApiVSphereControllerRepository":           imageRepository(versionsBundle.VSphere.ClusterAPIController),
+		"ClusterApiVSphereControllerTag":                  versionsBundle.VSphere.ClusterAPIController.Tag(),
+		"ClusterApiNutanixControllerRepository":           imageRepository(versionsBundle.Nutanix.ClusterAPIController),
+		"ClusterApiNutanixControllerTag":                  versionsBundle.Nutanix.ClusterAPIController.Tag(),
+		"ClusterApiCloudStackManagerRepository":           imageRepository(versionsBundle.CloudStack.ClusterAPIController),
+		"ClusterApiCloudStackManagerTag":                  versionsBundle.CloudStack.ClusterAPIController.Tag(),
+		"ClusterApiCloudStackKubeRbacProxyRepository":     imageRepository(versionsBundle.CloudStack.KubeRbacProxy),
+		"ClusterApiCloudStackKubeRbacProxyTag":            versionsBundle.CloudStack.KubeRbacProxy.Tag(),
+		"ClusterApiVSphereKubeRbacProxyRepository":        imageRepository(versionsBundle.VSphere.KubeProxy),
+		"ClusterApiVSphereKubeRbacProxyTag":               versionsBundle.VSphere.KubeProxy.Tag(),
+		"DockerKubeRbacProxyRepository":                   imageRepository(versionsBundle.Docker.KubeProxy),
+		"DockerKubeRbacProxyTag":                          versionsBundle.Docker.KubeProxy.Tag(),
+		"DockerManagerRepository":                         imageRepository(versionsBundle.Docker.Manager),
+		"DockerManagerTag":                                versionsBundle.Docker.Manager.Tag(),
+		"EtcdadmBootstrapProviderRepository":              imageRepository(versionsBundle.ExternalEtcdBootstrap.Controller),
+		"EtcdadmBootstrapProviderTag":                     versionsBundle.ExternalEtcdBootstrap.Controller.Tag(),
+		"EtcdadmBootstrapProviderKubeRbacProxyRepository": imageRepository(versionsBundle.ExternalEtcdBootstrap.KubeProxy),
+		"EtcdadmBootstrapProviderKubeRbacProxyTag":        versionsBundle.ExternalEtcdBootstrap.KubeProxy.Tag(),
+		"EtcdadmControllerRepository":                     imageRepository(versionsBundle.ExternalEtcdController.Controller),
+		"EtcdadmControllerTag":                            versionsBundle.ExternalEtcdController.Controller.Tag(),
+		"EtcdadmControllerKubeRbacProxyRepository":        imageRepository(versionsBundle.ExternalEtcdController.KubeProxy),
+		"EtcdadmControllerKubeRbacProxyTag":               versionsBundle.ExternalEtcdController.KubeProxy.Tag(),
+		"DockerProviderVersion":                           versionsBundle.Docker.Version,
+		"VSphereProviderVersion":                          versionsBundle.VSphere.Version,
+		"CloudStackProviderVersion":                       versionsBundle.CloudStack.Version,
+		"SnowProviderVersion":                             versionsBundle.Snow.Version,
+		"TinkerbellProviderVersion":                       versionsBundle.Tinkerbell.Version,
+		"NutanixProviderVersion":                          versionsBundle.Nutanix.Version,
+		"ClusterApiProviderVersion":                       versionsBundle.ClusterAPI.Version,
+		"KubeadmControlPlaneProviderVersion":              versionsBundle.ControlPlane.Version,
+		"KubeadmBootstrapProviderVersion":                 versionsBundle.Bootstrap.Version,
+		"EtcdadmBootstrapProviderVersion":                 versionsBundle.ExternalEtcdBootstrap.Version,
+		"EtcdadmControllerProviderVersion":                versionsBundle.ExternalEtcdController.Version,
 		"dir":                                             path + "/" + clusterName + capiPrefix,
 	}
 
@@ -338,11 +338,11 @@ func (c *Clusterctl) buildConfig(clusterSpec *cluster.Spec, clusterName string, 
 
 	return &clusterctlConfiguration{
 		configFile:               filePath,
-		bootstrapVersion:         fmt.Sprintf("%s:%s", kubeadmBootstrapProviderName, bundle.Bootstrap.Version),
-		controlPlaneVersion:      fmt.Sprintf("kubeadm:%s", bundle.ControlPlane.Version),
-		coreVersion:              fmt.Sprintf("cluster-api:%s", bundle.ClusterAPI.Version),
-		etcdadmBootstrapVersion:  fmt.Sprintf("%s:%s", etcdadmBootstrapProviderName, bundle.ExternalEtcdBootstrap.Version),
-		etcdadmControllerVersion: fmt.Sprintf("%s:%s", etcdadmControllerProviderName, bundle.ExternalEtcdController.Version),
+		bootstrapVersion:         fmt.Sprintf("%s:%s", kubeadmBootstrapProviderName, versionsBundle.Bootstrap.Version),
+		controlPlaneVersion:      fmt.Sprintf("kubeadm:%s", versionsBundle.ControlPlane.Version),
+		coreVersion:              fmt.Sprintf("cluster-api:%s", versionsBundle.ClusterAPI.Version),
+		etcdadmBootstrapVersion:  fmt.Sprintf("%s:%s", etcdadmBootstrapProviderName, versionsBundle.ExternalEtcdBootstrap.Version),
+		etcdadmControllerVersion: fmt.Sprintf("%s:%s", etcdadmControllerProviderName, versionsBundle.ExternalEtcdController.Version),
 	}, nil
 }
 

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -535,7 +535,7 @@ func TestReplacePath(t *testing.T) {
 }
 
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {
-	s.VersionsBundle = versionBundle
+	s.VersionsBundles["1.19"] = versionBundle
 })
 
 func createTestDirectory(t *testing.T, dirpath string) {

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -180,16 +180,16 @@ func (k *Kind) DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluste
 }
 
 func (k *Kind) setupExecConfig(clusterSpec *cluster.Spec) error {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	k.execConfig = &kindExecConfig{
-		KindImage:            registryMirror.ReplaceRegistry(bundle.EksD.KindNode.VersionedImage()),
-		KubernetesRepository: registryMirror.ReplaceRegistry(bundle.KubeDistro.Kubernetes.Repository),
-		KubernetesVersion:    bundle.KubeDistro.Kubernetes.Tag,
-		EtcdRepository:       registryMirror.ReplaceRegistry(bundle.KubeDistro.Etcd.Repository),
-		EtcdVersion:          bundle.KubeDistro.Etcd.Tag,
-		CorednsRepository:    registryMirror.ReplaceRegistry(bundle.KubeDistro.CoreDNS.Repository),
-		CorednsVersion:       bundle.KubeDistro.CoreDNS.Tag,
+		KindImage:            registryMirror.ReplaceRegistry(versionsBundle.EksD.KindNode.VersionedImage()),
+		KubernetesRepository: registryMirror.ReplaceRegistry(versionsBundle.KubeDistro.Kubernetes.Repository),
+		KubernetesVersion:    versionsBundle.KubeDistro.Kubernetes.Tag,
+		EtcdRepository:       registryMirror.ReplaceRegistry(versionsBundle.KubeDistro.Etcd.Repository),
+		EtcdVersion:          versionsBundle.KubeDistro.Etcd.Tag,
+		CorednsRepository:    registryMirror.ReplaceRegistry(versionsBundle.KubeDistro.CoreDNS.Repository),
+		CorednsVersion:       versionsBundle.KubeDistro.CoreDNS.Tag,
 		env:                  make(map[string]string),
 	}
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/executables/kind_test.go
+++ b/pkg/executables/kind_test.go
@@ -31,7 +31,7 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 	clusterName := "test_cluster"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
-		s.VersionsBundle = versionBundle
+		s.VersionsBundles["1.19"] = versionBundle
 	})
 	eksClusterName := "test_cluster-eks-a-cluster"
 	kubeConfigFile := "test_cluster.kind.kubeconfig"
@@ -165,7 +165,7 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 			wantKubeconfig: kubeConfigFile,
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Cluster.Name = clusterName
-				s.VersionsBundle = versionBundle
+				s.VersionsBundles["1.19"] = versionBundle
 				s.Cluster.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{
 					Endpoint: registryMirror,
 					Port:     constants.DefaultHttpsPort,
@@ -185,7 +185,7 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 			wantKubeconfig: kubeConfigFile,
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Cluster.Name = clusterName
-				s.VersionsBundle = versionBundle
+				s.VersionsBundles["1.19"] = versionBundle
 				s.Cluster.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{
 					Endpoint:      registryMirror,
 					Port:          constants.DefaultHttpsPort,
@@ -200,7 +200,7 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 			wantKubeconfig: kubeConfigFile,
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Cluster.Name = clusterName
-				s.VersionsBundle = versionBundle
+				s.VersionsBundles["1.19"] = versionBundle
 				s.Cluster.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{
 					Endpoint: registryMirror,
 					Port:     constants.DefaultHttpsPort,
@@ -271,7 +271,7 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 func TestKindCreateBootstrapClusterExecutableError(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = "clusterName"
-		s.VersionsBundle = versionBundle
+		s.VersionsBundles["1.19"] = versionBundle
 	})
 
 	ctx := context.Background()
@@ -295,7 +295,7 @@ func TestKindCreateBootstrapClusterExecutableWithRegistryMirrorError(t *testing.
 	registryMirror := "registry-mirror.test"
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = "clusterName"
-		s.VersionsBundle = versionBundle
+		s.VersionsBundles["1.19"] = versionBundle
 		s.Cluster.Spec.RegistryMirrorConfiguration = &v1alpha1.RegistryMirrorConfiguration{
 			Endpoint:     registryMirror,
 			Port:         constants.DefaultHttpsPort,

--- a/pkg/gitops/flux/files.go
+++ b/pkg/gitops/flux/files.go
@@ -150,12 +150,13 @@ func (g *FileGenerator) WriteFluxSync() error {
 }
 
 func (g *FileGenerator) WriteFluxPatch(clusterSpec *cluster.Spec) error {
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 	values := map[string]string{
 		"Namespace":                   clusterSpec.FluxConfig.Spec.SystemNamespace,
-		"SourceControllerImage":       clusterSpec.VersionsBundle.Flux.SourceController.VersionedImage(),
-		"KustomizeControllerImage":    clusterSpec.VersionsBundle.Flux.KustomizeController.VersionedImage(),
-		"HelmControllerImage":         clusterSpec.VersionsBundle.Flux.HelmController.VersionedImage(),
-		"NotificationControllerImage": clusterSpec.VersionsBundle.Flux.NotificationController.VersionedImage(),
+		"SourceControllerImage":       versionsBundle.Flux.SourceController.VersionedImage(),
+		"KustomizeControllerImage":    versionsBundle.Flux.KustomizeController.VersionedImage(),
+		"HelmControllerImage":         versionsBundle.Flux.HelmController.VersionedImage(),
+		"NotificationControllerImage": versionsBundle.Flux.NotificationController.VersionedImage(),
 	}
 	if path, err := g.fluxTemplater.WriteToFile(fluxPatchContent, values, fluxPatchFileName, filewriter.PersistentFile); err != nil {
 		return fmt.Errorf("creating flux-system patch manifest file into %s: %v", path, err)

--- a/pkg/gitops/flux/flux_test.go
+++ b/pkg/gitops/flux/flux_test.go
@@ -161,7 +161,7 @@ func newClusterSpec(t *testing.T, clusterConfig *v1alpha1.Cluster, fluxPath stri
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster = clusterConfig
-		s.VersionsBundle.Flux = fluxBundle()
+		s.VersionsBundles["1.19"].Flux = fluxBundle()
 		s.FluxConfig = &fluxConfig
 	})
 	if err := cluster.SetConfigDefaults(clusterSpec.Config); err != nil {

--- a/pkg/gitops/flux/upgrader.go
+++ b/pkg/gitops/flux/upgrader.go
@@ -53,8 +53,10 @@ func FluxChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 		logger.V(1).Info("Skipping Flux upgrades, GitOps not enabled")
 		return nil
 	}
-	oldVersion := currentSpec.VersionsBundle.Flux.Version
-	newVersion := newSpec.VersionsBundle.Flux.Version
+	oldVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	oldVersion := oldVersionsBundle.Flux.Version
+	newVersion := newVersionsBundle.Flux.Version
 	if oldVersion != newVersion {
 		logger.V(1).Info("Flux change diff ", "oldVersion ", oldVersion, "newVersion ", newVersion)
 		return &types.ChangeDiff{

--- a/pkg/gitops/flux/upgrader_test.go
+++ b/pkg/gitops/flux/upgrader_test.go
@@ -30,7 +30,7 @@ type upgraderTest struct {
 func newUpgraderTest(t *testing.T) *upgraderTest {
 	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Bundles.Spec.Number = 1
-		s.VersionsBundle.Flux.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].Flux.Version = "v0.1.0"
 		s.Cluster = &v1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "management-cluster",
@@ -39,6 +39,7 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 				GitOpsRef: &v1alpha1.Ref{
 					Name: "testGitOpsRef",
 				},
+				KubernetesVersion: "1.19",
 			},
 		}
 	})
@@ -81,14 +82,14 @@ func TestFluxUpgradeNoSelfManaged(t *testing.T) {
 func TestFluxUpgradeNoChanges(t *testing.T) {
 	tt := newUpgraderTest(t)
 	g := newFluxTest(t)
-	tt.newSpec.VersionsBundle.Flux.Version = "v0.1.0"
+	tt.newSpec.VersionsBundles["1.19"].Flux.Version = "v0.1.0"
 
 	tt.Expect(g.gitOpsFlux.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil())
 }
 
 func TestFluxUpgradeSuccess(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.VersionsBundle.Flux.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].Flux.Version = "v0.2.0"
 
 	tt.newSpec.FluxConfig = &tt.fluxConfig
 
@@ -124,7 +125,7 @@ func TestFluxUpgradeSuccess(t *testing.T) {
 
 func TestFluxUpgradeBootstrapGithubError(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.VersionsBundle.Flux.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].Flux.Version = "v0.2.0"
 
 	tt.newSpec.FluxConfig = &tt.fluxConfig
 	g := newFluxTest(t)
@@ -148,7 +149,7 @@ func TestFluxUpgradeBootstrapGithubError(t *testing.T) {
 
 func TestFluxUpgradeBootstrapGitError(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.VersionsBundle.Flux.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].Flux.Version = "v0.2.0"
 
 	tt.newSpec.FluxConfig = &tt.fluxConfig
 	g := newFluxTest(t)
@@ -173,7 +174,7 @@ func TestFluxUpgradeBootstrapGitError(t *testing.T) {
 
 func TestFluxUpgradeAddError(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.newSpec.VersionsBundle.Flux.Version = "v0.2.0"
+	tt.newSpec.VersionsBundles["1.19"].Flux.Version = "v0.2.0"
 
 	tt.newSpec.FluxConfig = &tt.fluxConfig
 

--- a/pkg/manifests/bundles/images.go
+++ b/pkg/manifests/bundles/images.go
@@ -3,13 +3,22 @@ package bundles
 import (
 	"fmt"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/aws/eks-anywhere/pkg/manifests/eksd"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-func ReadImages(reader Reader, bundles *releasev1.Bundles) ([]releasev1.Image, error) {
+// ReadImages returns a list of all images included in the Bundles and the referenced
+// EKS-D Releases, all of them filtered by kubernetes version. If not kubernetes versions
+// all provided, all images are returned.
+func ReadImages(reader Reader, bundles *releasev1.Bundles, kubeVersions ...string) ([]releasev1.Image, error) {
 	var images []releasev1.Image
 	for _, v := range bundles.Spec.VersionsBundles {
+		if len(kubeVersions) > 0 && !slices.Contains(kubeVersions, v.KubeVersion) {
+			continue
+		}
+
 		images = append(images, v.Images()...)
 
 		eksdRelease, err := ReadEKSD(reader, v)

--- a/pkg/networking/cilium/cilium_test.go
+++ b/pkg/networking/cilium/cilium_test.go
@@ -42,7 +42,9 @@ func newCiliumTest(t *testing.T) *ciliumtest {
 			KubeconfigFile: "config.kubeconfig",
 		},
 		spec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.VersionsBundle.Cilium = v1alpha1.CiliumBundle{
+			s.Cluster.Spec.KubernetesVersion = "1.21"
+			s.VersionsBundles["1.21"] = test.VersionBundle()
+			s.VersionsBundles["1.21"].Cilium = v1alpha1.CiliumBundle{
 				Cilium: v1alpha1.Image{
 					URI: "public.ecr.aws/isovalent/cilium:v1.9.13-eksa.2",
 				},
@@ -54,7 +56,7 @@ func newCiliumTest(t *testing.T) *ciliumtest {
 					URI:  "public.ecr.aws/isovalent/cilium:1.9.13-eksa.2",
 				},
 			}
-			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.21.9-eks-1-21-10"
+			s.VersionsBundles["1.21"].KubeDistro.Kubernetes.Tag = "v1.21.9-eks-1-21-10"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha12.CNIConfig{Cilium: &v1alpha12.CiliumConfig{}}
 		}),
 		ciliumValues: []byte("manifest"),

--- a/pkg/networking/cilium/reconciler/reconciler_test.go
+++ b/pkg/networking/cilium/reconciler/reconciler_test.go
@@ -148,8 +148,8 @@ func TestReconcilerReconcileUpgradeButCiliumDaemonSetNotReady(t *testing.T) {
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -168,8 +168,8 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDaemonSetNotAvailab
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -190,8 +190,8 @@ func TestReconcilerReconcileUpgradeErrorGeneratingPreflight(t *testing.T) {
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -210,8 +210,8 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDeploymentNotAvaila
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -233,8 +233,8 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightNotReady(t *testing
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -256,8 +256,8 @@ func TestReconcilerReconcileUpgradePreflightDaemonSetNotReady(t *testing.T) {
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator, ciliumPreflightDaemonSet(), ciliumPreflightDeployment())
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -277,8 +277,8 @@ func TestReconcilerReconcileUpgradePreflightDeploymentSetNotReady(t *testing.T) 
 	preflight := ciliumPreflightDaemonSet()
 	tt := newReconcileTest(t).withObjects(ds, operator, preflight, ciliumPreflightDeployment())
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
-		s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.11.1-eksa-1"
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.11.1-eksa-1"
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -303,8 +303,8 @@ func TestReconcilerReconcileUpgradeInvalidCiliumInstalledVersion(t *testing.T) {
 
 	tt := newReconcileTest(t).withObjects(ds, operator, preflight, ciliumPreflightDeployment())
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = newDSImage
-		s.VersionsBundle.Cilium.Operator.URI = newOperatorImage
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = newDSImage
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = newOperatorImage
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -328,8 +328,8 @@ func TestReconcilerReconcileUpgradeErrorGeneratingManifest(t *testing.T) {
 
 	tt := newReconcileTest(t).withObjects(ds, operator, preflight, ciliumPreflightDeployment())
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = newDSImage
-		s.VersionsBundle.Cilium.Operator.URI = newOperatorImage
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = newDSImage
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = newOperatorImage
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -356,8 +356,8 @@ func TestReconcilerReconcileUpgradePreflightErrorYamlReconcile(t *testing.T) {
 
 	tt := newReconcileTest(t).withObjects(ds, operator, preflight, ciliumPreflightDeployment())
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = newDSImage
-		s.VersionsBundle.Cilium.Operator.URI = newOperatorImage
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = newDSImage
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = newOperatorImage
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -387,8 +387,8 @@ func TestReconcilerReconcileUpgradePreflightReady(t *testing.T) {
 
 	tt := newReconcileTest(t).withObjects(ds, operator, preflight, ciliumPreflightDeployment())
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = newDSImage
-		s.VersionsBundle.Cilium.Operator.URI = newOperatorImage
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = newDSImage
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = newOperatorImage
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{},
 		}
@@ -422,8 +422,8 @@ func TestReconcilerReconcileUpdateConfigConfigMapEnablePolicyChange(t *testing.T
 	upgradeManifest := tt.buildManifest(ds, operator, cm)
 
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Cilium.Cilium.URI = newDSImage
-		s.VersionsBundle.Cilium.Operator.URI = newOperatorImage
+		s.VersionsBundles["1.19"].Cilium.Cilium.URI = newDSImage
+		s.VersionsBundles["1.19"].Cilium.Operator.URI = newOperatorImage
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 			Cilium: &anywherev1.CiliumConfig{
 				PolicyEnforcementMode: "always",
@@ -561,8 +561,8 @@ func newReconcileTest(t *testing.T) *reconcileTest {
 		t:     t,
 		ctx:   context.Background(),
 		spec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.VersionsBundle.Cilium.Cilium.URI = "cilium:1.10.1-eksa-1"
-			s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:1.10.1-eksa-1"
+			s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:1.10.1-eksa-1"
+			s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:1.10.1-eksa-1"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 				Cilium: &anywherev1.CiliumConfig{
 					PolicyEnforcementMode: "default",

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -40,10 +40,11 @@ func NewTemplater(helm Helm) *Templater {
 }
 
 func (t *Templater) GenerateUpgradePreflightManifest(ctx context.Context, spec *cluster.Spec) ([]byte, error) {
-	v := templateValues(spec)
+	versionsBundle := spec.ControlPlaneVersionsBundle()
+	v := templateValues(spec, versionsBundle)
 	v.set(true, "preflight", "enabled")
-	v.set(spec.VersionsBundle.Cilium.Cilium.Image(), "preflight", "image", "repository")
-	v.set(spec.VersionsBundle.Cilium.Cilium.Tag(), "preflight", "image", "tag")
+	v.set(versionsBundle.Cilium.Cilium.Image(), "preflight", "image", "repository")
+	v.set(versionsBundle.Cilium.Cilium.Tag(), "preflight", "image", "tag")
 	v.set(false, "agent")
 	v.set(false, "operator", "enabled")
 
@@ -72,9 +73,9 @@ func (t *Templater) GenerateUpgradePreflightManifest(ctx context.Context, spec *
 	}
 	v.set(tolerationsList, "preflight", "tolerations")
 
-	uri, version := getChartUriAndVersion(spec)
+	uri, version := getChartURIAndVersion(versionsBundle)
 
-	kubeVersion, err := getKubeVersionString(spec)
+	kubeVersion, err := getKubeVersionString(spec, versionsBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -130,13 +131,14 @@ func WithPolicyAllowedNamespaces(namespaces []string) ManifestOpt {
 }
 
 func (t *Templater) GenerateManifest(ctx context.Context, spec *cluster.Spec, opts ...ManifestOpt) ([]byte, error) {
-	kubeVersion, err := getKubeVersionString(spec)
+	versionsBundle := spec.ControlPlaneVersionsBundle()
+	kubeVersion, err := getKubeVersionString(spec, versionsBundle)
 	if err != nil {
 		return nil, err
 	}
 
 	c := &ManifestConfig{
-		values:      templateValues(spec),
+		values:      templateValues(spec, versionsBundle),
 		kubeVersion: kubeVersion,
 		retrier:     retrier.NewWithMaxRetries(maxRetries, defaultBackOffPeriod),
 	}
@@ -144,7 +146,7 @@ func (t *Templater) GenerateManifest(ctx context.Context, spec *cluster.Spec, op
 		o(c)
 	}
 
-	uri, version := getChartUriAndVersion(spec)
+	uri, version := getChartURIAndVersion(versionsBundle)
 	var manifest []byte
 
 	if spec.Cluster.Spec.RegistryMirrorConfiguration != nil {
@@ -210,7 +212,7 @@ func (c values) set(value interface{}, path ...string) {
 	element[path[len(path)-1]] = value
 }
 
-func templateValues(spec *cluster.Spec) values {
+func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) values {
 	val := values{
 		"cni": values{
 			"chainingMode": "portmap",
@@ -225,15 +227,15 @@ func templateValues(spec *cluster.Spec) values {
 		"rollOutCiliumPods": true,
 		"tunnel":            "geneve",
 		"image": values{
-			"repository": spec.VersionsBundle.Cilium.Cilium.Image(),
-			"tag":        spec.VersionsBundle.Cilium.Cilium.Tag(),
+			"repository": versionsBundle.Cilium.Cilium.Image(),
+			"tag":        versionsBundle.Cilium.Cilium.Tag(),
 		},
 		"operator": values{
 			"image": values{
 				// The chart expects an "incomplete" repository
 				// and will add the necessary suffix ("-generic" in our case)
-				"repository": strings.TrimSuffix(spec.VersionsBundle.Cilium.Operator.Image(), "-generic"),
-				"tag":        spec.VersionsBundle.Cilium.Operator.Tag(),
+				"repository": strings.TrimSuffix(versionsBundle.Cilium.Operator.Image(), "-generic"),
+				"tag":        versionsBundle.Cilium.Operator.Tag(),
 			},
 			"prometheus": values{
 				"enabled": true,
@@ -256,23 +258,23 @@ func templateValues(spec *cluster.Spec) values {
 	return val
 }
 
-func getChartUriAndVersion(spec *cluster.Spec) (uri, version string) {
-	chart := spec.VersionsBundle.Cilium.HelmChart
+func getChartURIAndVersion(versionsBundle *cluster.VersionsBundle) (uri, version string) {
+	chart := versionsBundle.Cilium.HelmChart
 	uri = fmt.Sprintf("oci://%s", chart.Image())
 	version = chart.Tag()
 	return uri, version
 }
 
-func getKubeVersion(spec *cluster.Spec) (*semver.Version, error) {
-	k8sVersion, err := semver.New(spec.VersionsBundle.KubeDistro.Kubernetes.Tag)
+func getKubeVersion(versionsBundle *cluster.VersionsBundle) (*semver.Version, error) {
+	k8sVersion, err := semver.New(versionsBundle.KubeDistro.Kubernetes.Tag)
 	if err != nil {
-		return nil, fmt.Errorf("parsing kubernetes version %v: %v", spec.Cluster.Spec.KubernetesVersion, err)
+		return nil, fmt.Errorf("parsing kubernetes version %v: %v", versionsBundle.KubeDistro.Kubernetes.Tag, err)
 	}
 	return k8sVersion, nil
 }
 
-func getKubeVersionString(spec *cluster.Spec) (string, error) {
-	k8sVersion, err := getKubeVersion(spec)
+func getKubeVersionString(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) (string, error) {
+	k8sVersion, err := getKubeVersion(versionsBundle)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -44,19 +44,23 @@ func newtemplaterTest(t *testing.T) *templaterTest {
 		version:   "1.9.11-eksa.1",
 		namespace: "kube-system",
 		currentSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.VersionsBundle.Cilium.Version = "v1.9.10-eksa.1"
-			s.VersionsBundle.Cilium.Cilium.URI = "public.ecr.aws/isovalent/cilium:v1.9.10-eksa.1"
-			s.VersionsBundle.Cilium.Operator.URI = "public.ecr.aws/isovalent/operator-generic:v1.9.10-eksa.1"
-			s.VersionsBundle.Cilium.HelmChart.URI = "public.ecr.aws/isovalent/cilium:1.9.10-eksa.1"
-			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
+			s.Cluster.Spec.KubernetesVersion = "1.22"
+			s.VersionsBundles["1.22"] = test.VersionBundle()
+			s.VersionsBundles["1.22"].Cilium.Version = "v1.9.10-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.Cilium.URI = "public.ecr.aws/isovalent/cilium:v1.9.10-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.Operator.URI = "public.ecr.aws/isovalent/operator-generic:v1.9.10-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.HelmChart.URI = "public.ecr.aws/isovalent/cilium:1.9.10-eksa.1"
+			s.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		spec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.VersionsBundle.Cilium.Version = "v1.9.11-eksa.1"
-			s.VersionsBundle.Cilium.Cilium.URI = "public.ecr.aws/isovalent/cilium:v1.9.11-eksa.1"
-			s.VersionsBundle.Cilium.Operator.URI = "public.ecr.aws/isovalent/operator-generic:v1.9.11-eksa.1"
-			s.VersionsBundle.Cilium.HelmChart.URI = "public.ecr.aws/isovalent/cilium:1.9.11-eksa.1"
-			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
+			s.Cluster.Spec.KubernetesVersion = "1.22"
+			s.VersionsBundles["1.22"] = test.VersionBundle()
+			s.VersionsBundles["1.22"].Cilium.Version = "v1.9.11-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.Cilium.URI = "public.ecr.aws/isovalent/cilium:v1.9.11-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.Operator.URI = "public.ecr.aws/isovalent/operator-generic:v1.9.11-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.HelmChart.URI = "public.ecr.aws/isovalent/cilium:1.9.11-eksa.1"
+			s.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 	}
@@ -173,7 +177,7 @@ func TestTemplaterGenerateUpgradePreflightManifestError(t *testing.T) {
 
 func TestTemplaterGenerateUpgradePreflightManifestInvalidKubeVersion(t *testing.T) {
 	tt := newtemplaterTest(t)
-	tt.spec.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1-invalid"
+	tt.spec.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1-invalid"
 	_, err := tt.t.GenerateUpgradePreflightManifest(tt.ctx, tt.spec)
 	tt.Expect(err).To(HaveOccurred(), "templater.GenerateUpgradePreflightManifest() should fail")
 	tt.Expect(err).To(MatchError(ContainSubstring("invalid major version in semver")))
@@ -304,7 +308,7 @@ func TestTemplaterGenerateManifestError(t *testing.T) {
 
 func TestTemplaterGenerateManifestInvalidKubeVersion(t *testing.T) {
 	tt := newtemplaterTest(t)
-	tt.spec.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1-invalid"
+	tt.spec.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1-invalid"
 	_, err := tt.t.GenerateManifest(tt.ctx, tt.spec)
 	tt.Expect(err).To(HaveOccurred(), "templater.GenerateManifest() should fail")
 	tt.Expect(err).To(MatchError(ContainSubstring("invalid major version in semver")))
@@ -314,7 +318,9 @@ func TestTemplaterGenerateManifestUpgradeSameKubernetesVersionSuccess(t *testing
 	tt := newtemplaterTest(t)
 	tt.expectHelmTemplateWith(eqMap(wantUpgradeValues()), "1.22").Return(tt.manifest, nil)
 
-	oldCiliumVersion, err := semver.New(tt.currentSpec.VersionsBundle.Cilium.Version)
+	vb := tt.currentSpec.ControlPlaneVersionsBundle()
+
+	oldCiliumVersion, err := semver.New(vb.Cilium.Version)
 	tt.Expect(err).NotTo(HaveOccurred())
 
 	tt.Expect(
@@ -328,7 +334,8 @@ func TestTemplaterGenerateManifestUpgradeNewKubernetesVersionSuccess(t *testing.
 	tt := newtemplaterTest(t)
 	tt.expectHelmTemplateWith(eqMap(wantUpgradeValues()), "1.21").Return(tt.manifest, nil)
 
-	oldCiliumVersion, err := semver.New(tt.currentSpec.VersionsBundle.Cilium.Version)
+	vb := tt.currentSpec.ControlPlaneVersionsBundle()
+	oldCiliumVersion, err := semver.New(vb.Cilium.Version)
 	tt.Expect(err).NotTo(HaveOccurred())
 
 	tt.Expect(
@@ -408,7 +415,6 @@ func TestTemplaterGenerateNetworkPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			temp := newtemplaterTest(t)
-			temp.spec.VersionsBundle.KubeDistro.Kubernetes.Tag = tt.k8sVersion
 			if !tt.selfManaged {
 				temp.spec.Cluster.Spec.ManagementCluster.Name = "managed"
 			}

--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -142,7 +142,8 @@ func BuildUpgradePlan(installation *Installation, clusterSpec *cluster.Spec) Upg
 }
 
 func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) VersionedComponentUpgradePlan {
-	dsImage := clusterSpec.VersionsBundle.Cilium.Cilium.VersionedImage()
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	dsImage := versionsBundle.Cilium.Cilium.VersionedImage()
 	info := VersionedComponentUpgradePlan{
 		NewImage: dsImage,
 	}
@@ -170,7 +171,8 @@ func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) Versi
 }
 
 func operatorUpgradePlan(operator *appsv1.Deployment, clusterSpec *cluster.Spec) VersionedComponentUpgradePlan {
-	newImage := clusterSpec.VersionsBundle.Cilium.Operator.VersionedImage()
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	newImage := versionsBundle.Cilium.Operator.VersionedImage()
 	info := VersionedComponentUpgradePlan{
 		NewImage: newImage,
 	}

--- a/pkg/networking/cilium/upgrade_plan_test.go
+++ b/pkg/networking/cilium/upgrade_plan_test.go
@@ -29,8 +29,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -65,8 +65,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -102,8 +102,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.1"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.1"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -147,8 +147,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.1"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.1"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -184,8 +184,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -223,8 +223,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.1"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.1"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -260,8 +260,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.1"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.1"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -297,8 +297,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				Operator:  deployment("cilium-operator:v1.0.0"),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{},
 				}
@@ -334,8 +334,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", ""),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{
 						PolicyEnforcementMode: anywherev1.CiliumPolicyModeAlways,
@@ -377,8 +377,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				}),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{
 						PolicyEnforcementMode: anywherev1.CiliumPolicyModeAlways,
@@ -418,8 +418,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				ConfigMap: ciliumConfigMap("default", "old"),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{
 						EgressMasqueradeInterfaces: "new",
@@ -463,8 +463,8 @@ func TestBuildUpgradePlan(t *testing.T) {
 				}),
 			},
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.Cilium.Cilium.URI = "cilium:v1.0.0"
-				s.VersionsBundle.Cilium.Operator.URI = "cilium-operator:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Cilium.URI = "cilium:v1.0.0"
+				s.VersionsBundles["1.19"].Cilium.Operator.URI = "cilium-operator:v1.0.0"
 				s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
 					Cilium: &anywherev1.CiliumConfig{
 						EgressMasqueradeInterfaces: "new",

--- a/pkg/networking/cilium/upgrader_test.go
+++ b/pkg/networking/cilium/upgrader_test.go
@@ -40,13 +40,17 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 		u:        u,
 		manifest: []byte("manifestContent"),
 		currentSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.VersionsBundle.Cilium.Version = "v1.9.10-eksa.1"
-			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
+			s.Cluster.Spec.KubernetesVersion = "1.22"
+			s.VersionsBundles["1.22"] = test.VersionBundle()
+			s.VersionsBundles["1.22"].Cilium.Version = "v1.9.10-eksa.1"
+			s.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		newSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-			s.VersionsBundle.Cilium.Version = "v1.9.11-eksa.1"
-			s.VersionsBundle.KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
+			s.Cluster.Spec.KubernetesVersion = "1.22"
+			s.VersionsBundles["1.22"] = test.VersionBundle()
+			s.VersionsBundles["1.22"].Cilium.Version = "v1.9.11-eksa.1"
+			s.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		cluster: &types.Cluster{
@@ -95,16 +99,16 @@ func TestUpgraderUpgradeSuccess(t *testing.T) {
 
 func TestUpgraderUpgradeNotNeeded(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
-	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.currentSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
 
 	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
 }
 
 func TestUpgraderUpgradeSuccessValuesChanged(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
-	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.currentSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
 
 	// setting policy enforcement mode to something other than the "default" mode
 	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode = v1alpha1.CiliumPolicyModeNever
@@ -127,8 +131,8 @@ func TestUpgraderUpgradeSuccessValuesChanged(t *testing.T) {
 
 func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCNIConfigSpec(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
-	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.currentSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
 
 	// simulate the case where existing cluster's CNIConfig is nil
 	tt.currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig = nil
@@ -153,8 +157,8 @@ func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCNIConfigSpec(t *testi
 
 func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCiliumConfigSpec(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
-	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.currentSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
 
 	// simulate the case where existing cluster's CNIConfig is nil
 	tt.currentSpec.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: nil}
@@ -179,8 +183,8 @@ func TestUpgraderUpgradeSuccessValuesChangedUpgradeFromNilCiliumConfigSpec(t *te
 
 func TestUpgraderUpgradeSuccessEgressMasqueradeInterfacesValueChanged(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.currentSpec.VersionsBundle.Cilium.Version = "v1.0.0"
-	tt.newSpec.VersionsBundle.Cilium.Version = "v1.0.0"
+	tt.currentSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
+	tt.newSpec.VersionsBundles["1.22"].Cilium.Version = "v1.0.0"
 
 	// setting egress masquerade interfaces to something other than ""
 	tt.newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces = "test"

--- a/pkg/networking/kindnetd/installer_test.go
+++ b/pkg/networking/kindnetd/installer_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestInstallerInstallErrorGeneratingManifest(t *testing.T) {
 	tt := newKindnetdTest(t)
-	tt.spec.VersionsBundle.Kindnetd.Manifest.URI = "testdata/missing_manifest.yaml"
+	tt.spec.VersionsBundles["1.19"].Kindnetd.Manifest.URI = "testdata/missing_manifest.yaml"
 
 	tt.Expect(
 		tt.k.Installer.Install(tt.ctx, tt.cluster, tt.spec),

--- a/pkg/networking/kindnetd/kindnetd_test.go
+++ b/pkg/networking/kindnetd/kindnetd_test.go
@@ -43,7 +43,7 @@ func newKindnetdTest(t *testing.T) *kindnetdTest {
 		k:      kindnetd.NewKindnetd(client, reader),
 		spec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.1.0/24"}
-			s.VersionsBundle.Kindnetd = kindnetdBundle
+			s.VersionsBundles["1.19"].Kindnetd = kindnetdBundle
 		}),
 	}
 }

--- a/pkg/networking/kindnetd/manifest.go
+++ b/pkg/networking/kindnetd/manifest.go
@@ -17,7 +17,8 @@ import (
 )
 
 func generateManifest(reader manifests.FileReader, clusterSpec *cluster.Spec) ([]byte, error) {
-	kindnetdManifest, err := bundles.ReadManifest(reader, clusterSpec.VersionsBundle.Kindnetd.Manifest)
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	kindnetdManifest, err := bundles.ReadManifest(reader, versionsBundle.Kindnetd.Manifest)
 	if err != nil {
 		return nil, fmt.Errorf("can't load kindnetd manifest: %v", err)
 	}

--- a/pkg/networking/kindnetd/upgrader.go
+++ b/pkg/networking/kindnetd/upgrader.go
@@ -45,14 +45,16 @@ func (u Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSp
 }
 
 func kindnetdChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	if currentSpec.VersionsBundle.Kindnetd.Version == newSpec.VersionsBundle.Kindnetd.Version {
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if currentVersionsBundle.Kindnetd.Version == newVersionsBundle.Kindnetd.Version {
 		return nil
 	}
 
 	return &types.ComponentChangeDiff{
 		ComponentName: "kindnetd",
-		OldVersion:    currentSpec.VersionsBundle.Kindnetd.Version,
-		NewVersion:    newSpec.VersionsBundle.Kindnetd.Version,
+		OldVersion:    currentVersionsBundle.Kindnetd.Version,
+		NewVersion:    newVersionsBundle.Kindnetd.Version,
 	}
 }
 

--- a/pkg/networking/kindnetd/upgrader_test.go
+++ b/pkg/networking/kindnetd/upgrader_test.go
@@ -32,13 +32,13 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 		manifest:     []byte(test.ReadFile(t, "testdata/expected_kindnetd_manifest.yaml")),
 		currentSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.1.0/24"}
-			s.VersionsBundle.Kindnetd = *kindnetdBundle.DeepCopy()
-			s.VersionsBundle.Kindnetd.Version = "v1.9.10-eksa.1"
+			s.VersionsBundles["1.19"].Kindnetd = *kindnetdBundle.DeepCopy()
+			s.VersionsBundles["1.19"].Kindnetd.Version = "v1.9.10-eksa.1"
 		}),
 		newSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.1.0/24"}
-			s.VersionsBundle.Kindnetd = *kindnetdBundle.DeepCopy()
-			s.VersionsBundle.Kindnetd.Version = "v1.9.11-eksa.1"
+			s.VersionsBundles["1.19"].Kindnetd = *kindnetdBundle.DeepCopy()
+			s.VersionsBundles["1.19"].Kindnetd.Version = "v1.9.11-eksa.1"
 		}),
 		cluster: &types.Cluster{
 			KubeconfigFile: "kubeconfig",
@@ -60,8 +60,8 @@ func TestUpgraderUpgradeSuccess(t *testing.T) {
 
 func TestUpgraderUpgradeNotNeeded(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.currentSpec.VersionsBundle.Kindnetd.Version = "v1.0.0"
-	tt.newSpec.VersionsBundle.Kindnetd.Version = "v1.0.0"
+	tt.currentSpec.VersionsBundles["1.19"].Kindnetd.Version = "v1.0.0"
+	tt.newSpec.VersionsBundles["1.19"].Kindnetd.Version = "v1.0.0"
 
 	tt.Expect(tt.u.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec, []string{})).To(BeNil(), "upgrader.Upgrade() should succeed and return nil ChangeDiff")
 }

--- a/pkg/providers/cloudstack/apibuilder.go
+++ b/pkg/providers/cloudstack/apibuilder.go
@@ -19,8 +19,8 @@ import (
 // CloudStackMachineTemplateKind defines the K8s Kind corresponding with the MachineTemplate.
 const CloudStackMachineTemplateKind = "CloudStackMachineTemplate"
 
-func machineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, kubeadmConfigTemplate *bootstrapv1.KubeadmConfigTemplate, cloudstackMachineTemplate *cloudstackv1.CloudStackMachineTemplate) clusterv1.MachineDeployment {
-	return *clusterapi.MachineDeployment(clusterSpec, workerNodeGroupConfig, kubeadmConfigTemplate, cloudstackMachineTemplate)
+func machineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1.WorkerNodeGroupConfiguration, kubeadmConfigTemplate *bootstrapv1.KubeadmConfigTemplate, cloudstackMachineTemplate *cloudstackv1.CloudStackMachineTemplate) *clusterv1.MachineDeployment {
+	return clusterapi.MachineDeployment(clusterSpec, workerNodeGroupConfig, kubeadmConfigTemplate, cloudstackMachineTemplate)
 }
 
 // MachineDeployments returns generated CAPI MachineDeployment objects for a given cluster spec.
@@ -32,7 +32,8 @@ func MachineDeployments(clusterSpec *cluster.Spec, kubeadmConfigTemplates map[st
 			kubeadmConfigTemplates[workerNodeGroupConfig.Name],
 			machineTemplates[workerNodeGroupConfig.Name],
 		)
-		m[workerNodeGroupConfig.Name] = &deployment
+
+		m[workerNodeGroupConfig.Name] = deployment
 	}
 	return m
 }

--- a/pkg/providers/cloudstack/apibuilder_test.go
+++ b/pkg/providers/cloudstack/apibuilder_test.go
@@ -160,10 +160,12 @@ func TestBasicCloudStackMachineDeployment(t *testing.T) {
 		workerNodeGroupConfig.Name: fullMatchineTemplate,
 	}
 	spec := &cluster.Spec{
-		VersionsBundle: &cluster.VersionsBundle{
-			KubeDistro: &cluster.KubeDistro{
-				Kubernetes: cluster.VersionedRepository{
-					Tag: "eksd-tag",
+		VersionsBundles: map[v1alpha1.KubernetesVersion]*cluster.VersionsBundle{
+			v1alpha1.Kube119: {
+				KubeDistro: &cluster.KubeDistro{
+					Kubernetes: cluster.VersionedRepository{
+						Tag: "eksd-tag",
+					},
 				},
 			},
 		},
@@ -173,6 +175,7 @@ func TestBasicCloudStackMachineDeployment(t *testing.T) {
 					WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
 						workerNodeGroupConfig,
 					},
+					KubernetesVersion: v1alpha1.Kube119,
 				},
 			},
 		},

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -203,14 +203,16 @@ func (p *cloudstackProvider) ValidateNewSpec(ctx context.Context, cluster *types
 }
 
 func (p *cloudstackProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	if currentSpec.VersionsBundle.CloudStack.Version == newSpec.VersionsBundle.CloudStack.Version {
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if currentVersionsBundle.CloudStack.Version == newVersionsBundle.CloudStack.Version {
 		return nil
 	}
 
 	return &types.ComponentChangeDiff{
 		ComponentName: constants.CloudStackProviderName,
-		NewVersion:    newSpec.VersionsBundle.CloudStack.Version,
-		OldVersion:    currentSpec.VersionsBundle.CloudStack.Version,
+		NewVersion:    newVersionsBundle.CloudStack.Version,
+		OldVersion:    currentVersionsBundle.CloudStack.Version,
 	}
 }
 
@@ -810,7 +812,8 @@ func (p *cloudstackProvider) BootstrapSetup(ctx context.Context, clusterConfig *
 }
 
 func (p *cloudstackProvider) Version(clusterSpec *cluster.Spec) string {
-	return clusterSpec.VersionsBundle.CloudStack.Version
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	return versionsBundle.CloudStack.Version
 }
 
 func (p *cloudstackProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
@@ -830,14 +833,14 @@ func (p *cloudstackProvider) GetDeployments() map[string][]string {
 }
 
 func (p *cloudstackProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	bundle := clusterSpec.VersionsBundle
-	folderName := fmt.Sprintf("infrastructure-cloudstack/%s/", bundle.CloudStack.Version)
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	folderName := fmt.Sprintf("infrastructure-cloudstack/%s/", versionsBundle.CloudStack.Version)
 
 	infraBundle := types.InfrastructureBundle{
 		FolderName: folderName,
 		Manifests: []releasev1alpha1.Manifest{
-			bundle.CloudStack.Components,
-			bundle.CloudStack.Metadata,
+			versionsBundle.CloudStack.Components,
+			versionsBundle.CloudStack.Metadata,
 		},
 	}
 	return &infraBundle

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -904,7 +904,7 @@ func TestVersion(t *testing.T) {
 	cloudStackProviderVersion := "v4.14.1"
 	provider := givenProvider(t)
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
-	clusterSpec.VersionsBundle.CloudStack.Version = cloudStackProviderVersion
+	clusterSpec.VersionsBundles["1.21"].CloudStack.Version = cloudStackProviderVersion
 	setupContext(t)
 
 	result := provider.Version(clusterSpec)
@@ -1049,7 +1049,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 		{
 			testName: "correct Overrides layer",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
-				s.VersionsBundle.CloudStack = releasev1alpha1.CloudStackBundle{
+				s.VersionsBundles["1.19"].CloudStack = releasev1alpha1.CloudStackBundle{
 					Version: "v0.1.0",
 					ClusterAPIController: releasev1alpha1.Image{
 						URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.1.0",
@@ -1081,9 +1081,10 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 			}
 			assert.Equal(t, "infrastructure-cloudstack/v0.1.0/", infraBundle.FolderName, "Incorrect folder name")
 			assert.Equal(t, len(infraBundle.Manifests), 2, "Wrong number of files in the infrastructure bundle")
+			bundle := tt.clusterSpec.ControlPlaneVersionsBundle()
 			wantManifests := []releasev1alpha1.Manifest{
-				tt.clusterSpec.VersionsBundle.CloudStack.Components,
-				tt.clusterSpec.VersionsBundle.CloudStack.Metadata,
+				bundle.CloudStack.Components,
+				bundle.CloudStack.Metadata,
 			}
 			assert.ElementsMatch(t, infraBundle.Manifests, wantManifests, "Incorrect manifests")
 		})
@@ -1135,10 +1136,10 @@ func TestChangeDiffNoChange(t *testing.T) {
 func TestChangeDiffWithChange(t *testing.T) {
 	provider := givenProvider(t)
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.CloudStack.Version = "v0.2.0"
+		s.VersionsBundles["1.19"].CloudStack.Version = "v0.2.0"
 	})
 	newClusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.CloudStack.Version = "v0.1.0"
+		s.VersionsBundles["1.19"].CloudStack.Version = "v0.1.0"
 	})
 
 	wantDiff := &types.ComponentChangeDiff{
@@ -1564,6 +1565,79 @@ func TestProviderGenerateCAPISpecForUpgradeMultipleWorkerNodeGroups(t *testing.T
 				t.Fatalf("failed to generate cluster api spec contents: %v", err)
 			}
 
+			test.AssertContentToFile(t, string(md), tt.wantMDFile)
+		})
+	}
+}
+
+func TestProviderGenerateCAPISpecForUpgradeWorkerNodeGroupsKubernetesVersion(t *testing.T) {
+	tests := []struct {
+		testName          string
+		clusterconfigFile string
+		wantMDFile        string
+		wantCPFile        string
+	}{
+		{
+			testName:          "adding a worker node group",
+			clusterconfigFile: "cluster_main_worker_node_group_kubernetes_version.yaml",
+			wantMDFile:        "testdata/expected_results_main_md_worker_kubernetes_version.yaml",
+			wantCPFile:        "testdata/expected_results_main_cp.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			setupContext(t)
+			ctx := context.Background()
+			kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+			cluster := &types.Cluster{
+				Name: "test",
+			}
+			bootstrapCluster := &types.Cluster{
+				Name: "bootstrap-test",
+			}
+			clusterSpec := givenClusterSpec(t, tt.clusterconfigFile)
+			cloudstackDatacenter := &v1alpha1.CloudStackDatacenterConfig{
+				Spec: v1alpha1.CloudStackDatacenterConfigSpec{},
+			}
+			cloudstackMachineConfig := &v1alpha1.CloudStackMachineConfig{
+				Spec: v1alpha1.CloudStackMachineConfigSpec{
+					Users: []v1alpha1.UserConfiguration{
+						{
+							Name:              "capv",
+							SshAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=="},
+						},
+					},
+				},
+			}
+
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup1MachineDeployment(), nil)
+			kubectl.EXPECT().GetMachineDeployment(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(workerNodeGroup2MachineDeployment(), nil)
+			kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.Name).Return(clusterSpec.Cluster, nil)
+			kubectl.EXPECT().GetEksaCloudStackDatacenterConfig(ctx, cluster.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(cloudstackDatacenter, nil)
+			kubectl.EXPECT().GetEksaCloudStackMachineConfig(ctx, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(cloudstackMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCloudStackMachineConfig(ctx, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(cloudstackMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCloudStackMachineConfig(ctx, clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[1].MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(cloudstackMachineConfig, nil)
+			kubectl.EXPECT().GetEksaCloudStackMachineConfig(ctx, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name, cluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return(cloudstackMachineConfig, nil)
+			kubectl.EXPECT().UpdateAnnotation(ctx, "etcdadmcluster", fmt.Sprintf("%s-etcd", cluster.Name), map[string]string{etcdv1.UpgradeInProgressAnnotation: "true"}, gomock.AssignableToTypeOf(executables.WithCluster(bootstrapCluster)))
+			datacenterConfig := givenDatacenterConfig(t, tt.clusterconfigFile)
+			validator := givenWildcardValidator(mockCtrl, clusterSpec)
+			provider := newProviderWithKubectl(t, datacenterConfig, clusterSpec.Cluster, kubectl, validator)
+			if provider == nil {
+				t.Fatalf("provider object is nil")
+			}
+
+			err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+			if err != nil {
+				t.Fatalf("failed to setup and validate: %v", err)
+			}
+
+			cp, md, err := provider.GenerateCAPISpecForUpgrade(context.Background(), bootstrapCluster, cluster, clusterSpec, clusterSpec.DeepCopy())
+			if err != nil {
+				t.Fatalf("failed to generate cluster api spec contents: %v", err)
+			}
+
+			test.AssertContentToFile(t, string(cp), tt.wantCPFile)
 			test.AssertContentToFile(t, string(md), tt.wantMDFile)
 		})
 	}

--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -70,18 +70,6 @@ func TestControlPlaneSpecNewCluster(t *testing.T) {
 	g.Expect(cp.ControlPlaneMachineTemplate.Name).To(Equal("test-control-plane-1"))
 }
 
-func TestControlPlaneSpecNoKubeVersion(t *testing.T) {
-	g := NewWithT(t)
-	logger := test.NewNullLogger()
-	ctx := context.Background()
-	client := test.NewFakeKubeClient()
-	spec := test.NewFullClusterSpec(t, testClusterConfigFilename)
-	spec.Cluster.Spec.KubernetesVersion = ""
-
-	_, err := ControlPlaneSpec(ctx, logger, client, spec)
-	g.Expect(err).To(MatchError(ContainSubstring("generating cloudstack control plane yaml spec")))
-}
-
 func TestControlPlaneSpecNoChangesMachineTemplates(t *testing.T) {
 	g := NewWithT(t)
 	logger := test.NewNullLogger()

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -331,16 +331,6 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 	)
 }
 
-func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
-	tt := newReconcilerTest(t)
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.secret)
-	tt.createAllObjs()
-	spec := tt.buildSpec()
-	spec.Cluster.Spec.KubernetesVersion = ""
-	_, err := tt.reconciler().ReconcileControlPlane(tt.ctx, test.NewNullLogger(), spec)
-	tt.Expect(err).To(MatchError(ContainSubstring("generating cloudstack control plane yaml spec")))
-}
-
 func TestReconcileCNISuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
@@ -689,7 +679,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 			managementCluster,
 			workloadClusterDatacenter,
 			bundle,
-			test.EksdRelease(),
+			test.EksdRelease("1-22"),
 			test.EKSARelease(),
 		},
 		cluster:                   cluster,

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -100,7 +100,8 @@ func (cs *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 // nolint:gocyclo
 func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, error) {
 	datacenterConfigSpec := clusterSpec.CloudStackDatacenter.Spec
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	format := "cloud-config"
 	host, port, err := getValidControlPlaneHostPort(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
 	if err != nil {
@@ -140,19 +141,19 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"controlPlaneEndpointHost":                   host,
 		"controlPlaneEndpointPort":                   port,
 		"controlPlaneReplicas":                       clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count,
-		"kubernetesRepository":                       bundle.KubeDistro.Kubernetes.Repository,
-		"kubernetesVersion":                          bundle.KubeDistro.Kubernetes.Tag,
-		"etcdRepository":                             bundle.KubeDistro.Etcd.Repository,
-		"etcdImageTag":                               bundle.KubeDistro.Etcd.Tag,
-		"corednsRepository":                          bundle.KubeDistro.CoreDNS.Repository,
-		"corednsVersion":                             bundle.KubeDistro.CoreDNS.Tag,
-		"nodeDriverRegistrarImage":                   bundle.KubeDistro.NodeDriverRegistrar.VersionedImage(),
-		"livenessProbeImage":                         bundle.KubeDistro.LivenessProbe.VersionedImage(),
-		"externalAttacherImage":                      bundle.KubeDistro.ExternalAttacher.VersionedImage(),
-		"externalProvisionerImage":                   bundle.KubeDistro.ExternalProvisioner.VersionedImage(),
-		"managerImage":                               bundle.CloudStack.ClusterAPIController.VersionedImage(),
-		"kubeRbacProxyImage":                         bundle.CloudStack.KubeRbacProxy.VersionedImage(),
-		"kubeVipImage":                               bundle.CloudStack.KubeVip.VersionedImage(),
+		"kubernetesRepository":                       versionsBundle.KubeDistro.Kubernetes.Repository,
+		"kubernetesVersion":                          versionsBundle.KubeDistro.Kubernetes.Tag,
+		"etcdRepository":                             versionsBundle.KubeDistro.Etcd.Repository,
+		"etcdImageTag":                               versionsBundle.KubeDistro.Etcd.Tag,
+		"corednsRepository":                          versionsBundle.KubeDistro.CoreDNS.Repository,
+		"corednsVersion":                             versionsBundle.KubeDistro.CoreDNS.Tag,
+		"nodeDriverRegistrarImage":                   versionsBundle.KubeDistro.NodeDriverRegistrar.VersionedImage(),
+		"livenessProbeImage":                         versionsBundle.KubeDistro.LivenessProbe.VersionedImage(),
+		"externalAttacherImage":                      versionsBundle.KubeDistro.ExternalAttacher.VersionedImage(),
+		"externalProvisionerImage":                   versionsBundle.KubeDistro.ExternalProvisioner.VersionedImage(),
+		"managerImage":                               versionsBundle.CloudStack.ClusterAPIController.VersionedImage(),
+		"kubeRbacProxyImage":                         versionsBundle.CloudStack.KubeRbacProxy.VersionedImage(),
+		"kubeVipImage":                               versionsBundle.CloudStack.KubeVip.VersionedImage(),
 		"cloudstackKubeVip":                          !features.IsActive(features.CloudStackKubeVipDisabled()),
 		"cloudstackAvailabilityZones":                datacenterConfigSpec.AvailabilityZones,
 		"cloudstackAnnotationSuffix":                 constants.CloudstackAnnotationSuffix,
@@ -184,8 +185,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"controllermanagerExtraArgs":                 controllerManagerExtraArgs.ToPartialYaml(),
 		"schedulerExtraArgs":                         sharedExtraArgs.ToPartialYaml(),
 		"format":                                     format,
-		"externalEtcdVersion":                        bundle.KubeDistro.EtcdVersion,
-		"etcdImage":                                  bundle.KubeDistro.EtcdImage.VersionedImage(),
+		"externalEtcdVersion":                        versionsBundle.KubeDistro.EtcdVersion,
+		"etcdImage":                                  versionsBundle.KubeDistro.EtcdImage.VersionedImage(),
 		"eksaSystemNamespace":                        constants.EksaSystemNamespace,
 	}
 
@@ -311,7 +312,7 @@ func fillProxyConfigurations(values map[string]interface{}, clusterSpec *cluster
 }
 
 func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.WorkerNodeGroupVersionsBundle(workerNodeGroupConfiguration)
 	format := "cloud-config"
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.WorkerNodeLabelsExtraArgs(workerNodeGroupConfiguration)).
@@ -326,7 +327,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 
 	values := map[string]interface{}{
 		"clusterName":                      clusterSpec.Cluster.Name,
-		"kubernetesVersion":                bundle.KubeDistro.Kubernetes.Tag,
+		"kubernetesVersion":                versionsBundle.KubeDistro.Kubernetes.Tag,
 		"cloudstackAnnotationSuffix":       constants.CloudstackAnnotationSuffix,
 		"cloudstackTemplateId":             workerNodeGroupMachineSpec.Template.Id,
 		"cloudstackTemplateName":           workerNodeGroupMachineSpec.Template.Name,

--- a/pkg/providers/cloudstack/template_test.go
+++ b/pkg/providers/cloudstack/template_test.go
@@ -28,15 +28,6 @@ func TestTemplateBuilderGenerateCAPISpecControlPlaneNilDatacenter(t *testing.T) 
 	g.Expect(err).To(MatchError(ContainSubstring("provided clusterSpec CloudStackDatacenter is nil. Unable to generate CAPI spec control plane")))
 }
 
-func TestTemplateBuilderGenerateCAPISpecControlPlaneNoKubernetesVersion(t *testing.T) {
-	g := NewWithT(t)
-	templateBuilder := cloudstack.NewTemplateBuilder(time.Now)
-	clusterSpec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
-	clusterSpec.Cluster.Spec.KubernetesVersion = ""
-	_, err := templateBuilder.GenerateCAPISpecControlPlane(clusterSpec)
-	g.Expect(err).To(MatchError(ContainSubstring("error building template map from CP error converting kubeVersion")))
-}
-
 func TestTemplateBuilderGenerateCAPISpecControlPlaneMissingNames(t *testing.T) {
 	clusterSpec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
 

--- a/pkg/providers/cloudstack/testdata/cluster_main_worker_node_group_kubernetes_version.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main_worker_node_group_kubernetes_version.yaml
@@ -1,0 +1,133 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test-cp
+  datacenterRef:
+    kind: CloudStackDatacenterConfig
+    name: test
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test-etcd
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+  - count: 3
+    name: md-0
+    kubernetesVersion: "1.20"
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test
+  - count: 2
+    name: md-1
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  account: "admin"
+  domain: "domain1"
+  zones:
+  - name: "zone1"
+    network:
+      name: "net1"
+  managementApiEndpoint: "http://127.16.0.1:8080/client/api"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+  diskOffering:
+    name: "Small"
+    mountPath: "/data-small"
+    device: /dev/vdb
+    filesystem: ext4
+    label: data_disk
+  symlinks:
+    /var/log/kubernetes: /data-small/var/log/kubernetes
+  affinityGroupIds:
+  - control-plane-anti-affinity
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+  diskOffering:
+    name: "Small"
+    mountPath: "/data-small"
+    device: /dev/vdb
+    filesystem: ext4
+    label: data_disk
+  affinityGroupIds:
+  - worker-affinity
+  userCustomDetails:
+    foo: bar
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test-etcd
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+  diskOffering:
+    name: "Small"
+    mountPath: "/data-small"
+    device: /dev/vdb
+    filesystem: ext4
+    label: data_disk
+  symlinks:
+    /var/lib/: /data-small/var/lib
+  affinityGroupIds:
+  - etcd-affinity
+
+---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_md_worker_kubernetes_version.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_md_worker_kubernetes_version.yaml
@@ -1,0 +1,226 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-0-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+            read-only-port: "0"
+            anonymous-auth: "false"
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: "{{ ds.meta_data.hostname }}"
+      preKubeadmCommands:
+      - swapoff -a
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      diskSetup:
+        filesystems:
+          - device: /dev/vdb1
+            overwrite: false
+            extraOpts:
+              - -E
+              - lazy_itable_init=1,lazy_journal_init=1
+            filesystem: ext4
+            label: data_disk
+        partitions:
+          - device: /dev/vdb
+            layout: true
+            overwrite: false
+            tableType: gpt
+      mounts:
+        - - LABEL=data_disk
+          - /data-small
+      users:
+      - name: mySshUsername
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 3
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-0-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+        kind: CloudStackMachineTemplate
+        name: test-md-0-1234567890000
+      version: v1.20.4-eks-1-20-1
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+kind: CloudStackMachineTemplate
+metadata:
+  annotations:
+    device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /dev/vdb
+    filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: ext4
+    label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: data_disk
+    mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /data-small
+  creationTimestamp: null
+  name: test-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      affinityGroupIDs:
+      - worker-affinity
+      details:
+        foo: bar
+      diskOffering:
+        customSizeInGB: 0
+        device: /dev/vdb
+        filesystem: ext4
+        label: data_disk
+        mountPath: /data-small
+        name: Small
+      offering:
+        name: m4-large
+      sshKey: ""
+      template:
+        name: centos7-k8s-118
+
+---
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-1-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+            read-only-port: "0"
+            anonymous-auth: "false"
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: "{{ ds.meta_data.hostname }}"
+      preKubeadmCommands:
+      - swapoff -a
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      diskSetup:
+        filesystems:
+          - device: /dev/vdb1
+            overwrite: false
+            extraOpts:
+              - -E
+              - lazy_itable_init=1,lazy_journal_init=1
+            filesystem: ext4
+            label: data_disk
+        partitions:
+          - device: /dev/vdb
+            layout: true
+            overwrite: false
+            tableType: gpt
+      mounts:
+        - - LABEL=data_disk
+          - /data-small
+      users:
+      - name: mySshUsername
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-1
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 2
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-1-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+        kind: CloudStackMachineTemplate
+        name: test-md-1-1234567890000
+      version: v1.21.2-eks-1-21-4
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+kind: CloudStackMachineTemplate
+metadata:
+  annotations:
+    device.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /dev/vdb
+    filesystem.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: ext4
+    label.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: data_disk
+    mountpath.diskoffering.cloudstack.anywhere.eks.amazonaws.com/v1alpha1: /data-small
+  creationTimestamp: null
+  name: test-md-1-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      affinityGroupIDs:
+      - worker-affinity
+      details:
+        foo: bar
+      diskOffering:
+        customSizeInGB: 0
+        device: /dev/vdb
+        filesystem: ext4
+        label: data_disk
+        mountPath: /data-small
+        name: Small
+      offering:
+        name: m4-large
+      sshKey: ""
+      template:
+        name: centos7-k8s-118
+
+---
+
+---

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -317,28 +317,30 @@ func testClusterSpec(opts ...test.ClusterSpecOpt) *cluster.Spec {
 			},
 		}
 
-		s.VersionsBundle = &cluster.VersionsBundle{
-			KubeDistro: &cluster.KubeDistro{
-				Kubernetes: cluster.VersionedRepository{
-					Repository: "public.ecr.aws/eks-distro/kubernetes",
-					Tag:        "v1.23.12-eks-1-23-6",
+		s.VersionsBundles = map[anywherev1.KubernetesVersion]*cluster.VersionsBundle{
+			"1.23": {
+				KubeDistro: &cluster.KubeDistro{
+					Kubernetes: cluster.VersionedRepository{
+						Repository: "public.ecr.aws/eks-distro/kubernetes",
+						Tag:        "v1.23.12-eks-1-23-6",
+					},
+					CoreDNS: cluster.VersionedRepository{
+						Repository: "public.ecr.aws/eks-distro/coredns",
+						Tag:        "v1.8.7-eks-1-23-6",
+					},
+					Etcd: cluster.VersionedRepository{
+						Repository: "public.ecr.aws/eks-distro/etcd-io",
+						Tag:        "v3.5.4-eks-1-23-6",
+					},
+					EtcdVersion: "3.5.4",
 				},
-				CoreDNS: cluster.VersionedRepository{
-					Repository: "public.ecr.aws/eks-distro/coredns",
-					Tag:        "v1.8.7-eks-1-23-6",
-				},
-				Etcd: cluster.VersionedRepository{
-					Repository: "public.ecr.aws/eks-distro/etcd-io",
-					Tag:        "v3.5.4-eks-1-23-6",
-				},
-				EtcdVersion: "3.5.4",
-			},
-			VersionsBundle: &releasev1alpha1.VersionsBundle{
-				EksD: releasev1alpha1.EksDRelease{
-					KindNode: releasev1alpha1.Image{
-						Description: "kind/node container image",
-						Name:        "kind/node",
-						URI:         "public.ecr.aws/eks-anywhere/kubernetes-sigs/kind/node:v1.23.12-eks-d-1-23-6-eks-a-19",
+				VersionsBundle: &releasev1alpha1.VersionsBundle{
+					EksD: releasev1alpha1.EksDRelease{
+						KindNode: releasev1alpha1.Image{
+							Description: "kind/node container image",
+							Name:        "kind/node",
+							URI:         "public.ecr.aws/eks-anywhere/kubernetes-sigs/kind/node:v1.23.12-eks-d-1-23-6-eks-a-19",
+						},
 					},
 				},
 			},

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -142,7 +142,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
@@ -157,7 +157,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.24"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
@@ -173,7 +173,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
@@ -189,7 +189,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
@@ -206,7 +206,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), Taints: wnTaints, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}, {Count: ptr.Int(3), Taints: wnTaints2, MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-1"}}
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 			}),
 			wantCPFile: "testdata/valid_deployment_cp_taints_expected.yaml",
@@ -220,7 +220,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Labels: nodeLabels, Name: "md-0"}}
 			}),
@@ -236,7 +236,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 				s.Cluster.Spec.ControlPlaneConfiguration.Labels = nodeLabels
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
@@ -252,7 +252,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"192.168.0.0/16", "10.10.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.DNS.ResolvConf = &v1alpha1.ResolvConf{Path: "/etc/my-custom-resolv.conf"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 			}),
@@ -267,7 +267,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 
@@ -289,7 +289,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 				s.OIDCConfig = &v1alpha1.OIDCConfig{
@@ -320,7 +320,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateMachineTemplate(t *testing.T
 				s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 				s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 				s.Cluster.Spec.ControlPlaneConfiguration.Count = 3
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 				s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 				s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0", AutoScalingConfiguration: &v1alpha1.AutoScalingConfiguration{MinCount: 3, MaxCount: 5}}}
 			}),
@@ -393,7 +393,7 @@ func TestProviderGenerateDeploymentFileSuccessUpdateKubeadmConfigTemplate(t *tes
 	clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count = 3
 	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints = cpTaints
-	clusterSpec.VersionsBundle = versionsBundle
+	clusterSpec.VersionsBundles["1.19"] = versionsBundle
 	clusterSpec.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, Name: "md-0"}}
 
@@ -442,7 +442,7 @@ func TestProviderGenerateDeploymentFileSuccessNotUpdateMachineTemplate(t *testin
 	client := dockerMocks.NewMockProviderClient(mockCtrl)
 	kubectl := dockerMocks.NewMockProviderKubectlClient(mockCtrl)
 	clusterSpec := test.NewClusterSpec()
-	clusterSpec.Cluster.Spec.KubernetesVersion = v1alpha1.Kube122
+	clusterSpec.Cluster.Spec.KubernetesVersion = v1alpha1.Kube119
 	clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 	clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(0), MachineGroupRef: &v1alpha1.Ref{Name: "fluxTestCluster"}, Name: "md-0"}}
@@ -505,7 +505,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 			testName: "create overrides layer",
 			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 				s.Cluster.Name = "test-cluster"
-				s.VersionsBundle = versionsBundle
+				s.VersionsBundles["1.19"] = versionsBundle
 			}),
 		},
 	}
@@ -583,6 +583,56 @@ var versionsBundle = &cluster.VersionsBundle{
 	},
 }
 
+var workerVersionsBundle = &cluster.VersionsBundle{
+	KubeDistro: &cluster.KubeDistro{
+		Kubernetes: cluster.VersionedRepository{
+			Repository: "public.ecr.aws/eks-distro/kubernetes",
+			Tag:        "v1.18.4-eks-1-18-3",
+		},
+		CoreDNS: cluster.VersionedRepository{
+			Repository: "public.ecr.aws/eks-distro/coredns",
+			Tag:        "v1.8.0-eks-1-19-2",
+		},
+		Etcd: cluster.VersionedRepository{
+			Repository: "public.ecr.aws/eks-distro/etcd-io",
+			Tag:        "v3.4.14-eks-1-19-2",
+		},
+		EtcdVersion: "3.4.14",
+	},
+	VersionsBundle: &releasev1alpha1.VersionsBundle{
+		EksD: releasev1alpha1.EksDRelease{
+			KindNode: releasev1alpha1.Image{
+				Description: "kind/node container image",
+				Name:        "kind/node",
+				URI:         "public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa",
+			},
+		},
+		Docker: releasev1alpha1.DockerBundle{
+			Version: "v0.3.19",
+			Manager: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/capd-manager:v0.3.15-6bdb9fc78bb926135843c58ec8b77b54d8f2c82c",
+			},
+			KubeProxy: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.8.0-25df7d96779e2a305a22c6e3f9425c3465a77244",
+			},
+			Components: releasev1alpha1.Manifest{
+				URI: "embed:///config/clusterctl/overrides/infrastructure-docker/v0.3.19/infrastructure-components-development.yaml",
+			},
+			ClusterTemplate: releasev1alpha1.Manifest{
+				URI: "embed:///config/clusterctl/overrides/infrastructure-docker/v0.3.19/cluster-template-development.yaml",
+			},
+			Metadata: releasev1alpha1.Manifest{
+				URI: "embed:///config/clusterctl/overrides/infrastructure-docker/v0.3.19/metadata.yaml",
+			},
+		},
+		Haproxy: releasev1alpha1.HaproxyBundle{
+			Image: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/haproxy:v0.11.1-eks-a-v0.0.0-dev-build.1464",
+			},
+		},
+	},
+}
+
 func TestChangeDiffNoChange(t *testing.T) {
 	tt := newTest(t)
 	clusterSpec := test.NewClusterSpec()
@@ -592,10 +642,10 @@ func TestChangeDiffNoChange(t *testing.T) {
 func TestChangeDiffWithChange(t *testing.T) {
 	tt := newTest(t)
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Docker.Version = "v0.3.18"
+		s.VersionsBundles["1.19"].Docker.Version = "v0.3.18"
 	})
 	newClusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundle.Docker.Version = "v0.3.19"
+		s.VersionsBundles["1.19"].Docker.Version = "v0.3.19"
 	})
 
 	wantDiff := &types.ComponentChangeDiff{
@@ -622,7 +672,7 @@ func TestProviderGenerateCAPISpecForCreateWithPodIAMConfig(t *testing.T) {
 		s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
-		s.VersionsBundle = versionsBundle
+		s.VersionsBundles["1.19"] = versionsBundle
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 3}
 		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
 	})
@@ -659,7 +709,7 @@ func TestProviderGenerateCAPISpecForCreateWithStackedEtcd(t *testing.T) {
 		s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
-		s.VersionsBundle = versionsBundle
+		s.VersionsBundles["1.19"] = versionsBundle
 		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{{Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}}}
 	})
 
@@ -679,6 +729,47 @@ func TestProviderGenerateCAPISpecForCreateWithStackedEtcd(t *testing.T) {
 	test.AssertContentToFile(t, string(cp), "testdata/valid_deployment_cp_stacked_etcd_expected.yaml")
 }
 
+func TestProviderGenerateCAPISpecForCreateWithWorkerKubernetesVersion(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	ctx := context.Background()
+	client := dockerMocks.NewMockProviderClient(mockCtrl)
+	kubectl := dockerMocks.NewMockProviderKubectlClient(mockCtrl)
+	provider := docker.NewProvider(&v1alpha1.DockerDatacenterConfig{}, client, kubectl, test.FakeNow)
+	clusterObj := &types.Cluster{
+		Name: "test-cluster",
+	}
+	workerVersion := v1alpha1.KubernetesVersion("1.18")
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster.Name = "test-cluster"
+		s.Cluster.Spec.KubernetesVersion = "1.19"
+		s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
+		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
+		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
+		s.VersionsBundles["1.19"] = versionsBundle
+		s.VersionsBundles["1.18"] = workerVersionsBundle
+
+		s.Cluster.Spec.WorkerNodeGroupConfigurations = []v1alpha1.WorkerNodeGroupConfiguration{
+			{Name: "md-0", Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}, KubernetesVersion: &workerVersion},
+			{Name: "md-1", Count: ptr.Int(3), MachineGroupRef: &v1alpha1.Ref{Name: "test-cluster"}},
+		}
+	})
+
+	if provider == nil {
+		t.Fatalf("provider object is nil")
+	}
+
+	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+	if err != nil {
+		t.Fatalf("failed to setup and validate: %v", err)
+	}
+
+	_, md, err := provider.GenerateCAPISpecForCreate(context.Background(), clusterObj, clusterSpec)
+	if err != nil {
+		t.Fatalf("failed to generate cluster api spec contents: %v", err)
+	}
+	test.AssertContentToFile(t, string(md), "testdata/valid_deployment_md_expected_worker_version.yaml")
+}
+
 func TestDockerTemplateBuilderGenerateCAPISpecControlPlane(t *testing.T) {
 	type args struct {
 		clusterSpec  *cluster.Spec
@@ -691,11 +782,10 @@ func TestDockerTemplateBuilderGenerateCAPISpecControlPlane(t *testing.T) {
 		wantErr     error
 	}{
 		{
-			name: "kube 122 test",
+			name: "kube 119 test",
 			args: args{
 				clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 					s.Cluster.Name = "test-cluster"
-					s.Cluster.Spec.KubernetesVersion = "1.22"
 				}),
 				buildOptions: nil,
 			},
@@ -706,6 +796,7 @@ func TestDockerTemplateBuilderGenerateCAPISpecControlPlane(t *testing.T) {
 			args: args{
 				clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 					s.Cluster.Name = "test-cluster"
+					s.Cluster.Spec.KubernetesVersion = ""
 				}),
 				buildOptions: nil,
 			},
@@ -743,7 +834,7 @@ func TestProviderGenerateDeploymentFileForSingleNodeCluster(t *testing.T) {
 		s.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"192.168.0.0/16"}
 		s.Cluster.Spec.ClusterNetwork.Services.CidrBlocks = []string{"10.128.0.0/12"}
 		s.Cluster.Spec.ControlPlaneConfiguration.Count = 1
-		s.VersionsBundle = versionsBundle
+		s.VersionsBundles["1.21"] = versionsBundle
 		s.Cluster.Spec.WorkerNodeGroupConfigurations = nil
 	})
 
@@ -779,6 +870,7 @@ func TestDockerTemplateBuilderGenerateCAPISpecWorkers(t *testing.T) {
 			args: args{
 				clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 					s.Cluster.Name = "test-cluster"
+					s.Cluster.Spec.KubernetesVersion = ""
 				}),
 			},
 			wantErr: fmt.Errorf("error building template map for MD "),
@@ -866,12 +958,6 @@ func TestDockerGenerateDeploymentFileWithMirrorAndCertConfig(t *testing.T) {
 		t.Fatalf("failed to generate cluster api spec contents: %v", err)
 	}
 
-	fmt.Println("CP template starts")
-	fmt.Println(string(cp))
-	fmt.Println("CP template ends")
-	fmt.Println("MD template starts")
-	fmt.Println(string(md))
-	fmt.Println("MDtemplate ends")
 	test.AssertContentToFile(t, string(cp), "testdata/expected_results_mirror_with_cert_config_cp.yaml")
 	test.AssertContentToFile(t, string(md), "testdata/expected_results_mirror_with_cert_config_md.yaml")
 }

--- a/pkg/providers/docker/reconciler/reconciler_test.go
+++ b/pkg/providers/docker/reconciler/reconciler_test.go
@@ -492,7 +492,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 			managementCluster,
 			workloadClusterDatacenter,
 			bundle,
-			test.EksdRelease(),
+			test.EksdRelease("1-22"),
 			test.EKSARelease(),
 		},
 		datacenterConfig: workloadClusterDatacenter,

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected_worker_version.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected_worker_version.yaml
@@ -1,0 +1,114 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-cluster-md-0-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: test-cluster-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test-cluster
+  replicas: 3
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-cluster-md-0-template-1234567890000
+          namespace: eksa-system
+      clusterName: test-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: test-cluster-md-0-1234567890000
+        namespace: eksa-system
+      version: v1.18.4-eks-1-18-3
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-cluster-md-1-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            cgroup-driver: cgroupfs
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: test-cluster-md-1
+  namespace: eksa-system
+spec:
+  clusterName: test-cluster
+  replicas: 3
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-cluster-md-1-template-1234567890000
+          namespace: eksa-system
+      clusterName: test-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: test-cluster-md-1-1234567890000
+        namespace: eksa-system
+      version: v1.19.6-eks-1-19-2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: test-cluster-md-1-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      customImage: public.ecr.aws/eks-distro/kubernetes-sigs/kind/node:v1.18.16-eks-1-18-4-216edda697a37f8bf16651af6c23b7e2bb7ef42f-62681885fe3a97ee4f2b110cc277e084e71230fa
+
+---

--- a/pkg/providers/docker/workers_test.go
+++ b/pkg/providers/docker/workers_test.go
@@ -114,7 +114,7 @@ func TestWorkersSpecUpgradeCluster(t *testing.T) {
 	expectedGroup1.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
 
 	// This will cause a change in the docker machine templates, which are immutable
-	spec.VersionsBundle.EksD.KindNode = releasev1.Image{
+	spec.VersionsBundles["1.23"].EksD.KindNode = releasev1.Image{
 		URI: "my-new-kind-image:tag",
 	}
 	expectedGroup1.ProviderMachineTemplate.Spec.Template.Spec.CustomImage = "my-new-kind-image:tag"

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -501,6 +501,7 @@ func (p *Provider) GenerateStorageClass() []byte {
 	return nil
 }
 
+// GenerateMHC returns MachineHealthCheck for the cluster in yaml format.
 func (p *Provider) GenerateMHC(_ *cluster.Spec) ([]byte, error) {
 	data := map[string]string{
 		"clusterName":         p.clusterConfig.Name,
@@ -519,8 +520,10 @@ func (p *Provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 	return nil
 }
 
+// Version returns the nutanix version from the VersionsBundle.
 func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	return clusterSpec.VersionsBundle.Nutanix.Version
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	return versionsBundle.Nutanix.Version
 }
 
 func (p *Provider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
@@ -543,11 +546,11 @@ func (p *Provider) GetDeployments() map[string][]string {
 }
 
 func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 	manifests := []releasev1alpha1.Manifest{
-		bundle.Nutanix.Components,
-		bundle.Nutanix.Metadata,
-		bundle.Nutanix.ClusterTemplate,
+		versionsBundle.Nutanix.Components,
+		versionsBundle.Nutanix.Metadata,
+		versionsBundle.Nutanix.ClusterTemplate,
 	}
 	folderName := fmt.Sprintf("infrastructure-nutanix/%s/", p.Version(clusterSpec))
 	infraBundle := types.InfrastructureBundle{
@@ -561,6 +564,7 @@ func (p *Provider) DatacenterConfig(_ *cluster.Spec) providers.DatacenterConfig 
 	return p.datacenterConfig
 }
 
+// MachineConfigs returns a MachineConfig slice.
 func (p *Provider) MachineConfigs(_ *cluster.Spec) []providers.MachineConfig {
 	configs := make(map[string]providers.MachineConfig, len(p.machineConfigs))
 	controlPlaneMachineName := p.clusterConfig.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
@@ -608,14 +612,16 @@ func (p *Provider) ValidateNewSpec(_ context.Context, _ *types.Cluster, _ *clust
 }
 
 func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	if currentSpec.VersionsBundle.Nutanix.Version == newSpec.VersionsBundle.Nutanix.Version {
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if currentVersionsBundle.Nutanix.Version == newVersionsBundle.Nutanix.Version {
 		return nil
 	}
 
 	return &types.ComponentChangeDiff{
 		ComponentName: constants.NutanixProviderName,
-		NewVersion:    newSpec.VersionsBundle.Nutanix.Version,
-		OldVersion:    currentSpec.VersionsBundle.Nutanix.Version,
+		NewVersion:    newVersionsBundle.Nutanix.Version,
+		OldVersion:    currentVersionsBundle.Nutanix.Version,
 	}
 }
 

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -552,6 +552,27 @@ func TestNutanixProviderGenerateCAPISpecForCreate(t *testing.T) {
 	assert.NotNil(t, workerSpec)
 }
 
+func TestNutanixProviderGenerateCAPISpecForCreateWorkerVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	executable := mockexecutables.NewMockExecutable(ctrl)
+	executable.EXPECT().ExecuteWithStdin(gomock.Any(), gomock.Any(), gomock.Any()).Return(bytes.Buffer{}, nil).Times(2)
+	kubectl := executables.NewKubectl(executable)
+	mockClient := mocknutanix.NewMockClient(ctrl)
+	mockCertValidator := mockCrypto.NewMockTlsValidator(ctrl)
+	mockTransport := mocknutanix.NewMockRoundTripper(ctrl)
+	mockTransport.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{}, nil).AnyTimes()
+	mockHTTPClient := &http.Client{Transport: mockTransport}
+	mockWriter := filewritermocks.NewMockFileWriter(ctrl)
+	provider := testNutanixProvider(t, mockClient, kubectl, mockCertValidator, mockHTTPClient, mockWriter)
+
+	cluster := &types.Cluster{Name: "eksa-unit-test"}
+	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster-worker-version.yaml")
+	cpSpec, workerSpec, err := provider.GenerateCAPISpecForCreate(context.Background(), cluster, clusterSpec)
+	assert.NoError(t, err)
+	assert.NotNil(t, cpSpec)
+	assert.NotNil(t, workerSpec)
+}
+
 func TestNutanixProviderGenerateCAPISpecForCreate_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	executable := mockexecutables.NewMockExecutable(ctrl)
@@ -929,8 +950,8 @@ func TestNutanixProviderChangeDiffWithChange(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
 	newClusterSpec := clusterSpec.DeepCopy()
-	clusterSpec.VersionsBundle.Nutanix.Version = "v0.5.2"
-	newClusterSpec.VersionsBundle.Nutanix.Version = "v1.0.0"
+	clusterSpec.VersionsBundles["1.19"].Nutanix.Version = "v0.5.2"
+	newClusterSpec.VersionsBundles["1.19"].Nutanix.Version = "v1.0.0"
 	want := &types.ComponentChangeDiff{
 		ComponentName: "nutanix",
 		NewVersion:    "v1.0.0",

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -150,7 +150,7 @@ func buildTemplateMapCP(
 	controlPlaneMachineSpec v1alpha1.NutanixMachineConfigSpec,
 	etcdMachineSpec v1alpha1.NutanixMachineConfigSpec,
 ) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 	format := "cloud-config"
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
@@ -170,17 +170,17 @@ func buildTemplateMapCP(
 		"format":                       format,
 		"podCidrs":                     clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
 		"serviceCidrs":                 clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks,
-		"kubernetesVersion":            bundle.KubeDistro.Kubernetes.Tag,
-		"kubernetesRepository":         bundle.KubeDistro.Kubernetes.Repository,
-		"corednsRepository":            bundle.KubeDistro.CoreDNS.Repository,
-		"corednsVersion":               bundle.KubeDistro.CoreDNS.Tag,
-		"etcdRepository":               bundle.KubeDistro.Etcd.Repository,
-		"etcdImageTag":                 bundle.KubeDistro.Etcd.Tag,
+		"kubernetesVersion":            versionsBundle.KubeDistro.Kubernetes.Tag,
+		"kubernetesRepository":         versionsBundle.KubeDistro.Kubernetes.Repository,
+		"corednsRepository":            versionsBundle.KubeDistro.CoreDNS.Repository,
+		"corednsVersion":               versionsBundle.KubeDistro.CoreDNS.Tag,
+		"etcdRepository":               versionsBundle.KubeDistro.Etcd.Repository,
+		"etcdImageTag":                 versionsBundle.KubeDistro.Etcd.Tag,
 		"kubeletExtraArgs":             kubeletExtraArgs.ToPartialYaml(),
-		"kubeVipImage":                 bundle.Nutanix.KubeVip.VersionedImage(),
+		"kubeVipImage":                 versionsBundle.Nutanix.KubeVip.VersionedImage(),
 		"kubeVipSvcEnable":             false,
 		"kubeVipLBEnable":              false,
-		"externalEtcdVersion":          bundle.KubeDistro.EtcdVersion,
+		"externalEtcdVersion":          versionsBundle.KubeDistro.EtcdVersion,
 		"etcdCipherSuites":             crypto.SecureCipherSuitesString(),
 		"nutanixEndpoint":              datacenterSpec.Endpoint,
 		"nutanixPort":                  datacenterSpec.Port,
@@ -254,7 +254,7 @@ func buildTemplateMapCP(
 }
 
 func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1alpha1.NutanixMachineConfigSpec, workerNodeGroupConfiguration v1alpha1.WorkerNodeGroupConfiguration) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.WorkerNodeGroupVersionsBundle(workerNodeGroupConfiguration)
 	format := "cloud-config"
 
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
@@ -264,7 +264,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		"clusterName":            clusterSpec.Cluster.Name,
 		"eksaSystemNamespace":    constants.EksaSystemNamespace,
 		"format":                 format,
-		"kubernetesVersion":      bundle.KubeDistro.Kubernetes.Tag,
+		"kubernetesVersion":      versionsBundle.KubeDistro.Kubernetes.Tag,
 		"workerReplicas":         *workerNodeGroupConfiguration.Count,
 		"workerPoolName":         "md-0",
 		"workerSshAuthorizedKey": workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],

--- a/pkg/providers/nutanix/testdata/eksa-cluster-worker-version.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-worker-version.yaml
@@ -1,0 +1,75 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  kubernetesVersion: "1.19"
+  controlPlaneConfiguration:
+    name: eksa-unit-test
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: NutanixMachineConfig
+  workerNodeGroupConfigurations:
+    - count: 4
+      name: md-0
+      kubernetesVersion: "1.18"
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+    - count: 4
+      name: md-1
+      machineGroupRef:
+        name: eksa-unit-test
+        kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -41,7 +41,9 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 		return nil, fmt.Errorf("generating KubeadmControlPlane: %v", err)
 	}
 
-	if err := clusterapi.SetKubeVipInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host, clusterSpec.VersionsBundle.Snow.KubeVip.VersionedImage()); err != nil {
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
+	if err := clusterapi.SetKubeVipInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host, versionsBundle.Snow.KubeVip.VersionedImage()); err != nil {
 		return nil, fmt.Errorf("setting kube-vip: %v", err)
 	}
 
@@ -60,11 +62,11 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 	case v1alpha1.Bottlerocket:
 		clusterapi.SetProxyConfigInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster)
 		clusterapi.SetRegistryMirrorInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
-		clusterapi.SetBottlerocketInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
-		clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
-		clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle)
+		clusterapi.SetBottlerocketInKubeadmControlPlane(kcp, versionsBundle)
+		clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(kcp, versionsBundle)
+		clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(kcp, versionsBundle)
 		clusterapi.SetUnstackedEtcdConfigInKubeadmControlPlaneForBottlerocket(kcp, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration)
-		addBottlerocketBootstrapSnowInKubeadmControlPlane(kcp, clusterSpec.VersionsBundle.Snow.BottlerocketBootstrapSnow)
+		addBottlerocketBootstrapSnowInKubeadmControlPlane(kcp, versionsBundle.Snow.BottlerocketBootstrapSnow)
 		clusterapi.SetBottlerocketHostConfigInKubeadmControlPlane(kcp, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
@@ -100,6 +102,8 @@ func KubeadmConfigTemplate(log logr.Logger, clusterSpec *cluster.Spec, workerNod
 		return nil, fmt.Errorf("generating KubeadmConfigTemplate: %v", err)
 	}
 
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	joinConfigKubeletExtraArg := kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
@@ -109,10 +113,10 @@ func KubeadmConfigTemplate(log logr.Logger, clusterSpec *cluster.Spec, workerNod
 	case v1alpha1.Bottlerocket:
 		clusterapi.SetProxyConfigInKubeadmConfigTemplateForBottlerocket(kct, clusterSpec.Cluster)
 		clusterapi.SetRegistryMirrorInKubeadmConfigTemplateForBottlerocket(kct, clusterSpec.Cluster.Spec.RegistryMirrorConfiguration)
-		clusterapi.SetBottlerocketInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
-		clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
-		clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle)
-		addBottlerocketBootstrapSnowInKubeadmConfigTemplate(kct, clusterSpec.VersionsBundle.Snow.BottlerocketBootstrapSnow)
+		clusterapi.SetBottlerocketInKubeadmConfigTemplate(kct, versionsBundle)
+		clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(kct, versionsBundle)
+		clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(kct, versionsBundle)
+		addBottlerocketBootstrapSnowInKubeadmConfigTemplate(kct, versionsBundle.Snow.BottlerocketBootstrapSnow)
 		clusterapi.SetBottlerocketHostConfigInKubeadmConfigTemplate(kct, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
@@ -144,18 +148,20 @@ func machineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1
 func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.AWSSnowMachineTemplate) *etcdv1.EtcdadmCluster {
 	etcd := clusterapi.EtcdadmCluster(clusterSpec, snowMachineTemplate)
 
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	machineConfig := clusterSpec.SnowMachineConfig(clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name)
 	osFamily := machineConfig.OSFamily()
 	switch osFamily {
 	case v1alpha1.Bottlerocket:
-		clusterapi.SetBottlerocketInEtcdCluster(etcd, clusterSpec.VersionsBundle)
-		clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(etcd, clusterSpec.VersionsBundle.BottleRocketHostContainers.Admin)
-		clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(etcd, clusterSpec.VersionsBundle.BottleRocketHostContainers.Control)
-		addBottlerocketBootstrapSnowInEtcdCluster(etcd, clusterSpec.VersionsBundle.Snow.BottlerocketBootstrapSnow)
+		clusterapi.SetBottlerocketInEtcdCluster(etcd, versionsBundle)
+		clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(etcd, versionsBundle.BottleRocketHostContainers.Admin)
+		clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(etcd, versionsBundle.BottleRocketHostContainers.Control)
+		addBottlerocketBootstrapSnowInEtcdCluster(etcd, versionsBundle.Snow.BottlerocketBootstrapSnow)
 		clusterapi.SetBottlerocketHostConfigInEtcdCluster(etcd, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
-		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, clusterSpec.VersionsBundle.KubeDistro.EtcdVersion)
+		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle.KubeDistro.EtcdVersion)
 		etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = append(etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands,
 			"/etc/eks/bootstrap.sh",
 		)

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -396,7 +396,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 			managementCluster,
 			workloadClusterDatacenter,
 			bundle,
-			test.EksdRelease(),
+			test.EksdRelease("1-22"),
 			credentialsSecret,
 			ipPool,
 			test.EKSARelease(),

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -190,7 +190,8 @@ func (p *SnowProvider) UpdateKubeConfig(content *[]byte, clusterName string) err
 }
 
 func (p *SnowProvider) Version(clusterSpec *cluster.Spec) string {
-	return clusterSpec.VersionsBundle.Snow.Version
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	return versionsBundle.Snow.Version
 }
 
 func (p *SnowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, error) {
@@ -198,7 +199,9 @@ func (p *SnowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, err
 	envMap[snowCredentialsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCredentialsKey])
 	envMap[snowCertsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCertificatesKey])
 
-	envMap["SNOW_CONTROLLER_IMAGE"] = clusterSpec.VersionsBundle.Snow.Manager.VersionedImage()
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
+	envMap["SNOW_CONTROLLER_IMAGE"] = versionsBundle.Snow.Manager.VersionedImage()
 
 	return envMap, nil
 }
@@ -210,14 +213,14 @@ func (p *SnowProvider) GetDeployments() map[string][]string {
 }
 
 func (p *SnowProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	bundle := clusterSpec.VersionsBundle
-	folderName := fmt.Sprintf("infrastructure-snow/%s/", bundle.Snow.Version)
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	folderName := fmt.Sprintf("infrastructure-snow/%s/", versionsBundle.Snow.Version)
 
 	infraBundle := types.InfrastructureBundle{
 		FolderName: folderName,
 		Manifests: []releasev1alpha1.Manifest{
-			bundle.Snow.Components,
-			bundle.Snow.Metadata,
+			versionsBundle.Snow.Components,
+			versionsBundle.Snow.Metadata,
 		},
 	}
 	return &infraBundle
@@ -248,14 +251,16 @@ func (p *SnowProvider) ValidateNewSpec(ctx context.Context, cluster *types.Clust
 }
 
 func (p *SnowProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	if currentSpec.VersionsBundle.Snow.Version == newSpec.VersionsBundle.Snow.Version {
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if currentVersionsBundle.Snow.Version == newVersionsBundle.Snow.Version {
 		return nil
 	}
 
 	return &types.ComponentChangeDiff{
 		ComponentName: constants.SnowProviderName,
-		NewVersion:    newSpec.VersionsBundle.Snow.Version,
-		OldVersion:    currentSpec.VersionsBundle.Snow.Version,
+		NewVersion:    newVersionsBundle.Snow.Version,
+		OldVersion:    currentVersionsBundle.Snow.Version,
 	}
 }
 
@@ -328,12 +333,14 @@ func (p *SnowProvider) validateUpgradeRolloutStrategy(clusterSpec *cluster.Spec)
 // UpgradeNeeded compares the new snow version bundle and objects with the existing ones in the cluster and decides whether
 // to trigger a cluster upgrade or not.
 // TODO: revert the change once cluster.BuildSpec is used in cluster_manager to replace the deprecated cluster.BuildSpecForCluster
-func (p *SnowProvider) UpgradeNeeded(ctx context.Context, newSpec, oldSpec *cluster.Spec, cluster *types.Cluster) (bool, error) {
-	if !bundleImagesEqual(newSpec.VersionsBundle.Snow, oldSpec.VersionsBundle.Snow) {
+func (p *SnowProvider) UpgradeNeeded(ctx context.Context, newSpec, oldSpec *cluster.Spec, c *types.Cluster) (bool, error) {
+	oldVersionBundle := oldSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if !bundleImagesEqual(newVersionsBundle.Snow, oldVersionBundle.Snow) {
 		return true, nil
 	}
 
-	datacenterChanged, err := p.datacenterChanged(ctx, cluster, newSpec)
+	datacenterChanged, err := p.datacenterChanged(ctx, c, newSpec)
 	if err != nil {
 		return false, err
 	}
@@ -341,7 +348,7 @@ func (p *SnowProvider) UpgradeNeeded(ctx context.Context, newSpec, oldSpec *clus
 		return true, nil
 	}
 
-	return p.machineConfigsChanged(ctx, cluster, newSpec)
+	return p.machineConfigsChanged(ctx, c, newSpec)
 }
 
 func (p *SnowProvider) DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error {

--- a/pkg/providers/snow/testdata/expected_results_main_md_ubuntu_worker_version.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md_ubuntu_worker_version.yaml
@@ -1,0 +1,208 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  creationTimestamp: null
+  name: snow-test-md-0-1
+  namespace: eksa-system
+spec:
+  template:
+    metadata: {}
+    spec:
+      clusterConfiguration:
+        apiServer: {}
+        bottlerocketAdmin: {}
+        bottlerocketBootstrap: {}
+        bottlerocketControl: {}
+        controllerManager: {}
+        dns: {}
+        etcd: {}
+        networking: {}
+        pause: {}
+        proxy: {}
+        registryMirror: {}
+        scheduler: {}
+      joinConfiguration:
+        bottlerocketAdmin: {}
+        bottlerocketBootstrap: {}
+        bottlerocketControl: {}
+        discovery: {}
+        nodeRegistration:
+          kubeletExtraArgs:
+            provider-id: aws-snow:////'{{ ds.meta_data.instance_id }}'
+        pause: {}
+        proxy: {}
+        registryMirror: {}
+      preKubeadmCommands:
+      - /etc/eks/bootstrap.sh
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.anywhere.eks.amazonaws.com/cluster-name: snow-test
+    cluster.anywhere.eks.amazonaws.com/cluster-namespace: test-namespace
+    cluster.x-k8s.io/cluster-name: snow-test
+  name: snow-test-md-0
+  namespace: eksa-system
+spec:
+  clusterName: snow-test
+  replicas: 3
+  selector: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: snow-test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: snow-test-md-0-1
+      clusterName: snow-test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSSnowMachineTemplate
+        name: snow-test-md-0-1
+      version: v1.20.2-eks-1-20-7
+status:
+  availableReplicas: 0
+  readyReplicas: 0
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSSnowMachineTemplate
+metadata:
+  creationTimestamp: null
+  name: snow-test-md-0-1
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      ami:
+        id: eks-d-v1-21-5-ubuntu-ami-02833ca9a8f29c2ea
+      cloudInit:
+        insecureSkipSecretsManager: true
+      devices:
+      - 1.2.3.4
+      - 1.2.3.5
+      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: sbe-c.xlarge
+      network:
+        directNetworkInterfaces:
+        - dhcp: true
+          index: 1
+          primary: true
+      osFamily: ubuntu
+      physicalNetworkConnectorType: SFP_PLUS
+      sshKeyName: default
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  creationTimestamp: null
+  name: snow-test-md-1-1
+  namespace: eksa-system
+spec:
+  template:
+    metadata: {}
+    spec:
+      clusterConfiguration:
+        apiServer: {}
+        bottlerocketAdmin: {}
+        bottlerocketBootstrap: {}
+        bottlerocketControl: {}
+        controllerManager: {}
+        dns: {}
+        etcd: {}
+        networking: {}
+        pause: {}
+        proxy: {}
+        registryMirror: {}
+        scheduler: {}
+      joinConfiguration:
+        bottlerocketAdmin: {}
+        bottlerocketBootstrap: {}
+        bottlerocketControl: {}
+        discovery: {}
+        nodeRegistration:
+          kubeletExtraArgs:
+            provider-id: aws-snow:////'{{ ds.meta_data.instance_id }}'
+        pause: {}
+        proxy: {}
+        registryMirror: {}
+      preKubeadmCommands:
+      - /etc/eks/bootstrap.sh
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.anywhere.eks.amazonaws.com/cluster-name: snow-test
+    cluster.anywhere.eks.amazonaws.com/cluster-namespace: test-namespace
+    cluster.x-k8s.io/cluster-name: snow-test
+  name: snow-test-md-1
+  namespace: eksa-system
+spec:
+  clusterName: snow-test
+  replicas: 3
+  selector: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: snow-test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: snow-test-md-1-1
+      clusterName: snow-test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSSnowMachineTemplate
+        name: snow-test-md-1-1
+      version: v1.21.5-eks-1-21-9
+status:
+  availableReplicas: 0
+  readyReplicas: 0
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSSnowMachineTemplate
+metadata:
+  creationTimestamp: null
+  name: snow-test-md-1-1
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      ami:
+        id: eks-d-v1-21-5-ubuntu-ami-02833ca9a8f29c2ea
+      cloudInit:
+        insecureSkipSecretsManager: true
+      devices:
+      - 1.2.3.4
+      - 1.2.3.5
+      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
+      instanceType: sbe-c.xlarge
+      network:
+        directNetworkInterfaces:
+        - dhcp: true
+          index: 1
+          primary: true
+      osFamily: ubuntu
+      physicalNetworkConnectorType: SFP_PLUS
+      sshKeyName: default
+
+---

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -28,9 +28,11 @@ func (p *Provider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.Bootstr
 func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	logger.V(4).Info("Installing Tinkerbell stack on bootstrap cluster")
 
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	err := p.stackInstaller.Install(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell,
+		versionsBundle.Tinkerbell,
 		p.tinkerbellIP,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
@@ -74,9 +76,11 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 		logger.Info("Warning: Skipping load balancer deployment. Please install and configure a load balancer once the cluster is created.")
 	}
 
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	err := p.stackInstaller.Install(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell,
+		versionsBundle.Tinkerbell,
 		p.templateBuilder.datacenterSpec.TinkerbellIP,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -543,7 +543,7 @@ func TestReconcilerValidateHardwareCountRollingUpdateFail(t *testing.T) {
 
 	logger := test.NewNullLogger()
 	scope := tt.buildScope()
-	scope.ClusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag = "1.23"
+	scope.ClusterSpec.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "1.23"
 	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
 	tt.Expect(err).NotTo(HaveOccurred())
 	_, err = tt.reconciler().DetectOperation(tt.ctx, logger, scope)
@@ -662,7 +662,7 @@ func TestReconcilerDetectOperationK8sVersionUpgrade(t *testing.T) {
 
 	logger := test.NewNullLogger()
 	scope := tt.buildScope()
-	scope.ClusterSpec.VersionsBundle.KubeDistro.Kubernetes.Tag = "1.23"
+	scope.ClusterSpec.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "1.23"
 	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
 	tt.Expect(err).NotTo(HaveOccurred())
 	op, err := tt.reconciler().DetectOperation(tt.ctx, logger, scope)
@@ -898,7 +898,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 			workloadClusterDatacenter,
 			managementClusterDatacenter,
 			bundle,
-			test.EksdRelease(),
+			test.EksdRelease("1-22"),
 			test.EKSARelease(),
 		},
 		cluster:                   cluster,

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -65,8 +65,12 @@ func NewTemplateBuilder(datacenterSpec *v1alpha1.TinkerbellDatacenterConfigSpec,
 
 func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	cpTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[tb.controlPlaneMachineSpec.TemplateRef.Name]
+	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	if err != nil {
+		return nil, err
+	}
 	if cpTemplateConfig == nil {
-		versionBundle := clusterSpec.VersionsBundle.VersionsBundle
+		versionBundle := bundle.VersionsBundle
 		cpTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, *versionBundle, tb.datacenterSpec.OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, tb.controlPlaneMachineSpec.OSFamily)
 	}
 
@@ -81,7 +85,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 		etcdMachineSpec = *tb.etcdMachineSpec
 		etcdTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[tb.etcdMachineSpec.TemplateRef.Name]
 		if etcdTemplateConfig == nil {
-			versionBundle := clusterSpec.VersionsBundle.VersionsBundle
+			versionBundle := bundle.VersionsBundle
 			etcdTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, *versionBundle, tb.datacenterSpec.OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, tb.etcdMachineSpec.OSFamily)
 		}
 		etcdTemplateString, err = etcdTemplateConfig.ToTemplateString()
@@ -106,11 +110,12 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 
 func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error) {
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
+	bundle := clusterSpec.ControlPlaneVersionsBundle()
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		workerNodeMachineSpec := tb.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name]
 		wTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[workerNodeMachineSpec.TemplateRef.Name]
 		if wTemplateConfig == nil {
-			versionBundle := clusterSpec.VersionsBundle.VersionsBundle
+			versionBundle := bundle.VersionsBundle
 			wTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, *versionBundle, tb.datacenterSpec.OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, workerNodeMachineSpec.OSFamily)
 		}
 
@@ -357,7 +362,7 @@ func buildTemplateMapCP(
 	etcdTemplateOverride string,
 	datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec,
 ) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 	format := "cloud-config"
 
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
@@ -381,20 +386,20 @@ func buildTemplateMapCP(
 		"controlPlaneSshUsername":       controlPlaneMachineSpec.Users[0].Name,
 		"eksaSystemNamespace":           constants.EksaSystemNamespace,
 		"format":                        format,
-		"kubernetesVersion":             bundle.KubeDistro.Kubernetes.Tag,
-		"kubeVipImage":                  bundle.Tinkerbell.KubeVip.VersionedImage(),
+		"kubernetesVersion":             versionsBundle.KubeDistro.Kubernetes.Tag,
+		"kubeVipImage":                  versionsBundle.Tinkerbell.KubeVip.VersionedImage(),
 		"podCidrs":                      clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks,
 		"serviceCidrs":                  clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks,
 		"apiserverExtraArgs":            apiServerExtraArgs.ToPartialYaml(),
 		"baseRegistry":                  "", // TODO: need to get this values for creating template IMAGE_URL
 		"osDistro":                      "", // TODO: need to get this values for creating template IMAGE_URL
 		"osVersion":                     "", // TODO: need to get this values for creating template IMAGE_URL
-		"kubernetesRepository":          bundle.KubeDistro.Kubernetes.Repository,
-		"corednsRepository":             bundle.KubeDistro.CoreDNS.Repository,
-		"corednsVersion":                bundle.KubeDistro.CoreDNS.Tag,
-		"etcdRepository":                bundle.KubeDistro.Etcd.Repository,
-		"etcdImageTag":                  bundle.KubeDistro.Etcd.Tag,
-		"externalEtcdVersion":           bundle.KubeDistro.EtcdVersion,
+		"kubernetesRepository":          versionsBundle.KubeDistro.Kubernetes.Repository,
+		"corednsRepository":             versionsBundle.KubeDistro.CoreDNS.Repository,
+		"corednsVersion":                versionsBundle.KubeDistro.CoreDNS.Tag,
+		"etcdRepository":                versionsBundle.KubeDistro.Etcd.Repository,
+		"etcdImageTag":                  versionsBundle.KubeDistro.Etcd.Tag,
+		"externalEtcdVersion":           versionsBundle.KubeDistro.EtcdVersion,
 		"etcdCipherSuites":              crypto.SecureCipherSuitesString(),
 		"kubeletExtraArgs":              kubeletExtraArgs.ToPartialYaml(),
 		"hardwareSelector":              controlPlaneMachineSpec.HardwareSelector,
@@ -440,10 +445,10 @@ func buildTemplateMapCP(
 
 	if controlPlaneMachineSpec.OSFamily == v1alpha1.Bottlerocket {
 		values["format"] = string(v1alpha1.Bottlerocket)
-		values["pauseRepository"] = bundle.KubeDistro.Pause.Image()
-		values["pauseVersion"] = bundle.KubeDistro.Pause.Tag()
-		values["bottlerocketBootstrapRepository"] = bundle.BottleRocketHostContainers.KubeadmBootstrap.Image()
-		values["bottlerocketBootstrapVersion"] = bundle.BottleRocketHostContainers.KubeadmBootstrap.Tag()
+		values["pauseRepository"] = versionsBundle.KubeDistro.Pause.Image()
+		values["pauseVersion"] = versionsBundle.KubeDistro.Pause.Tag()
+		values["bottlerocketBootstrapRepository"] = versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.Image()
+		values["bottlerocketBootstrapVersion"] = versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.Tag()
 	}
 
 	if clusterSpec.AWSIamConfig != nil {
@@ -476,7 +481,7 @@ func buildTemplateMapMD(
 	workerTemplateOverride string,
 	datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec,
 ) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.WorkerNodeGroupVersionsBundle(workerNodeGroupConfiguration)
 	format := "cloud-config"
 
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
@@ -488,7 +493,7 @@ func buildTemplateMapMD(
 		"eksaSystemNamespace":    constants.EksaSystemNamespace,
 		"kubeletExtraArgs":       kubeletExtraArgs.ToPartialYaml(),
 		"format":                 format,
-		"kubernetesVersion":      bundle.KubeDistro.Kubernetes.Tag,
+		"kubernetesVersion":      versionsBundle.KubeDistro.Kubernetes.Tag,
 		"workerNodeGroupName":    workerNodeGroupConfiguration.Name,
 		"workerSshAuthorizedKey": workerNodeGroupMachineSpec.Users[0].SshAuthorizedKeys[0],
 		"workerSshUsername":      workerNodeGroupMachineSpec.Users[0].Name,
@@ -498,10 +503,10 @@ func buildTemplateMapMD(
 
 	if workerNodeGroupMachineSpec.OSFamily == v1alpha1.Bottlerocket {
 		values["format"] = string(v1alpha1.Bottlerocket)
-		values["pauseRepository"] = bundle.KubeDistro.Pause.Image()
-		values["pauseVersion"] = bundle.KubeDistro.Pause.Tag()
-		values["bottlerocketBootstrapRepository"] = bundle.BottleRocketHostContainers.KubeadmBootstrap.Image()
-		values["bottlerocketBootstrapVersion"] = bundle.BottleRocketHostContainers.KubeadmBootstrap.Tag()
+		values["pauseRepository"] = versionsBundle.KubeDistro.Pause.Image()
+		values["pauseVersion"] = versionsBundle.KubeDistro.Pause.Tag()
+		values["bottlerocketBootstrapRepository"] = versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.Image()
+		values["bottlerocketBootstrapVersion"] = versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.Tag()
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_worker_version.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_worker_version.yaml
@@ -1,0 +1,209 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    count: 1
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: TinkerbellMachineConfig
+    labels:
+      key1-cp: value1-cp
+      key2-cp: value2-cp
+  datacenterRef:
+    kind: TinkerbellDatacenterConfig
+    name: test
+  kubernetesVersion: "1.21"
+  managementCluster:
+    name: test
+  workerNodeGroupConfigurations:
+  - count: 1
+    kubernetesVersion: "1.20"
+    name: md-0
+    machineGroupRef:
+      name: test-md
+      kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    labels:
+      key1-md: value1-md
+      key2-md: value2-md
+  - count: 1
+    name: md-1
+    machineGroupRef:
+      name: test-md
+      kind: TinkerbellMachineConfig
+    upgradeRolloutStrategy:
+      type: "RollingUpdate"
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  tinkerbellIP: "5.6.7.8"
+  osImageURL: "https://ubuntu.gz"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  hardwareSelector:
+    type: "cp"
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: tink-test
+  users:
+    - name: tink-user
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: test-md
+  namespace: test-namespace
+spec:
+  hardwareSelector:
+    type: "worker"
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: tink-test
+  users:
+    - name: tink-user
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellTemplateConfig
+metadata:
+  name: tink-test
+spec:
+  template:
+    global_timeout: 6000
+    id: ""
+    name: tink-test
+    tasks:
+    - actions:
+      - environment:
+          COMPRESSED: "true"
+          DEST_DISK: /dev/sda
+          IMG_URL: ""
+        image: image2disk:v1.0.0
+        name: stream-image
+        timeout: 360
+      - environment:
+          BLOCK_DEVICE: /dev/sda2
+          CHROOT: "y"
+          CMD_LINE: apt -y update && apt -y install openssl
+          DEFAULT_INTERPRETER: /bin/sh -c
+          FS_TYPE: ext4
+        image: cexec:v1.0.0
+        name: install-openssl
+        timeout: 90
+      - environment:
+          CONTENTS: |
+            network:
+              version: 2
+              renderer: networkd
+              ethernets:
+                  eno1:
+                      dhcp4: true
+                  eno2:
+                      dhcp4: true
+                  eno3:
+                      dhcp4: true
+                  eno4:
+                      dhcp4: true
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/netplan/config.yaml
+          DIRMODE: "0755"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0644"
+          UID: "0"
+        image: writefile:v1.0.0
+        name: write-netplan
+        timeout: 90
+      - environment:
+          CONTENTS: |
+            datasource:
+              Ec2:
+                metadata_urls: []
+                strict_id: false
+            system_info:
+              default_user:
+                name: tink
+                groups: [wheel, adm]
+                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                shell: /bin/bash
+            manage_etc_hosts: localhost
+            warnings:
+              dsid_missing_source: off
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+          DIRMODE: "0700"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0600"
+        image: writefile:v1.0.0
+        name: add-tink-cloud-init-config
+        timeout: 90
+      - environment:
+          CONTENTS: |
+            datasource: Ec2
+          DEST_DISK: /dev/sda2
+          DEST_PATH: /etc/cloud/ds-identify.cfg
+          DIRMODE: "0700"
+          FS_TYPE: ext4
+          GID: "0"
+          MODE: "0600"
+          UID: "0"
+        image: writefile:v1.0.0
+        name: add-tink-cloud-init-ds-config
+        timeout: 90
+      - environment:
+          BLOCK_DEVICE: /dev/sda2
+          FS_TYPE: ext4
+        image: kexec:v1.0.0
+        name: kexec-image
+        pid: host
+        timeout: 90
+      name: tink-test
+      volumes:
+      - /dev:/dev
+      - /dev/console:/dev/console
+      - /lib/firmware:/lib/firmware:ro
+      worker: '{{.device_1}}'
+    version: "0.1"
+---

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml
@@ -1,0 +1,341 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+    pool: md-0
+  name: test-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 1
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+        pool: md-0
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-0-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: TinkerbellMachineTemplate
+        name: test-md-0-1234567890000
+      version: v1.20.4-eks-1-20-1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: TinkerbellMachineTemplate
+metadata:
+  name: test-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      hardwareAffinity:
+        required:
+        - labelSelector:
+            matchLabels: 
+              type: worker
+      templateOverride: |
+        global_timeout: 6000
+        id: ""
+        name: tink-test
+        tasks:
+        - actions:
+          - environment:
+              COMPRESSED: "true"
+              DEST_DISK: /dev/sda
+              IMG_URL: ""
+            image: image2disk:v1.0.0
+            name: stream-image
+            timeout: 360
+          - environment:
+              BLOCK_DEVICE: /dev/sda2
+              CHROOT: "y"
+              CMD_LINE: apt -y update && apt -y install openssl
+              DEFAULT_INTERPRETER: /bin/sh -c
+              FS_TYPE: ext4
+            image: cexec:v1.0.0
+            name: install-openssl
+            timeout: 90
+          - environment:
+              CONTENTS: |
+                network:
+                  version: 2
+                  renderer: networkd
+                  ethernets:
+                      eno1:
+                          dhcp4: true
+                      eno2:
+                          dhcp4: true
+                      eno3:
+                          dhcp4: true
+                      eno4:
+                          dhcp4: true
+              DEST_DISK: /dev/sda2
+              DEST_PATH: /etc/netplan/config.yaml
+              DIRMODE: "0755"
+              FS_TYPE: ext4
+              GID: "0"
+              MODE: "0644"
+              UID: "0"
+            image: writefile:v1.0.0
+            name: write-netplan
+            timeout: 90
+          - environment:
+              CONTENTS: |
+                datasource:
+                  Ec2:
+                    metadata_urls: []
+                    strict_id: false
+                system_info:
+                  default_user:
+                    name: tink
+                    groups: [wheel, adm]
+                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                    shell: /bin/bash
+                manage_etc_hosts: localhost
+                warnings:
+                  dsid_missing_source: off
+              DEST_DISK: /dev/sda2
+              DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+              DIRMODE: "0700"
+              FS_TYPE: ext4
+              GID: "0"
+              MODE: "0600"
+            image: writefile:v1.0.0
+            name: add-tink-cloud-init-config
+            timeout: 90
+          - environment:
+              CONTENTS: |
+                datasource: Ec2
+              DEST_DISK: /dev/sda2
+              DEST_PATH: /etc/cloud/ds-identify.cfg
+              DIRMODE: "0700"
+              FS_TYPE: ext4
+              GID: "0"
+              MODE: "0600"
+              UID: "0"
+            image: writefile:v1.0.0
+            name: add-tink-cloud-init-ds-config
+            timeout: 90
+          - environment:
+              BLOCK_DEVICE: /dev/sda2
+              FS_TYPE: ext4
+            image: kexec:v1.0.0
+            name: kexec-image
+            pid: host
+            timeout: 90
+          name: tink-test
+          volumes:
+          - /dev:/dev
+          - /dev/console:/dev/console
+          - /lib/firmware:/lib/firmware:ro
+          worker: '{{.device_1}}'
+        version: "0.1"
+        
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-0-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            provider-id: PROVIDER_ID
+            read-only-port: "0"
+            anonymous-auth: "false"
+            node-labels: key1-md=value1-md,key2-md=value2-md
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      users:
+      - name: tink-user
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+    pool: md-1
+  name: test-md-1
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 1
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+        pool: md-1
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-1-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: TinkerbellMachineTemplate
+        name: test-md-1-1234567890000
+      version: v1.21.2-eks-1-21-4
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: TinkerbellMachineTemplate
+metadata:
+  name: test-md-1-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      hardwareAffinity:
+        required:
+        - labelSelector:
+            matchLabels: 
+              type: worker
+      templateOverride: |
+        global_timeout: 6000
+        id: ""
+        name: tink-test
+        tasks:
+        - actions:
+          - environment:
+              COMPRESSED: "true"
+              DEST_DISK: /dev/sda
+              IMG_URL: ""
+            image: image2disk:v1.0.0
+            name: stream-image
+            timeout: 360
+          - environment:
+              BLOCK_DEVICE: /dev/sda2
+              CHROOT: "y"
+              CMD_LINE: apt -y update && apt -y install openssl
+              DEFAULT_INTERPRETER: /bin/sh -c
+              FS_TYPE: ext4
+            image: cexec:v1.0.0
+            name: install-openssl
+            timeout: 90
+          - environment:
+              CONTENTS: |
+                network:
+                  version: 2
+                  renderer: networkd
+                  ethernets:
+                      eno1:
+                          dhcp4: true
+                      eno2:
+                          dhcp4: true
+                      eno3:
+                          dhcp4: true
+                      eno4:
+                          dhcp4: true
+              DEST_DISK: /dev/sda2
+              DEST_PATH: /etc/netplan/config.yaml
+              DIRMODE: "0755"
+              FS_TYPE: ext4
+              GID: "0"
+              MODE: "0644"
+              UID: "0"
+            image: writefile:v1.0.0
+            name: write-netplan
+            timeout: 90
+          - environment:
+              CONTENTS: |
+                datasource:
+                  Ec2:
+                    metadata_urls: []
+                    strict_id: false
+                system_info:
+                  default_user:
+                    name: tink
+                    groups: [wheel, adm]
+                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+                    shell: /bin/bash
+                manage_etc_hosts: localhost
+                warnings:
+                  dsid_missing_source: off
+              DEST_DISK: /dev/sda2
+              DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+              DIRMODE: "0700"
+              FS_TYPE: ext4
+              GID: "0"
+              MODE: "0600"
+            image: writefile:v1.0.0
+            name: add-tink-cloud-init-config
+            timeout: 90
+          - environment:
+              CONTENTS: |
+                datasource: Ec2
+              DEST_DISK: /dev/sda2
+              DEST_PATH: /etc/cloud/ds-identify.cfg
+              DIRMODE: "0700"
+              FS_TYPE: ext4
+              GID: "0"
+              MODE: "0600"
+              UID: "0"
+            image: writefile:v1.0.0
+            name: add-tink-cloud-init-ds-config
+            timeout: 90
+          - environment:
+              BLOCK_DEVICE: /dev/sda2
+              FS_TYPE: ext4
+            image: kexec:v1.0.0
+            name: kexec-image
+            pid: host
+            timeout: 90
+          name: tink-test
+          volumes:
+          - /dev:/dev
+          - /dev/console:/dev/console
+          - /lib/firmware:/lib/firmware:ro
+          worker: '{{.device_1}}'
+        version: "0.1"
+        
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-1-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            provider-id: PROVIDER_ID
+            read-only-port: "0"
+            anonymous-auth: "false"
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      users:
+      - name: tink-user
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+
+---

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -208,7 +208,8 @@ func (p *Provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 }
 
 func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	return clusterSpec.VersionsBundle.Tinkerbell.Version
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	return versionsBundle.Tinkerbell.Version
 }
 
 func (p *Provider) EnvMap(spec *cluster.Spec) (map[string]string, error) {
@@ -242,15 +243,15 @@ func (p *Provider) GetDeployments() map[string][]string {
 }
 
 func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	bundle := clusterSpec.VersionsBundle
-	folderName := fmt.Sprintf("infrastructure-tinkerbell/%s/", bundle.Tinkerbell.Version)
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	folderName := fmt.Sprintf("infrastructure-tinkerbell/%s/", versionsBundle.Tinkerbell.Version)
 
 	infraBundle := types.InfrastructureBundle{
 		FolderName: folderName,
 		Manifests: []releasev1alpha1.Manifest{
-			bundle.Tinkerbell.Components,
-			bundle.Tinkerbell.Metadata,
-			bundle.Tinkerbell.ClusterTemplate,
+			versionsBundle.Tinkerbell.Components,
+			versionsBundle.Tinkerbell.Metadata,
+			versionsBundle.Tinkerbell.ClusterTemplate,
 		},
 	}
 	return &infraBundle
@@ -294,14 +295,16 @@ func (p *Provider) MachineConfigs(_ *cluster.Spec) []providers.MachineConfig {
 }
 
 func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	if currentSpec.VersionsBundle.Tinkerbell.Version == newSpec.VersionsBundle.Tinkerbell.Version {
+	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	if currentVersionsBundle.Tinkerbell.Version == newVersionsBundle.Tinkerbell.Version {
 		return nil
 	}
 
 	return &types.ComponentChangeDiff{
 		ComponentName: constants.TinkerbellProviderName,
-		NewVersion:    newSpec.VersionsBundle.Tinkerbell.Version,
-		OldVersion:    currentSpec.VersionsBundle.Tinkerbell.Version,
+		NewVersion:    newVersionsBundle.Tinkerbell.Version,
+		OldVersion:    currentVersionsBundle.Tinkerbell.Version,
 	}
 }
 

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -295,6 +295,40 @@ func TestTinkerbellProviderGenerateDeploymentFileWithNodeLabels(t *testing.T) {
 	test.AssertContentToFile(t, string(md), "testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml")
 }
 
+func TestTinkerbellProviderGenerateDeploymentFileWithWorkerVersion(t *testing.T) {
+	clusterSpecManifest := "cluster_tinkerbell_worker_version.yaml"
+	mockCtrl := gomock.NewController(t)
+	docker := stackmocks.NewMockDocker(mockCtrl)
+	helm := stackmocks.NewMockHelm(mockCtrl)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+	cluster := &types.Cluster{Name: "test"}
+	forceCleanup := false
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	ctx := context.Background()
+
+	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CleanupLocalBoots(ctx, forceCleanup)
+
+	if err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec); err != nil {
+		t.Fatalf("failed to setup and validate: %v", err)
+	}
+
+	cp, md, err := provider.GenerateCAPISpecForCreate(context.Background(), cluster, clusterSpec)
+	if err != nil {
+		t.Fatalf("failed to generate cluster api spec contents: %v", err)
+	}
+
+	test.AssertContentToFile(t, string(cp), "testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml")
+	test.AssertContentToFile(t, string(md), "testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml")
+}
+
 func TestTinkerbellProviderGenerateDeploymentFileWithNodeTaints(t *testing.T) {
 	clusterSpecManifest := "cluster_tinkerbell_node_taints.yaml"
 	mockCtrl := gomock.NewController(t)
@@ -382,9 +416,11 @@ func TestPreCAPIInstallOnBootstrapSuccess(t *testing.T) {
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 	provider.stackInstaller = stackInstaller
 
+	bundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	stackInstaller.EXPECT().Install(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell,
+		bundle.Tinkerbell,
 		testIP,
 		"test.kubeconfig",
 		"",
@@ -417,9 +453,11 @@ func TestPostWorkloadInitSuccess(t *testing.T) {
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 	provider.stackInstaller = stackInstaller
 
+	bundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	stackInstaller.EXPECT().Install(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell,
+		bundle.Tinkerbell,
 		testIP,
 		"test.kubeconfig",
 		"",

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -376,11 +376,13 @@ func (p *Provider) PreCoreComponentsUpgrade(
 		return errors.New("cluster spec is nil")
 	}
 
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+
 	// Attempt the upgrade. This should upgrade the stack in the mangement cluster by updating
 	// images, installing new CRDs and possibly removing old ones.
 	err := p.stackInstaller.Upgrade(
 		ctx,
-		clusterSpec.VersionsBundle.Tinkerbell,
+		versionsBundle.Tinkerbell,
 		p.datacenterConfig.Spec.TinkerbellIP,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -72,10 +72,11 @@ func TestProviderPreCoreComponentsUpgrade_StackUpgradeError(t *testing.T) {
 	tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
 	expect := "foobar"
+	bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
 	tconfig.Installer.EXPECT().
 		Upgrade(
 			gomock.Any(),
-			tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
+			bundle.Tinkerbell,
 			tconfig.DatacenterConfig.Spec.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
 			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
@@ -96,10 +97,12 @@ func TestProviderPreCoreComponentsUpgrade_StackUpgradeError(t *testing.T) {
 func TestProviderPreCoreComponentsUpgrade_HasBaseboardManagementCRDError(t *testing.T) {
 	tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
+	bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+
 	tconfig.Installer.EXPECT().
 		Upgrade(
 			gomock.Any(),
-			tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
+			bundle.Tinkerbell,
 			tconfig.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
 			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
@@ -129,10 +132,12 @@ func TestProviderPreCoreComponentsUpgrade_HasBaseboardManagementCRDError(t *test
 func TestProviderPreCoreComponentsUpgrade_NoBaseboardManagementCRD(t *testing.T) {
 	tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
+	bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+
 	tconfig.Installer.EXPECT().
 		Upgrade(
 			gomock.Any(),
-			tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
+			bundle.Tinkerbell,
 			tconfig.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
 			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
@@ -436,12 +441,14 @@ func TestProviderPreCoreComponentsUpgrade_RufioConversions(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
+			bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+
 			// Configure the mocks to successfully upgrade the Tinkerbell stack using the installer
 			// and identify the need to convert deprecated Rufio custom resources.
 			tconfig.Installer.EXPECT().
 				Upgrade(
 					gomock.Any(),
-					tconfig.ClusterSpec.VersionsBundle.Tinkerbell,
+					bundle.Tinkerbell,
 					tconfig.DatacenterConfig.Spec.TinkerbellIP,
 					tconfig.Management.KubeconfigFile,
 					tconfig.DatacenterConfig.Spec.HookImagesURLPath,
@@ -606,10 +613,12 @@ func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
 
 // WithStackUpgrade configures t mocks to get successfully reach Rufio CRD conversion.
 func (t *PreCoreComponentsUpgradeTestConfig) WithStackUpgrade() *PreCoreComponentsUpgradeTestConfig {
+	bundle := t.ClusterSpec.ControlPlaneVersionsBundle()
+
 	t.Installer.EXPECT().
 		Upgrade(
 			gomock.Any(),
-			t.ClusterSpec.VersionsBundle.Tinkerbell,
+			bundle.Tinkerbell,
 			t.TinkerbellIP,
 			t.Management.KubeconfigFile,
 			t.DatacenterConfig.Spec.HookImagesURLPath,

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -116,18 +116,6 @@ func TestControlPlaneSpecNewCluster(t *testing.T) {
 	g.Expect(cp.EtcdMachineTemplate.Name).To(Equal("test-etcd-1"))
 }
 
-func TestControlPlaneSpecNoKubeVersion(t *testing.T) {
-	g := NewWithT(t)
-	logger := test.NewNullLogger()
-	ctx := context.Background()
-	client := test.NewFakeKubeClient()
-	spec := test.NewFullClusterSpec(t, testClusterConfigMainFilename)
-	spec.Cluster.Spec.KubernetesVersion = ""
-
-	_, err := vsphere.ControlPlaneSpec(ctx, logger, client, spec)
-	g.Expect(err).To(MatchError(ContainSubstring("generating vsphere control plane yaml spec")))
-}
-
 func TestControlPlaneSpecUpdateMachineTemplates(t *testing.T) {
 	g := NewWithT(t)
 	logger := test.NewNullLogger()

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -331,17 +331,6 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cpi-manifests", Namespace: "eksa-system"}})
 }
 
-func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
-	tt := newReconcilerTest(t)
-	tt.createAllObjs()
-	spec := tt.buildSpec()
-	spec.Cluster.Spec.KubernetesVersion = ""
-
-	_, err := tt.reconciler().ReconcileControlPlane(tt.ctx, test.NewNullLogger(), spec)
-
-	tt.Expect(err).To(HaveOccurred())
-}
-
 type reconcilerTest struct {
 	t testing.TB
 	*WithT
@@ -462,7 +451,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 			managementCluster,
 			workloadClusterDatacenter,
 			bundle,
-			test.EksdRelease(),
+			test.EksdRelease("1-22"),
 			credentialsSecret,
 			test.EKSARelease(),
 		},

--- a/pkg/providers/vsphere/tags.go
+++ b/pkg/providers/vsphere/tags.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 )
 
-func requiredTemplateTags(clusterSpec *cluster.Spec, machineConfig *v1alpha1.VSphereMachineConfig) []string {
-	tagsByCategory := requiredTemplateTagsByCategory(clusterSpec, machineConfig)
+func requiredTemplateTags(machineConfig *v1alpha1.VSphereMachineConfig, versionsBundle *cluster.VersionsBundle) []string {
+	tagsByCategory := requiredTemplateTagsByCategory(machineConfig, versionsBundle)
 	tags := make([]string, 0, len(tagsByCategory))
 	for _, t := range tagsByCategory {
 		tags = append(tags, t...)
@@ -18,10 +18,10 @@ func requiredTemplateTags(clusterSpec *cluster.Spec, machineConfig *v1alpha1.VSp
 	return tags
 }
 
-func requiredTemplateTagsByCategory(clusterSpec *cluster.Spec, machineConfig *v1alpha1.VSphereMachineConfig) map[string][]string {
+func requiredTemplateTagsByCategory(machineConfig *v1alpha1.VSphereMachineConfig, versionsBundle *cluster.VersionsBundle) map[string][]string {
 	osFamily := machineConfig.Spec.OSFamily
 	return map[string][]string{
-		"eksdRelease": {fmt.Sprintf("eksdRelease:%s", clusterSpec.VersionsBundle.EksD.Name)},
+		"eksdRelease": {fmt.Sprintf("eksdRelease:%s", versionsBundle.EksD.Name)},
 		"os":          {fmt.Sprintf("os:%s", strings.ToLower(string(osFamily)))},
 	}
 }

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -60,8 +60,8 @@ func (vs *VsphereTemplateBuilder) GenerateCAPISpecControlPlane(
 	return bytes, nil
 }
 
-func (vs *VsphereTemplateBuilder) isCgroupDriverSystemd(clusterSpec *cluster.Spec) (bool, error) {
-	bundle := clusterSpec.VersionsBundle
+func (vs *VsphereTemplateBuilder) isCgroupDriverSystemd(clusterSpec *cluster.Spec, worker anywherev1.WorkerNodeGroupConfiguration) (bool, error) {
+	bundle := clusterSpec.WorkerNodeGroupVersionsBundle(worker)
 	k8sVersion, err := semver.New(bundle.KubeDistro.Kubernetes.Tag)
 	if err != nil {
 		return false, fmt.Errorf("parsing kubernetes version %v: %v", bundle.KubeDistro.Kubernetes.Tag, err)
@@ -85,16 +85,15 @@ func (vs *VsphereTemplateBuilder) GenerateCAPISpecWorkers(
 	workloadTemplateNames,
 	kubeadmconfigTemplateNames map[string]string,
 ) (content []byte, err error) {
-	// pin cgroupDriver to systemd for k8s >= 1.21 when generating template in controller
-	// remove this check once the controller supports order upgrade.
-	// i.e. control plane, etcd upgrade before worker nodes.
-	cgroupDriverSystemd, err := vs.isCgroupDriverSystemd(clusterSpec)
-	if err != nil {
-		return nil, err
-	}
-
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		// pin cgroupDriver to systemd for k8s >= 1.21 when generating template in controller
+		// remove this check once the controller supports order upgrade.
+		// i.e. control plane, etcd upgrade before worker nodes.
+		cgroupDriverSystemd, err := vs.isCgroupDriverSystemd(clusterSpec, workerNodeGroupConfiguration)
+		if err != nil {
+			return nil, err
+		}
 		values, err := buildTemplateMapMD(
 			clusterSpec,
 			clusterSpec.VSphereDatacenter.Spec,
@@ -125,7 +124,7 @@ func buildTemplateMapCP(
 	datacenterSpec anywherev1.VSphereDatacenterConfigSpec,
 	controlPlaneMachineSpec, etcdMachineSpec anywherev1.VSphereMachineConfigSpec,
 ) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
 	format := "cloud-config"
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
@@ -151,22 +150,22 @@ func buildTemplateMapCP(
 		"clusterName":                          clusterSpec.Cluster.Name,
 		"controlPlaneEndpointIp":               clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
 		"controlPlaneReplicas":                 clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count,
-		"kubernetesRepository":                 bundle.KubeDistro.Kubernetes.Repository,
-		"kubernetesVersion":                    bundle.KubeDistro.Kubernetes.Tag,
-		"etcdRepository":                       bundle.KubeDistro.Etcd.Repository,
-		"etcdImageTag":                         bundle.KubeDistro.Etcd.Tag,
-		"corednsRepository":                    bundle.KubeDistro.CoreDNS.Repository,
-		"corednsVersion":                       bundle.KubeDistro.CoreDNS.Tag,
-		"nodeDriverRegistrarImage":             bundle.KubeDistro.NodeDriverRegistrar.VersionedImage(),
-		"livenessProbeImage":                   bundle.KubeDistro.LivenessProbe.VersionedImage(),
-		"externalAttacherImage":                bundle.KubeDistro.ExternalAttacher.VersionedImage(),
-		"externalProvisionerImage":             bundle.KubeDistro.ExternalProvisioner.VersionedImage(),
+		"kubernetesRepository":                 versionsBundle.KubeDistro.Kubernetes.Repository,
+		"kubernetesVersion":                    versionsBundle.KubeDistro.Kubernetes.Tag,
+		"etcdRepository":                       versionsBundle.KubeDistro.Etcd.Repository,
+		"etcdImageTag":                         versionsBundle.KubeDistro.Etcd.Tag,
+		"corednsRepository":                    versionsBundle.KubeDistro.CoreDNS.Repository,
+		"corednsVersion":                       versionsBundle.KubeDistro.CoreDNS.Tag,
+		"nodeDriverRegistrarImage":             versionsBundle.KubeDistro.NodeDriverRegistrar.VersionedImage(),
+		"livenessProbeImage":                   versionsBundle.KubeDistro.LivenessProbe.VersionedImage(),
+		"externalAttacherImage":                versionsBundle.KubeDistro.ExternalAttacher.VersionedImage(),
+		"externalProvisionerImage":             versionsBundle.KubeDistro.ExternalProvisioner.VersionedImage(),
 		"thumbprint":                           datacenterSpec.Thumbprint,
 		"vsphereDatacenter":                    datacenterSpec.Datacenter,
 		"controlPlaneVsphereDatastore":         controlPlaneMachineSpec.Datastore,
 		"controlPlaneVsphereFolder":            controlPlaneMachineSpec.Folder,
-		"managerImage":                         bundle.VSphere.Manager.VersionedImage(),
-		"kubeVipImage":                         bundle.VSphere.KubeVip.VersionedImage(),
+		"managerImage":                         versionsBundle.VSphere.Manager.VersionedImage(),
+		"kubeVipImage":                         versionsBundle.VSphere.KubeVip.VersionedImage(),
 		"insecure":                             datacenterSpec.Insecure,
 		"vsphereNetwork":                       datacenterSpec.Network,
 		"controlPlaneVsphereResourcePool":      controlPlaneMachineSpec.ResourcePool,
@@ -190,8 +189,8 @@ func buildTemplateMapCP(
 		"schedulerExtraArgs":                   sharedExtraArgs.ToPartialYaml(),
 		"kubeletExtraArgs":                     kubeletExtraArgs.ToPartialYaml(),
 		"format":                               format,
-		"externalEtcdVersion":                  bundle.KubeDistro.EtcdVersion,
-		"etcdImage":                            bundle.KubeDistro.EtcdImage.VersionedImage(),
+		"externalEtcdVersion":                  versionsBundle.KubeDistro.EtcdVersion,
+		"etcdImage":                            versionsBundle.KubeDistro.EtcdImage.VersionedImage(),
 		"eksaSystemNamespace":                  constants.EksaSystemNamespace,
 		"cpiResourceSetName":                   cpiResourceSetName(clusterSpec),
 		"eksaVsphereUsername":                  vuc.EksaVsphereUsername,
@@ -294,10 +293,10 @@ func buildTemplateMapCP(
 
 	if controlPlaneMachineSpec.OSFamily == anywherev1.Bottlerocket {
 		values["format"] = string(anywherev1.Bottlerocket)
-		values["pauseRepository"] = bundle.KubeDistro.Pause.Image()
-		values["pauseVersion"] = bundle.KubeDistro.Pause.Tag()
-		values["bottlerocketBootstrapRepository"] = bundle.BottleRocketHostContainers.KubeadmBootstrap.Image()
-		values["bottlerocketBootstrapVersion"] = bundle.BottleRocketHostContainers.KubeadmBootstrap.Tag()
+		values["pauseRepository"] = versionsBundle.KubeDistro.Pause.Image()
+		values["pauseVersion"] = versionsBundle.KubeDistro.Pause.Tag()
+		values["bottlerocketBootstrapRepository"] = versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.Image()
+		values["bottlerocketBootstrapVersion"] = versionsBundle.BottleRocketHostContainers.KubeadmBootstrap.Tag()
 	}
 
 	if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
@@ -333,7 +332,10 @@ func buildTemplateMapMD(
 	workerNodeGroupMachineSpec anywherev1.VSphereMachineConfigSpec,
 	workerNodeGroupConfiguration anywherev1.WorkerNodeGroupConfiguration,
 ) (map[string]interface{}, error) {
-	bundle := clusterSpec.VersionsBundle
+	bundle := clusterSpec.WorkerNodeGroupVersionsBundle(workerNodeGroupConfiguration)
+	if bundle == nil {
+		return nil, fmt.Errorf("could not find VersionsBundle")
+	}
 	format := "cloud-config"
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.WorkerNodeLabelsExtraArgs(workerNodeGroupConfiguration)).

--- a/pkg/providers/vsphere/template_test.go
+++ b/pkg/providers/vsphere/template_test.go
@@ -14,14 +14,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
-func TestVsphereTemplateBuilderGenerateCAPISpecControlPlaneNoKubeVersion(t *testing.T) {
-	clusterSpec := vsphereClusterSpec()
-	g := NewWithT(t)
-	vs := vsphere.NewVsphereTemplateBuilder(time.Now)
-	_, err := vs.GenerateCAPISpecControlPlane(clusterSpec)
-	g.Expect(err).NotTo(MatchError(ContainSubstring("error building template map from CP")))
-}
-
 func TestVsphereTemplateBuilderGenerateCAPISpecWorkersInvalidSSHKey(t *testing.T) {
 	g := NewWithT(t)
 	spec := test.NewFullClusterSpec(t, "testdata/cluster_main.yaml")

--- a/pkg/providers/vsphere/testdata/cluster_main_worker_version.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_main_worker_version.yaml
@@ -1,0 +1,143 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.21"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: test-wn
+        kind: VSphereMachineConfig
+      name: md-0
+    - count: 3
+      machineGroupRef:
+        name: test-wn-2
+        kind: VSphereMachineConfig
+      name: md-1
+      kubernetesVersion: "1.19"
+      taints:
+      - key: key2
+        value: val2
+        effect: PreferNoSchedule
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.21.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-wn-2
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-wn
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.21.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  datacenter: "SDDC-Datacenter"
+  network: "/SDDC-Datacenter/network/sddc-cgw-network-1"
+  server: "vsphere_server"
+  thumbprint: "ABCDEFG"
+  insecure: false
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.21.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_worker_version.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_worker_version.yaml
@@ -1,0 +1,263 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-0-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            cloud-provider: external
+            read-only-port: "0"
+            anonymous-auth: "false"
+            cgroup-driver: systemd
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      preKubeadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+      - name: capv
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 3
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-0-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: test-md-0-1234567890000
+      version: v1.21.2-eks-1-21-4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'SDDC-Datacenter'
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 4096
+      network:
+        devices:
+        - dhcp4: true
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.21.6
+      thumbprint: 'ABCDEFG'
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-1-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints:
+            - key: key2
+              value: val2
+              effect: PreferNoSchedule
+          kubeletExtraArgs:
+            cloud-provider: external
+            read-only-port: "0"
+            anonymous-auth: "false"
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      preKubeadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+      - name: capv
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-1
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 3
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-1-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: test-md-1-1234567890000
+      version: v1.19.8-eks-1-19-4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-md-1-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'SDDC-Datacenter'
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 4096
+      network:
+        devices:
+        - dhcp4: true
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6
+      thumbprint: 'ABCDEFG'
+
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-2-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            cloud-provider: external
+            read-only-port: "0"
+            anonymous-auth: "false"
+            cgroup-driver: systemd
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      preKubeadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+      - name: capv
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-2
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 1
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-2-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: test-md-2-1234567890000
+      version: v1.21.2-eks-1-21-4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-md-2-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'SDDC-Datacenter'
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 4096
+      network:
+        devices:
+        - dhcp4: true
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.21.6
+      thumbprint: 'ABCDEFG'
+
+---

--- a/pkg/validations/upgradevalidations/immutable_fields_test.go
+++ b/pkg/validations/upgradevalidations/immutable_fields_test.go
@@ -318,10 +318,6 @@ func TestValidateImmutableFields(t *testing.T) {
 						},
 					},
 				},
-				VersionsBundle: &cluster.VersionsBundle{
-					VersionsBundle: &releasev1alpha1.VersionsBundle{},
-					KubeDistro:     &cluster.KubeDistro{},
-				},
 				Bundles: &releasev1alpha1.Bundles{},
 			}
 			desired := current.DeepCopy()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
NewSpec and BuildSpec will now include eksd release and version bundles corresponding to worker node group's kubernetes version.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

