### PR TITLE
make vsphere dc thumbprint mutable

### DIFF
--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -131,20 +131,6 @@ func validateImmutableFieldsVSphereCluster(new, old *VSphereDatacenterConfig) fi
 		)
 	}
 
-	if old.Spec.Insecure != new.Spec.Insecure {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("insecure"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.Thumbprint != new.Spec.Thumbprint {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("thumbprint"), "field is immutable"),
-		)
-	}
-
 	return allErrs
 }
 

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
@@ -41,24 +41,24 @@ func TestVSphereDatacenterValidateUpdateNetworkImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.network: Forbidden: field is immutable")))
 }
 
-func TestVSphereDatacenterValidateUpdateTLSInsecureImmutable(t *testing.T) {
+func TestVSphereDatacenterValidateUpdateTLSInsecureMutable(t *testing.T) {
 	vOld := vsphereDatacenterConfig()
 	vOld.Spec.Insecure = true
 	c := vOld.DeepCopy()
 
 	c.Spec.Insecure = false
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.insecure: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestVSphereDatacenterValidateUpdateTlsThumbprintImmutable(t *testing.T) {
+func TestVSphereDatacenterValidateUpdateTlsThumbprintMutable(t *testing.T) {
 	vOld := vsphereDatacenterConfig()
 	vOld.Spec.Thumbprint = "5334E1D85B267B78F99BAF553FEB2F94E72EFDFD"
 	c := vOld.DeepCopy()
 
 	c.Spec.Thumbprint = "B3D1C464976E725E599D3548180CB56311818F224E701F9D56F22E8079A7B396"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.thumbprint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestVSphereDatacenterValidateUpdateWithPausedAnnotation(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/6143

*Description of changes:*
remove immutable check in webhook. It's already mutable in preflight check https://github.com/aws/eks-anywhere/pull/1880, which included in [release 0.9.0](https://github.com/aws/eks-anywhere/compare/v0.8.2...v0.9.0)

*Testing (if applicable):*
unit-test
e2e test in NN

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

