### PR TITLE
Fix stalling on upgrade from latest minor release with flux

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -46,7 +46,7 @@ func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *Cluster
 		ObjectMeta: ObjectMeta{
 			Name: clusterName,
 		},
-		Spec: ClusterSpec{
+		Spec: ClusterSpecGenerate{
 			KubernetesVersion: GetClusterDefaultKubernetesVersion(),
 			ClusterNetwork: ClusterNetwork{
 				Pods: Pods{

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -72,6 +72,34 @@ type ClusterSpec struct {
 	MachineHealthCheck *MachineHealthCheck `json:"machineHealthCheck,omitempty"`
 }
 
+// ClusterSpecGenerate is the same as ClusterSpec except for removing the omitempty tag from BundlesRef.
+// TODO: We needed this specifically such that we could generate a yaml with bundlesRef null so that it would
+// not be omitted from the kubeapi-server. There was an issue where the apply ekas yaml resources step when
+// upgrading from the latest minor release with gitps v0.16.2 to v0.17, where the newly added eksaVersion field
+// and the bundlesRef should were both populated in submission to the kubeapi server, though bundlesRef was nil
+// in the initially applied Cluster spec. After addressing that issue, we should clean this up
+// https://github.com/aws/eks-anywhere-internal/issues/1611
+type ClusterSpecGenerate struct {
+	KubernetesVersion             KubernetesVersion              `json:"kubernetesVersion,omitempty"`
+	ControlPlaneConfiguration     ControlPlaneConfiguration      `json:"controlPlaneConfiguration,omitempty"`
+	WorkerNodeGroupConfigurations []WorkerNodeGroupConfiguration `json:"workerNodeGroupConfigurations,omitempty"`
+	DatacenterRef                 Ref                            `json:"datacenterRef,omitempty"`
+	IdentityProviderRefs          []Ref                          `json:"identityProviderRefs,omitempty"`
+	GitOpsRef                     *Ref                           `json:"gitOpsRef,omitempty"`
+	ClusterNetwork                ClusterNetwork                 `json:"clusterNetwork,omitempty"`
+	// +kubebuilder:validation:Optional
+	ExternalEtcdConfiguration   *ExternalEtcdConfiguration   `json:"externalEtcdConfiguration,omitempty"`
+	ProxyConfiguration          *ProxyConfiguration          `json:"proxyConfiguration,omitempty"`
+	RegistryMirrorConfiguration *RegistryMirrorConfiguration `json:"registryMirrorConfiguration,omitempty"`
+	ManagementCluster           ManagementCluster            `json:"managementCluster,omitempty"`
+	PodIAMConfig                *PodIAMConfig                `json:"podIamConfig,omitempty"`
+	Packages                    *PackageConfiguration        `json:"packages,omitempty"`
+	// BundlesRef contains a reference to the Bundles containing the desired dependencies for the cluster.
+	// DEPRECATED: Use EksaVersion instead.
+	BundlesRef  *BundlesRef  `json:"bundlesRef"`
+	EksaVersion *EksaVersion `json:"eksaVersion,omitempty"`
+}
+
 // EksaVersion is the semver identifying the release of eks-a used to populate the cluster components.
 type EksaVersion string
 
@@ -1256,7 +1284,7 @@ type ClusterGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
 
-	Spec ClusterSpec `json:"spec,omitempty"`
+	Spec ClusterSpecGenerate `json:"spec,omitempty"`
 }
 
 func (c *Cluster) Kind() string {
@@ -1417,7 +1445,23 @@ func (c *Cluster) ConvertConfigToConfigGenerateStruct() *ClusterGenerate {
 			Annotations: c.Annotations,
 			Namespace:   namespace,
 		},
-		Spec: c.Spec,
+		Spec: ClusterSpecGenerate{
+			KubernetesVersion:             c.Spec.KubernetesVersion,
+			ControlPlaneConfiguration:     c.Spec.ControlPlaneConfiguration,
+			WorkerNodeGroupConfigurations: c.Spec.WorkerNodeGroupConfigurations,
+			DatacenterRef:                 c.Spec.DatacenterRef,
+			IdentityProviderRefs:          c.Spec.IdentityProviderRefs,
+			GitOpsRef:                     c.Spec.GitOpsRef,
+			ClusterNetwork:                c.Spec.ClusterNetwork,
+			ExternalEtcdConfiguration:     c.Spec.ExternalEtcdConfiguration,
+			ProxyConfiguration:            c.Spec.ProxyConfiguration,
+			RegistryMirrorConfiguration:   c.Spec.RegistryMirrorConfiguration,
+			ManagementCluster:             c.Spec.ManagementCluster,
+			PodIAMConfig:                  c.Spec.PodIAMConfig,
+			Packages:                      c.Spec.Packages,
+			BundlesRef:                    c.Spec.BundlesRef,
+			EksaVersion:                   c.Spec.EksaVersion,
+		},
 	}
 
 	return config

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
@@ -3089,4 +3090,39 @@ func TestKubernetesVersions(t *testing.T) {
 	cluster.Spec.WorkerNodeGroupConfigurations = append(cluster.Spec.WorkerNodeGroupConfigurations, *wng)
 	expected := []v1alpha1.KubernetesVersion{v1alpha1.Kube121, v1alpha1.Kube120}
 	g.Expect(cluster.KubernetesVersions()).To(Equal(expected))
+}
+
+func TestCluster_ConvertConfigToConfigGenerateStruct(t *testing.T) {
+	g := NewWithT(t)
+	testCluster := newCluster(func(c *v1alpha1.Cluster) {
+		c.Namespace = constants.EksaSystemNamespace
+	})
+	wantClusterGenerate := &v1alpha1.ClusterGenerate{
+		TypeMeta: testCluster.TypeMeta,
+		ObjectMeta: v1alpha1.ObjectMeta{
+			Name:        testCluster.Name,
+			Annotations: testCluster.Annotations,
+			Namespace:   testCluster.Namespace,
+		},
+		Spec: v1alpha1.ClusterSpecGenerate{
+			KubernetesVersion:             testCluster.Spec.KubernetesVersion,
+			ControlPlaneConfiguration:     testCluster.Spec.ControlPlaneConfiguration,
+			WorkerNodeGroupConfigurations: testCluster.Spec.WorkerNodeGroupConfigurations,
+			DatacenterRef:                 testCluster.Spec.DatacenterRef,
+			IdentityProviderRefs:          testCluster.Spec.IdentityProviderRefs,
+			GitOpsRef:                     testCluster.Spec.GitOpsRef,
+			ClusterNetwork:                testCluster.Spec.ClusterNetwork,
+			ExternalEtcdConfiguration:     testCluster.Spec.ExternalEtcdConfiguration,
+			ProxyConfiguration:            testCluster.Spec.ProxyConfiguration,
+			RegistryMirrorConfiguration:   testCluster.Spec.RegistryMirrorConfiguration,
+			ManagementCluster:             testCluster.Spec.ManagementCluster,
+			PodIAMConfig:                  testCluster.Spec.PodIAMConfig,
+			Packages:                      testCluster.Spec.Packages,
+			BundlesRef:                    testCluster.Spec.BundlesRef,
+			EksaVersion:                   testCluster.Spec.EksaVersion,
+		},
+	}
+
+	got := testCluster.ConvertConfigToConfigGenerateStruct()
+	g.Expect(got).To(Equal(wantClusterGenerate))
 }

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mycluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mycluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mycluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
@@ -4,6 +4,7 @@ metadata:
   name: testcluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/gitops/flux/files_test.go
+++ b/pkg/gitops/flux/files_test.go
@@ -23,6 +23,7 @@ metadata:
   name: test-cluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-default-path-management.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-default-path-management.yaml
@@ -4,6 +4,7 @@ metadata:
   name: management-cluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-default-path-workload.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-default-path-workload.yaml
@@ -6,6 +6,7 @@ metadata:
   name: workload-cluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-user-provided-path.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-user-provided-path.yaml
@@ -4,6 +4,7 @@ metadata:
   name: management-cluster
   namespace: default
 spec:
+  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a `ClusterSpecGenerate` struct when marshalling the cluster spec. We needed this specifically such that we could generate a yaml with bundlesRef null so that it would
not be omitted from the kubeapi-server.

There was an issue when upgrading from the latest minor release with gitps v0.16.2 to v0.17 during the "Applying eksa yaml resources to cluster" step stalled indefinitely because both the newly added eksaVersion field and the bundlesRef were populated in submission to the kubeapi server. There is a webhook validation that does not allow both to be set at the same time, so that was throwing an error in the kube-api-server pod. This is strange because, in the original submission of the Cluster resource yaml, bundlesRef was nil. As a result of using the force apply for this operation, it was attempting to delete the eksa Cluster resource and stalled on that operation.

This solution is a temporary patch for the issue. After addressing, we should clean this up.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

