### PR TITLE
add backup cluster retries on infrastructure error

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -71,6 +71,7 @@ const (
 
 var (
 	clusterctlNetworkErrorRegex = regexp.MustCompile(`.*failed to connect to the management cluster:.*`)
+	clusterctlMoveErrorRegex    = regexp.MustCompile(`.*cannot start the move operation while.*`)
 	eksaClusterResourceType     = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 )
 
@@ -273,7 +274,7 @@ func WithNoTimeouts() ClusterManagerOpt {
 }
 
 func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
-	// Exponential backoff on network errors.  Retrier built-in backoff is linear, so implementing here.
+	// Exponential backoff on network and cluster move errors.  Retrier built-in backoff is linear, so implementing here.
 
 	// Retrier first calls the policy before retry #1.  We want it zero-based for exponentiation.
 	if totalRetries < 1 {
@@ -284,7 +285,7 @@ func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait ti
 	const backoffFactor = 1.5
 	waitTime := time.Duration(float64(networkFaultBaseRetryTime) * math.Pow(backoffFactor, float64(totalRetries-1)))
 
-	if match := clusterctlNetworkErrorRegex.MatchString(err.Error()); match {
+	if match := (clusterctlNetworkErrorRegex.MatchString(err.Error()) || clusterctlMoveErrorRegex.MatchString(err.Error())); match {
 		return true, waitTime
 	}
 	return false, 0

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1342,6 +1342,8 @@ func TestClusterManagerBackupCAPIRetrySuccess(t *testing.T) {
 func TestClusterctlWaitRetryPolicy(t *testing.T) {
 	connectionRefusedError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:53733/api?timeout=30s\": dial tcp 127.0.0.1:53733: connect: connection refused")
 	ioTimeoutError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": net/http: TLS handshake timeout")
+	infrastructureError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while cluster is still provisioning the infrastructure")
+	nodeError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while machine is still provisioning the node")
 	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
 
 	_, wait := clustermanager.ClusterctlMoveRetryPolicy(1, connectionRefusedError)
@@ -1362,6 +1364,16 @@ func TestClusterctlWaitRetryPolicy(t *testing.T) {
 	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, ioTimeoutError)
 	if wait != 10*time.Second {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, infrastructureError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for infrastructureError")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, nodeError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for nodeError")
 	}
 
 	retry, _ := clustermanager.ClusterctlMoveRetryPolicy(1, miscellaneousError)


### PR DESCRIPTION
*Issue #, if available:*
[1551](https://github.com/aws/eks-anywhere-internal/issues/1551)
Bootstrap cluster backup can fail if `clusterctl move` detects that infrastructure/objects are still being provisioned. This is not caught in retries.

*Description of changes:*
Added `clusterctl move` provisioning errors to retries.

*Testing (if applicable):*
tested locally and added unit tests

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

