### PR TITLE
Override CAPC commit hash with temporary tag

### DIFF
--- a/release/pkg/bundles/cloudstack.go
+++ b/release/pkg/bundles/cloudstack.go
@@ -87,6 +87,9 @@ func GetCloudStackBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]
 		return anywherev1alpha1.CloudStackBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-cloudstack")
 	}
 
+	_ = version
+	version = "v0.4.9-rc6"
+
 	bundle := anywherev1alpha1.CloudStackBundle{
 		Version:              version,
 		ClusterAPIController: bundleImageArtifacts["cluster-api-provider-cloudstack"],

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -164,7 +164,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.6.0-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/0d26a04b661f567a4131d64df63416ea4a133cd9/metadata.yaml
-      version: 0d26a04b661f567a4131d64df63416ea4a133cd9+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.4.3/core-components.yaml
@@ -941,7 +941,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.6.0-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/0d26a04b661f567a4131d64df63416ea4a133cd9/metadata.yaml
-      version: 0d26a04b661f567a4131d64df63416ea4a133cd9+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.4.3/core-components.yaml
@@ -1718,7 +1718,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.6.0-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/0d26a04b661f567a4131d64df63416ea4a133cd9/metadata.yaml
-      version: 0d26a04b661f567a4131d64df63416ea4a133cd9+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.4.3/core-components.yaml
@@ -2468,7 +2468,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.6.0-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/0d26a04b661f567a4131d64df63416ea4a133cd9/metadata.yaml
-      version: 0d26a04b661f567a4131d64df63416ea4a133cd9+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.4.3/core-components.yaml
@@ -3218,7 +3218,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.6.0-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/0d26a04b661f567a4131d64df63416ea4a133cd9/metadata.yaml
-      version: 0d26a04b661f567a4131d64df63416ea4a133cd9+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.4.3/core-components.yaml

--- a/release/pkg/test/testdata/release-0.16-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.16-bundle-release.yaml
@@ -164,7 +164,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
-      version: v0.4.9-rc5+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
@@ -941,7 +941,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
-      version: v0.4.9-rc5+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
@@ -1718,7 +1718,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
-      version: v0.4.9-rc5+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
@@ -2468,7 +2468,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
-      version: v0.4.9-rc5+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml
@@ -3218,7 +3218,7 @@ spec:
         uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.5.12-eks-a-v0.0.0-dev-release-0.16-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc5/metadata.yaml
-      version: v0.4.9-rc5+abcdef1
+      version: v0.4.9-rc6
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api/manifests/cluster-api/v1.4.2/core-components.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudstack E2Es are failing due to using a commit hash instead of a GIT TAG. This temporarily hardcodes it to the next rc version instead of that commit hash.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
