### PR TITLE
Update custom CNI docs with specific Cilium CLI version

### DIFF
--- a/docs/content/en/docs/clustermgmt/networking/cluster-replace-cilium.md
+++ b/docs/content/en/docs/clustermgmt/networking/cluster-replace-cilium.md
@@ -16,7 +16,7 @@ When replacing EKS Anywhere Cilium with a custom CNI, it is your responsibility 
 ## Prerequisites
 
 * EKS Anywhere v0.15+.
-* A recent version of [Cilium CLI](https://github.com/cilium/cilium-cli).
+* [Cilium CLI](https://github.com/cilium/cilium-cli) v1.14.
 
 ## Add a custom CNI to a new cluster
 


### PR DESCRIPTION
Fixes #6337.

Cilium CLI v1.14 works with Cilium v1.11 through 1.13. CLI v1.15 only works with Cilium v1.14. See the README for more details.

https://github.com/cilium/cilium-cli