### PR TITLE
Revert "[Docs]Add CNI chaining support with Cilium in EKS-A (#6215)"

### DIFF
--- a/docs/content/en/docs/clustermgmt/networking/cluster-replace-cilium.md
+++ b/docs/content/en/docs/clustermgmt/networking/cluster-replace-cilium.md
@@ -11,7 +11,6 @@ For more information on CNI customization see [Use a custom CNI]({{< ref "../../
 
 {{% alert title="Note" color="primary" %}}
 When replacing EKS Anywhere Cilium with a custom CNI, it is your responsibility to manage the custom CNI, including version upgrades and support.
-Operators can also leverage the CNI chaining feature from Isovalent where in both Cilium as the CNI and another CNI can work in a chain mode (https://docs.cilium.io/en/v1.13/installation/cni-chaining/).
 {{% /alert %}}
 
 ## Prerequisites


### PR DESCRIPTION
This reverts commit 05193320d345543e7e11494a78dd394fb72bca77.

The reference is unnecessary for the alert and is included in the ingress documentation.