### PR TITLE
Add Make target to validate the Tinkerbell hardware count file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,3 +766,11 @@ $(BINARY_DEPS_DIR)/linux-%:
 ifneq ($(FETCH_BINARIES_TARGETS),)
 .SECONDARY: $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
 endif
+
+E2E_BINARY?=./bin/e2e.test
+TINKERBELL_HARDWARE_REQUIREMENTS?=test/e2e/tinkerbell_hardware_count.yaml
+
+# validate-tinkerbell-hardware-requirements checks the tinkerbell hardware requirement file with pre-defined validations
+.PHONY: validate-tinkerbell-hardware-requirements # Run eksa controller from local repo with tilt
+validate-tinkerbell-hardware-requirements: build-e2e-test-binary
+	scripts/validate_tinkerbell_hardware_file.sh $(E2E_BINARY) $(TINKERBELL_HARDWARE_REQUIREMENTS)

--- a/Makefile
+++ b/Makefile
@@ -771,6 +771,6 @@ E2E_BINARY?=./bin/e2e.test
 TINKERBELL_HARDWARE_REQUIREMENTS?=test/e2e/tinkerbell_hardware_count.yaml
 
 # validate-tinkerbell-hardware-requirements checks the tinkerbell hardware requirement file with pre-defined validations
-.PHONY: validate-tinkerbell-hardware-requirements # Run eksa controller from local repo with tilt
+.PHONY: validate-tinkerbell-hardware-requirements
 validate-tinkerbell-hardware-requirements: build-e2e-test-binary
 	scripts/validate_tinkerbell_hardware_file.sh $(E2E_BINARY) $(TINKERBELL_HARDWARE_REQUIREMENTS)

--- a/Makefile
+++ b/Makefile
@@ -767,8 +767,8 @@ ifneq ($(FETCH_BINARIES_TARGETS),)
 .SECONDARY: $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
 endif
 
-E2E_BINARY?=./bin/e2e.test
-TINKERBELL_HARDWARE_REQUIREMENTS?=test/e2e/tinkerbell_hardware_count.yaml
+E2E_BINARY?=bin/e2e.test
+TINKERBELL_HARDWARE_REQUIREMENTS?=test/e2e/TINKERBELL_HARDWARE_COUNT.yaml
 
 # validate-tinkerbell-hardware-requirements checks the tinkerbell hardware requirement file with pre-defined validations
 .PHONY: validate-tinkerbell-hardware-requirements

--- a/scripts/validate_tinkerbell_hardware_file.sh
+++ b/scripts/validate_tinkerbell_hardware_file.sh
@@ -36,8 +36,8 @@ do
             echo "hardware count for $test is not a integer"
         else
             if ! [[ $count -ge 1 && $count -le 10 ]]; then
-                    HARDWARE_COUNT_VALIDATION_STATUS=false 
-                    echo "$test has count higher than permissible range 1 - 10"
+                HARDWARE_COUNT_VALIDATION_STATUS=false 
+                echo "$test has count higher than permissible range 1 - 10"
             fi
         fi
     # validation fails if any test is missed from the count file

--- a/scripts/validate_tinkerbell_hardware_file.sh
+++ b/scripts/validate_tinkerbell_hardware_file.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+E2E_BINARY="${1?Specify first argument - E2E tests binary for the current build}"
+TINKERBELL_HARDWARE_COUNT_FILE="${2?Specify second argument - tinkerbell hardware requirements file}"
+
+ALL_TINKERBELL_TESTS=$(exec $E2E_BINARY -test.list 'TestTinkerbell')
+
+declare -A TINKERBELL_HARDWARE_COUNT_LIST
+
+HARDWARE_COUNT_VALIDATION_STATUS=true 
+while IFS="@" read -r TEST_NAME HARDWARE_COUNT
+do
+    TINKERBELL_HARDWARE_COUNT_LIST[$TEST_NAME]="$HARDWARE_COUNT"
+done < <(yq e 'to_entries | .[] | (.key + "@" + .value)' ${TINKERBELL_HARDWARE_COUNT_FILE})
+for test in $ALL_TINKERBELL_TESTS
+do 
+    if [[ ${!TINKERBELL_HARDWARE_COUNT_LIST[@]} =~ $test ]] 
+    then 
+        if  [[ ${TINKERBELL_HARDWARE_COUNT_LIST[$test]} =~ ^[0-9]+$ ]]; then
+            if (( ${TINKERBELL_HARDWARE_COUNT_LIST[$test]} >= 1 && ${TINKERBELL_HARDWARE_COUNT_LIST[$test]} <= 10)); then
+                :
+            else
+                HARDWARE_COUNT_VALIDATION_STATUS=false 
+                echo "$test has count higher than permissible range 1 - 10"
+            fi
+        else
+            HARDWARE_COUNT_VALIDATION_STATUS=false 
+            echo "hardware count for $test is not a integer"
+        fi
+    else
+        HARDWARE_COUNT_VALIDATION_STATUS=false
+        echo "$test not found in $TINKERBELL_HARDWARE_COUNT_FILE"
+    fi
+done
+if [ $HARDWARE_COUNT_VALIDATION_STATUS = false ]; then
+    echo "Hardware Count file validations failed"
+    exit 1
+else    
+    echo "Hardware Count file validations passed!"
+    exit 0
+fi

--- a/scripts/validate_tinkerbell_hardware_file.sh
+++ b/scripts/validate_tinkerbell_hardware_file.sh
@@ -28,20 +28,17 @@ do
 done < <(yq e 'to_entries | .[] | (.key + "@" + .value)' ${TINKERBELL_HARDWARE_COUNT_FILE})
 for test in ${ALL_TINKERBELL_TESTS[@]}
 do 
-    if [[ ${!TINKERBELL_HARDWARE_COUNT_LIST[@]} =~ $test ]] 
-    then 
+    if [[ -n "${TINKERBELL_HARDWARE_COUNT_LIST[$test]}" ]]; then 
+        count=${TINKERBELL_HARDWARE_COUNT_LIST[$test]}
     # check if the count value is a number and between 1-10
-        if  [[ ${TINKERBELL_HARDWARE_COUNT_LIST[$test]} =~ ^[0-9]+$ ]]; then
-            if (( ${TINKERBELL_HARDWARE_COUNT_LIST[$test]} >= 1 && ${TINKERBELL_HARDWARE_COUNT_LIST[$test]} <= 10)); then
-                :
-            else
-                HARDWARE_COUNT_VALIDATION_STATUS=false 
-                echo "$test has count higher than permissible range 1 - 10"
-            fi
-    # validation fails if the count value is not a number
-        else
+        if ! [[ $count =~ ^[0-9]+$ ]]; then
             HARDWARE_COUNT_VALIDATION_STATUS=false 
             echo "hardware count for $test is not a integer"
+        else
+            if ! [[ $count -ge 1 && $count -le 10 ]]; then
+                    HARDWARE_COUNT_VALIDATION_STATUS=false 
+                    echo "$test has count higher than permissible range 1 - 10"
+            fi
         fi
     # validation fails if any test is missed from the count file
     else


### PR DESCRIPTION
*Issue #, if available:*
Dynamic hardware reservation #6127  introduces a hardware requirements file (tinkerbell_hardware_count.file) that maps each Tinkerbell tests to it's hardware requirements. This change adds a make target validation which checks if all the Tinkerbell tests defined in the current build is present in the hardware requirements file. This will help detect any newly added tinkerbell tests that is missed in the hardware requirements file.
 
*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

