### PR TITLE
Increase end to end test timeout 

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -29,7 +29,7 @@ const (
 	tinkerbellIPPoolSize = 2
 
 	// Default timeout for E2E test instance.
-	e2eTimeout           = 120 * time.Minute
+	e2eTimeout           = 150 * time.Minute
 	e2eSSMTimeoutPadding = 10 * time.Minute
 
 	// Default timeout used for all SSM commands besides running the actual E2E test.


### PR DESCRIPTION
Bump E2E test timeout from 120 to 150 mins to prevent Tinkerbell airgapped E2E tests from timing out. 

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

