### PR TITLE
Update docs development README guidance

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,17 @@
 DOCS_FOLDER=$(shell git rev-parse --show-toplevel)/docs
 IMAGE_REGISTRY ?= public.ecr.aws/eks-distro-build-tooling
 CONTAINER_IMAGE   = $(IMAGE_REGISTRY)/eks-a-hugo
-CONTAINER_RUN     = docker run --rm --interactive --tty --volume $(CURDIR)/../:/src
 DOCS_ARCHIVE      = public.zip
 HTMLTEST_VERSION?=v0.16.0
+
+# Detach can be used with the container-serve command to run the container in the background.
+DETACH ?= false
+
+# _FOCUS_OPTS describes the options for focusing the serve container (background vs foreground).
+_FOCUS_OPTS := --interactive --tty
+ifeq ($(DETACH),true)
+	_FOCUS_OPTS := --detach
+endif
 
 .PHONY: help build release submodule zip deploy serve server container-build container-serve container-server clean
 
@@ -20,18 +28,18 @@ release: build
 
 submodule: ## initialize the docsy theme submodule
 	git submodule update --init --recursive
+
+submodule-apply-patches: submodule ## apply submodule patches
 	cd themes/docsy; git am ../../patches/0001-Make-docsy-js-files-static.patch; cd ../..
+
+submodule-reset: ## reset submodules to tracked commit
+	git submodule update --init --recursive --force
 
 htmltest: install-htmltest
 	bin/htmltest -c $(DOCS_FOLDER)/.htmltest.yml -s $(DOCS_FOLDER)/public
 
 install-htmltest:
 	curl https://htmltest.wjdp.uk | bash -s $(HTMLTEST_VERSION)
-
-submodule-reset: ## reset submodules to tracked commit
-	rm -rf themes/docsy
-	git submodule update --init --recursive
-	git submodule foreach --recursive git reset --hard
 
 zip: clean build ## Create zip file of assets to upload
 	# move into public folder so zip file doesn't have a public folder
@@ -46,11 +54,15 @@ serve: submodule build ## Boot the development server.
 
 server: serve
 
-container-build: submodule ## Build a container image for the preview of the website
+container-build: submodule-apply-patches ## Build a container image for the preview of the website
 	docker build -t $(CONTAINER_IMAGE) .
+	$(MAKE) submodule-reset
 
 container-serve: ## Boot the development server using container. Run `make container-build` before this.
-	$(CONTAINER_RUN) --mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \
+	docker run \
+		--rm $(_FOCUS_OPTS) \
+		--volume $(CURDIR)/../:/src \
+		--mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \
 		--workdir /src/docs \
 		-p 1313:1313 $(CONTAINER_IMAGE) server \
 		--buildFuture \

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,17 +15,14 @@ make container-serve
 Open http://127.0.0.1:1313 to see the local site.
 With the serve container running you can now edit the documentation in your git clone and changes will be rebuilt automatically.
 
-To serve documentation more permanently, detach the container from the current shell.
-One way to do that is to install the `tmux` package and run:
+To serve documentation more permanently, detach the container using the `DETACH=true` option to the `container-serve` recipe.
 
 ```bash
-tmux
 make container-build
-make container-serve
-Ctrl-b d
+make container-serve DETACH=true
 ```
-This runs the commands in a tmux session, then detaches it from the current shell.
-To reopen the `tmux` session later, type `tmux attach`.
+
+You may notice an update to the `/docs/themes/docsy` submodule which is the result of a patch. The submodule patches should not be committed with your docs changes. Before committing your changes, reset the submodule using `make submodule-reset` (this will impact any containers serving the site locally).
 
 ## Public development
 

--- a/docs/content/en/docs/community/docs_contributing.md
+++ b/docs/content/en/docs/community/docs_contributing.md
@@ -70,6 +70,7 @@ Documentation for software that is not part of EKS Anywhere software can still b
 * **Partners**: Documentation PRs for software from vendors listed on the [EKS Anywhere Partner page]({{< relref "../concepts/eksafeatures/" >}})) can be considered to add to the EKS Anywhere docs.
   Links point to partners from the [Compare EKS Anywhere to EKS](https://anywhere.eks.amazonaws.com/docs/concepts/eksafeatures/) page and other content can be added to EKS Anywhere documentation for features from those partners.
   Contact the AWS container partner team if you are interested in becoming a partner: aws-container-partners@amazon.com
+
 ### Tips for contributing third-party docs
 
 The Kubernetes docs project itself describes a similar approach to docs covering third-party software in the [How Docs Handle Third Party and Dual Sourced Content](https://kubernetes.io/blog/2020/05/third-party-dual-sourced-content/) blog.


### PR DESCRIPTION
This change improves the developers experience when wanting to detach the container hosting the docs site for local development and provies guidance on how to manage the submodules for the docs site.


