### PR TITLE
best effort backup and bootstrap backup to different directory

### DIFF
--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -118,17 +118,6 @@ func NewWriter(t *testing.T) (dir string, writer filewriter.FileWriter) {
 	return dir, writer
 }
 
-// NewDirectory creates new test directory with cleanup.
-func NewDirectory(t *testing.T) (dir string) {
-	dir, err := os.MkdirTemp(".", SanitizePath(t.Name())+"-")
-	if err != nil {
-		t.Fatalf("error setting up folder for test: %v", err)
-	}
-
-	t.Cleanup(cleanupDir(t, dir))
-	return dir
-}
-
 func cleanupDir(t *testing.T, dir string) func() {
 	return func() {
 		if !t.Failed() {

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -277,8 +277,24 @@ func WithNoTimeouts() ClusterManagerOpt {
 	}
 }
 
+func clusterctlMoveWaitForInfrastructureRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
+	// Retry both network and cluster move errors.
+	if match := (clusterctlNetworkErrorRegex.MatchString(err.Error()) || clusterctlMoveErrorRegex.MatchString(err.Error())); match {
+		return true, clusterctlMoveRetryWaitTime(totalRetries)
+	}
+	return false, 0
+}
+
 func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
-	// Exponential backoff on network and cluster move errors.  Retrier built-in backoff is linear, so implementing here.
+	// Retry only network errors.
+	if match := clusterctlNetworkErrorRegex.MatchString(err.Error()); match {
+		return true, clusterctlMoveRetryWaitTime(totalRetries)
+	}
+	return false, 0
+}
+
+func clusterctlMoveRetryWaitTime(totalRetries int) time.Duration {
+	// Exponential backoff on errors.  Retrier built-in backoff is linear, so implementing here.
 
 	// Retrier first calls the policy before retry #1.  We want it zero-based for exponentiation.
 	if totalRetries < 1 {
@@ -287,15 +303,11 @@ func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait ti
 
 	const networkFaultBaseRetryTime = 10 * time.Second
 	const backoffFactor = 1.5
-	waitTime := time.Duration(float64(networkFaultBaseRetryTime) * math.Pow(backoffFactor, float64(totalRetries-1)))
 
-	if match := (clusterctlNetworkErrorRegex.MatchString(err.Error()) || clusterctlMoveErrorRegex.MatchString(err.Error())); match {
-		return true, waitTime
-	}
-	return false, 0
+	return time.Duration(float64(networkFaultBaseRetryTime) * math.Pow(backoffFactor, float64(totalRetries-1)))
 }
 
-// BackupCAPI takes backup of management cluster's resources during uograde process.
+// BackupCAPI takes backup of management cluster's resources during the upgrade process.
 func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error {
 	// Network errors, most commonly connection refused or timeout, can occur if either source
 	// cluster becomes inaccessible during the move operation.  If this occurs without retries, clusterctl
@@ -306,7 +318,18 @@ func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster,
 	// Keeping clusterctlMoveTimeout to the same as MoveManagement since both uses the same command with the differrent params.
 
 	r := retrier.New(c.clusterctlMoveTimeout, retrier.WithRetryPolicy(clusterctlMoveRetryPolicy))
-	err := r.Retry(func() error {
+	return c.backupCAPI(ctx, cluster, managementStatePath, clusterName, r)
+}
+
+// BackupCAPIWaitForInfrastructure takes backup of bootstrap cluster's resources during the upgrade process
+// like BackupCAPI but with a retry policy to wait for infrastructure provisioning in addition to network errors.
+func (c *ClusterManager) BackupCAPIWaitForInfrastructure(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error {
+	r := retrier.New(c.clusterctlMoveTimeout, retrier.WithRetryPolicy(clusterctlMoveWaitForInfrastructureRetryPolicy))
+	return c.backupCAPI(ctx, cluster, managementStatePath, clusterName, r)
+}
+
+func (c *ClusterManager) backupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string, retrier *retrier.Retrier) error {
+	err := retrier.Retry(func() error {
 		return c.clusterClient.BackupManagement(ctx, cluster, managementStatePath, clusterName)
 	})
 	if err != nil {

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1343,11 +1343,24 @@ func TestClusterManagerBackupCAPIRetrySuccess(t *testing.T) {
 	}
 }
 
+func TestClusterManagerBackupCAPIWaitForInfrastructureSuccess(t *testing.T) {
+	from := &types.Cluster{
+		Name: "from-cluster",
+	}
+
+	ctx := context.Background()
+
+	c, m := newClusterManager(t)
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name)
+
+	if err := c.BackupCAPIWaitForInfrastructure(ctx, from, managementStatePath, from.Name); err != nil {
+		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
+	}
+}
+
 func TestClusterctlWaitRetryPolicy(t *testing.T) {
 	connectionRefusedError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:53733/api?timeout=30s\": dial tcp 127.0.0.1:53733: connect: connection refused")
 	ioTimeoutError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": net/http: TLS handshake timeout")
-	infrastructureError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while cluster is still provisioning the infrastructure")
-	nodeError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while machine is still provisioning the node")
 	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
 
 	_, wait := clustermanager.ClusterctlMoveRetryPolicy(1, connectionRefusedError)
@@ -1370,17 +1383,50 @@ func TestClusterctlWaitRetryPolicy(t *testing.T) {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
 	}
 
-	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, infrastructureError)
+	retry, _ := clustermanager.ClusterctlMoveRetryPolicy(1, miscellaneousError)
+	if retry != false {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't not-retry on non-network error")
+	}
+}
+
+func TestClusterctlWaitForInfrastructureRetryPolicy(t *testing.T) {
+	connectionRefusedError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:53733/api?timeout=30s\": dial tcp 127.0.0.1:53733: connect: connection refused")
+	ioTimeoutError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": net/http: TLS handshake timeout")
+	infrastructureError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while cluster is still provisioning the infrastructure")
+	nodeError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while machine is still provisioning the node")
+	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
+
+	_, wait := clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, connectionRefusedError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for connection refused")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(-1, connectionRefusedError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly protect for total retries < 0")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(2, connectionRefusedError)
+	if wait != 15*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly protect for second retry wait")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, ioTimeoutError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, infrastructureError)
 	if wait != 10*time.Second {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for infrastructureError")
 	}
 
-	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, nodeError)
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, nodeError)
 	if wait != 10*time.Second {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for nodeError")
 	}
 
-	retry, _ := clustermanager.ClusterctlMoveRetryPolicy(1, miscellaneousError)
+	retry, _ := clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, miscellaneousError)
 	if retry != false {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't not-retry on non-network error")
 	}

--- a/pkg/clustermanager/cluster_manager_wb_test.go
+++ b/pkg/clustermanager/cluster_manager_wb_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 var ClusterctlMoveRetryPolicy = clusterctlMoveRetryPolicy
+var ClusterctlMoveWaitForInfrastructureRetryPolicy = clusterctlMoveWaitForInfrastructureRetryPolicy
 
 func TestClusterManager_totalTimeoutForMachinesReadyWait(t *testing.T) {
 	tests := []struct {

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -225,7 +224,6 @@ func TestClusterctlBackupManagement(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
-		setup        func(*testing.T, *clusterctlTest)
 		wantMoveArgs []interface{}
 	}{
 		{
@@ -234,46 +232,21 @@ func TestClusterctlBackupManagement(t *testing.T) {
 				Name:           clusterName,
 				KubeconfigFile: "cluster.kubeconfig",
 			},
-			setup: func(t *testing.T, clusterTest *clusterctlTest) {
-				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
-				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
-			},
+			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName},
 		},
 		{
 			testName: "no kubeconfig file",
 			cluster: &types.Cluster{
 				Name: clusterName,
 			},
-			setup: func(t *testing.T, clusterTest *clusterctlTest) {
-				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
-				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
-			},
-		},
-		{
-			testName: "existing backup",
-			cluster: &types.Cluster{
-				Name:           clusterName,
-				KubeconfigFile: "cluster.kubeconfig",
-			},
-			setup: func(t *testing.T, clusterTest *clusterctlTest) {
-				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
-				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
-				createTestDirectory(t, existingPath)
-				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
-			},
+			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			tc := newClusterctlTest(t)
-			tc.writer, _ = tc.writer.WithDir(clusterName)
-			tc.clusterctl = executables.NewClusterctl(tc.e, tc.writer, files.NewReader())
-
-			tt.setup(t, tc)
+			tc.e.EXPECT().Execute(tc.ctx, tt.wantMoveArgs...)
 
 			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState, clusterName); err != nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
@@ -284,55 +257,18 @@ func TestClusterctlBackupManagement(t *testing.T) {
 
 func TestClusterctlBackupManagementFailed(t *testing.T) {
 	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
-	clusterName := "cluster"
+	tt := newClusterctlTest(t)
 
-	tests := []struct {
-		testName     string
-		cluster      *types.Cluster
-		setup        func(*testing.T, *clusterctlTest)
-		wantMoveArgs []interface{}
-	}{
-		{
-			testName: "backup failed",
-			cluster: &types.Cluster{
-				Name:           clusterName,
-				KubeconfigFile: "cluster.kubeconfig",
-			},
-			setup: func(t *testing.T, clusterTest *clusterctlTest) {
-				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
-				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...).
-					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
-			},
-		},
-		{
-			testName: "temp backup failed",
-			cluster: &types.Cluster{
-				Name:           clusterName,
-				KubeconfigFile: "cluster.kubeconfig",
-			},
-			setup: func(t *testing.T, clusterTest *clusterctlTest) {
-				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
-				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
-				createTestDirectory(t, existingPath)
-				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...).
-					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
-			},
-		},
+	cluster := &types.Cluster{
+		Name:           "cluster",
+		KubeconfigFile: "cluster.kubeconfig",
 	}
-	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
-			tc := newClusterctlTest(t)
-			tc.writer, _ = tc.writer.WithDir(clusterName)
-			tc.clusterctl = executables.NewClusterctl(tc.e, tc.writer, files.NewReader())
 
-			tt.setup(t, tc)
+	wantMoveArgs := []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", cluster.Name}
 
-			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState, clusterName); err == nil {
-				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
-			}
-		})
+	tt.e.EXPECT().Execute(tt.ctx, wantMoveArgs...).Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+	if err := tt.clusterctl.BackupManagement(tt.ctx, cluster, managementClusterState, cluster.Name); err == nil {
+		t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
 	}
 }
 
@@ -489,64 +425,9 @@ func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).NotTo(Succeed())
 }
 
-func TestReplacePath(t *testing.T) {
-	oldpath := "oldDir"
-	newpath := "newDir"
-
-	tests := []struct {
-		testName    string
-		directories []string
-		wantErr     error
-	}{
-		{
-			testName:    "replace success",
-			directories: []string{"oldDir", "newDir"},
-			wantErr:     nil,
-		},
-		{
-			testName:    "fail temp path",
-			directories: []string{"oldDir", "newDir", "newDir_temp"},
-			wantErr:     errors.New("renaming new path to temp"),
-		},
-		{
-			testName:    "fail old path",
-			directories: []string{"newDir"},
-			wantErr:     errors.New("renaming old path"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
-			g := NewWithT(t)
-			testpath := test.NewDirectory(t)
-
-			for _, dir := range tt.directories {
-				createTestDirectory(t, filepath.Join(testpath, dir))
-			}
-
-			err := executables.ReplacePath(filepath.Join(testpath, oldpath), filepath.Join(testpath, newpath))
-			if tt.wantErr != nil {
-				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr.Error())))
-			} else {
-				g.Expect(err).To(BeNil())
-			}
-		})
-	}
-}
-
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {
 	s.VersionsBundles["1.19"] = versionBundle
 })
-
-func createTestDirectory(t *testing.T, dirpath string) {
-	err := os.MkdirAll(dirpath, os.ModePerm)
-	if err != nil {
-		t.Fatalf("Could not create directory: %s", err)
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dirpath)
-	})
-}
 
 var versionBundle = &cluster.VersionsBundle{
 	KubeDistro: &cluster.KubeDistro{

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -18,6 +18,7 @@ type Bootstrapper interface {
 
 type ClusterManager interface {
 	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
+	BackupCAPIWaitForInfrastructure(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -139,6 +139,20 @@ func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2, arg3 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2, arg3)
 }
 
+// BackupCAPIWaitForInfrastructure mocks base method.
+func (m *MockClusterManager) BackupCAPIWaitForInfrastructure(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackupCAPIWaitForInfrastructure", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BackupCAPIWaitForInfrastructure indicates an expected call of BackupCAPIWaitForInfrastructure.
+func (mr *MockClusterManagerMockRecorder) BackupCAPIWaitForInfrastructure(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPIWaitForInfrastructure", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPIWaitForInfrastructure), arg0, arg1, arg2, arg3)
+}
+
 // CreateAwsIamAuthCaSecret mocks base method.
 func (m *MockClusterManager) CreateAwsIamAuthCaSecret(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -269,7 +269,7 @@ func (c *upgradeTestSetup) expectUpgradeWorkloadToReturn(managementCluster *type
 
 func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath, c.managementCluster.Name),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath, ""),
 		c.clusterManager.EXPECT().PauseCAPIWorkloadClusters(c.ctx, c.managementCluster),
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.managementCluster, c.bootstrapCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
@@ -280,15 +280,22 @@ func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	)
 }
 
-func (c *upgradeTestSetup) expectBackupManagementFromCluster(cluster *types.Cluster) {
+func (c *upgradeTestSetup) expectBackupManagementFromBootstrapCluster(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath, c.managementCluster.Name),
+		c.clusterManager.EXPECT().BackupCAPIWaitForInfrastructure(c.ctx, cluster, gomock.Any(), gomock.Any()),
+	)
+}
+
+func (c *upgradeTestSetup) expectBackupManagementFromBootstrapClusterFailed(cluster *types.Cluster) {
+	gomock.InOrder(
+		c.clusterManager.EXPECT().BackupCAPIWaitForInfrastructure(c.ctx, cluster, gomock.Any(), gomock.Any()).Return(fmt.Errorf("backup management failed")),
 	)
 }
 
 func (c *upgradeTestSetup) expectBackupManagementFromClusterFailed(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath, c.managementCluster.Name).Return(fmt.Errorf("backup management failed")),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, gomock.Any(), gomock.Any()).Return(fmt.Errorf("backup management failed")),
+		c.clusterManager.EXPECT().BackupCAPIWaitForInfrastructure(c.ctx, cluster, gomock.Any(), gomock.Any()).Return(fmt.Errorf("backup management failed")),
 	)
 }
 
@@ -613,7 +620,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test.expectCreateBootstrap()
 	test.expectMoveManagementToBootstrap()
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
-	test.expectBackupManagementFromClusterFailed(test.bootstrapCluster)
+	test.expectBackupManagementFromBootstrapClusterFailed(test.bootstrapCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()
@@ -715,7 +722,7 @@ func TestUpgradeWithCheckpointSecondRunSuccess(t *testing.T) {
 	test.expectCreateBootstrap()
 	test.expectMoveManagementToBootstrap()
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
-	test.expectBackupManagementFromCluster(test.bootstrapCluster)
+	test.expectBackupManagementFromBootstrapCluster(test.bootstrapCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating first workload cluster backup to be best effort. Will first attempt a backup with no cluster filter, then backup with filter if that fails.

Added a check to only take bootstrap cluster backup if bootstrap cluster reference is not nil. Also updated bootstrap backup to not overwrite workload backup and instead write to a separate folder.

*Testing (if applicable):*
unit tests added

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

