### PR TITLE
Update cluster config for upgrades during modular upgrade e2e tests

### DIFF
--- a/test/e2e/side_effects.go
+++ b/test/e2e/side_effects.go
@@ -25,7 +25,7 @@ type eksaPackagedBinary interface {
 // runFlowUpgradeManagementClusterCheckForSideEffects creates management and workload cluster
 // with a specific eks-a version then upgrades the management cluster with another CLI version
 // and checks that this doesn't cause any side effects (machine rollout) in the workload clusters.
-func runFlowUpgradeManagementClusterCheckForSideEffects(test *framework.MulticlusterE2ETest, currentEKSA, newEKSA eksaPackagedBinary) {
+func runFlowUpgradeManagementClusterCheckForSideEffects(test *framework.MulticlusterE2ETest, currentEKSA, newEKSA eksaPackagedBinary, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.T.Logf("Creating management cluster with EKS-A version %s", currentEKSA.Version())
 	test.CreateManagementCluster(framework.ExecuteWithBinary(currentEKSA))
 
@@ -41,7 +41,7 @@ func runFlowUpgradeManagementClusterCheckForSideEffects(test *framework.Multiclu
 	printStateOfMachines(test.ManagementCluster.ClusterConfig.Cluster, preUpgradeWorkloadClustersState)
 
 	test.T.Logf("Upgrading management cluster with EKS-A version %s", newEKSA.Version())
-	test.ManagementCluster.UpgradeCluster(framework.ExecuteWithBinary(newEKSA))
+	test.ManagementCluster.UpgradeClusterWithNewConfig(clusterOpts, framework.ExecuteWithBinary(newEKSA))
 
 	checker := machineSideEffectChecker{
 		tb:                 test.T,
@@ -254,5 +254,6 @@ func runTestManagementClusterUpgradeSideEffects(t *testing.T, provider framework
 	runFlowUpgradeManagementClusterCheckForSideEffects(test,
 		framework.NewEKSAReleasePackagedBinary(latestRelease),
 		newEKSAPackagedBinaryForLocalBinary(t),
+		framework.WithUpgradeClusterConfig(provider.WithKubeVersionAndOS(kubeVersion, os, nil)),
 	)
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -804,6 +804,14 @@ func WithClusterUpgrade(fillers ...api.ClusterFiller) ClusterE2ETestOpt {
 	}
 }
 
+// WithUpgradeClusterConfig adds a cluster upgrade.
+// When we migrate usages of ClusterFiller to ClusterConfigFiller we can rename this to WithClusterUpgrade.
+func WithUpgradeClusterConfig(fillers ...api.ClusterConfigFiller) ClusterE2ETestOpt {
+	return func(e *ClusterE2ETest) {
+		e.UpdateClusterConfig(fillers...)
+	}
+}
+
 // LoadClusterConfigGeneratedByCLI loads the full cluster config from the file generated when a cluster is created using the CLI.
 func (e *ClusterE2ETest) LoadClusterConfigGeneratedByCLI(fillers ...api.ClusterConfigFiller) {
 	fullClusterConfigLocation := filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a-cluster.yaml")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We never updated the cluster config to use the new template during upgrades in this test, so this PR does that.

*Testing (if applicable):*
```
--- PASS: TestVSphereKubernetes126ManagementClusterUpgradeFromLatestSideEffects (3425.69s)
PASS
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

