### PR TITLE
Refactoring constants for skip validations

### DIFF
--- a/pkg/validations/createvalidations/createvalidations.go
+++ b/pkg/validations/createvalidations/createvalidations.go
@@ -4,14 +4,9 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
-// string values of supported validation names that can be skipped.
-const (
-	VSphereUserPriv = "vsphere-user-privilege"
-)
-
 // SkippableValidations represents all the validations we offer for users to skip.
 var SkippableValidations = []string{
-	VSphereUserPriv,
+	validations.VSphereUserPriv,
 }
 
 func New(opts *validations.Opts) *CreateValidations {

--- a/pkg/validations/skipvalidations.go
+++ b/pkg/validations/skipvalidations.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+// string values of supported validation names that can be skipped.
+const (
+	PDB             = "pod-disruption"
+	VSphereUserPriv = "vsphere-user-privilege"
+)
+
 // ValidSkippableValidationsMap returns a map for all valid skippable validations as keys, defaulting values to false.
 // Defaulting to False means these validations won't be skipped unless set to True.
 func validSkippableValidationsMap(skippableValidations []string) map[string]bool {

--- a/pkg/validations/skipvalidations_test.go
+++ b/pkg/validations/skipvalidations_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/validations"
+	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
 )
 
@@ -23,16 +24,17 @@ func TestValidateSkippableValidation(t *testing.T) {
 			want:                 nil,
 			wantErr:              fmt.Errorf("invalid validation name to be skipped. The supported validations that can be skipped using --skip-validations are %s", strings.Join(upgradevalidations.SkippableValidations[:], ",")),
 			skippedValidations:   []string{"test"},
-			skippableValidations: []string{validations.PDB},
+			skippableValidations: upgradevalidations.SkippableValidations,
 		},
 		{
 			name: "valid upgrade validation param",
 			want: map[string]bool{
-				validations.PDB: true,
+				validations.PDB:             true,
+				validations.VSphereUserPriv: false,
 			},
 			wantErr:              nil,
 			skippedValidations:   []string{validations.PDB},
-			skippableValidations: []string{validations.PDB},
+			skippableValidations: upgradevalidations.SkippableValidations,
 		},
 		{
 			name: "valid create validation param",
@@ -41,7 +43,7 @@ func TestValidateSkippableValidation(t *testing.T) {
 			},
 			wantErr:              nil,
 			skippedValidations:   []string{validations.VSphereUserPriv},
-			skippableValidations: []string{validations.VSphereUserPriv},
+			skippableValidations: createvalidations.SkippableValidations,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/validations/skipvalidations_test.go
+++ b/pkg/validations/skipvalidations_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/eks-anywhere/pkg/validations"
-	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
 )
 
@@ -24,25 +23,25 @@ func TestValidateSkippableValidation(t *testing.T) {
 			want:                 nil,
 			wantErr:              fmt.Errorf("invalid validation name to be skipped. The supported validations that can be skipped using --skip-validations are %s", strings.Join(upgradevalidations.SkippableValidations[:], ",")),
 			skippedValidations:   []string{"test"},
-			skippableValidations: []string{upgradevalidations.PDB},
+			skippableValidations: []string{validations.PDB},
 		},
 		{
 			name: "valid upgrade validation param",
 			want: map[string]bool{
-				upgradevalidations.PDB: true,
+				validations.PDB: true,
 			},
 			wantErr:              nil,
-			skippedValidations:   []string{upgradevalidations.PDB},
-			skippableValidations: []string{upgradevalidations.PDB},
+			skippedValidations:   []string{validations.PDB},
+			skippableValidations: []string{validations.PDB},
 		},
 		{
 			name: "valid create validation param",
 			want: map[string]bool{
-				createvalidations.VSphereUserPriv: true,
+				validations.VSphereUserPriv: true,
 			},
 			wantErr:              nil,
-			skippedValidations:   []string{createvalidations.VSphereUserPriv},
-			skippableValidations: []string{createvalidations.VSphereUserPriv},
+			skippedValidations:   []string{validations.VSphereUserPriv},
+			skippableValidations: []string{validations.VSphereUserPriv},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/validations/upgradevalidations/poddisruptionbudgets.go
+++ b/pkg/validations/upgradevalidations/poddisruptionbudgets.go
@@ -22,7 +22,7 @@ func ValidatePodDisruptionBudgets(ctx context.Context, k validations.KubectlClie
 	}
 
 	if len(podDisruptionBudgets.Items) != 0 {
-		return fmt.Errorf("one or more pod disruption budgets were detected on the cluster. Use the --skip-validations=%s flag if you wish to skip the validations for pod disruption budgets and proceed with the upgrade operation", PDB)
+		return fmt.Errorf("one or more pod disruption budgets were detected on the cluster. Use the --skip-validations=%s flag if you wish to skip the validations for pod disruption budgets and proceed with the upgrade operation", validations.PDB)
 	}
 
 	return nil

--- a/pkg/validations/upgradevalidations/poddisruptionbudgets_test.go
+++ b/pkg/validations/upgradevalidations/poddisruptionbudgets_test.go
@@ -55,7 +55,7 @@ func TestValidatePodDisruptionBudgets(t *testing.T) {
 					},
 				},
 			},
-			wantErr: fmt.Errorf("one or more pod disruption budgets were detected on the cluster. Use the --skip-validations=%s flag if you wish to skip the validations for pod disruption budgets and proceed with the upgrade operation", upgradevalidations.PDB),
+			wantErr: fmt.Errorf("one or more pod disruption budgets were detected on the cluster. Use the --skip-validations=%s flag if you wish to skip the validations for pod disruption budgets and proceed with the upgrade operation", validations.PDB),
 		},
 		{
 			name: "PDBs don't exist on cluster",

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -105,7 +105,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 			})
 	}
 
-	if !u.Opts.SkippedValidations[PDB] {
+	if !u.Opts.SkippedValidations[validations.PDB] {
 		upgradeValidations = append(
 			upgradeValidations,
 			func() *validations.ValidationResult {

--- a/pkg/validations/upgradevalidations/upgradevalidations.go
+++ b/pkg/validations/upgradevalidations/upgradevalidations.go
@@ -4,14 +4,10 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
-// string values of supported validation names that can be skipped.
-const (
-	PDB = "pod-disruption"
-)
-
 // SkippableValidations represents all the validations we offer for users to skip.
 var SkippableValidations = []string{
-	PDB,
+	validations.PDB,
+	validations.VSphereUserPriv,
 }
 
 func New(opts *validations.Opts) *UpgradeValidations {


### PR DESCRIPTION
*Issue #5865:*

*Description of changes:*
Refactoring constants and adding `vsphere-user-privilege` for upgrade.

*Testing:*
Tested creating a cluster by skipping the check
```bash
./eksctl-anywhere create cluster -f ./config.yaml
```

*Documentation added/planned :*
Plan to document the new flag and user experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

