### PR TITLE
Make OS Image URL mutable for Tinkerbell

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
@@ -34,13 +34,13 @@ func TestTinkerbellDatacenterValidateUpdateSucceed(t *testing.T) {
 	g.Expect(tNew.ValidateUpdate(&tOld)).To(Succeed())
 }
 
-func TestTinkerbellDatacenterValidateUpdateFailOSImageURL(t *testing.T) {
+func TestTinkerbellDatacenterValidateUpdateSucceedOSImageURL(t *testing.T) {
 	tOld := tinkerbellDatacenterConfig()
 	tNew := tOld.DeepCopy()
 
-	tNew.Spec.OSImageURL = "test"
+	tNew.Spec.OSImageURL = "https://os-image-url"
 	g := NewWithT(t)
-	g.Expect(tNew.ValidateUpdate(&tOld)).ToNot(Succeed())
+	g.Expect(tNew.ValidateUpdate(&tOld)).To(Succeed())
 }
 
 func TestTinkerbellDatacenterValidateUpdateFailBadReq(t *testing.T) {

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -262,11 +262,8 @@ func (p *Provider) ValidateNewSpec(ctx context.Context, cluster *types.Cluster, 
 		return fmt.Errorf("spec.TinkerbellIP is immutable. Previous value %s,   New value %s", oSpec.TinkerbellIP, nSpec.TinkerbellIP)
 	}
 
-	// for any operation other than k8s version change, osImageURL and hookImageURL are immutable
+	// for any operation other than k8s version change, hookImageURL is immutable
 	if prevSpec.Spec.KubernetesVersion == clusterSpec.Cluster.Spec.KubernetesVersion {
-		if nSpec.OSImageURL != oSpec.OSImageURL {
-			return fmt.Errorf("spec.OSImageURL is immutable. Previous value %s,   New value %s", oSpec.OSImageURL, nSpec.OSImageURL)
-		}
 		if nSpec.HookImagesURLPath != oSpec.HookImagesURLPath {
 			return fmt.Errorf("spec.HookImagesURLPath is immutable. Previous value %s,   New value %s", oSpec.HookImagesURLPath, nSpec.HookImagesURLPath)
 		}

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -207,7 +207,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 			},
 		},
 		{
-			name:               "ValidationOSImageURLImmutable",
+			name:               "ValidationOSImageURLMutable",
 			clusterVersion:     "v1.19.16-eks-1-19-4",
 			upgradeVersion:     "1.19",
 			getClusterResponse: goodClusterResponse,
@@ -215,7 +215,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("spec.OSImageURL is immutable. Previous value http://old-os-image-url,   New value http://os-image-url"),
+			wantErr:            nil,
 			modifyDatacenterFunc: func(s *anywherev1.TinkerbellDatacenterConfig) {
 				s.Spec.OSImageURL = "http://old-os-image-url"
 			},

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -179,7 +179,7 @@ func TestTinkerbellKubernetes126To127Ubuntu2204Upgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube127,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes126Image()),
+		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes127Image()),
 	)
 }
 
@@ -217,7 +217,7 @@ func TestTinkerbellKubernetes127Ubuntu2004To2204Upgrade(t *testing.T) {
 	)
 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
 		test,
-		v1alpha1.Kube126,
+		v1alpha1.Kube127,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes127Image()),
 	)


### PR DESCRIPTION
Make OS Image URL mutable to support upgrading OS version without upgrading Kubernetes version.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

