### PR TITLE
Add image information to docs style guide

### DIFF
--- a/docs/content/en/docs/community/docs_contributing.md
+++ b/docs/content/en/docs/community/docs_contributing.md
@@ -43,9 +43,16 @@ EKS Anywhere documentation uses the [Hugo](https://gohugo.io/categories/fundamen
 
 * **General style issues**: Unless otherwise instructed, follow the [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/) for formatting and presentation guidance.
 
+* **Creating images**: Screen shots and other images should be published in PNG format.
+  For complex diagrams, create them in SVG format, then export the image to PNG and store both in the EKS Anywhere GitHub site’s [docs/static/images](https://github.com/aws/eks-anywhere/tree/main/docs/static/images) directory.
+  To include an image in a docs page, use the following format:
+
+  <b><tt>\!\[Create workload clusters\]\(/images/eks-a_cluster_management.png\)</b></tt>
+
+You can use tools such as [draw.io](https://diagrams.net) or image creation programs, such as gimp, to create SVG diagrams.
+
 ## Where to put content
 
-* **Images**: Put all images into the EKS Anywhere GitHub site’s [docs/static/images](https://github.com/aws/eks-anywhere/tree/main/docs/static/images) directory.
 * **Yaml examples**: Put full yaml file examples into the EKS Anywhere GitHub site’s [docs/static/manifests](https://github.com/aws/eks-anywhere/tree/main/docs/static/manifests) directory.
   In kubectl examples, you can point to those files using: `https://anywhere.eks.amazonaws.com/manifests/whatever.yaml`
 * **Generic instructions for creating a cluster** should go into the [getting started]({{< relref "/docs/getting-started/chooseprovider" >}}) documentation for the appropriate provider.

--- a/docs/content/en/docs/community/docs_contributing.md
+++ b/docs/content/en/docs/community/docs_contributing.md
@@ -49,7 +49,8 @@ EKS Anywhere documentation uses the [Hugo](https://gohugo.io/categories/fundamen
 
   <b><tt>\!\[Create workload clusters\]\(/images/eks-a_cluster_management.png\)</b></tt>
 
-You can use tools such as [draw.io](https://diagrams.net) or image creation programs, such as gimp, to create SVG diagrams.
+You can use tools such as [draw.io](https://diagrams.net) or image creation programs, such as inkscape, to create SVG diagrams.
+Use a white background for images and have cropping focus on the content you are highlighing (in other words, don't show a whole web page if you are only interested in one field).
 
 ## Where to put content
 


### PR DESCRIPTION
*Issue #, if available:*
Need to add information about creating and including images into the EKS Anywhere style guide.

*Description of changes:*
Updated the EKS Anywhere  [Contributing to documentation] guide to include information about images.

*Documentation added/planned (if applicable):* This PR is documentation only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

