### PR TITLE
updating taint validation to management cluster only

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -507,7 +507,9 @@ func validateWorkerNodeGroups(clusterConfig *Cluster) error {
 	}
 
 	if len(workerNodeGroupConfigs) > 0 && len(noExecuteNoScheduleTaintedNodeGroups) == len(workerNodeGroupConfigs) {
-		return errors.New("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")
+		if clusterConfig.IsSelfManaged() {
+			return errors.New("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")
+		}
 	}
 
 	if len(workerNodeGroupConfigs) == 0 && len(clusterConfig.Spec.ControlPlaneConfiguration.Taints) != 0 {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -742,6 +742,81 @@ func TestGetAndValidateClusterConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			testName: "valid tainted workload cluster machine configs",
+			fileName: "testdata/cluster_valid_taints_workload_cluster.yaml",
+			wantCluster: &Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       ClusterKind,
+					APIVersion: SchemeBuilder.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "eksa-unit-test",
+				},
+				Spec: ClusterSpec{
+					KubernetesVersion: Kube119,
+					ManagementCluster: ManagementCluster{
+						Name: "mgmt",
+					},
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						Count: 3,
+						Endpoint: &Endpoint{
+							Host: "test-ip",
+						},
+						MachineGroupRef: &Ref{
+							Kind: VSphereMachineConfigKind,
+							Name: "eksa-unit-test",
+						},
+					},
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{
+						{
+							Name:  "md-0",
+							Count: ptr.Int(3),
+							MachineGroupRef: &Ref{
+								Kind: VSphereMachineConfigKind,
+								Name: "eksa-unit-test-2",
+							},
+							Taints: []v1.Taint{
+								{
+									Key:    "key1",
+									Value:  "val1",
+									Effect: v1.TaintEffectNoSchedule,
+								},
+							},
+						},
+						{
+							Name:  "md-1",
+							Count: ptr.Int(3),
+							MachineGroupRef: &Ref{
+								Kind: VSphereMachineConfigKind,
+								Name: "eksa-unit-test-2",
+							},
+							Taints: []v1.Taint{
+								{
+									Key:    "key1",
+									Value:  "val1",
+									Effect: v1.TaintEffectNoExecute,
+								},
+							},
+						},
+					},
+					DatacenterRef: Ref{
+						Kind: VSphereDatacenterKind,
+						Name: "eksa-unit-test",
+					},
+					ClusterNetwork: ClusterNetwork{
+						CNIConfig: &CNIConfig{Cilium: &CiliumConfig{}},
+						Pods: Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			testName:    "with no worker node groups",
 			fileName:    "testdata/cluster_invalid_no_worker_node_groups.yaml",
 			wantCluster: nil,

--- a/pkg/api/v1alpha1/testdata/cluster_valid_taints_workload_cluster.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_valid_taints_workload_cluster.yaml
@@ -1,0 +1,94 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: eksa-unit-test
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: test-ip
+    machineGroupRef:
+      name: eksa-unit-test
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.19"
+  managementCluster:
+    name: mgmt
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test-2
+        kind: VSphereMachineConfig
+      name: "md-0"
+      taints:
+        - key: key1
+          value: val1
+          effect: NoSchedule
+    - count: 3
+      machineGroupRef:
+        name: eksa-unit-test-2
+        kind: VSphereMachineConfig
+      name: "md-1"
+      taints:
+        - key: key1
+          value: val1
+          effect: NoExecute
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: eksa-unit-test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  diskGiB: 25
+  datastore: "myDatastore"
+  folder: "myFolder"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: "ubuntu"
+  resourcePool: "myResourcePool"
+  storagePolicyName: "myStoragePolicyName"
+  template: "myTemplate"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: eksa-unit-test-2
+spec:
+  diskGiB: 20
+  datastore: "myDatastore2"
+  folder: "myFolder2"
+  memoryMiB: 2048
+  numCPUs: 4
+  osFamily: "bottlerocket"
+  resourcePool: "myResourcePool2"
+  storagePolicyName: "myStoragePolicyName2"
+  template: "myTemplate2"
+  users:
+    - name: "mySshUsername2"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey2"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: eksa-unit-test
+spec:
+  datacenter: "myDatacenter"
+  network: "myNetwork"
+  server: "myServer"
+  thumbprint: "myTlsThumbprint"
+  insecure: false

--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -23,6 +23,16 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 	test.DeleteManagementCluster()
 }
 
+func runWorkloadClusterExistingConfigFlow(test *framework.MulticlusterE2ETest) {
+	test.CreateManagementClusterWithConfig()
+	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.CreateCluster()
+		w.DeleteCluster()
+	})
+	time.Sleep(5 * time.Minute)
+	test.DeleteManagementCluster()
+}
+
 func runWorkloadClusterPrevVersionCreateFlow(test *framework.MulticlusterE2ETest, latestMinorRelease *releasev1.EksARelease) {
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {


### PR DESCRIPTION
*Issue #, if available:*
[#1527](https://github.com/aws/eks-anywhere-internal/issues/1527)

*Description of changes:*
The requirement that at least one worker node group must not have NoSchedule and NoExecute taints is only applicable to management clusters. This PR updates the validation to only apply to management clusters

*Testing (if applicable):*
added unit and docker/vsphere e2e tests. Tests run locally

*Documentation added/planned (if applicable):*
Troubleshooting documentation previously added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

