### PR TITLE
Adding skip validation support for vsphere validations

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +29,7 @@ type createClusterOptions struct {
 	hardwareCSVPath       string
 	tinkerbellBootstrapIP string
 	installPackages       string
+	skipValidations       []string
 }
 
 var cc = &createClusterOptions{}
@@ -50,6 +52,7 @@ func init() {
 	createClusterCmd.Flags().BoolVar(&cc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	createClusterCmd.Flags().BoolVar(&cc.skipIpCheck, "skip-ip-check", false, "Skip check for whether cluster control plane ip is in use")
 	createClusterCmd.Flags().StringVar(&cc.installPackages, "install-packages", "", "Location of curated packages configuration files to install to the cluster")
+	createClusterCmd.Flags().StringArrayVar(&cc.skipValidations, "skip-validations", []string{}, fmt.Sprintf("Bypass create validations by name. Valid arguments you can pass are --skip-validations=%s", strings.Join(createvalidations.SkippableValidations[:], ",")))
 
 	if err := createClusterCmd.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -113,11 +116,19 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return fmt.Errorf("failed to build cluster manager opts: %v", err)
 	}
 
+	var skippedValidations map[string]bool
+	if len(cc.skipValidations) != 0 {
+		skippedValidations, err = validations.ValidateSkippableValidation(cc.skipValidations, createvalidations.SkippableValidations)
+		if err != nil {
+			return err
+		}
+	}
+
 	factory := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).
-		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareCSVPath, cc.forceClean, cc.tinkerbellBootstrapIP).
+		WithProvider(cc.fileName, clusterSpec.Cluster, cc.skipIpCheck, cc.hardwareCSVPath, cc.forceClean, cc.tinkerbellBootstrapIP, skippedValidations).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithEksdInstaller().
@@ -157,9 +168,10 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 			Name:           clusterSpec.Cluster.Name,
 			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		},
-		ManagementCluster: getManagementCluster(clusterSpec),
-		Provider:          deps.Provider,
-		CliConfig:         cliConfig,
+		ManagementCluster:  getManagementCluster(clusterSpec),
+		Provider:           deps.Provider,
+		CliConfig:          cliConfig,
+		SkippedValidations: skippedValidations,
 	}
 	createValidations := createvalidations.New(validationOpts)
 

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -94,7 +94,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, nil).
-		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false, dc.tinkerbellBootstrapIP).
+		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false, dc.tinkerbellBootstrapIP, map[string]bool{}).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -89,7 +89,7 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP).
+		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP, map[string]bool{}).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -89,7 +89,7 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false, csbo.tinkerbellBootstrapIP).
+		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false, csbo.tinkerbellBootstrapIP, map[string]bool{}).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -112,7 +112,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).
 		WithKubeProxyCLIUpgrader().
-		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
+		WithProvider(uc.fileName, clusterSpec.Cluster, cc.skipIpCheck, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP, skippedValidations).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithCAPIManager().

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -78,7 +78,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster, nil).
-		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP).
+		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP, map[string]bool{}).
 		WithGitOpsFlux(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
 		WithCAPIManager().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
+++ b/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
@@ -73,7 +73,7 @@ func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []str
 		WithWriterFolder(tmpPath).
 		WithDocker().
 		WithKubectl().
-		WithProvider(valOpt.fileName, clusterSpec.Cluster, false, valOpt.hardwareCSVPath, true, valOpt.tinkerbellBootstrapIP).
+		WithProvider(valOpt.fileName, clusterSpec.Cluster, false, valOpt.hardwareCSVPath, true, valOpt.tinkerbellBootstrapIP, map[string]bool{}).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithUnAuthKubeClient().
 		WithValidatorClients().

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -379,12 +379,13 @@ func (f *Factory) WithExecutableBuilder() *Factory {
 	return f
 }
 
-func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1.Cluster, skipIpCheck bool, hardwareCSVPath string, force bool, tinkerbellBootstrapIp string) *Factory {
+// WithProvider initializes the provider dependency and adds to the build steps.
+func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1.Cluster, skipIPCheck bool, hardwareCSVPath string, force bool, tinkerbellBootstrapIP string, skippedValidations map[string]bool) *Factory { // nolint:gocyclo
 	switch clusterConfig.Spec.DatacenterRef.Kind {
 	case v1alpha1.VSphereDatacenterKind:
 		f.WithKubectl().WithGovc().WithWriter().WithIPValidator()
 	case v1alpha1.CloudStackDatacenterKind:
-		f.WithKubectl().WithCloudStackValidatorRegistry(skipIpCheck).WithWriter()
+		f.WithKubectl().WithCloudStackValidatorRegistry(skipIPCheck).WithWriter()
 	case v1alpha1.DockerDatacenterKind:
 		f.WithDocker().WithKubectl()
 	case v1alpha1.TinkerbellDatacenterKind:
@@ -419,7 +420,8 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				f.dependencies.Writer,
 				f.dependencies.IPValidator,
 				time.Now,
-				skipIpCheck,
+				skipIPCheck,
+				skippedValidations,
 			)
 
 		case v1alpha1.CloudStackDatacenterKind:
@@ -442,7 +444,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 			f.dependencies.Provider = snow.NewProvider(
 				f.dependencies.UnAuthKubeClient,
 				f.dependencies.SnowConfigManager,
-				skipIpCheck,
+				skipIPCheck,
 			)
 
 		case v1alpha1.TinkerbellDatacenterKind:
@@ -456,16 +458,16 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				return fmt.Errorf("unable to get machine config from file %s: %v", clusterConfigFile, err)
 			}
 
-			tinkerbellIp := tinkerbellBootstrapIp
-			if tinkerbellIp == "" {
+			tinkerbellIP := tinkerbellBootstrapIP
+			if tinkerbellIP == "" {
 				logger.V(4).Info("Inferring local Tinkerbell Bootstrap IP from environment")
 				localIp, err := networkutils.GetLocalIP()
 				if err != nil {
 					return err
 				}
-				tinkerbellIp = localIp.String()
+				tinkerbellIP = localIp.String()
 			}
-			logger.V(4).Info("Tinkerbell IP", "tinkerbell-ip", tinkerbellIp)
+			logger.V(4).Info("Tinkerbell IP", "tinkerbell-ip", tinkerbellIP)
 
 			provider, err := tinkerbell.NewProvider(
 				datacenterConfig,
@@ -476,10 +478,10 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				f.dependencies.DockerClient,
 				f.dependencies.Helm,
 				f.dependencies.Kubectl,
-				tinkerbellIp,
+				tinkerbellIP,
 				time.Now,
 				force,
-				skipIpCheck,
+				skipIPCheck,
 			)
 			if err != nil {
 				return err
@@ -524,7 +526,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				crypto.NewTlsValidator(),
 				httpClient,
 				time.Now,
-				skipIpCheck,
+				skipIPCheck,
 			)
 			f.dependencies.Provider = provider
 		default:

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -75,7 +75,7 @@ func TestFactoryBuildWithProvidervSphere(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -87,7 +87,7 @@ func TestFactoryBuildWithProviderTinkerbell(t *testing.T) {
 	tt := newTest(t, tinkerbell)
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -103,7 +103,7 @@ func TestFactoryBuildWithProviderSnow(t *testing.T) {
 
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -136,7 +136,7 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 
 		deps, err := dependencies.NewFactory().
 			WithLocalExecutables().
-			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 			WithNutanixValidator().
 			Build(context.Background())
 
@@ -157,7 +157,7 @@ func TestFactoryBuildWithInvalidProvider(t *testing.T) {
 
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).NotTo(BeNil())
@@ -202,7 +202,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithBootstrapper().
 		WithCliConfig(&tt.cliConfig).
 		WithClusterManager(tt.clusterSpec.Cluster, timeoutOpts).
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		WithGitOpsFlux(tt.clusterSpec.Cluster, tt.clusterSpec.FluxConfig, nil).
 		WithWriter().
 		WithEksdInstaller().
@@ -506,7 +506,7 @@ func TestFactoryBuildWithCNIInstallerCilium(t *testing.T) {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		Build(tt.ctx)
 	tt.Expect(err).To(BeNil())
 
@@ -528,7 +528,7 @@ func TestFactoryBuildWithCNIInstallerKindnetd(t *testing.T) {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
 		Build(tt.ctx)
 	tt.Expect(err).To(BeNil())
 

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/common"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/validations"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
@@ -76,6 +77,7 @@ type vsphereProvider struct {
 	validator             *Validator
 	defaulter             *Defaulter
 	ipValidator           IPValidator
+	skippedValidations    map[string]bool
 }
 
 type ProviderGovcClient interface {
@@ -140,7 +142,18 @@ type IPValidator interface {
 	ValidateControlPlaneIPUniqueness(cluster *v1alpha1.Cluster) error
 }
 
-func NewProvider(datacenterConfig *v1alpha1.VSphereDatacenterConfig, clusterConfig *v1alpha1.Cluster, providerGovcClient ProviderGovcClient, providerKubectlClient ProviderKubectlClient, writer filewriter.FileWriter, ipValidator IPValidator, now types.NowFunc, skipIpCheck bool) *vsphereProvider { //nolint:revive
+// NewProvider initializes and returns a new vsphereProvider.
+func NewProvider(
+	datacenterConfig *v1alpha1.VSphereDatacenterConfig,
+	clusterConfig *v1alpha1.Cluster,
+	providerGovcClient ProviderGovcClient,
+	providerKubectlClient ProviderKubectlClient,
+	writer filewriter.FileWriter,
+	ipValidator IPValidator,
+	now types.NowFunc,
+	skipIPCheck bool,
+	skippedValidations map[string]bool,
+) *vsphereProvider { //nolint:revive
 	// TODO(g-gaston): ignoring linter error for exported function returning unexported member
 	// We should make it exported, but that would involve a bunch of changes, so will do it separately
 	vcb := govmomi.NewVMOMIClientBuilder()
@@ -157,12 +170,25 @@ func NewProvider(datacenterConfig *v1alpha1.VSphereDatacenterConfig, clusterConf
 		writer,
 		ipValidator,
 		now,
-		skipIpCheck,
+		skipIPCheck,
 		v,
+		skippedValidations,
 	)
 }
 
-func NewProviderCustomNet(datacenterConfig *v1alpha1.VSphereDatacenterConfig, clusterConfig *v1alpha1.Cluster, providerGovcClient ProviderGovcClient, providerKubectlClient ProviderKubectlClient, writer filewriter.FileWriter, ipValidator IPValidator, now types.NowFunc, skipIpCheck bool, v *Validator) *vsphereProvider { //nolint:revive
+// NewProviderCustomNet initializes and returns a new vsphereProvider.
+func NewProviderCustomNet(
+	datacenterConfig *v1alpha1.VSphereDatacenterConfig,
+	clusterConfig *v1alpha1.Cluster,
+	providerGovcClient ProviderGovcClient,
+	providerKubectlClient ProviderKubectlClient,
+	writer filewriter.FileWriter,
+	ipValidator IPValidator,
+	now types.NowFunc,
+	skipIPCheck bool,
+	v *Validator,
+	skippedValidations map[string]bool,
+) *vsphereProvider { //nolint:revive
 	// TODO(g-gaston): ignoring linter error for exported function returning unexported member
 	// We should make it exported, but that would involve a bunch of changes, so will do it separately
 	retrier := retrier.NewWithMaxRetries(maxRetries, backOffPeriod)
@@ -174,11 +200,12 @@ func NewProviderCustomNet(datacenterConfig *v1alpha1.VSphereDatacenterConfig, cl
 		templateBuilder: NewVsphereTemplateBuilder(
 			now,
 		),
-		skipIPCheck: skipIpCheck,
-		Retrier:     retrier,
-		validator:   v,
-		defaulter:   NewDefaulter(providerGovcClient),
-		ipValidator: ipValidator,
+		skipIPCheck:        skipIPCheck,
+		Retrier:            retrier,
+		validator:          v,
+		defaulter:          NewDefaulter(providerGovcClient),
+		ipValidator:        ipValidator,
+		skippedValidations: skippedValidations,
 	}
 }
 
@@ -339,8 +366,10 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 		logger.Info("Skipping check for whether control plane ip is in use")
 	}
 
-	if err := p.validator.validateVsphereUserPrivs(ctx, vSphereClusterSpec); err != nil {
-		return fmt.Errorf("validating vsphere user privileges: %v", err)
+	if !p.skippedValidations[validations.VSphereUserPriv] {
+		if err := p.validator.validateVsphereUserPrivs(ctx, vSphereClusterSpec); err != nil {
+			return fmt.Errorf("validating vsphere user privileges: %v", err)
+		}
 	}
 
 	return nil
@@ -380,8 +409,10 @@ func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cl
 		return fmt.Errorf("validating vsphere machine configs datastore usage: %v", err)
 	}
 
-	if err := p.validator.validateVsphereUserPrivs(ctx, vSphereClusterSpec); err != nil {
-		return fmt.Errorf("validating vsphere user privileges: %v", err)
+	if !p.skippedValidations[validations.VSphereUserPriv] {
+		if err := p.validator.validateVsphereUserPrivs(ctx, vSphereClusterSpec); err != nil {
+			return fmt.Errorf("validating vsphere user privileges: %v", err)
+		}
 	}
 
 	err := p.validateMachineConfigsNameUniqueness(ctx, cluster, clusterSpec)

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1370,6 +1370,46 @@ func TestSetupAndValidateCreateClusterNoPassword(t *testing.T) {
 	thenErrorExpected(t, "failed setup and validations: EKSA_VSPHERE_PASSWORD is not set or is empty", err)
 }
 
+func TestSetupAndValidateCreateClusterMissingPrivError(t *testing.T) {
+	ctx := context.Background()
+	provider := givenProvider(t)
+	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	setupContext(t)
+	mockCtrl := gomock.NewController(t)
+	ipValidator := mocks.NewMockIPValidator(mockCtrl)
+	ipValidator.EXPECT().ValidateControlPlaneIPUniqueness(clusterSpec.Cluster).Return(nil)
+	provider.ipValidator = ipValidator
+	vscb := mocks.NewMockVSphereClientBuilder(mockCtrl)
+	vscb.EXPECT().Build(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), clusterSpec.VSphereDatacenter.Spec.Datacenter).Return(nil, fmt.Errorf("error"))
+	provider.validator.vSphereClientBuilder = vscb
+
+	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+
+	thenErrorExpected(t, "validating vsphere user privileges: error", err)
+}
+
+func TestSetupAndValidateUpgradeClusterMissingPrivError(t *testing.T) {
+	ctx := context.Background()
+	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	cluster := &types.Cluster{}
+	provider := givenProvider(t)
+	mockCtrl := gomock.NewController(t)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	provider.providerKubectlClient = kubectl
+	setupContext(t)
+
+	kubectl.EXPECT().GetEksaCluster(ctx, cluster, clusterSpec.Cluster.GetName()).Return(clusterSpec.Cluster.DeepCopy(), nil).Times(1)
+	kubectl.EXPECT().GetEksaVSphereMachineConfig(ctx, gomock.Any(), cluster.KubeconfigFile, clusterSpec.Cluster.GetNamespace()).Times(3)
+
+	vscb := mocks.NewMockVSphereClientBuilder(mockCtrl)
+	vscb.EXPECT().Build(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), clusterSpec.VSphereDatacenter.Spec.Datacenter).Return(nil, fmt.Errorf("error"))
+	provider.validator.vSphereClientBuilder = vscb
+
+	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
+
+	thenErrorExpected(t, "validating vsphere user privileges: error", err)
+}
+
 func TestSetupAndValidateCreateCPUpgradeRolloutStrategy(t *testing.T) {
 	ctx := context.Background()
 	clusterSpec := givenClusterSpec(t, testClusterConfigWithCPUpgradeStrategy)

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -389,6 +389,7 @@ func TestNewProvider(t *testing.T) {
 	ipValidator := mocks.NewMockIPValidator(mockCtrl)
 	_, writer := test.NewWriter(t)
 	skipIPCheck := true
+	skippedValidations := map[string]bool{}
 
 	provider := NewProvider(
 		datacenterConfig,
@@ -399,6 +400,7 @@ func TestNewProvider(t *testing.T) {
 		ipValidator,
 		time.Now,
 		skipIPCheck,
+		skippedValidations,
 	)
 
 	if provider == nil {
@@ -503,6 +505,7 @@ func newProvider(t *testing.T, datacenterConfig *v1alpha1.VSphereDatacenterConfi
 		test.FakeNow,
 		false,
 		v,
+		map[string]bool{},
 	)
 }
 


### PR DESCRIPTION
*Issue #5865:*

*Description of changes:*
The PR adds support for `--skip-validations` for create cluster and also pass's it to the provider level validations.
Originally we had it limited to upgrade cluster's preflight level checks alone.

*Testing:*
Created a user with missing permissions and tested validations. Now the error shows as

If we pass --skip-validations, the check is skipped.
```bash
root@ip-10-0-59-81:/home/ubuntu# ./eksctl-anywhere create cluster --help
This command is used to create workload clusters

Usage:
  anywhere create cluster -f <cluster-config-file> [flags]

Flags:
...
      --skip-validations stringArray        Bypass create validations by name. Valid arguments you can pass are --skip-validations=vsphere-user-privilege
...
```

Tested creating a cluster by skipping the check
```bash
./eksctl-anywhere create cluster -f ./config.yaml --skip-validations=vsphere-user-privilege
```

*Documentation added/planned :*
Plan to document the new flag and change in user experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

