### PR TITLE
Add control plane components healthy check when computing ControlPlaneReady condition

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -65,6 +65,10 @@ func testKubeadmControlPlaneFromCluster(cluster *anywherev1.Cluster) *controlpla
 			ReadyReplicas:   expectedReplicas,
 			Conditions: clusterv1.Conditions{
 				{
+					Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+					Status: apiv1.ConditionStatus("True"),
+				},
+				{
 					Type:   controlplanev1.AvailableCondition,
 					Status: apiv1.ConditionStatus("True"),
 				},
@@ -234,6 +238,10 @@ func TestClusterReconcilerReconcileConditions(t *testing.T) {
 				UpdatedReplicas: 1,
 				Conditions: clusterv1.Conditions{
 					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Status: apiv1.ConditionStatus("True"),
+					},
+					{
 						Type:   controlplanev1.AvailableCondition,
 						Status: apiv1.ConditionStatus("True"),
 					},
@@ -259,6 +267,10 @@ func TestClusterReconcilerReconcileConditions(t *testing.T) {
 				Replicas:        1,
 				UpdatedReplicas: 1,
 				Conditions: clusterv1.Conditions{
+					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Status: apiv1.ConditionStatus("True"),
+					},
 					{
 						Type:   controlplanev1.AvailableCondition,
 						Status: apiv1.ConditionStatus("True"),
@@ -404,6 +416,10 @@ func TestClusterReconcilerReconcileSelfManagedClusterConditions(t *testing.T) {
 				UpdatedReplicas: 1,
 				Conditions: clusterv1.Conditions{
 					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Status: apiv1.ConditionStatus("True"),
+					},
+					{
 						Type:   controlplanev1.AvailableCondition,
 						Status: apiv1.ConditionStatus("True"),
 					},
@@ -432,6 +448,10 @@ func TestClusterReconcilerReconcileSelfManagedClusterConditions(t *testing.T) {
 				UpdatedReplicas: 1,
 				Conditions: clusterv1.Conditions{
 					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Status: apiv1.ConditionStatus("True"),
+					},
+					{
 						Type:   controlplanev1.AvailableCondition,
 						Status: apiv1.ConditionStatus("True"),
 					},
@@ -459,6 +479,10 @@ func TestClusterReconcilerReconcileSelfManagedClusterConditions(t *testing.T) {
 				Replicas:        1,
 				UpdatedReplicas: 1,
 				Conditions: clusterv1.Conditions{
+					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Status: apiv1.ConditionStatus("True"),
+					},
 					{
 						Type:   controlplanev1.AvailableCondition,
 						Status: apiv1.ConditionStatus("True"),
@@ -491,6 +515,10 @@ func TestClusterReconcilerReconcileSelfManagedClusterConditions(t *testing.T) {
 				Replicas:        1,
 				UpdatedReplicas: 1,
 				Conditions: clusterv1.Conditions{
+					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Status: apiv1.ConditionStatus("True"),
+					},
 					{
 						Type:   controlplanev1.AvailableCondition,
 						Status: apiv1.ConditionStatus("True"),

--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -36,6 +36,9 @@ const (
 	// NodesNotReadyReason reports the Cluster has some nodes that are not ready.
 	NodesNotReadyReason = "NodesNotReady"
 
+	// ControlPlaneComponentsUnhealthyReason reports that the Cluster control plane components are unhealthy.
+	ControlPlaneComponentsUnhealthyReason = "ControlPlaneComponentsUnhealthy"
+
 	// ScalingUpReason reports the Cluster is increasing the number of replicas for a set of nodes.
 	ScalingUpReason = "ScalingUp"
 

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -117,6 +117,13 @@ func updateControlPlaneReadyCondition(cluster *anywherev1.Cluster, kcp *controlp
 		return
 	}
 
+	// We check the condition signifying the overall health of the control plane components. Usually, the control plane should be healthy
+	// at this point but if that is not the case, we report it as an error.
+	if conditions.IsFalse(kcp, controlplanev1.ControlPlaneComponentsHealthyCondition) {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, conditions.GetMessage(kcp, controlplanev1.ControlPlaneComponentsHealthyCondition))
+		return
+	}
+
 	conditions.MarkTrue(cluster, anywherev1.ControlPlaneReadyCondition)
 }
 

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -119,8 +120,14 @@ func updateControlPlaneReadyCondition(cluster *anywherev1.Cluster, kcp *controlp
 
 	// We check the condition signifying the overall health of the control plane components. Usually, the control plane should be healthy
 	// at this point but if that is not the case, we report it as an error.
-	if conditions.IsFalse(kcp, controlplanev1.ControlPlaneComponentsHealthyCondition) {
-		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, conditions.GetMessage(kcp, controlplanev1.ControlPlaneComponentsHealthyCondition))
+	kcpControlPlaneHealthyCondition := conditions.Get(kcp, controlplanev1.ControlPlaneComponentsHealthyCondition)
+	if kcpControlPlaneHealthyCondition == nil {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, "")
+		return
+	}
+
+	if kcpControlPlaneHealthyCondition.Status == v1.ConditionFalse {
+		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, kcpControlPlaneHealthyCondition.Message)
 		return
 	}
 

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -121,12 +121,7 @@ func updateControlPlaneReadyCondition(cluster *anywherev1.Cluster, kcp *controlp
 	// We check the condition signifying the overall health of the control plane components. Usually, the control plane should be healthy
 	// at this point but if that is not the case, we report it as an error.
 	kcpControlPlaneHealthyCondition := conditions.Get(kcp, controlplanev1.ControlPlaneComponentsHealthyCondition)
-	if kcpControlPlaneHealthyCondition == nil {
-		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, "")
-		return
-	}
-
-	if kcpControlPlaneHealthyCondition.Status == v1.ConditionFalse {
+	if kcpControlPlaneHealthyCondition != nil && kcpControlPlaneHealthyCondition.Status == v1.ConditionFalse {
 		conditions.MarkFalse(cluster, anywherev1.ControlPlaneReadyCondition, anywherev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, kcpControlPlaneHealthyCondition.Message)
 		return
 	}

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -273,6 +273,42 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 			},
 		},
 		{
+			name: "control plane components unhealthy",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Replicas = 3
+				kcp.Status.ReadyReplicas = 3
+				kcp.Status.UpdatedReplicas = 3
+
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:   clusterv1.ReadyCondition,
+						Status: "True",
+					},
+					{
+						Type:     controlplanev1.ControlPlaneComponentsHealthyCondition,
+						Reason:   controlplanev1.ControlPlaneComponentsUnhealthyReason,
+						Severity: clusterv1.ConditionSeverityError,
+						Message:  "test message",
+						Status:   "False",
+					},
+				}
+			}),
+			controlPlaneCount: 3,
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Reason:   anywherev1.ControlPlaneComponentsUnhealthyReason,
+				Severity: clusterv1.ConditionSeverityError,
+				Message:  "test message",
+				Status:   "False",
+			},
+		},
+		{
 			name: "control plane ready",
 			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
 				kcp.Status.Replicas = 3

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -277,36 +277,6 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 				Message:  "Control plane nodes not ready yet",
 			},
 		},
-
-		{
-			name: "no control plane components healthy condition",
-			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-				kcp.Status.Replicas = 3
-				kcp.Status.ReadyReplicas = 3
-				kcp.Status.UpdatedReplicas = 3
-
-				kcp.Status.Conditions = []clusterv1.Condition{
-					{
-						Type:   clusterv1.ReadyCondition,
-						Status: "True",
-					},
-				}
-			}),
-			controlPlaneCount: 3,
-			conditions: []anywherev1.Condition{
-				{
-					Type:   anywherev1.ControlPlaneInitializedCondition,
-					Status: "True",
-				},
-			},
-			wantCondition: &anywherev1.Condition{
-				Type:     anywherev1.ControlPlaneReadyCondition,
-				Reason:   anywherev1.ControlPlaneComponentsUnhealthyReason,
-				Severity: clusterv1.ConditionSeverityError,
-				Message:  "",
-				Status:   "False",
-			},
-		},
 		{
 			name: "control plane components unhealthy",
 			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
@@ -353,10 +323,6 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 				kcp.Status.Conditions = []clusterv1.Condition{
 					{
 						Type:   clusterv1.ReadyCondition,
-						Status: "True",
-					},
-					{
-						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
 						Status: "True",
 					},
 				}

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -34,9 +34,10 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 		wantCondition     *anywherev1.Condition
 	}{
 		{
-			name:       "kcp is nil",
-			kcp:        nil,
-			conditions: []anywherev1.Condition{},
+			name:              "kcp is nil",
+			kcp:               nil,
+			controlPlaneCount: 1,
+			conditions:        []anywherev1.Condition{},
 			wantCondition: &anywherev1.Condition{
 				Type:     "ControlPlaneInitialized",
 				Status:   "False",
@@ -55,6 +56,7 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 					},
 				}
 			}),
+			controlPlaneCount: 1,
 			conditions: []anywherev1.Condition{
 				{
 					Type:   anywherev1.ControlPlaneInitializedCondition,
@@ -72,6 +74,7 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 				kcp.ObjectMeta.Generation = 1
 				kcp.Status.ObservedGeneration = 0
 			}),
+			controlPlaneCount: 1,
 			wantCondition: &anywherev1.Condition{
 				Type:     anywherev1.ControlPlaneInitializedCondition,
 				Status:   "False",
@@ -90,7 +93,8 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 					},
 				}
 			}),
-			conditions: []anywherev1.Condition{},
+			controlPlaneCount: 1,
+			conditions:        []anywherev1.Condition{},
 			wantCondition: &anywherev1.Condition{
 				Type:     anywherev1.ControlPlaneInitializedCondition,
 				Status:   "False",
@@ -109,7 +113,8 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 					},
 				}
 			}),
-			conditions: []anywherev1.Condition{},
+			controlPlaneCount: 1,
+			conditions:        []anywherev1.Condition{},
 			wantCondition: &anywherev1.Condition{
 				Type:   anywherev1.ControlPlaneInitializedCondition,
 				Status: "True",
@@ -272,6 +277,36 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 				Message:  "Control plane nodes not ready yet",
 			},
 		},
+
+		{
+			name: "no control plane components healthy condition",
+			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+				kcp.Status.Replicas = 3
+				kcp.Status.ReadyReplicas = 3
+				kcp.Status.UpdatedReplicas = 3
+
+				kcp.Status.Conditions = []clusterv1.Condition{
+					{
+						Type:   clusterv1.ReadyCondition,
+						Status: "True",
+					},
+				}
+			}),
+			controlPlaneCount: 3,
+			conditions: []anywherev1.Condition{
+				{
+					Type:   anywherev1.ControlPlaneInitializedCondition,
+					Status: "True",
+				},
+			},
+			wantCondition: &anywherev1.Condition{
+				Type:     anywherev1.ControlPlaneReadyCondition,
+				Reason:   anywherev1.ControlPlaneComponentsUnhealthyReason,
+				Severity: clusterv1.ConditionSeverityError,
+				Message:  "",
+				Status:   "False",
+			},
+		},
 		{
 			name: "control plane components unhealthy",
 			kcp: test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
@@ -318,6 +353,10 @@ func TestUpdateClusterStatusForControlPlane(t *testing.T) {
 				kcp.Status.Conditions = []clusterv1.Condition{
 					{
 						Type:   clusterv1.ReadyCondition,
+						Status: "True",
+					},
+					{
+						Type:   controlplanev1.ControlPlaneComponentsHealthyCondition,
 						Status: "True",
 					},
 				}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While testing upgrades, we ran into an edge case where all the old control plane machines were removed and all the new control plane machines and nodes were all rolled out. However, an old node still remained in the cluster, which resulted in the   `ControlPlaneReady` condition being marked as ready when it was actually not. We use the status on the `KubeadmControlPlane` to compute this and determine the control plane is ready when there are no outdated CAPI machines, number of replicas  match the expected and all are ready. 

Example KCP status in this case

```
status:
  conditions:
  - lastTransitionTime: "2023-07-11T22:24:33Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2023-07-11T22:01:55Z"
    status: "True"
    type: Available
  - lastTransitionTime: "2023-07-11T22:01:54Z"
    status: "True"
    type: CertificatesAvailable
  - lastTransitionTime: "2023-07-11T22:24:01Z"
    message: Control plane node eksa-test-405f3e3-tzcfc does not have a corresponding
      machine
    reason: ControlPlaneComponentsUnhealthy
    severity: Error
    status: "False"
    type: ControlPlaneComponentsHealthy
  - lastTransitionTime: "2023-07-11T22:01:55Z"
    status: "True"
    type: EtcdClusterHealthy
  - lastTransitionTime: "2023-07-11T22:01:55Z"
    status: "True"
    type: MachinesCreated
  - lastTransitionTime: "2023-07-11T22:24:33Z"
    status: "True"
    type: MachinesReady
  - lastTransitionTime: "2023-07-11T22:24:33Z"
    status: "True"
    type: MachinesSpecUpToDate
  - lastTransitionTime: "2023-07-11T22:24:33Z"
    status: "True"
```

In this edge case, an old node still existed in the cluster, but all the machines had already been deleted. This PR adds a control plane components healthy check when determining the status of the `ControlPlaneReady` condition.

*Testing (if applicable):*
- Unit testing
- Manual testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

