### PR TITLE
Fix incorrect k8s versions in cloudstack e2e

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -936,7 +936,7 @@ func TestCloudStackKubernetes124InstallGitFluxDuringUpgrade(t *testing.T) {
 }
 
 func TestCloudStackKubernetes125InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat124())
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat125())
 	test := framework.NewClusterE2ETest(t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
@@ -1783,7 +1783,7 @@ func TestCloudStackKubernetes124To125OIDCUpgrade(t *testing.T) {
 	)
 	runUpgradeFlowWithOIDC(
 		test,
-		v1alpha1.Kube124,
+		v1alpha1.Kube125,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
 		provider.WithProviderUpgrade(provider.UpdateRedhatTemplate125Var()),
 	)
@@ -3007,7 +3007,7 @@ func TestCloudStackKubernetes125RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
 			"worker-2",
 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
 		),
-		framework.WithCloudStackRedhat124(),
+		framework.WithCloudStackRedhat125(),
 	)
 	test := framework.NewClusterE2ETest(
 		t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes incorrect k8s versions in cloudstack e2e. There were a couple places where the wrong k8s version was used in the tests. This resolves that

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

