### PR TITLE
Add E2E tests for Redhat latest minor release upgrades on vsphere

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2271,6 +2271,32 @@ func TestVSphereKubernetes124UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	)
 }
 
+func TestVSphereKubernetes127RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
+	release := latestMinorRelease(t)
+	provider := framework.NewVSphere(t,
+		framework.WithVSphereFillers(
+			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+		),
+		framework.WithRedhatForRelease(release, v1alpha1.Kube127),
+	)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFromReleaseFlow(
+		test,
+		release,
+		v1alpha1.Kube127,
+		provider.WithProviderUpgrade(
+			provider.Redhat127Template(), // Set the template so it doesn't get autoimported
+		),
+	)
+}
+
 func TestVSphereKubernetes126WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewVSphere(t)
 	runTestManagementClusterUpgradeSideEffects(t, provider, v1alpha1.Ubuntu, v1alpha1.Kube126)
@@ -2448,6 +2474,33 @@ func TestVSphereKubernetes127BottlerocketAndRemoveWorkerNodeGroups(t *testing.T)
 				api.WithCount(1),
 			),
 		),
+	)
+}
+
+func TestVSphereKubernetes126To127RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
+	release := latestMinorRelease(t)
+	provider := framework.NewVSphere(t,
+		framework.WithVSphereFillers(
+			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+		),
+		framework.WithRedhatForRelease(release, v1alpha1.Kube126),
+	)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+	)
+	runUpgradeFromReleaseFlow(
+		test,
+		release,
+		v1alpha1.Kube127,
+		provider.WithProviderUpgrade(
+			provider.Redhat127Template(), // Set the template so it doesn't get auto-imported
+		),
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
 	)
 }
 

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -588,6 +588,11 @@ func (v *VSphere) Bottlerocket127Template() api.VSphereFiller {
 	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.Bottlerocket, anywherev1.Kube127))
 }
 
+// Redhat127Template returns vsphere filler for 1.27 Redhat.
+func (v *VSphere) Redhat127Template() api.VSphereFiller {
+	return api.WithTemplateForAllMachines(v.templateForDevRelease(anywherev1.RedHat, anywherev1.Kube127))
+}
+
 func (v *VSphere) getDevRelease() *releasev1.EksARelease {
 	v.t.Helper()
 	if v.devRelease == nil {
@@ -648,6 +653,11 @@ func WithUbuntuForRelease(release *releasev1.EksARelease, kubeVersion anywherev1
 
 func WithBottlerocketFromRelease(release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
 	return optionToSetTemplateForRelease(anywherev1.Bottlerocket, release, kubeVersion)
+}
+
+// WithRedhatForRelease sets the redhat template for the given release.
+func WithRedhatForRelease(release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) VSphereOpt {
+	return optionToSetTemplateForRelease(anywherev1.RedHat, release, kubeVersion)
 }
 
 func (v *VSphere) WithBottleRocketForRelease(release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds coverage for latest minor release upgrades on VSphere with Redhat

```
    cluster.go:896: Skipping VM cleanup
--- PASS: TestVSphereKubernetes126To127RedhatUpgradeFromLatestMinorRelease (2075.17s)
PASS
```

*Testing (if applicable):*
Ran e2e

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

