### PR TITLE
Fix CAPI Backup and add filter for cluster name

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -106,7 +106,7 @@ type ClientFactory interface {
 
 type ClusterClient interface {
 	KubernetesClient
-	BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
+	BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveManagement(ctx context.Context, from, target *types.Cluster, clusterName string) error
 	WaitForClusterReady(ctx context.Context, cluster *types.Cluster, timeout string, clusterName string) error
 	WaitForControlPlaneAvailable(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error
@@ -298,7 +298,7 @@ func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait ti
 }
 
 // BackupCAPI takes backup of management cluster's resources during uograde process.
-func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error {
+func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error {
 	// Network errors, most commonly connection refused or timeout, can occur if either source
 	// cluster becomes inaccessible during the move operation.  If this occurs without retries, clusterctl
 	// abandons the move operation, and fails cluster upgrade.
@@ -309,7 +309,7 @@ func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster,
 
 	r := retrier.New(c.clusterctlMoveTimeout, retrier.WithRetryPolicy(clusterctlMoveRetryPolicy))
 	err := r.Retry(func() error {
-		return c.clusterClient.BackupManagement(ctx, cluster, managementStatePath)
+		return c.clusterClient.BackupManagement(ctx, cluster, managementStatePath, clusterName)
 	})
 	if err != nil {
 		return fmt.Errorf("backing up CAPI resources of management cluster before moving to bootstrap cluster: %v", err)

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1316,9 +1316,9 @@ func TestClusterManagerBackupCAPISuccess(t *testing.T) {
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
-	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath)
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name)
 
-	if err := c.BackupCAPI(ctx, from, managementStatePath); err != nil {
+	if err := c.BackupCAPI(ctx, from, managementStatePath, from.Name); err != nil {
 		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }
@@ -1332,13 +1332,13 @@ func TestClusterManagerBackupCAPIRetrySuccess(t *testing.T) {
 
 	c, m := newClusterManager(t)
 	// m.client.EXPECT().BackupManagement(ctx, from, managementStatePath)
-	firstTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(errors.New("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": EOF"))
-	secondTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(nil)
+	firstTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name).Return(errors.New("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": EOF"))
+	secondTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name).Return(nil)
 	gomock.InOrder(
 		firstTry,
 		secondTry,
 	)
-	if err := c.BackupCAPI(ctx, from, managementStatePath); err != nil {
+	if err := c.BackupCAPI(ctx, from, managementStatePath, from.Name); err != nil {
 		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }
@@ -1387,14 +1387,16 @@ func TestClusterctlWaitRetryPolicy(t *testing.T) {
 }
 
 func TestClusterManagerBackupCAPIError(t *testing.T) {
-	from := &types.Cluster{}
+	from := &types.Cluster{
+		Name: "from-cluster",
+	}
 
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
-	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(errors.New("backing up CAPI resources"))
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name).Return(errors.New("backing up CAPI resources"))
 
-	if err := c.BackupCAPI(ctx, from, managementStatePath); err == nil {
+	if err := c.BackupCAPI(ctx, from, managementStatePath, from.Name); err == nil {
 		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -104,17 +104,17 @@ func (mr *MockClusterClientMockRecorder) ApplyKubeSpecFromBytesWithNamespace(arg
 }
 
 // BackupManagement mocks base method.
-func (m *MockClusterClient) BackupManagement(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+func (m *MockClusterClient) BackupManagement(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupManagement", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "BackupManagement", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BackupManagement indicates an expected call of BackupManagement.
-func (mr *MockClusterClientMockRecorder) BackupManagement(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) BackupManagement(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupManagement", reflect.TypeOf((*MockClusterClient)(nil).BackupManagement), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupManagement", reflect.TypeOf((*MockClusterClient)(nil).BackupManagement), arg0, arg1, arg2, arg3)
 }
 
 // CountMachineDeploymentReplicasReady mocks base method.

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -237,7 +237,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 			setup: func(t *testing.T, clusterTest *clusterctlTest) {
 				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 			setup: func(t *testing.T, clusterTest *clusterctlTest) {
 				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace}...)
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
 				createTestDirectory(t, existingPath)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
 			},
 		},
 	}
@@ -275,7 +275,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 
 			tt.setup(t, tc)
 
-			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err != nil {
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState, clusterName); err != nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
 			}
 		})
@@ -301,7 +301,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 			setup: func(t *testing.T, clusterTest *clusterctlTest) {
 				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...).
 					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
 			},
 		},
@@ -316,7 +316,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
 				createTestDirectory(t, existingPath)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...).
 					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
 			},
 		},
@@ -329,7 +329,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 
 			tt.setup(t, tc)
 
-			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err == nil {
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState, clusterName); err == nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
 			}
 		})

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -17,7 +17,7 @@ type Bootstrapper interface {
 }
 
 type ClusterManager interface {
-	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
+	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error
@@ -79,4 +79,3 @@ type EksdUpgrader interface {
 type PackageInstaller interface {
 	InstallCuratedPackages(ctx context.Context)
 }
-

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -126,17 +126,17 @@ func (mr *MockClusterManagerMockRecorder) ApplyReleases(arg0, arg1, arg2 interfa
 }
 
 // BackupCAPI mocks base method.
-func (m *MockClusterManager) BackupCAPI(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+func (m *MockClusterManager) BackupCAPI(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupCAPI", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "BackupCAPI", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BackupCAPI indicates an expected call of BackupCAPI.
-func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2, arg3)
 }
 
 // CreateAwsIamAuthCaSecret mocks base method.

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -457,7 +457,7 @@ func (s *installCAPITask) Restore(ctx context.Context, commandContext *task.Comm
 
 func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Backing up workload cluster's management resources before moving to bootstrap cluster")
-	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir)
+	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
@@ -514,7 +514,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	if err != nil {
 		commandContext.SetError(err)
 		logger.Info("Backing up management components from bootstrap cluster")
-		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.BootstrapCluster, commandContext.ManagementClusterStateDir)
+		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.ManagementCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
 		if err != nil {
 			logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
 		}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -269,7 +269,7 @@ func (c *upgradeTestSetup) expectUpgradeWorkloadToReturn(managementCluster *type
 
 func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath, c.managementCluster.Name),
 		c.clusterManager.EXPECT().PauseCAPIWorkloadClusters(c.ctx, c.managementCluster),
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.managementCluster, c.bootstrapCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
@@ -282,13 +282,13 @@ func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 
 func (c *upgradeTestSetup) expectBackupManagementFromCluster(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath, c.managementCluster.Name),
 	)
 }
 
 func (c *upgradeTestSetup) expectBackupManagementFromClusterFailed(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath, c.managementCluster.Name).Return(fmt.Errorf("backup management failed")),
 	)
 }
 


### PR DESCRIPTION
*Description of changes:*
Set the context to right management cluster when upgrading both mgmt and workload cluster for taking backup. 
Set cluster name filter for backing up the cluster that is getting upgraded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

