### PR TITLE
Skip cloudstack E2E tests that cannot be run

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -3,6 +3,8 @@ skipped_tests:
 #Airgapped tests
 - TestCloudStackKubernetes123RedhatAirgappedRegistryMirror
 - TestCloudStackKubernetes124RedhatAirgappedRegistryMirror
+- TestCloudStackKubernetes125RedhatAirgappedRegistryMirror
+- TestCloudStackKubernetes126RedhatAirgappedRegistryMirror
 # This test will fail until we the latest minor release version is 15.x as there is a preflight for 1.24
 - TestCloudStackKubernetes124RedhatUpgradeFromLatestMinorReleaseAlwaysNetworkPolicy
 - TestCloudStackKubernetes124ManagementClusterUpgradeFromLatest
@@ -19,8 +21,18 @@ skipped_tests:
 - TestCloudStackKubernetes126MultiEndpointSimpleFlow
 - TestCloudStackKubernetes127MultiEndpointSimpleFlow
 
-# CloudStack Registry Mirror endpoint was not set up
-- TestCloudStackKubernetes123UbuntuAirgappedRegistryMirror
+# These tests will fail until there is a new latest minor release version as 16.2 has a preflight check to prevent k8s version > 1.24
+- TestCloudStackKubernetes125WithOIDCManagementClusterUpgradeFromLatestSideEffects
+- TestCloudStackKubernetes126WithOIDCManagementClusterUpgradeFromLatestSideEffects
+- TestCloudStackKubernetes127WithOIDCManagementClusterUpgradeFromLatestSideEffects
+
+# Proxy tests
+- TestCloudStackKubernetes123RedhatProxyConfigAPI
+- TestCloudStackKubernetes124RedhatProxyConfigAPI
+- TestCloudStackKubernetes125RedhatProxyConfigAPI
+- TestCloudStackKubernetes126RedhatProxyConfigAPI
+- TestCloudStackKubernetes127RedhatProxyConfigAPI
+
 # Nutanix
 
 # Snow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
skips cloudstack E2E tests that cannot be run right now

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


