### PR TITLE
Sort Tinkerbell in reverse order to run larger tests first

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -396,9 +396,9 @@ func appendNonAirgappedTinkerbellRunConfs(awsSession *session.Session, testsList
 			tinkerbellTestsWithCount = append(tinkerbellTestsWithCount, TinkerbellTest{Name: testName, Count: hwCount})
 		}
 	}
-	// sort tests by Hardware count, to enable running smaller tests first for Tink Provider
+	// sort tests by Hardware count, to enable running larger tests first for Tinkerbell Provider
 	sort.Slice(tinkerbellTestsWithCount, func(i, j int) bool {
-		return tinkerbellTestsWithCount[i].Count < tinkerbellTestsWithCount[j].Count
+		return tinkerbellTestsWithCount[i].Count > tinkerbellTestsWithCount[j].Count
 	})
 
 	for i, test := range tinkerbellTestsWithCount {


### PR DESCRIPTION
*Issue #, if available:*
Test if enabling the larger tests to run first makes the Tinkerbell CI runs more time efficient.

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

