### PR TITLE
Refactoring to fail on vsphere perms validations

### DIFF
--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -11,7 +11,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
@@ -170,7 +169,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, vsphereCl
 	logger.MarkPass("Control plane and Workload templates validated")
 
 	for _, mc := range vsphereClusterSpec.VSphereMachineConfigs {
-		if mc.OSFamily() == v1alpha1.Bottlerocket {
+		if mc.OSFamily() == anywherev1.Bottlerocket {
 			if err := v.validateBRHardDiskSize(ctx, vsphereClusterSpec, mc); err != nil {
 				return fmt.Errorf("failed validating BR Hard Disk size: %v", err)
 			}
@@ -476,15 +475,15 @@ func (v *Validator) validatePrivs(ctx context.Context, privObjs []PrivAssociatio
 	var err error
 	missingPrivs := []missingPriv{}
 	passed := false
+	username := vsc.Username()
 
 	for _, obj := range privObjs {
 		path := obj.path
 		privsContent := obj.privsContent
 		t := obj.objectType
-		username := vsc.Username()
 		privs, err = v.getMissingPrivs(ctx, vsc, path, t, privsContent, username)
 		if err != nil {
-			return passed, err
+			return passed, fmt.Errorf("failed to get missing privs: %v", err)
 		} else if len(privs) > 0 {
 			mp := missingPriv{
 				Username:    username,
@@ -493,22 +492,22 @@ func (v *Validator) validatePrivs(ctx context.Context, privObjs []PrivAssociatio
 				Permissions: privs,
 			}
 			missingPrivs = append(missingPrivs, mp)
-			content, err := yaml.Marshal(mp)
-			if err == nil {
-				s := fmt.Sprintf("  Warning: User %s missing %d vSphere permissions on %s, cluster creation may fail.\nRe-run create cluster with --verbosity=3 to see specific missing permissions.", username, len(privs), path)
-				logger.MarkWarning(s)
-				s = fmt.Sprintf("Missing Permissions:\n%s", string(content))
-				logger.V(3).Info(s)
-			} else {
-				s := fmt.Sprintf("  Warning: failed to list missing privs: %v", err)
-				logger.MarkWarning(s)
-			}
 		}
 	}
 
-	if len(missingPrivs) == 0 {
-		passed = true
+	if len(missingPrivs) != 0 {
+		content, err := yaml.Marshal(missingPrivs)
+		if err != nil {
+			return passed, fmt.Errorf("failed to marshal missing permissions: %v", err)
+		}
+
+		errMsg := fmt.Sprintf("user %s missing vSphere permissions", username)
+		logger.V(3).Info(errMsg, "Permissions", string(content))
+
+		return passed, fmt.Errorf("user %s missing vSphere permissions", username)
 	}
+
+	passed = true
 
 	return passed, nil
 }

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -483,7 +483,7 @@ func (v *Validator) validatePrivs(ctx context.Context, privObjs []PrivAssociatio
 		t := obj.objectType
 		privs, err = v.getMissingPrivs(ctx, vsc, path, t, privsContent, username)
 		if err != nil {
-			return passed, fmt.Errorf("failed to get missing privs: %v", err)
+			return passed, fmt.Errorf("failed to get missing privileges: %v", err)
 		} else if len(privs) > 0 {
 			mp := missingPriv{
 				Username:    username,

--- a/pkg/providers/vsphere/validator_test.go
+++ b/pkg/providers/vsphere/validator_test.go
@@ -110,7 +110,7 @@ func TestValidatorValidatePrivsMissing(t *testing.T) {
 	passed, err := v.validatePrivs(ctx, objects, vsc)
 
 	g.Expect(passed).To(BeEquivalentTo(false))
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(BeNil())
 }
 
 func TestValidatorValidatePrivsBadJson(t *testing.T) {
@@ -217,7 +217,7 @@ func TestValidatorValidateVsphereCPUserPrivsError(t *testing.T) {
 	}
 
 	var privs []string
-	err := json.Unmarshal([]byte(config.VSphereUserPrivsFile), &privs)
+	err := json.Unmarshal([]byte(config.VSphereAdminPrivsFile), &privs)
 	if err != nil {
 		t.Fatalf("failed to validate privs: %v", err)
 	}


### PR DESCRIPTION
*Issue #5865:*

*Description of changes:*
Modified to fail on vsphere missing user permissions.

*Testing:*
Created a user with missing permissions and tested validations. Now the error shows as

```bash
2023-07-14T20:09:04.809Z  V3  user ramaliar-test@vsphere.local missing vSphere permissions  {"Permissions": "- username: ramaliar-test@vsphere.local\n  objectType: Network\n  path: /Denver/network/Dev\n  permissions:\n  - VirtualMachine.Interact.PowerOff\n  - VirtualMachine.Interact.PowerOn\n- username: ramaliar-test@vsphere.local\n  objectType: Datastore\n  path: /Denver/datastore/datastore1.1\n  permissions:\n  - VirtualMachine.Interact.PowerOff\n  - VirtualMachine.Interact.PowerOn\n- username: ramaliar-test@vsphere.local\n  objectType: ResourcePool\n  path: /Denver/host/EKS-A/Resources/CI\n  permissions:\n  - VirtualMachine.Interact.PowerOff\n  - VirtualMachine.Interact.PowerOn\n- username: ramaliar-test@vsphere.local\n  objectType: Folder\n  path: /Denver/vm/Dev/capv/ramaliar\n  permissions:\n  - VirtualMachine.Interact.PowerOff\n  - VirtualMachine.Interact.PowerOn\n- username: ramaliar-test@vsphere.local\n  objectType: VirtualMachine\n  path: /Denver/vm/Templates/bottlerocket-v1.25.11-kubernetes-1-25-eks-17-amd64-327823e\n  permissions:\n  - VirtualMachine.Interact.PowerOff\n  - VirtualMachine.Interact.PowerOn\n- username: ramaliar-test@vsphere.local\n  objectType: Folder\n  path: /Denver/vm/Templates\n  permissions:\n  - VirtualMachine.Interact.PowerOff\n  - VirtualMachine.Interact.PowerOn\n"}
2023-07-14T20:09:04.810Z  V0  ❌ Validation failed {"validation": "vsphere Provider setup is valid", "error": "validating vsphere user privileges: user ramaliar-test@vsphere.local missing vSphere permissions", "remediation": ""}
```

Tested creating a cluster
```bash
./eksctl-anywhere create cluster -f ./config.yaml
```

*Documentation added/planned :*
Plan to document the change in user experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

