### PR TITLE
Only apply DS to vsphere redhat nodes

### DIFF
--- a/pkg/providers/vsphere/testdata/cluster_redhat_external_etcd.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_redhat_external_etcd.yaml
@@ -1,0 +1,113 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: test-wn
+        kind: VSphereMachineConfig
+      name: md-0
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+    node:
+      cidrMaskSize: 8
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: redhat
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/redhat-kube-v1.25.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-wn
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: redhat
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/redhat-kube-v1.25.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: redhat
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/redhat-kube-v1.25.6"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  datacenter: "SDDC-Datacenter"
+  network: "/SDDC-Datacenter/network/sddc-cgw-network-1"
+  server: "vsphere_server"
+  thumbprint: "ABCDEFG"
+  insecure: false

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1183,7 +1183,7 @@ func (p *vsphereProvider) PreCoreComponentsUpgrade(
 	clusterSpec *cluster.Spec,
 ) error {
 	// This is only needed for EKS-A v0.17 because UDP offloading needs to be disabled for
-	// the new Cilium version to work with VSphere clusters. Since our templates that were shipped
+	// the new Cilium version to work with VSphere clusters with Redhat OS family. Since our templates that were shipped
 	// in v0.16 releases still have UDP offloading enabled in the nodes, we must apply the daemon set
 	// to disable UDP offloading in all the nodes before upgrading Cilium.
 	// We will remove this in EKS-A release v0.18.0.
@@ -1192,9 +1192,9 @@ func (p *vsphereProvider) PreCoreComponentsUpgrade(
 
 func (p *vsphereProvider) applyEthtoolDaemonSet(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	for _, mc := range clusterSpec.Config.VSphereMachineConfigs {
-		// This is only needed for Ubuntu and Redhat OS.
+		// This is only needed for Redhat OS.
 		// We only need to check one since the OS family has to be the same for all machine configs
-		if mc.Spec.OSFamily == v1alpha1.Bottlerocket {
+		if mc.Spec.OSFamily != v1alpha1.RedHat {
 			return nil
 		}
 	}

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -47,6 +47,7 @@ const (
 	testClusterConfigMain121CPOnlyFilename = "cluster_main_121_cp_only.yaml"
 	testClusterConfigWithCPUpgradeStrategy = "cluster_main_121_cp_upgrade_strategy.yaml"
 	testClusterConfigWithMDUpgradeStrategy = "cluster_main_121_md_upgrade_strategy.yaml"
+	testClusterConfigRedhatFilename        = "cluster_redhat_external_etcd.yaml"
 	testDataDir                            = "testdata"
 	expectedVSphereName                    = "vsphere"
 	expectedVSphereUsername                = "vsphere_username"
@@ -3807,9 +3808,9 @@ func TestProviderGenerateDeploymentFileForBottlerocketWithTrustedCertBundles(t *
 
 func TestPreCoreComponentsUpgradeSuccess(t *testing.T) {
 	ctx := context.Background()
-	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	datacenterConfig := givenDatacenterConfig(t, testClusterConfigRedhatFilename)
+	clusterConfig := givenClusterConfig(t, testClusterConfigRedhatFilename)
+	clusterSpec := givenClusterSpec(t, testClusterConfigRedhatFilename)
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	ipValidator := mocks.NewMockIPValidator(mockCtrl)
@@ -3879,9 +3880,9 @@ func TestPreCoreComponentsUpgradeBottlerocketNoOpSuccess(t *testing.T) {
 
 func TestPreCoreComponentsUpgradeApplyError(t *testing.T) {
 	ctx := context.Background()
-	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	datacenterConfig := givenDatacenterConfig(t, testClusterConfigRedhatFilename)
+	clusterConfig := givenClusterConfig(t, testClusterConfigRedhatFilename)
+	clusterSpec := givenClusterSpec(t, testClusterConfigRedhatFilename)
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	ipValidator := mocks.NewMockIPValidator(mockCtrl)
@@ -3916,9 +3917,9 @@ func TestPreCoreComponentsUpgradeApplyError(t *testing.T) {
 
 func TestPreCoreComponentsUpgradeDSNotReadyError(t *testing.T) {
 	ctx := context.Background()
-	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
-	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
+	datacenterConfig := givenDatacenterConfig(t, testClusterConfigRedhatFilename)
+	clusterConfig := givenClusterConfig(t, testClusterConfigRedhatFilename)
+	clusterSpec := givenClusterSpec(t, testClusterConfigRedhatFilename)
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	ipValidator := mocks.NewMockIPValidator(mockCtrl)
@@ -3964,8 +3965,8 @@ func TestPreCoreComponentsUpgradeDSNotReadyError(t *testing.T) {
 
 func TestPostBootstrapDeleteForUpgradeSuccess(t *testing.T) {
 	ctx := context.Background()
-	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
+	datacenterConfig := givenDatacenterConfig(t, testClusterConfigRedhatFilename)
+	clusterConfig := givenClusterConfig(t, testClusterConfigRedhatFilename)
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	ipValidator := mocks.NewMockIPValidator(mockCtrl)
@@ -3983,8 +3984,8 @@ func TestPostBootstrapDeleteForUpgradeSuccess(t *testing.T) {
 
 func TestPostBootstrapDeleteForUpgradeError(t *testing.T) {
 	ctx := context.Background()
-	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
-	clusterConfig := givenClusterConfig(t, testClusterConfigMainFilename)
+	datacenterConfig := givenDatacenterConfig(t, testClusterConfigRedhatFilename)
+	clusterConfig := givenClusterConfig(t, testClusterConfigRedhatFilename)
 	mockCtrl := gomock.NewController(t)
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	ipValidator := mocks.NewMockIPValidator(mockCtrl)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We do not need to apply the daemonset to disable udp offloading to ubuntu nodes, so updating that logic to only run for Redhat OS family on VSphere

*Testing (if applicable):*

*Documentation added/planned (if applicable):*
We will add a note about this in the v0.17 Changelog

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

