### PR TITLE
Fix preflight eksa version

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -119,13 +119,8 @@ func ValidateEksaVersion(ctx context.Context, cliVersion string, workload *clust
 }
 
 // ValidateEksaVersionSkew ensures that upgrades are sequential by CLI minor versions.
-func ValidateEksaVersionSkew(ctx context.Context, k KubectlClient, cluster, mgmtCluster *types.Cluster, spec *cluster.Spec) error {
-	managementCluster := cluster
-	if !cluster.ExistingManagement {
-		managementCluster = mgmtCluster
-	}
-
-	currentCluster, err := k.GetEksaCluster(ctx, managementCluster, cluster.Name)
+func ValidateEksaVersionSkew(ctx context.Context, k KubectlClient, mgmtCluster *types.Cluster, spec *cluster.Spec) error {
+	currentCluster, err := k.GetEksaCluster(ctx, mgmtCluster, spec.Cluster.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -119,8 +119,13 @@ func ValidateEksaVersion(ctx context.Context, cliVersion string, workload *clust
 }
 
 // ValidateEksaVersionSkew ensures that upgrades are sequential by CLI minor versions.
-func ValidateEksaVersionSkew(ctx context.Context, k KubectlClient, cluster *types.Cluster, spec *cluster.Spec) error {
-	currentCluster, err := k.GetEksaCluster(ctx, cluster, cluster.Name)
+func ValidateEksaVersionSkew(ctx context.Context, k KubectlClient, cluster, mgmtCluster *types.Cluster, spec *cluster.Spec) error {
+	managementCluster := cluster
+	if !cluster.ExistingManagement {
+		managementCluster = mgmtCluster
+	}
+
+	currentCluster, err := k.GetEksaCluster(ctx, managementCluster, cluster.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -413,7 +413,7 @@ func TestValidateEksaVersionSkew(t *testing.T) {
 			mgmtClusterObject.Spec.EksaVersion = tc.version
 			tt.clusterSpec.Cluster.Spec.EksaVersion = tc.upgradeVersion
 			ctx := context.Background()
-			tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, nil)
+			tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, tt.clusterSpec.Cluster.Name).Return(mgmtClusterObject, nil)
 			tt.kubectl.EXPECT().GetBundles(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(test.Bundle(), nil).AnyTimes()
 
 			err := validations.ValidateEksaVersionSkew(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -416,7 +416,7 @@ func TestValidateEksaVersionSkew(t *testing.T) {
 			tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, nil)
 			tt.kubectl.EXPECT().GetBundles(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(test.Bundle(), nil).AnyTimes()
 
-			err := validations.ValidateEksaVersionSkew(ctx, tt.kubectl, mgmtCluster, mgmtCluster, tt.clusterSpec)
+			err := validations.ValidateEksaVersionSkew(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
 			if err != nil {
 				tt.Expect(err.Error()).To(ContainSubstring(tc.wantErr.Error()))
 			} else {

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -416,7 +416,7 @@ func TestValidateEksaVersionSkew(t *testing.T) {
 			tt.kubectl.EXPECT().GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name).Return(mgmtClusterObject, nil)
 			tt.kubectl.EXPECT().GetBundles(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(test.Bundle(), nil).AnyTimes()
 
-			err := validations.ValidateEksaVersionSkew(ctx, tt.kubectl, mgmtCluster, tt.clusterSpec)
+			err := validations.ValidateEksaVersionSkew(ctx, tt.kubectl, mgmtCluster, mgmtCluster, tt.clusterSpec)
 			if err != nil {
 				tt.Expect(err.Error()).To(ContainSubstring(tc.wantErr.Error()))
 			} else {

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -138,7 +138,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				return &validations.ValidationResult{
 					Name:        "validate eksaVersion skew is one minor version",
 					Remediation: "ensure eksaVersion upgrades are sequential by minor version",
-					Err:         validations.ValidateEksaVersionSkew(ctx, k, u.Opts.WorkloadCluster, u.Opts.Spec),
+					Err:         validations.ValidateEksaVersionSkew(ctx, k, u.Opts.WorkloadCluster, u.Opts.ManagementCluster, u.Opts.Spec),
 				}
 			})
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -138,7 +138,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				return &validations.ValidationResult{
 					Name:        "validate eksaVersion skew is one minor version",
 					Remediation: "ensure eksaVersion upgrades are sequential by minor version",
-					Err:         validations.ValidateEksaVersionSkew(ctx, k, u.Opts.WorkloadCluster, u.Opts.ManagementCluster, u.Opts.Spec),
+					Err:         validations.ValidateEksaVersionSkew(ctx, k, u.Opts.ManagementCluster, u.Opts.Spec),
 				}
 			})
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This validation was using the wrong kubeconfig, so I fixed it to use the management cluster's kubeconfig

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

