### PR TITLE
Implement Provider interface method for Tinkerbell tests

### DIFF
--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -135,8 +135,13 @@ func (t *Tinkerbell) CleanupVMs(_ string) error {
 // WithKubeVersionAndOS returns a cluster config filler that sets the cluster kube version and the right image for all
 // tinkerbell machine configs.
 func (t *Tinkerbell) WithKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) api.ClusterConfigFiller {
-	// TODO: Update tests to use this
-	panic("Not implemented for Tinkerbell yet")
+	return api.JoinClusterConfigFillers(
+		api.ClusterToConfigFiller(api.WithKubernetesVersion(kubeVersion)),
+		api.TinkerbellToConfigFiller(
+			imageForKubeVersionAndOS(kubeVersion, os),
+			api.WithOsFamilyForAllTinkerbellMachines(osFamiliesForOS[os]),
+		),
+	)
 }
 
 // WithNewWorkerNodeGroup returns an api.ClusterFiller that adds a new workerNodeGroupConfiguration and


### PR DESCRIPTION
The Provider interface method `WithKubeVersionAndOS` was not implemented for Tinkerbell and so was causing a panic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

