### PR TITLE
Fix modular upgrade e2e test to grab the correct template 

### DIFF
--- a/test/e2e/side_effects.go
+++ b/test/e2e/side_effects.go
@@ -216,7 +216,7 @@ func runTestManagementClusterUpgradeSideEffects(t *testing.T, provider framework
 			api.WithWorkerNodeCount(1),
 			api.WithEtcdCountIfExternal(1),
 		),
-		provider.WithKubeVersionAndOS(osFamily, kubeVersion),
+		provider.WithKubeVersionAndOS(osFamily, kubeVersion, latestRelease),
 	)
 
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
@@ -241,7 +241,7 @@ func runTestManagementClusterUpgradeSideEffects(t *testing.T, provider framework
 				api.WithCount(2),
 				api.WithLabel("cluster.x-k8s.io/failure-domain", "ds.meta_data.failuredomain"))),
 		framework.WithOIDCClusterConfig(t),
-		provider.WithKubeVersionAndOS(osFamily, kubeVersion),
+		provider.WithKubeVersionAndOS(osFamily, kubeVersion, latestRelease),
 	)
 	test.WithWorkloadClusters(workloadCluster)
 

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -485,11 +485,18 @@ func (c *CloudStack) searchTemplate(ctx context.Context, template string) (strin
 
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
 // cloudstack machine configs.
-func (c *CloudStack) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (c *CloudStack) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller {
+	var template string
+	if release == nil {
+		template = c.templateForDevRelease(osFamily, kubeVersion)
+	} else {
+		template = c.templatesRegistry.templateForRelease(c.t, osFamily, release, kubeVersion)
+	}
+
 	return api.JoinClusterConfigFillers(
 		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
 		api.CloudStackToConfigFiller(
-			api.WithCloudStackTemplateForAllMachines(c.templateForDevRelease(osFamily, kubeVersion)),
+			api.WithCloudStackTemplateForAllMachines(template),
 		),
 	)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -42,6 +42,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/aws/eks-anywhere/pkg/templater"
 	"github.com/aws/eks-anywhere/pkg/types"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
 )
 
@@ -318,7 +319,7 @@ type Provider interface {
 	CleanupVMs(clusterName string) error
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	ClusterStateValidations() []clusterf.StateValidation
-	WithKubeVersionAndOS(osFamily v1alpha1.OSFamily, kubeVersion v1alpha1.KubernetesVersion) api.ClusterConfigFiller
+	WithKubeVersionAndOS(osFamily v1alpha1.OSFamily, kubeVersion v1alpha1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller
 	WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller
 }
 

--- a/test/framework/docker.go
+++ b/test/framework/docker.go
@@ -9,6 +9,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/providers/docker"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
 )
 
@@ -84,7 +85,7 @@ func (d *Docker) ClusterStateValidations() []clusterf.StateValidation {
 }
 
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version.
-func (d *Docker) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (d *Docker) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller {
 	return api.JoinClusterConfigFillers(
 		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
 	)

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/cleanup"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
 )
 
@@ -168,7 +169,7 @@ func (s *Nutanix) WithProviderUpgrade(fillers ...api.NutanixFiller) ClusterE2ETe
 
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
 // nutanix machine configs.
-func (s *Nutanix) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (s *Nutanix) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller {
 	// TODO: Update tests to use this
 	panic("Not implemented for Nutanix yet")
 }

--- a/test/framework/snow.go
+++ b/test/framework/snow.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
 )
 
@@ -299,7 +300,7 @@ func (s *Snow) WithBottlerocketStaticIP127() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu123() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube123)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube123, nil)
 }
 
 // WithUbuntu124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
@@ -307,7 +308,7 @@ func (s *Snow) WithUbuntu123() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu124() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube124)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube124, nil)
 }
 
 // WithUbuntu125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
@@ -315,7 +316,7 @@ func (s *Snow) WithUbuntu124() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu125() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube125)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube125, nil)
 }
 
 // WithUbuntu126 returns a cluster config filler that sets the kubernetes version of the cluster to 1.26
@@ -323,7 +324,7 @@ func (s *Snow) WithUbuntu125() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu126() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube126)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube126, nil)
 }
 
 // WithUbuntu127 returns a cluster config filler that sets the kubernetes version of the cluster to 1.27
@@ -331,12 +332,12 @@ func (s *Snow) WithUbuntu126() api.ClusterConfigFiller {
 // also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
 func (s *Snow) WithUbuntu127() api.ClusterConfigFiller {
 	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube127)
+	return s.WithKubeVersionAndOS(anywherev1.Ubuntu, anywherev1.Kube127, nil)
 }
 
 func (s *Snow) withBottlerocketForKubeVersion(kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	return api.JoinClusterConfigFillers(
-		s.WithKubeVersionAndOS(anywherev1.Bottlerocket, kubeVersion),
+		s.WithKubeVersionAndOS(anywherev1.Bottlerocket, kubeVersion, nil),
 		api.SnowToConfigFiller(api.WithChangeForAllSnowMachines(api.WithSnowContainersVolumeSize(100))),
 	)
 }
@@ -344,7 +345,7 @@ func (s *Snow) withBottlerocketForKubeVersion(kubeVersion anywherev1.KubernetesV
 func (s *Snow) withBottlerocketStaticIPForKubeVersion(kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	poolName := "pool-1"
 	return api.JoinClusterConfigFillers(
-		s.WithKubeVersionAndOS(anywherev1.Bottlerocket, kubeVersion),
+		s.WithKubeVersionAndOS(anywherev1.Bottlerocket, kubeVersion, nil),
 		api.SnowToConfigFiller(api.WithChangeForAllSnowMachines(api.WithSnowContainersVolumeSize(100))),
 		api.SnowToConfigFiller(api.WithChangeForAllSnowMachines(api.WithStaticIP(poolName))),
 		api.SnowToConfigFiller(s.withIPPoolFromEnvVar(poolName)),
@@ -353,7 +354,7 @@ func (s *Snow) withBottlerocketStaticIPForKubeVersion(kubeVersion anywherev1.Kub
 
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the correct AMI ID
 // and devices for the Snow machine configs.
-func (s *Snow) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (s *Snow) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller {
 	envar := fmt.Sprintf("T_SNOW_AMIID_%s_%s", strings.ToUpper(string(osFamily)), strings.ReplaceAll(string(kubeVersion), ".", "_"))
 
 	return api.JoinClusterConfigFillers(

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	clusterf "github.com/aws/eks-anywhere/test/framework/cluster"
 )
 
@@ -155,7 +156,7 @@ func (t *Tinkerbell) CleanupVMs(_ string) error {
 
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
 // tinkerbell machine configs.
-func (t *Tinkerbell) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (t *Tinkerbell) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller {
 	// TODO: Update tests to use this
 	panic("Not implemented for Tinkerbell yet")
 }

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -502,11 +502,18 @@ func (v *VSphere) ClusterConfigUpdates() []api.ClusterConfigFiller {
 
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right template for all
 // vsphere machine configs.
-func (v *VSphere) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion) api.ClusterConfigFiller {
+func (v *VSphere) WithKubeVersionAndOS(osFamily anywherev1.OSFamily, kubeVersion anywherev1.KubernetesVersion, release *releasev1.EksARelease) api.ClusterConfigFiller {
+	var template string
+	if release == nil {
+		template = v.templateForDevRelease(osFamily, kubeVersion)
+	} else {
+		template = v.templatesRegistry.templateForRelease(v.t, osFamily, release, kubeVersion)
+	}
+
 	return api.JoinClusterConfigFillers(
 		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
 		api.VSphereToConfigFiller(
-			api.WithTemplateForAllMachines(v.templateForDevRelease(osFamily, kubeVersion)),
+			api.WithTemplateForAllMachines(template),
 			api.WithOsFamilyForAllMachines(osFamily),
 		),
 	)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The mod upgrade e2e tests were using the dev release template when creating the cluster with the later minor release, resulting in errors. This passes in the `release` param to use the correct template. 

*Testing (if applicable):*
Confirmed that it now passes in the correct template in e2e test binary

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

