### PR TITLE
remove validation block bundlesRef and eksaVersion

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -846,10 +846,6 @@ func validatePackageControllerConfiguration(clusterConfig *Cluster) error {
 }
 
 func validateEksaVersion(clusterConfig *Cluster) error {
-	if clusterConfig.Spec.BundlesRef != nil && clusterConfig.Spec.EksaVersion != nil {
-		return fmt.Errorf("cannot pass both bundlesRef and eksaVersion. New clusters should use eksaVersion instead of bundlesRef")
-	}
-
 	if clusterConfig.Spec.EksaVersion != nil {
 		_, err := semver.New(string(*clusterConfig.Spec.EksaVersion))
 		if err != nil {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3422,12 +3422,6 @@ func TestValidateEksaVersion(t *testing.T) {
 		bundlesRef *BundlesRef
 	}{
 		{
-			name:       "both bundlesref and version",
-			wantErr:    "cannot pass both bundlesRef and eksaVersion",
-			version:    "v0.0.0",
-			bundlesRef: &BundlesRef{},
-		},
-		{
 			name:       "eksaversion success",
 			wantErr:    "",
 			version:    "v0.0.0",

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -57,6 +57,10 @@ func BuildSpec(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*
 
 // BuildSpecFromConfig constructs a cluster.Spec for an eks-a cluster config by retrieving all dependencies objects from the cluster using a kubernetes client.
 func BuildSpecFromConfig(ctx context.Context, client Client, config *Config) (*Spec, error) {
+	if config.Cluster.Spec.EksaVersion == nil && config.Cluster.Spec.BundlesRef == nil {
+		return nil, fmt.Errorf("either cluster's EksaVersion or BundlesRef need to be set")
+	}
+
 	eksaRelease, err := eksaReleaseForCluster(ctx, client, config.Cluster)
 	if err != nil {
 		return nil, err
@@ -107,6 +111,9 @@ func getEksdRelease(ctx context.Context, client Client, version v1alpha1.Kuberne
 
 // BundlesForCluster returns a bundles resource for the cluster.
 func BundlesForCluster(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*v1alpha1release.Bundles, error) {
+	if cluster.Spec.EksaVersion == nil && cluster.Spec.BundlesRef == nil {
+		return nil, fmt.Errorf("either cluster's EksaVersion or BundlesRef need to be set")
+	}
 	release, err := eksaReleaseForCluster(ctx, client, cluster)
 	if err != nil {
 		return nil, err
@@ -117,9 +124,6 @@ func BundlesForCluster(ctx context.Context, client Client, cluster *v1alpha1.Clu
 
 func eksaReleaseForCluster(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*v1alpha1release.EKSARelease, error) {
 	eksaRelease := &v1alpha1release.EKSARelease{}
-	if cluster.Spec.EksaVersion == nil && cluster.Spec.BundlesRef == nil {
-		return nil, fmt.Errorf("either cluster's EksaVersion or BundlesRef need to be set")
-	}
 	if cluster.Spec.EksaVersion != nil {
 		version := string(*cluster.Spec.EksaVersion)
 		eksaReleaseName := v1alpha1release.GenerateEKSAReleaseName(version)

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -117,14 +117,14 @@ func BundlesForCluster(ctx context.Context, client Client, cluster *v1alpha1.Clu
 
 func eksaReleaseForCluster(ctx context.Context, client Client, cluster *v1alpha1.Cluster) (*v1alpha1release.EKSARelease, error) {
 	eksaRelease := &v1alpha1release.EKSARelease{}
-	if cluster.Spec.BundlesRef == nil {
-		if cluster.Spec.EksaVersion == nil {
-			return nil, fmt.Errorf("either cluster's EksaVersion or BundlesRef need to be set")
-		}
+	if cluster.Spec.EksaVersion == nil && cluster.Spec.BundlesRef == nil {
+		return nil, fmt.Errorf("either cluster's EksaVersion or BundlesRef need to be set")
+	}
+	if cluster.Spec.EksaVersion != nil {
 		version := string(*cluster.Spec.EksaVersion)
 		eksaReleaseName := v1alpha1release.GenerateEKSAReleaseName(version)
 		if err := client.Get(ctx, eksaReleaseName, constants.EksaSystemNamespace, eksaRelease); err != nil {
-			return nil, fmt.Errorf("error getting EKSARelease %s", eksaReleaseName)
+			return nil, err
 		}
 	}
 

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -185,7 +185,7 @@ func TestBuildSpecGetEKSAReleaseError(t *testing.T) {
 	tt.client.EXPECT().Get(tt.ctx, "eksa-v0-0-0-dev", "eksa-system", &releasev1.EKSARelease{}).Return(errors.New("client error"))
 
 	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
-	tt.Expect(err).To(MatchError(ContainSubstring("error getting EKSARelease")))
+	tt.Expect(err).To(MatchError(ContainSubstring("client error")))
 }
 
 func TestBuildSpecNilEksaVersion(t *testing.T) {

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -197,6 +197,15 @@ func TestBuildSpecNilEksaVersion(t *testing.T) {
 	tt.Expect(err).To(MatchError(ContainSubstring("either cluster's EksaVersion or BundlesRef need to be set")))
 }
 
+func TestBundlesForClusterNilEksaVersion(t *testing.T) {
+	tt := newBuildSpecTest(t)
+	tt.cluster.Spec.BundlesRef = nil
+	tt.cluster.Spec.EksaVersion = nil
+
+	_, err := cluster.BundlesForCluster(tt.ctx, tt.client, tt.cluster)
+	tt.Expect(err).To(MatchError(ContainSubstring("either cluster's EksaVersion or BundlesRef need to be set")))
+}
+
 func TestBuildSpecGetBundlesError(t *testing.T) {
 	tt := newBuildSpecTest(t)
 	tt.expectGetEKSARelease()

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -2752,6 +2752,7 @@ func TestClusterManagerGetCurrentClusterSpecGetClusterError(t *testing.T) {
 
 func TestClusterManagerGetCurrentClusterSpecGetBundlesError(t *testing.T) {
 	tt := newTest(t)
+	tt.clusterSpec.Cluster.Spec.EksaVersion = nil
 	tt.clusterSpec.Cluster.Spec.BundlesRef = &v1alpha1.BundlesRef{}
 
 	tt.mocks.client.EXPECT().GetEksaCluster(tt.ctx, tt.cluster, tt.clusterName).Return(tt.clusterSpec.Cluster, nil)

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -1302,27 +1302,6 @@ func TestReconcile(s *testing.T) {
 		}
 	})
 
-	s.Run("errors when eksaVersion and bundlesRef are nil", func(t *testing.T) {
-		ctx := context.Background()
-		log := testr.New(t)
-		cluster := newReconcileTestCluster()
-		cluster.Spec.BundlesRef = nil
-		cluster.Spec.EksaVersion = nil
-		ctrl := gomock.NewController(t)
-		k := mocks.NewMockKubectlRunner(ctrl)
-		cm := mocks.NewMockChartManager(ctrl)
-
-		objs := []runtime.Object{cluster}
-		fakeClient := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-
-		pcc := curatedpackages.NewPackageControllerClientFullLifecycle(log, cm, k, nil)
-		expectedErr := "either cluster's EksaVersion or BundlesRef need to be set"
-		err := pcc.Reconcile(ctx, log, fakeClient, cluster)
-		if err == nil || !strings.Contains(err.Error(), expectedErr) {
-			t.Errorf("expected %s, got %s", expectedErr, err)
-		}
-	})
-
 	s.Run("errors when a matching k8s bundle version isn't found", func(t *testing.T) {
 		ctx := context.Background()
 		log := testr.New(t)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The validation that blocked users from having both bundlesRef and eksaVersion set was causing issues when upgrading a cluster with gitops enabled from latest minor release. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

