### PR TITLE
Set etcd url in cloud-config when external etcd is enabled

### DIFF
--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -293,6 +293,14 @@ func wantKubeDistroForEksdRelease() (*eksdv1.Release, *cluster.KubeDistro) {
 				{
 					Name:   "etcd",
 					GitTag: "v3.4.14",
+					Assets: []eksdv1.Asset{
+						{
+							Arch: []string{"amd64"},
+							Archive: &eksdv1.AssetArchive{
+								URI: "https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz",
+							},
+						},
+					},
 				},
 				{
 					Name: "comp-1",
@@ -404,6 +412,7 @@ func wantKubeDistroForEksdRelease() (*eksdv1.Release, *cluster.KubeDistro) {
 			URI: "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.19.8",
 		},
 		EtcdVersion: "3.4.14",
+		EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz",
 	}
 
 	return eksdRelease, kubeDistro

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -74,6 +74,7 @@ type KubeDistro struct {
 	Pause               v1alpha1.Image
 	EtcdImage           v1alpha1.Image
 	EtcdVersion         string
+	EtcdURL             string
 	AwsIamAuthImage     v1alpha1.Image
 	KubeProxy           v1alpha1.Image
 }
@@ -194,9 +195,17 @@ func buildKubeDistro(eksd *eksdv1alpha1.Release) (*KubeDistro, error) {
 			if asset.Image != nil {
 				assets[asset.Name] = asset.Image
 			}
-		}
-		if component.Name == "etcd" {
-			kubeDistro.EtcdVersion = strings.TrimPrefix(component.GitTag, "v")
+
+			if component.Name == "etcd" {
+				kubeDistro.EtcdVersion = strings.TrimPrefix(component.GitTag, "v")
+
+				// Get archive uri for amd64
+				if asset.Archive != nil && len(asset.Arch) > 0 {
+					if asset.Arch[0] == "amd64" {
+						kubeDistro.EtcdURL = asset.Archive.URI
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -119,6 +119,8 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 					EtcdImage: v1alpha1.Image{
 						URI: "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
 					},
+					EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz",
+					EtcdVersion: "3.4.14",
 					Pause: v1alpha1.Image{
 						URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
 					},

--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -14,11 +14,12 @@ import (
 )
 
 // SetUbuntuConfigInEtcdCluster sets up the etcd config in EtcdadmCluster.
-func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, version string) {
+func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle) {
 	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
-		Version:    version,
-		InstallDir: "/usr/bin",
+		Version:        versionsBundle.KubeDistro.EtcdVersion,
+		InstallDir:     "/usr/bin",
+		EtcdReleaseURL: versionsBundle.KubeDistro.EtcdURL,
 	}
 }
 

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -15,14 +15,15 @@ import (
 func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 	g := newApiBuilerTest(t)
 	got := wantEtcdCluster()
-	v := "0.0.1"
+	versionBundle := g.clusterSpec.VersionsBundles["1.21"]
 	want := got.DeepCopy()
 	want.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	want.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
-		Version:    v,
-		InstallDir: "/usr/bin",
+		Version:        versionBundle.KubeDistro.EtcdVersion,
+		InstallDir:     "/usr/bin",
+		EtcdReleaseURL: versionBundle.KubeDistro.EtcdURL,
 	}
-	clusterapi.SetUbuntuConfigInEtcdCluster(got, v)
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle)
 	g.Expect(got).To(Equal(want))
 }
 

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -379,6 +379,7 @@ spec:
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
       installDir: "/usr/bin"
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -186,6 +186,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"schedulerExtraArgs":                         sharedExtraArgs.ToPartialYaml(),
 		"format":                                     format,
 		"externalEtcdVersion":                        versionsBundle.KubeDistro.EtcdVersion,
+		"externalEtcdReleaseUrl":                     versionsBundle.KubeDistro.EtcdURL,
 		"etcdImage":                                  versionsBundle.KubeDistro.EtcdImage.VersionedImage(),
 		"eksaSystemNamespace":                        constants.EksaSystemNamespace,
 	}

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -364,6 +364,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
@@ -385,6 +385,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp_kubernetes_version.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp_kubernetes_version.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -383,6 +383,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_rollout_strategy_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_rollout_strategy_cp.yaml
@@ -384,6 +384,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -384,6 +384,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -373,6 +373,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -395,6 +395,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
@@ -387,6 +387,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
@@ -375,6 +375,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -268,6 +268,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
 {{- if .etcdCipherSuites }}
     cipherSuites: {{.etcdCipherSuites}}
 {{- end }}

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -261,6 +261,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"kubernetesVersion":             versionsBundle.KubeDistro.Kubernetes.Tag,
 		"etcdRepository":                versionsBundle.KubeDistro.Etcd.Repository,
 		"etcdVersion":                   versionsBundle.KubeDistro.Etcd.Tag,
+		"externalEtcdReleaseUrl":        versionsBundle.KubeDistro.EtcdURL,
 		"corednsRepository":             versionsBundle.KubeDistro.CoreDNS.Repository,
 		"corednsVersion":                versionsBundle.KubeDistro.CoreDNS.Tag,
 		"kindNodeImage":                 versionsBundle.EksD.KindNode.VersionedImage(),

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -548,6 +548,7 @@ var versionsBundle = &cluster.VersionsBundle{
 			Tag:        "v3.4.14-eks-1-19-2",
 		},
 		EtcdVersion: "3.4.14",
+		EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
 	},
 	VersionsBundle: &releasev1alpha1.VersionsBundle{
 		EksD: releasev1alpha1.EksDRelease{

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -299,6 +299,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -294,6 +294,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
@@ -302,6 +302,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.16
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -328,6 +328,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.16
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
@@ -325,6 +325,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.16
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -292,6 +292,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
@@ -320,6 +320,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -293,6 +293,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -312,6 +312,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -294,6 +294,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -294,6 +294,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -161,7 +161,7 @@ func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTempl
 		clusterapi.SetBottlerocketHostConfigInEtcdCluster(etcd, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
-		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle.KubeDistro.EtcdVersion)
+		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle)
 		etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = append(etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands,
 			"/etc/eks/bootstrap.sh",
 		)

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -1057,8 +1057,9 @@ func wantEtcdClusterUbuntu() *etcdv1.EtcdadmCluster {
 	etcd := wantEtcdCluster()
 	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
-		Version:    "3.4.16",
-		InstallDir: "/usr/bin",
+		Version:        "3.4.16",
+		InstallDir:     "/usr/bin",
+		EtcdReleaseURL: "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
 	}
 	etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = []string{
 		"/etc/eks/bootstrap.sh",

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -135,6 +135,7 @@ func givenVersionsBundle() *cluster.VersionsBundle {
 				URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
 			},
 			EtcdVersion: "3.4.16",
+			EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
 		},
 		VersionsBundle: &releasev1alpha1.VersionsBundle{
 			KubeVersion: "1.21",

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -409,6 +409,7 @@ spec:
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
       installDir: "/usr/bin"
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
     preEtcdadmCommands:
       - hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -400,6 +400,7 @@ func buildTemplateMapCP(
 		"etcdRepository":                versionsBundle.KubeDistro.Etcd.Repository,
 		"etcdImageTag":                  versionsBundle.KubeDistro.Etcd.Tag,
 		"externalEtcdVersion":           versionsBundle.KubeDistro.EtcdVersion,
+		"externalEtcdReleaseUrl":        versionsBundle.KubeDistro.EtcdURL,
 		"etcdCipherSuites":              crypto.SecureCipherSuitesString(),
 		"kubeletExtraArgs":              kubeletExtraArgs.ToPartialYaml(),
 		"hardwareSelector":              controlPlaneMachineSpec.HardwareSelector,

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -521,6 +521,7 @@ spec:
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
       installDir: "/usr/bin"
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
     preEtcdadmCommands:
       - hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -757,6 +757,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -154,6 +154,7 @@ func buildTemplateMapCP(
 		"kubernetesVersion":                    versionsBundle.KubeDistro.Kubernetes.Tag,
 		"etcdRepository":                       versionsBundle.KubeDistro.Etcd.Repository,
 		"etcdImageTag":                         versionsBundle.KubeDistro.Etcd.Tag,
+		"externalEtcdReleaseUrl":               versionsBundle.KubeDistro.EtcdURL,
 		"corednsRepository":                    versionsBundle.KubeDistro.CoreDNS.Repository,
 		"corednsVersion":                       versionsBundle.KubeDistro.CoreDNS.Tag,
 		"nodeDriverRegistrarImage":             versionsBundle.KubeDistro.NodeDriverRegistrar.VersionedImage(),

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -400,6 +400,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -400,6 +400,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -418,6 +418,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -407,6 +407,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -431,6 +431,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -432,6 +432,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -399,6 +399,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -410,6 +410,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere-internal/issues/1374

*Description of changes:*
When using external etcd, the nodes with role etcd do not use the container image of etcd from EKS-D but rather use the etcd binary. Till now the etcd url was not set to instruct etcdadm to pull the right binary, but instead etcdadm was using the etcd binary in the cache folder that was baked in the image-building process. In an air-gapped environment, when users are using an old image with old etcd version in the cache, this becomes a problem if the etcdadm looks for a newer version and cannot find it. This change fixes it by passing the EKS-D etcd binary url to etcdadm.

*Documentation added/planned (if applicable):*
Documentation not required. Its an internal change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

