### PR TITLE
Remove Bundle Create Validation

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -93,30 +93,6 @@ func ValidateManagementClusterName(ctx context.Context, k KubectlClient, mgmtClu
 	return nil
 }
 
-// ValidateManagementClusterBundlesVersion checks if management cluster's bundle version
-// is greater than or equal to the bundle version used to upgrade a workload cluster.
-func ValidateManagementClusterBundlesVersion(ctx context.Context, k KubectlClient, mgmtCluster *types.Cluster, workload *cluster.Spec) error {
-	cluster, err := k.GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name)
-	if err != nil {
-		return err
-	}
-
-	if cluster.Spec.BundlesRef == nil {
-		return fmt.Errorf("management cluster bundlesRef cannot be nil")
-	}
-
-	mgmtBundles, err := k.GetBundles(ctx, mgmtCluster.KubeconfigFile, cluster.Spec.BundlesRef.Name, cluster.Spec.BundlesRef.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if mgmtBundles.Spec.Number < workload.Bundles.Spec.Number {
-		return fmt.Errorf("cannot upgrade workload cluster with bundle spec.number %d while management cluster %s is on older bundle spec.number %d", workload.Bundles.Spec.Number, mgmtCluster.Name, mgmtBundles.Spec.Number)
-	}
-
-	return nil
-}
-
 // ValidateEksaVersion ensures that the version matches EKS-A CLI.
 func ValidateEksaVersion(ctx context.Context, cliVersion string, workload *cluster.Spec) error {
 	v := workload.Cluster.Spec.EksaVersion

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -14,13 +14,11 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
-	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type clusterTest struct {
@@ -311,109 +309,6 @@ func anywhereCluster(name string) *anywherev1.Cluster {
 			},
 		},
 	}
-}
-
-func TestValidateManagementClusterBundlesVersion(t *testing.T) {
-	type testParam struct {
-		mgmtBundlesName   string
-		mgmtBundlesNumber int
-		wkBundlesName     string
-		wkBundlesNumber   int
-		wantErr           string
-		errGetEksaCluster error
-		errGetBundles     error
-	}
-
-	testParams := []testParam{
-		{
-			mgmtBundlesName:   "bundles-28",
-			mgmtBundlesNumber: 28,
-			wkBundlesName:     "bundles-27",
-			wkBundlesNumber:   27,
-			wantErr:           "",
-		},
-		{
-			mgmtBundlesName:   "bundles-28",
-			mgmtBundlesNumber: 28,
-			wkBundlesName:     "bundles-29",
-			wkBundlesNumber:   29,
-			wantErr:           "cannot upgrade workload cluster with bundle spec.number 29 while management cluster management-cluster is on older bundle spec.number 28",
-		},
-		{
-			mgmtBundlesName:   "bundles-28",
-			mgmtBundlesNumber: 28,
-			wkBundlesName:     "bundles-27",
-			wkBundlesNumber:   27,
-			wantErr:           "failed to reach cluster",
-			errGetEksaCluster: errors.New("failed to reach cluster"),
-		},
-		{
-			mgmtBundlesName:   "bundles-28",
-			mgmtBundlesNumber: 28,
-			wkBundlesName:     "bundles-27",
-			wkBundlesNumber:   27,
-			wantErr:           "failed to reach cluster",
-			errGetBundles:     errors.New("failed to reach cluster"),
-		},
-	}
-
-	for _, p := range testParams {
-		tt := newTest(t, withKubectl())
-		mgmtName := "management-cluster"
-		mgmtCluster := managementCluster(mgmtName)
-		mgmtClusterObject := anywhereCluster(mgmtName)
-
-		mgmtClusterObject.Spec.BundlesRef = &anywherev1.BundlesRef{
-			Name:      p.mgmtBundlesName,
-			Namespace: constants.EksaSystemNamespace,
-		}
-
-		tt.clusterSpec.Config.Cluster.Spec.BundlesRef = &anywherev1.BundlesRef{
-			Name:      p.wkBundlesName,
-			Namespace: constants.EksaSystemNamespace,
-		}
-		wkBundle := &releasev1alpha1.Bundles{
-			Spec: releasev1alpha1.BundlesSpec{
-				Number: p.wkBundlesNumber,
-			},
-		}
-		tt.clusterSpec.Bundles = wkBundle
-
-		mgmtBundle := &releasev1alpha1.Bundles{
-			Spec: releasev1alpha1.BundlesSpec{
-				Number: p.mgmtBundlesNumber,
-			},
-		}
-
-		ctx := context.Background()
-		tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, p.errGetEksaCluster)
-		if p.errGetEksaCluster == nil {
-			tt.kubectl.EXPECT().GetBundles(ctx, mgmtCluster.KubeconfigFile, mgmtClusterObject.Spec.BundlesRef.Name, mgmtClusterObject.Spec.BundlesRef.Namespace).Return(mgmtBundle, p.errGetBundles)
-		}
-
-		if p.wantErr == "" {
-			err := validations.ValidateManagementClusterBundlesVersion(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
-			tt.Expect(err).To(BeNil())
-		} else {
-			err := validations.ValidateManagementClusterBundlesVersion(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
-			tt.Expect(err.Error()).To(Equal(p.wantErr))
-		}
-	}
-}
-
-func TestValidateManagementClusterBundlesVersionMissingBundlesRef(t *testing.T) {
-	tt := newTest(t, withKubectl())
-	wantErr := "management cluster bundlesRef cannot be nil"
-	mgmtName := "management-cluster"
-	mgmtCluster := managementCluster(mgmtName)
-	mgmtClusterObject := anywhereCluster(mgmtName)
-
-	mgmtClusterObject.Spec.BundlesRef = nil
-	ctx := context.Background()
-	tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, nil)
-
-	err := validations.ValidateManagementClusterBundlesVersion(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
-	tt.Expect(err.Error()).To(Equal(wantErr))
 }
 
 func TestValidateEksaVersion(t *testing.T) {

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -91,13 +91,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 			},
 			func() *validations.ValidationResult {
 				return &validations.ValidationResult{
-					Name:        "validate management cluster bundle version compatibility",
-					Remediation: fmt.Sprintf("upgrade management cluster %s before creating workload cluster %s", v.Opts.Spec.Cluster.ManagedBy(), v.Opts.WorkloadCluster.Name),
-					Err:         validations.ValidateManagementClusterBundlesVersion(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec),
-				}
-			},
-			func() *validations.ValidationResult {
-				return &validations.ValidationResult{
 					Name:        "validate management cluster eksaVersion compatibility",
 					Remediation: fmt.Sprintf("upgrade management cluster %s before creating workload cluster %s", v.Opts.Spec.Cluster.ManagedBy(), v.Opts.WorkloadCluster.Name),
 					Err:         validations.ValidateManagementClusterEksaVersion(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec),

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
-	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type preflightValidationsTest struct {
@@ -83,17 +82,10 @@ func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
 		},
 	}
 
-	mgmtBundle := &releasev1alpha1.Bundles{
-		Spec: releasev1alpha1.BundlesSpec{
-			Number: tt.c.Opts.Spec.Bundles.Spec.Number + 1,
-		},
-	}
-
 	tt.k.EXPECT().GetClusters(tt.ctx, tt.c.Opts.WorkloadCluster).Return(nil, nil)
 	tt.k.EXPECT().ValidateClustersCRD(tt.ctx, tt.c.Opts.WorkloadCluster).Return(nil)
 	tt.k.EXPECT().ValidateEKSAClustersCRD(tt.ctx, tt.c.Opts.WorkloadCluster).Return(nil)
 	tt.k.EXPECT().GetEksaCluster(tt.ctx, tt.c.Opts.ManagementCluster, mgmtClusterName).Return(mgmt, nil).MaxTimes(3)
-	tt.k.EXPECT().GetBundles(tt.ctx, tt.c.Opts.ManagementCluster.KubeconfigFile, mgmt.Spec.BundlesRef.Name, mgmt.Spec.BundlesRef.Namespace).Return(mgmtBundle, nil)
 
 	tt.Expect(validations.ProcessValidationResults(tt.c.PreflightValidations(tt.ctx))).To(Succeed())
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Newly created clusters will not use bundlesref, so we should remove the create preflight validations for it. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

