### PR TITLE
Fix upgrade from latest E2Es to use proper EksaVersion and bundesRef.

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -46,6 +46,13 @@ func WithBundlesRef(name string, namespace string, apiVersion string) ClusterFil
 	}
 }
 
+// WithEksaVersion sets EksaVersion with the provided name to use.
+func WithEksaVersion(eksaVersion *anywherev1.EksaVersion) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		c.Spec.EksaVersion = eksaVersion
+	}
+}
+
 func WithCiliumPolicyEnforcementMode(mode anywherev1.CiliumPolicyEnforcementMode) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		if c.Spec.ClusterNetwork.CNIConfig == nil {

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -88,7 +88,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 		wc.UpdateClusterConfig(
 			api.JoinClusterConfigFillers(upgradeChanges),
 			api.ClusterToConfigFiller(
-				api.WithBundlesRef(cluster.Spec.BundlesRef.Name, cluster.Spec.BundlesRef.Namespace, cluster.Spec.BundlesRef.APIVersion),
+				api.WithEksaVersion(cluster.Spec.EksaVersion),
 			),
 		)
 		wc.ApplyClusterManifest()
@@ -104,6 +104,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 		wc.UpdateClusterConfig(
 			api.ClusterToConfigFiller(
 				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
+				api.WithEksaVersion(nil),
 			),
 		)
 		wc.ApplyClusterManifest()
@@ -141,7 +142,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 		test.PushWorkloadClusterToGit(wc,
 			api.JoinClusterConfigFillers(upgradeChanges),
 			api.ClusterToConfigFiller(
-				api.WithBundlesRef(cluster.Spec.BundlesRef.Name, cluster.Spec.BundlesRef.Namespace, cluster.Spec.BundlesRef.APIVersion),
+				api.WithEksaVersion(cluster.Spec.EksaVersion),
 			),
 		)
 
@@ -155,6 +156,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 		test.PushWorkloadClusterToGit(wc,
 			api.ClusterToConfigFiller(
 				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
+				api.WithEksaVersion(nil),
 			),
 		)
 		wc.WaitForKubeconfig()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes the `runMulticlusterUpgradeFromReleaseFlowAPI` and `runMulticlusterUpgradeFromReleaseFlowAPIWithFlux` test flows to use eksaVersion once mgmt upgrades to latest, and bundlesRef when creating a workload cluster with old bundle.

This will fix `TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI`

*Testing (if applicable):*
--- PASS: TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

