### PR TITLE
Bump number of max EC2 instances to run one test per instance

### DIFF
--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 30
+    INTEGRATION_TEST_MAX_EC2_COUNT: 180
     INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 30
     EKSA_GIT_KNOWN_HOSTS: "/tmp/known_hosts"
     EKSA_GIT_PRIVATE_KEY: "/tmp/private-key"


### PR DESCRIPTION
*Issue #, if available:*
Bump up the max number of EC2 instances for Tinkerbell to enable running individual tests separately in an instance. 

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

