### PR TITLE
add helper function for Tinkerbell specific workflow for curated packages harbor flow

### DIFF
--- a/test/e2e/harbor.go
+++ b/test/e2e/harbor.go
@@ -29,13 +29,31 @@ func runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test *frame
 	})
 }
 
+func runCuratedPackageHarborInstall(test *framework.ClusterE2ETest) {
+	test.InstallLocalStorageProvisioner()
+	packagePrefix := "test"
+	installNs := "harbor"
+	test.CreateNamespace(installNs)
+	test.InstallCuratedPackage("harbor", packagePrefix, kubeconfig.FromClusterName(test.ClusterName),
+		"--set secretKey=use-a-secret-key",
+		"--set expose.tls.certSource=auto",
+		"--set expose.tls.auto.commonName=localhost",
+		"--set persistence.persistentVolumeClaim.registry.storageClass=local-path",
+		"--set persistence.persistentVolumeClaim.jobservice.jobLog.storageClass=local-path",
+		"--set persistence.persistentVolumeClaim.database.storageClass=local-path",
+		"--set persistence.persistentVolumeClaim.redis.storageClass=local-path",
+		"--set persistence.persistentVolumeClaim.trivy.storageClass=local-path",
+	)
+	test.VerifyHarborPackageInstalled(packagePrefix, installNs)
+}
+
 func runCuratedPackageHarborInstallTinkerbellSimpleFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
 	test.PowerOnHardware()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneNoTaints, framework.ValidateControlPlaneLabels)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstall(test)
 	test.DeleteCluster()
 	test.PowerOffHardware()
 	test.ValidateHardwareDecommissioned()

--- a/test/e2e/harbor.go
+++ b/test/e2e/harbor.go
@@ -28,3 +28,15 @@ func runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test *frame
 		test.VerifyHarborPackageInstalled(packagePrefix, installNs)
 	})
 }
+
+func runCuratedPackageHarborInstallTinkerbellSimpleFlow(test *framework.ClusterE2ETest) {
+	test.GenerateClusterConfig()
+	test.GenerateHardwareConfig()
+	test.PowerOnHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneNoTaints, framework.ValidateControlPlaneLabels)
+	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	test.DeleteCluster()
+	test.PowerOffHardware()
+	test.ValidateHardwareDecommissioned()
+}

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -189,7 +189,7 @@ func TestTinkerbellKubernetes127UbuntuSingleNodeCuratedPackagesHarborFlow(t *tes
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes127BottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
@@ -201,7 +201,7 @@ func TestTinkerbellKubernetes127BottleRocketSingleNodeCuratedPackagesHarborFlow(
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes127UbuntuCuratedPackagesAdotSimpleFlow(t *testing.T) {
@@ -313,7 +313,7 @@ func TestTinkerbellKubernetes126UbuntuSingleNodeCuratedPackagesHarborFlow(t *tes
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes126BottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
@@ -325,7 +325,7 @@ func TestTinkerbellKubernetes126BottleRocketSingleNodeCuratedPackagesHarborFlow(
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes126UbuntuCuratedPackagesAdotSimpleFlow(t *testing.T) {
@@ -437,7 +437,7 @@ func TestTinkerbellKubernetes125UbuntuSingleNodeCuratedPackagesHarborFlow(t *tes
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes125BottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
@@ -449,7 +449,7 @@ func TestTinkerbellKubernetes125BottleRocketSingleNodeCuratedPackagesHarborFlow(
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes125UbuntuCuratedPackagesAdotSimpleFlow(t *testing.T) {
@@ -561,7 +561,7 @@ func TestTinkerbellKubernetes124UbuntuSingleNodeCuratedPackagesHarborFlow(t *tes
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes124BottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
@@ -573,7 +573,7 @@ func TestTinkerbellKubernetes124BottleRocketSingleNodeCuratedPackagesHarborFlow(
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes124UbuntuCuratedPackagesAdotSimpleFlow(t *testing.T) {
@@ -685,7 +685,7 @@ func TestTinkerbellKubernetes123UbuntuSingleNodeCuratedPackagesHarborFlow(t *tes
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes123BottleRocketSingleNodeCuratedPackagesHarborFlow(t *testing.T) {
@@ -697,7 +697,7 @@ func TestTinkerbellKubernetes123BottleRocketSingleNodeCuratedPackagesHarborFlow(
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
+	runCuratedPackageHarborInstallTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes123UbuntuCuratedPackagesAdotSimpleFlow(t *testing.T) {


### PR DESCRIPTION


*Issue #, if available:*
Curated Packages Harbor flow is failing for Tink CI as provider specific workflow is not addressed by the generic harbor simple flow function. This change adds a helper function to address the provider specific workflow for Tinkerbell which is similar to other packages test for Tinkerbell provider.
*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

