### PR TITLE
Fix incorrect kubernetes version in tinkerbell E2E

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1377,7 +1377,7 @@ func TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleDown(t *testi
 	)
 	runSimpleWorkloadUpgradeFlowForBareMetal(
 		test,
-		v1alpha1.Kube126,
+		v1alpha1.Kube127,
 		framework.WithClusterUpgrade(
 			api.WithKubernetesVersion(v1alpha1.Kube127),
 			api.WithWorkerNodeCount(1),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes incorrect kubernetes version on `TestTinkerbellUpgrade127MulticlusterWorkloadClusterWorkerScaleDown` 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


