### PR TITLE
Fix for Default CNI condition in Cluster status

### DIFF
--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -42,7 +42,11 @@ func UpdateClusterStatusForWorkers(ctx context.Context, client client.Client, cl
 // UpdateClusterStatusForCNI updates the Cluster status for the default cni before the control plane is ready. The CNI reconciler
 // handles the rest of the logic for determining the condition and updating the status based on the current state of the cluster.
 func UpdateClusterStatusForCNI(ctx context.Context, cluster *anywherev1.Cluster) {
-	if !conditions.IsTrue(cluster, anywherev1.ControlPlaneReadyCondition) {
+	// Here, we want to initialize the DefaultCNIConfigured condition only when the condition does not exist,
+	// such as in the event of cluster creation. In this case, when the control plane is not ready, we can assume
+	// the CNI is not ready yet.
+	if !conditions.IsTrue(cluster, anywherev1.ControlPlaneReadyCondition) &&
+		conditions.Get(cluster, anywherev1.DefaultCNIConfiguredCondition) == nil {
 		conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.ControlPlaneNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 		return
 	}

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -716,7 +716,7 @@ func TestUpdateClusterStatusForCNI(t *testing.T) {
 			},
 		},
 		{
-			name:        "control plane is ready, default cni initialized",
+			name:        "control plane is not ready, default cni initialized",
 			skipUpgrade: ptr.Bool(false),
 			conditions: []anywherev1.Condition{
 				{
@@ -725,7 +725,7 @@ func TestUpdateClusterStatusForCNI(t *testing.T) {
 				},
 				{
 					Type:   anywherev1.ControlPlaneReadyCondition,
-					Status: "True",
+					Status: "False",
 				},
 			},
 			wantCondition: &anywherev1.Condition{

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -716,6 +716,24 @@ func TestUpdateClusterStatusForCNI(t *testing.T) {
 			},
 		},
 		{
+			name:        "control plane is ready, default cni initialized",
+			skipUpgrade: ptr.Bool(false),
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.DefaultCNIConfiguredCondition,
+					Status: "True",
+				},
+				{
+					Type:   anywherev1.ControlPlaneReadyCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:   anywherev1.DefaultCNIConfiguredCondition,
+				Status: "True",
+			},
+		},
+		{
 			name:        "cilium is unmanaged",
 			skipUpgrade: ptr.Bool(true),
 			conditions: []anywherev1.Condition{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a workload cluster control plane is upgraded, it is marked "False" with the `ControlPlaneNotReady`. It is not re-evaluated after the control plane becomes ready, as the controller stops reconciling before then. So, this PR addresses the issue by removing the condition update's dependency on ControlPlaneReady. We only need to change this status when there is a. change in the state of the CNI detected.

*Testing (if applicable):*
- Unit test
- Manual test
   - Create a workload cluster using the controller, then upgrade the control plane node count. The `DefaultCNIConfiguredCondition` should stay "True".

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

