### PR TITLE
Update package docs to include package bundle information

### DIFF
--- a/docs/content/en/docs/packages/best_practice.md
+++ b/docs/content/en/docs/packages/best_practice.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration best practices"
 linkTitle: "Best practices"
-weight: 15
+weight: 6
 aliases:
     /docs/reference/packagespec/best_practice/
 description: >

--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -1,0 +1,66 @@
+---
+title: "Managing package bundles"
+linkTitle: "Package bundles"
+weight: 5
+aliases:
+    /docs/tasks/packages/packagebundles/
+---
+
+### Getting new package bundles
+Package bundle resources are created and managed in the management cluster, so first set up the `KUBECONFIG` environment variable for the management cluster.
+```
+export KUBECONFIG=mgmt/mgmt-eks-a-cluster.kubeconfig
+```
+
+The EKS Anywhere package controller periodically checks upstream for the latest package bundle and applies it to your management cluster, except for when in an [airgapped environment](https://anywhere.eks.amazonaws.com/docs/getting-started/airgapped/). In that case, you would have to get the package bundle manually from outside of the airgapped environment and apply it to your management cluster.
+
+To view the available `packagebundles` in your cluster, run the following:
+
+```
+kubectl get packagebundles -n eksa-packages
+NAMESPACE       NAME        STATE
+eksa-packages   v1-27-125   available
+```
+
+To get a package bundle manually, you can use `oras` to pull the package bundle (bundle.yaml) from the `public.ecr.aws/eks-anywhere` repository. (See the [ORAS CLI official documentation](https://oras.land/docs/) for more details)
+
+```
+oras pull public.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles:v1-27-latest
+Downloading 1ba8253d19f9 bundle.yaml
+Downloaded  1ba8253d19f9 bundle.yaml
+Pulled [registry] public.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles:v1-27-latest
+```
+
+Use `kubectl` to apply the new package bundle to your cluster to make it available for use.
+```
+kubectl apply -f bundle.yaml
+```
+
+The package bundle should now be available for use in the management cluster.
+
+```
+kubectl get packagebundles -n eksa-packages
+NAMESPACE       NAME        STATE
+eksa-packages   v1-27-125   available
+eksa-packages   v1-27-126   available
+```
+
+### Activating a package bundle
+
+There are multiple `packagebundlecontrollers` resources in the management cluster which allows for each cluster to activate different package bundle versions. The active package bundle determines the versions of the packages that are installed on that cluster.
+
+To view which package bundles are active for each cluster, use the `kubectl` command to show the `packagebundlecontrollers` in the management cluster.
+```
+kubectl get packagebundlecontrollers -A
+NAMESPACE       NAME   ACTIVEBUNDLE   STATE    DETAIL
+eksa-packages   mgmt   v1-27-125     active   
+eksa-packages   w01    v1-27-125     active 
+```
+
+Use the EKS Anywhere packages CLI to upgrade the active package bundle of the target cluster. This command can also be used to downgrade to a previous package bundle version.
+```
+export CLUSTER_NAME=mgmt
+eksctl anywhere upgrade packages --bundle-version v1-27-126 --cluster $CLUSTER_NAME
+```
+
+

--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -49,7 +49,7 @@ eksa-packages   v1-27-126   available
 
 There are multiple `packagebundlecontrollers` resources in the management cluster which allows for each cluster to activate different package bundle versions. The active package bundle determines the versions of the packages that are installed on that cluster.
 
-To view which package bundles are active for each cluster, use the `kubectl` command to show the `packagebundlecontrollers` in the management cluster.
+To view which package bundles is active for each cluster, use the `kubectl` command to list the `packagebundlecontrollers` objects in the management cluster.
 ```
 kubectl get packagebundlecontrollers -A
 NAMESPACE       NAME   ACTIVEBUNDLE   STATE    DETAIL

--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -49,7 +49,7 @@ eksa-packages   v1-27-126   available
 
 There are multiple `packagebundlecontrollers` resources in the management cluster which allows for each cluster to activate different package bundle versions. The active package bundle determines the versions of the packages that are installed on that cluster.
 
-To view which package bundles is active for each cluster, use the `kubectl` command to list the `packagebundlecontrollers` objects in the management cluster.
+To view which package bundle is active for each cluster, use the `kubectl` command to list the `packagebundlecontrollers` objects in the management cluster.
 ```
 kubectl get packagebundlecontrollers -A
 NAMESPACE       NAME   ACTIVEBUNDLE   STATE    DETAIL

--- a/docs/content/en/docs/packages/packagecontroller.md
+++ b/docs/content/en/docs/packages/packagecontroller.md
@@ -1,0 +1,110 @@
+---
+title: "Managing the package controller"
+linkTitle: "Package controller"
+weight: 4
+aliases:
+    /docs/tasks/packages/packagecontroller/
+---
+
+### Installing the package controller
+
+{{% alert title="Important" color="warning" %}}
+The package controller installation creates a package bundle controller resource for each cluster, thus allowing each to activate different package bundle version. Ideally, you should never delete this resource because it would mean losing that information and upon re-installing, the latest bundle will be selected. However, you can always go back to the previous bundle version. For more information, see [Managing package bundles.]({{< relref "./packagebundles" >}})
+{{% /alert %}}
+
+The package controller is typically installed during cluster creation, but may be disabled intentionally in your `cluster.yaml` by setting `spec.packages.disable` to `true`.
+
+If you created a cluster without the package controller or if the package controller was not properly configured, you may need to manually install it.
+
+1. Enable the package controller in your `cluster.yaml`, if it was previously disabled:
+    ```yaml
+    apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    kind: Cluster
+    metadata:
+      name: mgmt
+    spec:
+      packages:
+        disable: false
+    ```
+
+2. Make sure you are authenticated with the AWS CLI. Use the credentials you set up for packages. These credentials should have [limited capabilities]({{< relref "./prereq#setup-authentication-to-use-curated-packages" >}}):
+
+    ```bash
+    export AWS_ACCESS_KEY_ID="your*access*id"
+    export AWS_SECRET_ACCESS_KEY="your*secret*key"
+    export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
+    export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"
+    ```
+
+3. Verify your credentials are working:
+    ```shell
+    aws sts get-caller-identity
+    ```
+
+4. Authenticate docker to the private AWS ECR registry on account `783794618700` with your AWS credentials. It houses the EKS Anywhere packages artifacts and authentication is required to pull imagaes from it.
+    ```bash
+    aws ecr get-login-password | docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
+    ```
+
+5. Verify you can pull an image from the packages registry:
+    ```bash
+    docker pull 783794618700.dkr.ecr.us-west-2.amazonaws.com/emissary-ingress/emissary:v3.5.1-bf70150bcdfe3a5383ec8ad9cd7eea801a0cb074
+    ```
+    If the image downloads successfully, it worked!
+
+6. Now, install the package controller using the eks anywhere package CLI:
+    ```shell
+    eksctl anywhere install packagecontroller -f cluster.yaml
+    ```
+
+    The package controller should now be installed!
+
+7. Verify, use kubectl to check the eks-anywhere-packages pod is running in your management cluster:
+    ```
+    kubectl get pods -n eksa-packages 
+    NAME                                     READY   STATUS    RESTARTS   AGE
+    eks-anywhere-packages-55bc54467c-jfhgp   1/1     Running   0          21s
+    ```
+
+### Updating the package credentials
+
+You may need to create or update your credentials which you can do with a command like this. Set the environment variables to the proper values before running the command.
+  ```bash
+  kubectl delete secret -n eksa-packages aws-secret
+  kubectl create secret -n eksa-packages generic aws-secret \
+    --from-literal=AWS_ACCESS_KEY_ID=${EKSA_AWS_ACCESS_KEY_ID} \
+    --from-literal=AWS_SECRET_ACCESS_KEY=${EKSA_AWS_SECRET_ACCESS_KEY}  \
+    --from-literal=REGION=${EKSA_AWS_REGION}
+  ```
+
+### Upgrade the packages controller
+
+EKS Anywhere v0.15.0 (packages controller v0.3.9+) and onwards includes support for eks-anywhere-packages controller as a self-managed package feature. The package controller now  upgrades automatically according to the version specified within the management cluster's selected package bundle.
+
+For any version prior to v0.3.X, manual steps must be executed to upgrade.
+
+{{% alert title="Important" color="warning" %}}
+This operation may change your cluster's selected package bundle to the latest, however, you can always go back to the previous bundle version. For more information, see [Managing package bundles.]({{< relref "./packagebundles" >}})
+{{% /alert %}}
+
+To manually upgrade the package controller, do the following:
+
+1. Ensure the namespace will be kept
+```
+kubectl annotate namespaces eksa-packages helm.sh/resource-policy=keep
+```
+
+2. Uninstall the eks-anywhere-packages helm release
+```
+helm uninstall -n eksa-packages eks-anywhere-packages
+```
+
+3. Remove the secret called aws-secret (we will need credentials when installing the new version)
+```
+kubectl delete secret -n eksa-packages aws-secret
+```
+
+4. Install the new version using the latest eksctl-anywhere binary on your management cluster
+```
+eksctl anywhere install packagecontroller -f eksa-mgmt-cluster.yaml
+```

--- a/docs/content/en/docs/packages/packagecontroller.md
+++ b/docs/content/en/docs/packages/packagecontroller.md
@@ -9,7 +9,7 @@ aliases:
 ### Installing the package controller
 
 {{% alert title="Important" color="warning" %}}
-The package controller installation creates a package bundle controller resource for each cluster, thus allowing each to activate different package bundle version. Ideally, you should never delete this resource because it would mean losing that information and upon re-installing, the latest bundle will be selected. However, you can always go back to the previous bundle version. For more information, see [Managing package bundles.]({{< relref "./packagebundles" >}})
+The package controller installation creates a package bundle controller resource for each cluster, thus allowing each to activate a different package bundle version. Ideally, you should never delete this resource because it would mean losing that information and upon re-installing, the latest bundle would be selected. However, you can always go back to the previous bundle version. For more information, see [Managing package bundles.]({{< relref "./packagebundles" >}})
 {{% /alert %}}
 
 The package controller is typically installed during cluster creation, but may be disabled intentionally in your `cluster.yaml` by setting `spec.packages.disable` to `true`.
@@ -41,7 +41,7 @@ If you created a cluster without the package controller or if the package contro
     aws sts get-caller-identity
     ```
 
-4. Authenticate docker to the private AWS ECR registry on account `783794618700` with your AWS credentials. It houses the EKS Anywhere packages artifacts and authentication is required to pull imagaes from it.
+4. Authenticate docker to the private AWS ECR registry on account `783794618700` with your AWS credentials. It houses the EKS Anywhere packages artifacts. Authentication is required to pull images from it.
     ```bash
     aws ecr get-login-password | docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
     ```
@@ -52,14 +52,14 @@ If you created a cluster without the package controller or if the package contro
     ```
     If the image downloads successfully, it worked!
 
-6. Now, install the package controller using the eks anywhere package CLI:
+6. Now, install the package controller using the EKS Anywhere Packages CLI:
     ```shell
     eksctl anywhere install packagecontroller -f cluster.yaml
     ```
 
     The package controller should now be installed!
 
-7. Verify, use kubectl to check the eks-anywhere-packages pod is running in your management cluster:
+7. Use kubectl to check the eks-anywhere-packages pod is running in your management cluster:
     ```
     kubectl get pods -n eksa-packages 
     NAME                                     READY   STATUS    RESTARTS   AGE
@@ -84,7 +84,7 @@ EKS Anywhere v0.15.0 (packages controller v0.3.9+) and onwards includes support 
 For any version prior to v0.3.X, manual steps must be executed to upgrade.
 
 {{% alert title="Important" color="warning" %}}
-This operation may change your cluster's selected package bundle to the latest, however, you can always go back to the previous bundle version. For more information, see [Managing package bundles.]({{< relref "./packagebundles" >}})
+This operation may change your cluster's selected package bundle to the latest version. However, you can always go back to the previous bundle version. For more information, see [Managing package bundles.]({{< relref "./packagebundles" >}})
 {{% /alert %}}
 
 To manually upgrade the package controller, do the following:

--- a/docs/content/en/docs/packages/packagelist.md
+++ b/docs/content/en/docs/packages/packagelist.md
@@ -1,7 +1,7 @@
 ---
 title: "Packages"
 linkTitle: "Curated packages list"
-weight: 80
+weight: 6
 description: >
   List of EKS Anywhere curated packages
 ---

--- a/docs/content/en/docs/packages/packages.md
+++ b/docs/content/en/docs/packages/packages.md
@@ -1,7 +1,7 @@
 ---
 title: "Packages configuration"
 linkTitle: "Packages configuration"
-weight: 14
+weight: 3
 description: >
   Full EKS Anywhere configuration reference for curated packages
 ---

--- a/docs/content/en/docs/packages/prereq.md
+++ b/docs/content/en/docs/packages/prereq.md
@@ -1,7 +1,7 @@
 ---
 title: "Prerequisites"
 linkTitle: "Prerequisites"
-weight: 5
+weight: 2
 aliases:
     /docs/tasks/packages/prereq/
 description: >
@@ -152,80 +152,3 @@ eksctl anywhere generate package harbor --cluster ${CLUSTER_NAME} --kube-version
 ```
 
 Available curated packages and troubleshooting guides are listed below.
-
-### Install package controller after installation
-
-If you created a cluster without the package controller or if the package controller was not properly configured, you may need to do some things to enable it.
-
-Make sure you are authenticated with the AWS CLI. Use the credentials you set up for packages. These credentials should have [limited capabilities]({{< relref "#setup-authentication-to-use-curated-packages" >}}):
-
-```bash
-export AWS_ACCESS_KEY_ID="your*access*id"
-export AWS_SECRET_ACCESS_KEY="your*secret*key"
-export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
-export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"
-```
-
-Verify your credentials are working:
-```shell
-aws sts get-caller-identity
-```
-Login to docker
-```bash
-aws ecr get-login-password |docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
-```
-
-Verify you can pull an image
-```bash
-docker pull 783794618700.dkr.ecr.us-west-2.amazonaws.com/emissary-ingress/emissary:v3.5.1-bf70150bcdfe3a5383ec8ad9cd7eea801a0cb074
-```
-If the image downloads successfully, it worked!
-
-If you do not have the package controller installed (it is installed by default), install it now:
-```shell
-eksctl anywhere install packagecontroller -f cluster.yaml
-```
-If you had the package controller disabled, you may need to modify your `cluster.yaml` to enable it.
-```yaml
-apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-kind: Cluster
-metadata:
-  name: billy
-spec:
-  packages:
-    disable: false
-```
-
-You may need to create or update your credentials which you can do with a command like this. Set the environment variables to the proper values before running the command.
-```bash
-kubectl delete secret -n eksa-packages aws-secret
-kubectl create secret -n eksa-packages generic aws-secret \
-   --from-literal=AWS_ACCESS_KEY_ID=${EKSA_AWS_ACCESS_KEY_ID} \
-   --from-literal=AWS_SECRET_ACCESS_KEY=${EKSA_AWS_SECRET_ACCESS_KEY}  \
-   --from-literal=REGION=${EKSA_AWS_REGION}
-```
-
-### Upgrade the packages controller
-
-Starting with EKS Anywhere v0.15.0 (packages controller v0.3.9+) the package controller will upgrade automatically according to the selected bundle. For any version prior to v0.3.X,
-manual steps must be executed to upgrade.
-
-1. Ensure the namespace will be kept
-```
-kubectl annotate namespaces eksa-packages helm.sh/resource-policy=keep
-```
-
-2. Uninstall the eks-anywhere-package helm release
-```
-helm uninstall eks-anywhere-packages
-```
-
-3. Remove the secret called aws-secret (we will need credentials when installing the new version)
-```
-kubectl delete secret -n eksa-package aws-secret
-```
-
-4. Install the new version using the latest eksctl-anywhere binary
-```
-eksctl anywhere install packagecontroller -f ${CLUSTER_NAME}.yaml
-```

--- a/docs/content/en/docs/packages/troubleshoot.md
+++ b/docs/content/en/docs/packages/troubleshoot.md
@@ -1,7 +1,7 @@
 ---
 title: "Curated packages troubleshooting"
 linkTitle: "Packages troubleshooting"
-weight: 70
+weight: 7
 description: >
   Troubleshooting specific to curated packages
 aliases:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1568

*Description of changes:*
This PR adds a page on package bundles. Additionally, it separates information from the prerequisites page into it's own page about the package controller.

*Testing (if applicable):*
Test by running docs server locally

<img width="1497" alt="image" src="https://github.com/aws/eks-anywhere/assets/113555337/b0337f0e-4178-4cc1-9aa6-37acf4a669bf">

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

