### PR TITLE
Apply DS to disable udp offloading before Cilium upgrades in VSphere

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -78,7 +78,8 @@ func (p *cloudstackProvider) PostBootstrapSetup(ctx context.Context, clusterConf
 	return nil
 }
 
-func (p *cloudstackProvider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
+// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
+func (p *cloudstackProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	return nil
 }
 

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -87,7 +87,8 @@ func (p *provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	return nil
 }
 
-func (p *provider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
+// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
+func (p *provider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	return nil
 }
 

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -242,17 +242,17 @@ func (mr *MockProviderMockRecorder) Name() *gomock.Call {
 }
 
 // PostBootstrapDeleteForUpgrade mocks base method.
-func (m *MockProvider) PostBootstrapDeleteForUpgrade(arg0 context.Context) error {
+func (m *MockProvider) PostBootstrapDeleteForUpgrade(arg0 context.Context, arg1 *types.Cluster) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostBootstrapDeleteForUpgrade", arg0)
+	ret := m.ctrl.Call(m, "PostBootstrapDeleteForUpgrade", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PostBootstrapDeleteForUpgrade indicates an expected call of PostBootstrapDeleteForUpgrade.
-func (mr *MockProviderMockRecorder) PostBootstrapDeleteForUpgrade(arg0 interface{}) *gomock.Call {
+func (mr *MockProviderMockRecorder) PostBootstrapDeleteForUpgrade(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBootstrapDeleteForUpgrade", reflect.TypeOf((*MockProvider)(nil).PostBootstrapDeleteForUpgrade), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBootstrapDeleteForUpgrade", reflect.TypeOf((*MockProvider)(nil).PostBootstrapDeleteForUpgrade), arg0, arg1)
 }
 
 // PostBootstrapSetup mocks base method.

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -122,7 +122,8 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	return nil
 }
 
-func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
+// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
+func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	// TODO(nutanix): figure out if we need something else here
 	return nil
 }

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -192,7 +192,7 @@ func TestNutanixProviderPostBootstrapSetup(t *testing.T) {
 
 func TestNutanixProviderPostBootstrapDeleteForUpgrade(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
-	err := provider.PostBootstrapDeleteForUpgrade(context.Background())
+	err := provider.PostBootstrapDeleteForUpgrade(context.Background(), &types.Cluster{Name: "eksa-unit-test"})
 	assert.NoError(t, err)
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -20,7 +20,7 @@ type Provider interface {
 	// PreCAPIInstallOnBootstrap is called after the bootstrap cluster is setup but before CAPI resources are installed on it. This allows us to do provider specific configuration on the bootstrap cluster.
 	PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	PostBootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error
-	PostBootstrapDeleteForUpgrade(ctx context.Context) error
+	PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error
 	PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error
 	// PostWorkloadInit is called after the workload cluster is created and initialized with a CNI. This allows us to do provider specific configuration on the workload cluster.
 	PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -168,7 +168,8 @@ func (p *SnowProvider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1
 	return nil
 }
 
-func (p *SnowProvider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
+// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
+func (p *SnowProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	return nil
 }
 

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -166,7 +166,8 @@ func (p *Provider) validateAvailableHardwareForUpgrade(ctx context.Context, curr
 	return nil
 }
 
-func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
+// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
+func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	if err := p.stackInstaller.UninstallLocal(ctx); err != nil {
 		return err
 	}

--- a/pkg/providers/vsphere/config/ethtool_daemonset.yaml
+++ b/pkg/providers/vsphere/config/ethtool_daemonset.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vsphere-disable-udp-offload
+  namespace: {{.eksaSystemNamespace}}
+spec:
+  selector:
+    matchLabels:
+      name: vsphere-disable-udp-offload
+  template:
+    metadata:
+      labels:
+        name: vsphere-disable-udp-offload
+    spec:
+      containers:
+        - name: vsphere-disable-udp-offload-complete
+          image: {{.kindNodeImage}}
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh" ]
+          args: [ "-c", "sleep infinity" ]
+      initContainers:
+        - name: vsphere-disable-udp-offload
+          image: {{.kindNodeImage}}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "ethtool -K eth0 tx-udp_tnl-segmentation off && ethtool -K eth0 tx-udp_tnl-csum-segmentation off && echo 'done'"
+          securityContext:
+            privileged: true
+      hostNetwork: true
+      restartPolicy: Always
+      tolerations:
+        - operator: "Exists"

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -9,12 +9,14 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	kubernetes "github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	executables "github.com/aws/eks-anywhere/pkg/executables"
 	govmomi "github.com/aws/eks-anywhere/pkg/govmomi"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	v1beta1 "github.com/aws/etcdadm-controller/api/v1beta1"
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/apps/v1"
+	v10 "k8s.io/api/core/v1"
 	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta11 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 )
@@ -558,7 +560,7 @@ func (mr *MockProviderKubectlClientMockRecorder) ApplyKubeSpecFromBytes(arg0, ar
 }
 
 // ApplyTolerationsFromTaintsToDaemonSet mocks base method.
-func (m *MockProviderKubectlClient) ApplyTolerationsFromTaintsToDaemonSet(arg0 context.Context, arg1, arg2 []v1.Taint, arg3, arg4 string) error {
+func (m *MockProviderKubectlClient) ApplyTolerationsFromTaintsToDaemonSet(arg0 context.Context, arg1, arg2 []v10.Taint, arg3, arg4 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyTolerationsFromTaintsToDaemonSet", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -583,6 +585,25 @@ func (m *MockProviderKubectlClient) CreateNamespaceIfNotPresent(arg0 context.Con
 func (mr *MockProviderKubectlClientMockRecorder) CreateNamespaceIfNotPresent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespaceIfNotPresent", reflect.TypeOf((*MockProviderKubectlClient)(nil).CreateNamespaceIfNotPresent), arg0, arg1, arg2)
+}
+
+// Delete mocks base method.
+func (m *MockProviderKubectlClient) Delete(arg0 context.Context, arg1, arg2 string, arg3 ...kubernetes.KubectlDeleteOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockProviderKubectlClientMockRecorder) Delete(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockProviderKubectlClient)(nil).Delete), varargs...)
 }
 
 // DeleteEksaDatacenterConfig mocks base method.
@@ -611,6 +632,21 @@ func (m *MockProviderKubectlClient) DeleteEksaMachineConfig(arg0 context.Context
 func (mr *MockProviderKubectlClientMockRecorder) DeleteEksaMachineConfig(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEksaMachineConfig", reflect.TypeOf((*MockProviderKubectlClient)(nil).DeleteEksaMachineConfig), arg0, arg1, arg2, arg3, arg4)
+}
+
+// GetDaemonSet mocks base method.
+func (m *MockProviderKubectlClient) GetDaemonSet(arg0 context.Context, arg1, arg2, arg3 string) (*v1.DaemonSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDaemonSet", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1.DaemonSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDaemonSet indicates an expected call of GetDaemonSet.
+func (mr *MockProviderKubectlClientMockRecorder) GetDaemonSet(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDaemonSet", reflect.TypeOf((*MockProviderKubectlClient)(nil).GetDaemonSet), arg0, arg1, arg2, arg3)
 }
 
 // GetEksaCluster mocks base method.
@@ -719,10 +755,10 @@ func (mr *MockProviderKubectlClientMockRecorder) GetMachineDeployment(arg0, arg1
 }
 
 // GetSecretFromNamespace mocks base method.
-func (m *MockProviderKubectlClient) GetSecretFromNamespace(arg0 context.Context, arg1, arg2, arg3 string) (*v1.Secret, error) {
+func (m *MockProviderKubectlClient) GetSecretFromNamespace(arg0 context.Context, arg1, arg2, arg3 string) (*v10.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretFromNamespace", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*v1.Secret)
+	ret0, _ := ret[0].(*v10.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -12,12 +12,15 @@ import (
 
 	"github.com/Masterminds/sprig"
 	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -28,6 +31,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
 	"github.com/aws/eks-anywhere/pkg/retrier"
+	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -48,6 +52,7 @@ const (
 	backOffPeriod            = 5 * time.Second
 	disk1                    = "Hard disk 1"
 	disk2                    = "Hard disk 2"
+	ethtoolDaemonSetName     = "vsphere-disable-udp-offload"
 )
 
 //go:embed config/template-cp.yaml
@@ -58,6 +63,9 @@ var defaultClusterConfigMD string
 
 //go:embed config/secret.yaml
 var defaultSecretObject string
+
+//go:embed config/ethtool_daemonset.yaml
+var ethtoolDaemonSetObject string
 
 var (
 	eksaVSphereDatacenterResourceType = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
@@ -135,6 +143,8 @@ type ProviderKubectlClient interface {
 	DeleteEksaDatacenterConfig(ctx context.Context, vsphereDatacenterResourceType string, vsphereDatacenterConfigName string, kubeconfigFile string, namespace string) error
 	DeleteEksaMachineConfig(ctx context.Context, vsphereMachineResourceType string, vsphereMachineConfigName string, kubeconfigFile string, namespace string) error
 	ApplyTolerationsFromTaintsToDaemonSet(ctx context.Context, oldTaints []corev1.Taint, newTaints []corev1.Taint, dsName string, kubeconfigFile string) error
+	GetDaemonSet(ctx context.Context, name, namespace, kubeconfig string) (*appsv1.DaemonSet, error)
+	Delete(ctx context.Context, resourceType, kubeconfig string, opts ...kubernetes.KubectlDeleteOption) error
 }
 
 // IPValidator is an interface that defines methods to validate the control plane IP.
@@ -1148,15 +1158,72 @@ func (p *vsphereProvider) InstallCustomProviderComponents(ctx context.Context, k
 	return nil
 }
 
-func (p *vsphereProvider) PostBootstrapDeleteForUpgrade(ctx context.Context) error {
+// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
+func (p *vsphereProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
+	// Delete the daemonset that was used to disable udp offloading in ubuntu/redhat nodes.
+	logger.V(3).Info("Deleting vsphere-disable-udp-offload daemonset")
+	o := &kubernetes.KubectlDeleteOptions{
+		Name:      ethtoolDaemonSetName,
+		Namespace: constants.EksaSystemNamespace,
+	}
+	if err := p.providerKubectlClient.Delete(ctx, "daemonset", cluster.KubeconfigFile, o); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting daemonset: %v", err)
+	}
 	return nil
 }
 
-// PreCoreComponentsUpgrade staisfies the Provider interface.
+// PreCoreComponentsUpgrade satisfies the Provider interface.
 func (p *vsphereProvider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
 	clusterSpec *cluster.Spec,
 ) error {
+	// This is only needed for EKS-A v0.17 because UDP offloading needs to be disabled for
+	// the new Cilium version to work with VSphere clusters. Since our templates that were shipped
+	// in v0.16 releases still have UDP offloading enabled in the nodes, we must apply the daemon set
+	// to disable UDP offloading in all the nodes before upgrading Cilium.
+	// We will remove this in EKS-A release v0.18.0.
+	return p.applyEthtoolDaemonSet(ctx, cluster, clusterSpec)
+}
+
+func (p *vsphereProvider) applyEthtoolDaemonSet(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
+	for _, mc := range clusterSpec.Config.VSphereMachineConfigs {
+		// This is only needed for Ubuntu and Redhat OS.
+		// We only need to check one since the OS family has to be the same for all machine configs
+		if mc.Spec.OSFamily == v1alpha1.Bottlerocket {
+			return nil
+		}
+	}
+	logger.V(4).Info("Applying vsphere-disable-udp-offload daemonset")
+	bundle := clusterSpec.VersionsBundle
+	values := map[string]interface{}{
+		"eksaSystemNamespace": constants.EksaSystemNamespace,
+		"kindNodeImage":       bundle.EksD.KindNode.VersionedImage(),
+	}
+	b, err := templater.Execute(ethtoolDaemonSetObject, values)
+	if err != nil {
+		return err
+	}
+
+	if err = p.providerKubectlClient.ApplyKubeSpecFromBytes(ctx, cluster, b); err != nil {
+		return err
+	}
+
+	return p.Retrier.Retry(
+		func() error {
+			return p.checkEthtoolDaemonSetReady(ctx, cluster)
+		},
+	)
+}
+
+func (p *vsphereProvider) checkEthtoolDaemonSetReady(ctx context.Context, cluster *types.Cluster) error {
+	ethtoolDaemonSet, err := p.providerKubectlClient.GetDaemonSet(ctx, ethtoolDaemonSetName, constants.EksaSystemNamespace, cluster.KubeconfigFile)
+	if err != nil {
+		return err
+	}
+
+	if ethtoolDaemonSet.Status.DesiredNumberScheduled != ethtoolDaemonSet.Status.NumberReady {
+		return fmt.Errorf("daemonSet %s is not ready: %d/%d ready", ethtoolDaemonSetName, ethtoolDaemonSet.Status.NumberReady, ethtoolDaemonSet.Status.DesiredNumberScheduled)
+	}
 	return nil
 }

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -706,8 +706,8 @@ func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *ta
 		if commandContext.OriginalError == nil {
 			logger.MarkSuccess("Cluster upgraded!")
 		}
-		if err := commandContext.Provider.PostBootstrapDeleteForUpgrade(ctx); err != nil {
-			// Cluster has been succesfully upgraded, bootstrap cluster successfully deleted
+		if err := commandContext.Provider.PostBootstrapDeleteForUpgrade(ctx, commandContext.ManagementCluster); err != nil {
+			// Cluster has been successfully upgraded, bootstrap cluster successfully deleted
 			// We don't necessarily need to return with an error here and abort
 			logger.Info(fmt.Sprintf("%v", err))
 		}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -399,7 +399,7 @@ func (c *upgradeTestSetup) expectResumeGitOpsReconcile(expectedCluster *types.Cl
 
 func (c *upgradeTestSetup) expectPostBootstrapDeleteForUpgrade() {
 	gomock.InOrder(
-		c.provider.EXPECT().PostBootstrapDeleteForUpgrade(c.ctx),
+		c.provider.EXPECT().PostBootstrapDeleteForUpgrade(c.ctx, c.managementCluster),
 	)
 }
 

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -56,7 +56,7 @@ func (tc *templateRegistry) templateForRelease(t *testing.T, osFamily anywherev1
 		tc.cache[cacheKey] = template
 		return template
 	}
-	t.Logf("Env var %s not is set, trying default generated template name", templateEnvVarName)
+	t.Logf("Env var %s is not set, trying default generated template name", templateEnvVarName)
 
 	// Env var is not set, try default template name
 	template = tc.generator.defaultNameForTemplate(osFamilyStr, eksDName)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is only needed for EKS-A v0.17 because UDP offloading needs to be disabled for the new Cilium version to work with VSphere clusters. Since our templates that were shipped in v0.16 releases still have UDP offloading enabled in the nodes, we must apply this daemon set to disable UDP offloading in all the nodes before upgrading Cilium in that cluster. We will remove this in EKS-A release v0.18.0.

The new DS is using our kind node image because ethtool is installed there.

*Testing (if applicable):*
Manual testing
LatestMinorReleaseE2E passed
```
    cluster.go:896: Skipping VM cleanup
--- PASS: TestVSphereKubernetes125To126UbuntuUpgradeFromLatestMinorRelease (2114.73s)
PASS
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

