### PR TITLE
Simplify Cluster Autoscaler Docs

### DIFF
--- a/docs/content/en/docs/getting-started/optional/autoscaling.md
+++ b/docs/content/en/docs/getting-started/optional/autoscaling.md
@@ -5,46 +5,43 @@ weight: 45
 aliases:
     /docs/reference/clusterspec/optional/autoscaling/
 description: >
- EKS Anywhere cluster yaml autoscaling configuration specification reference
+ EKS Anywhere cluster yaml autoscaling specification reference
 ---
 
-## Cluster Autoscaling (Optional)
+EKS Anywhere supports autoscaling worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/). The Kubernetes Cluster Autoscaler Curated Package is an image and helm chart installed via the [Curated Packages Controller]({{< relref "../../packages/overview" >}})
 
-### Cluster Autoscaler configuration in EKS Anywhere cluster spec
+The helm chart utilizes the Cluster Autoscaler [`clusterapi` mode](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/autoscaling.html) to scale resources.
 
-EKS Anywhere supports autoscaling worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/). The Kubernetes Cluster Autoscaler Curated Package is an image and helm chart installed via the Curated Packages Controller.
+Configure an EKS Anywhere worker node group to be picked up by a Cluster Autoscaler deployment by adding `autoscalingConfiguration` block to the `workerNodeGroupConfiguration`.
 
-The helm chart utilizes the Cluster Autoscaler binary's `clusterapi` mode to scale resources.
-
-- Configure a worker node group to be picked up by a cluster autoscaler deployment by adding a `autoscalingConfiguration` block to the `workerNodeGroupConfiguration`:
-    ```yaml
+```yaml
     apiVersion: anywhere.eks.amazonaws.com/v1alpha1
     kind: Cluster
     metadata:
       name: my-cluster-name
     spec:
       workerNodeGroupConfigurations:
-        - autoscalingConfiguration:
+        - name: md-0
+          autoscalingConfiguration:
             minCount: 1
             maxCount: 5
           machineGroupRef:
             kind: VSphereMachineConfig
             name: worker-machine-a
-          name: md-0
-        - count: 1
+        - name: md-1
           autoscalingConfiguration:
             minCount: 1
             maxCount: 3
           machineGroupRef:
             kind: VSphereMachineConfig
             name: worker-machine-b
-          name: md-1
-    ```
-
-Note that if no `count` is specified it will default to the `minCount` value.
-
-EKS Anywhere will automatically apply the following annotations to your MachineDeployment objects. The autoscaler component uses these annotations to identify which node groups to autoscale. If a node group is not auto scaling as expected, checking for these annotations on the machine deployment can be a good debugging step:
+          count: 1
 ```
-cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: <minCount>
+
+Note that if no `count` is specified for the worker node group it will default to the `autoscalingConfiguration.minCount` value.
+
+EKS Anywhere automatically applies the following annotations to your `MachineDeployment` objects for worker node groups with autoscaling enabled. The Cluster Autoscaler component uses these annotations to identify which node groups to autoscale. If a node group is not autoscaling as expected, check for these annotations on the `MachineDeployment` to troubleshoot.
+```
+cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: <minCount>
 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: <maxCount>
 ```

--- a/docs/content/en/docs/getting-started/optional/autoscaling.md
+++ b/docs/content/en/docs/getting-started/optional/autoscaling.md
@@ -12,8 +12,9 @@ description: >
 
 ### Cluster Autoscaler configuration in EKS Anywhere cluster spec
 
-EKS Anywhere supports autoscaling worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/)'s `clusterapi` cloudProvider.
+EKS Anywhere supports autoscaling worker node groups using the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/). The Kubernetes Cluster Autoscaler Curated Package is an image and helm chart installed via the Curated Packages Controller.
 
+The helm chart utilizes the Cluster Autoscaler binary's `clusterapi` mode to scale resources.
 
 - Configure a worker node group to be picked up by a cluster autoscaler deployment by adding a `autoscalingConfiguration` block to the `workerNodeGroupConfiguration`:
     ```yaml
@@ -42,25 +43,8 @@ EKS Anywhere supports autoscaling worker node groups using the [Kubernetes Clust
 
 Note that if no `count` is specified it will default to the `minCount` value.
 
-EKS Anywhere will automatically apply the following annotations to your MachineDeployment objects:
+EKS Anywhere will automatically apply the following annotations to your MachineDeployment objects. The autoscaler component uses these annotations to identify which node groups to autoscale. If a node group is not auto scaling as expected, checking for these annotations on the machine deployment can be a good debugging step:
 ```
 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: <minCount>
 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: <maxCount>
 ```
-
-After deploying the Kubernetes Cluster Autoscaler from upstream or as a [curated package]({{< relref "../../packages/cluster-autoscaler/" >}}).
-
-### Cluster Autoscaler Deployment Topologies
-
-The Kubernetes Cluster Autoscaler can only scale a single cluster per deployment.
-
-This means that each cluster you want to scale will need its own cluster autoscaler deployment.
-
-We support three deployment topologies:
-1. [RECOMMENDED] Cluster Autoscaler deployed in the management cluster to autoscale the management cluster itself
-2. [RECOMMENDED] Cluster Autoscaler deployed in the management cluster to autoscale a remote workload cluster
-3. Cluster Autoscaler deployed in the workload cluster to autoscale the workload cluster itself
-
-If your cluster architecture supports management clusters with resources to run additional workloads, you may want to consider using deployment topologies (1) and (2). Instructions for using this topology can be found on the [Cluster Autoscaler]({{< relref "../../packages/cluster-autoscaler/addclauto#install-cluster-autoscaler-in-management-cluster-recommended" >}}) page.
-
-If your deployment topology runs small management clusters though, you may want to follow deployment topology (3) and deploy the cluster autoscaler to run in a [workload cluster]({{< relref "../../packages/cluster-autoscaler/addclauto#install-cluster-autoscaler-in-workload-cluster" >}}).

--- a/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
+++ b/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
@@ -10,31 +10,12 @@ description: >
 If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
 Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}) in the event of a problem.
 
-  {{% alert title="Important" color="warning" %}}
-   * Starting at `eksctl anywhere` version `v0.12.0`, packages on workload clusters are remotely managed by the management cluster.
-   * While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster. The only exception is the `kubectl create namespace` command below, which should be run with `kubeconfig` pointing to the workload cluster.
-   {{% /alert %}}
-
-## Choose a Deployment Approach
-
-Each Cluster Autoscaler instance can target one cluster for autoscaling.
-
-There are three ways to deploy a Cluster Autoscaler instance:
-
-1. [RECOMMENDED] Cluster Autoscaler deployed in the management cluster to autoscale the management cluster itself
-1. [RECOMMENDED] Cluster Autoscaler deployed in the management cluster to autoscale a remote workload cluster
-1. Cluster Autoscaler deployed in the workload cluster to autoscale the workload cluster itself
-
-To read more about the tradeoffs of these different approaches, see [Autoscaling configuration]({{< relref "../../getting-started/optional/autoscaling/" >}}).
-
-## Install Cluster Autoscaler in management cluster [RECOMMENDED]
+## Autoscale A Cluster
 
 <!-- this content needs to be indented so the numbers are automatically incremented -->
 1. Ensure you have configured at least one WorkerNodeGroup in your cluster to support autoscaling as outlined [Autoscaling configuration]({{< relref "../../getting-started/optional/autoscaling/" >}})
 
-    Cluster autoscaler only works on node groups with an autoscalingConfiguration set:
-
-    **Note**: Here, the `<cluster-name>` value represents the name of the management or workload cluster you would like to autoscale.*
+    Cluster Autoscaler only works on node groups with an autoscalingConfiguration set:
 
     ```yaml
     apiVersion: anywhere.eks.amazonaws.com/v1alpha1
@@ -64,19 +45,17 @@ To read more about the tradeoffs of these different approaches, see [Autoscaling
 
    Please see [complete configuration options]({{< relref "../cluster-autoscaler" >}}) for all configuration options and their default values.
 
-    Example package file configuring a cluster autoscaler package to run in the management cluster.
-
-    *Note: Here, the `<cluster-name>` value represents the name of the management or workload cluster you would like to autoscale.*
+    Example package file configuring a cluster autoscaler package to scale cluster with <cluster-name>.
 
     ```yaml
     apiVersion: packages.eks.amazonaws.com/v1alpha1
     kind: Package
     metadata:
-      name: cluster-autoscaler
+      name: cluster-autoscaler-<cluster-name>
       namespace: eksa-packages-<cluster-name>
     spec:
       packageName: cluster-autoscaler
-      targetNamespace: <namespace-to-install-component>
+      targetNamespace: default
       config: |-
           cloudProvider: "clusterapi"
           autoDiscovery:
@@ -101,14 +80,14 @@ To read more about the tradeoffs of these different approaches, see [Autoscaling
    eksa-packages-mgmt-v-vmc   cluster-autoscaler            cluster-autoscaler   18h   installed   9.21.0-1.21-147e2a701f6ab625452fe311d5c94a167270f365         9.21.0-1.21-147e2a701f6ab625452fe311d5c94a167270f365 (latest)
    ```
 
-   To verify that autoscaling works, apply this deployment:
+   To verify that autoscaling works, apply the deployment below. You must continue scaling pods until the deployment has pods in a pending state.
+   This is when cluster autoscaler will begin to autoscale your machine deployment.
+   This process may take a few minutes.
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/aws/eks-anywhere/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/test/framework/testdata/hpa_busybox.yaml
    kubectl scale deployment hpa-busybox-test --replicas 100
    ```
-   You must continue scaling pods until the deployment has pods in a pending state.
-   This is when cluster autoscaler will begin to autoscale your machine deployment.
-   This process may take a few minutes.
+
 
 ## Update
 To update package configuration, update cluster-autoscaler.yaml file, and run the following command:
@@ -116,9 +95,16 @@ To update package configuration, update cluster-autoscaler.yaml file, and run th
 eksctl anywhere apply package -f cluster-autoscaler.yaml
 ```
 
+## Update Worker Node Group Autoscaling Configuration
+It is possible to change the autoscaling configuration of a worker node group by updating the WorkerNodeGroup.autoscalingConfiguration in your cluster specification and running a cluster upgrade.
+
 ## Upgrade
 
-Cluster Autoscaler will automatically be upgraded when a new bundle is activated.
+The Cluster Autoscaler can be upgraded by PackageController's `activeBundle` field to a newer version.
+The curated packages bundle contains the SHAs of the images and helm charts associated with a particular package. When a new version is activated, the Package Controller will reconcile all active packages to their newest versions as defined in the bundle.
+The Curated Packages Controller automatically polls the bundle repository for new bundle resources.
+The curated packages controller automatically polls for the latest bundle, but requires the activeBundle field on the PackageController resource to be updated before a new bundle will take effect and upgrade the resources.
+
 
 ## Uninstall
 
@@ -126,41 +112,4 @@ To uninstall Cluster Autoscaler, simply delete the package
 
 ```bash
 eksctl anywhere delete package --cluster <cluster-name> cluster-autoscaler
-```
-
-## Install Cluster Autoscaler in workload cluster
-
-A few extra steps are required to install cluster autoscaler in a workload cluster instead of the management cluster.
-
-First, retrieve the management cluster's kubeconfig secret:
-```yaml
-kubectl -n eksa-system get secrets <management-cluster-name>-kubeconfig -o yaml > mgmt-secret.yaml
-```
-
-Update the secret's namespace to the namespace in the workload cluster that you would like to deploy the cluster autoscaler to.
-Then, apply the secret to the workload cluster.
-```yaml
-kubectl --kubeconfig /path/to/workload/kubeconfig apply -f mgmt-secret.yaml
-```
-
-Now apply this package configuration to the management cluster:
-```yaml
-apiVersion: packages.eks.amazonaws.com/v1alpha1
-kind: Package
-metadata:
-    name: workload-cluster-autoscaler
-    namespace: eksa-packages-<workload-cluster-name>
-spec:
-    packageName: cluster-autoscaler
-    targetNamespace: <workload-cluster-namespace-to-install-components>
-    config: |-
-        cloudProvider: "clusterapi"
-        autoDiscovery:
-            clusterName: "<workload-cluster-name>"
-        clusterAPIMode: "incluster-kubeconfig"
-        clusterAPICloudConfigPath: "/etc/kubernetes/value"
-        extraVolumeSecrets:
-            cluster-autoscaler-cloud-config:
-                mountPath: "/etc/kubernetes"
-                name: "<management-cluster-name>-kubeconfig"
 ```

--- a/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
+++ b/docs/content/en/docs/packages/cluster-autoscaler/addclauto.md
@@ -2,20 +2,19 @@
 title: "Cluster Autoscaler"
 linkTitle: "Add Cluster Autoscaler"
 weight: 13
-date: 2022-10-20
+date: 2023-08-16
 description: >
   Install/upgrade/uninstall Cluster Autoscaler
 ---
 
-If you have not already done so, make sure your cluster meets the [package prerequisites.]({{< relref "../prereq" >}})
-Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}) in the event of a problem.
+If you have not already done so, make sure your EKS Anywhere cluster meets the [package prerequisites.]({{< relref "../prereq" >}}) 
 
-## Autoscale A Cluster
+Refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}) in the event of a problem.
+
+## Enable Cluster Autoscaling
 
 <!-- this content needs to be indented so the numbers are automatically incremented -->
-1. Ensure you have configured at least one WorkerNodeGroup in your cluster to support autoscaling as outlined [Autoscaling configuration]({{< relref "../../getting-started/optional/autoscaling/" >}})
-
-    Cluster Autoscaler only works on node groups with an autoscalingConfiguration set:
+1. Ensure you have configured at least one worker node group in your cluster specification to enable autoscaling as outlined in [Autoscaling configuration.]({{< relref "../../getting-started/optional/autoscaling/" >}}) Cluster Autoscaler only works on node groups with an `autoscalingConfiguration` set:
 
     ```yaml
     apiVersion: anywhere.eks.amazonaws.com/v1alpha1
@@ -34,18 +33,13 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
           count: 1
           name: md-0
     ```
-    See [Autoscaling configuration]({{< relref "../../getting-started/optional/autoscaling/" >}}) for details.
 
-1. Generate the package configuration
+1. Generate the package configuration.
    ```bash
    eksctl anywhere generate package cluster-autoscaler --cluster <cluster-name> > cluster-autoscaler.yaml
    ```
 
-1. Add the desired configuration to `cluster-autoscaler.yaml`
-
-   Please see [complete configuration options]({{< relref "../cluster-autoscaler" >}}) for all configuration options and their default values.
-
-    Example package file configuring a cluster autoscaler package to scale cluster with <cluster-name>.
+1. Add the desired configuration to `cluster-autoscaler.yaml`. See [configuration options]({{< relref "../cluster-autoscaler" >}}) for all configuration options and their default values. See below for an example package file configuring a Cluster Autoscaler package.
 
     ```yaml
     apiVersion: packages.eks.amazonaws.com/v1alpha1
@@ -73,30 +67,27 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
    ```bash
    eksctl anywhere get packages --cluster <cluster-name>
    ```
-
-   Example command output
-   ```
+   ```stdout
    NAMESPACE                  NAME                          PACKAGE              AGE   STATE       CURRENTVERSION                                               TARGETVERSION                                                         DETAIL
    eksa-packages-mgmt-v-vmc   cluster-autoscaler            cluster-autoscaler   18h   installed   9.21.0-1.21-147e2a701f6ab625452fe311d5c94a167270f365         9.21.0-1.21-147e2a701f6ab625452fe311d5c94a167270f365 (latest)
    ```
 
    To verify that autoscaling works, apply the deployment below. You must continue scaling pods until the deployment has pods in a pending state.
-   This is when cluster autoscaler will begin to autoscale your machine deployment.
+   This is when Cluster Autoscaler will begin to autoscale your machine deployment.
    This process may take a few minutes.
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/aws/eks-anywhere/d8575bbd2a85a6c6bbcb1a54868cf7790df56a63/test/framework/testdata/hpa_busybox.yaml
    kubectl scale deployment hpa-busybox-test --replicas 100
    ```
 
-
 ## Update
-To update package configuration, update cluster-autoscaler.yaml file, and run the following command:
+To update package configuration, update the `cluster-autoscaler.yaml` file and run the following command:
 ```bash
 eksctl anywhere apply package -f cluster-autoscaler.yaml
 ```
 
 ## Update Worker Node Group Autoscaling Configuration
-It is possible to change the autoscaling configuration of a worker node group by updating the WorkerNodeGroup.autoscalingConfiguration in your cluster specification and running a cluster upgrade.
+It is possible to change the autoscaling configuration of a worker node group by updating the `autoscalingConfiguration` in your cluster specification and running a cluster upgrade.
 
 ## Upgrade
 
@@ -108,7 +99,7 @@ The curated packages controller automatically polls for the latest bundle, but r
 
 ## Uninstall
 
-To uninstall Cluster Autoscaler, simply delete the package
+To uninstall Cluster Autoscaler, delete the package
 
 ```bash
 eksctl anywhere delete package --cluster <cluster-name> cluster-autoscaler


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
People are consistently confused by the many options we present for them to deploy cluster autoscaler.
This PR removes references to alternative deployment topologies. It recommends that all cluster autoscaler packages
be deployed to the management cluster, whether the deployment scales a workload or a management cluster.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*
This is the documentation :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->