### PR TITLE
Fix unnecessary KCP spec update when reconciler ControlPlane

### DIFF
--- a/pkg/controller/clusters/controlplane.go
+++ b/pkg/controller/clusters/controlplane.go
@@ -101,6 +101,25 @@ func ReconcileControlPlane(ctx context.Context, c client.Client, cp *ControlPlan
 		clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1.PausedAnnotation, "true")
 	}
 
+	// When the controller reconciles the control plane for a cluster with an external etcd configuration
+	// the KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints field is
+	// defaulted to an empty slice. However, at some point that field in KubeadmControlPlane object is filled
+	// and updated by another component
+
+	// We do not want to update the field with an empty slice again, so here we check if the endpoints for the
+	// external etcd have already been populated on the KubeadmControlPlane object and override ours before applying it.
+	kcp := &controlplanev1.KubeadmControlPlane{}
+	kcpKey := client.ObjectKeyFromObject(cp.KubeadmControlPlane)
+
+	if err = c.Get(ctx, kcpKey, kcp); err != nil {
+		return controller.Result{}, errors.Wrap(err, "reading kubeadmcontrolplane object")
+	}
+
+	externalEndpoints := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints
+	if len(externalEndpoints) != 0 {
+		cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = externalEndpoints
+	}
+
 	return controller.Result{}, applyAllControlPlaneObjects(ctx, c, cp)
 }
 

--- a/pkg/controller/clusters/controlplane.go
+++ b/pkg/controller/clusters/controlplane.go
@@ -109,8 +109,10 @@ func ReconcileControlPlane(ctx context.Context, c client.Client, cp *ControlPlan
 	// We do not want to update the field with an empty slice again, so here we check if the endpoints for the
 	// external etcd have already been populated on the KubeadmControlPlane object and override ours before applying it.
 	kcp := &controlplanev1.KubeadmControlPlane{}
-	kcpKey := client.ObjectKeyFromObject(cp.KubeadmControlPlane)
-
+	kcpKey := client.ObjectKey{
+		Name:      cluster.Spec.ControlPlaneRef.Name,
+		Namespace: cluster.Spec.ControlPlaneRef.Namespace,
+	}
 	if err = c.Get(ctx, kcpKey, kcp); err != nil {
 		return controller.Result{}, errors.Wrap(err, "reading kubeadmcontrolplane object")
 	}

--- a/pkg/controller/clusters/controlplane_test.go
+++ b/pkg/controller/clusters/controlplane_test.go
@@ -160,6 +160,7 @@ func TestReconcileControlPlaneExternalEtcdWithExistingEndpoints(t *testing.T) {
 }
 
 func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
+	clusterName := "my-cluster"
 	return &clusters.ControlPlane{
 		Cluster: &clusterv1.Cluster{
 			TypeMeta: metav1.TypeMeta{
@@ -167,8 +168,14 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 				Kind:       "Cluster",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-cluster",
+				Name:      clusterName,
 				Namespace: namespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				ControlPlaneRef: &corev1.ObjectReference{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
 			},
 		},
 		KubeadmControlPlane: &controlplanev1.KubeadmControlPlane{
@@ -177,7 +184,7 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 				Kind:       "KubeadmControlPlane",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-cluster",
+				Name:      clusterName,
 				Namespace: namespace,
 			},
 			Spec: controlplanev1.KubeadmControlPlaneSpec{
@@ -192,7 +199,7 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 				Kind:       "DockerCluster",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-cluster",
+				Name:      clusterName,
 				Namespace: namespace,
 			},
 		},

--- a/pkg/controller/clusters/controlplane_test.go
+++ b/pkg/controller/clusters/controlplane_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,6 +133,32 @@ func TestReconcileControlPlaneExternalEtcdUpgradeWithNoNamespace(t *testing.T) {
 	api.ShouldEventuallyExist(ctx, cp.EtcdMachineTemplate)
 }
 
+func TestReconcileControlPlaneExternalEtcdWithExistingEndpoints(t *testing.T) {
+	g := NewWithT(t)
+	c := env.Client()
+	api := envtest.NewAPIExpecter(t, c)
+	ctx := context.Background()
+	ns := env.CreateNamespaceForTest(ctx, t)
+	cp := controlPlaneExternalEtcd(ns)
+	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = []string{"https://1.1.1.1:2379"}
+	envtest.CreateObjs(ctx, t, c, cp.AllObjects()...)
+
+	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = []string{}
+	g.Expect(clusters.ReconcileControlPlane(ctx, c, cp)).To(Equal(controller.Result{}))
+	api.ShouldEventuallyExist(ctx, cp.Cluster)
+	api.ShouldEventuallyExist(ctx, cp.KubeadmControlPlane)
+	api.ShouldEventuallyExist(ctx, cp.ControlPlaneMachineTemplate)
+	api.ShouldEventuallyExist(ctx, cp.ProviderCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdCluster)
+	api.ShouldEventuallyExist(ctx, cp.EtcdMachineTemplate)
+
+	kcp := envtest.CloneNameNamespace(cp.KubeadmControlPlane)
+	api.ShouldEventuallyMatch(ctx, kcp, func(g Gomega) {
+		endpoints := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints
+		g.Expect(endpoints).To(ContainElement("https://1.1.1.1:2379"))
+	})
+}
+
 func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 	return &clusters.ControlPlane{
 		Cluster: &clusterv1.Cluster{
@@ -152,6 +179,11 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-cluster",
 				Namespace: namespace,
+			},
+			Spec: controlplanev1.KubeadmControlPlaneSpec{
+				KubeadmConfigSpec: v1beta1.KubeadmConfigSpec{
+					ClusterConfiguration: &v1beta1.ClusterConfiguration{},
+				},
 			},
 		},
 		ProviderCluster: &dockerv1.DockerCluster{
@@ -179,6 +211,14 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 
 func controlPlaneExternalEtcd(namespace string) *clusters.ControlPlane {
 	cp := controlPlaneStackedEtcd(namespace)
+	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &v1beta1.ExternalEtcd{
+		// Endpoints of etcd members. Required for ExternalEtcd.
+		Endpoints: []string{},
+		CAFile:    "",
+		CertFile:  "",
+		KeyFile:   "",
+	}
+
 	cp.EtcdCluster = &etcdv1.EtcdadmCluster{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "etcdcluster.cluster.x-k8s.io/v1beta1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When the controller reconciles the control plane for a cluster with an external ETCD configuration, the `KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints` field is defaulted to an empty slice. However,  at some point that field in KubeadmControlPlane object is filled and updated by another component 

During subsequent reconciliation loops, the controller applies a spec with an empty slice again, causing unnecessary updates to the `.metadata.generation` field, which is integral for tracking that object's status is up to date through it's `.status.observedGeneration` field. These unnecessary updates causes issues with getting correct timely status updates from the KubeadmControlPlane and is also causes the `.metadata.generation` and `.status.observedGeneration` values to balloon quickly.

This PR cleans up these unnecessary updates by overriding the external etcd endpoints on the `KubeadmControlPlane` object generated by the controller with the existing ones from the object in the cluster before applying it.  

*Testing (if applicable):*
- Unit testing
- Manual testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

