### PR TITLE
[release-0.16] Add CAPI backup from bootstrap cluster + filter-cluster flags for backups

### DIFF
--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -118,6 +118,17 @@ func NewWriter(t *testing.T) (dir string, writer filewriter.FileWriter) {
 	return dir, writer
 }
 
+// NewDirectory creates new test directory with cleanup.
+func NewDirectory(t *testing.T) (dir string) {
+	dir, err := os.MkdirTemp(".", SanitizePath(t.Name())+"-")
+	if err != nil {
+		t.Fatalf("error setting up folder for test: %v", err)
+	}
+
+	t.Cleanup(cleanupDir(t, dir))
+	return dir
+}
+
 func cleanupDir(t *testing.T, dir string) func() {
 	return func() {
 		if !t.Failed() {

--- a/internal/test/files.go
+++ b/internal/test/files.go
@@ -118,17 +118,6 @@ func NewWriter(t *testing.T) (dir string, writer filewriter.FileWriter) {
 	return dir, writer
 }
 
-// NewDirectory creates new test directory with cleanup.
-func NewDirectory(t *testing.T) (dir string) {
-	dir, err := os.MkdirTemp(".", SanitizePath(t.Name())+"-")
-	if err != nil {
-		t.Fatalf("error setting up folder for test: %v", err)
-	}
-
-	t.Cleanup(cleanupDir(t, dir))
-	return dir
-}
-
 func cleanupDir(t *testing.T, dir string) func() {
 	return func() {
 		if !t.Failed() {

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -70,9 +70,9 @@ const (
 )
 
 var (
-	clusterctlNetworkErrorRegex = regexp.MustCompile(`.*failed to connect to the management cluster:.*`)
-	clusterctlMoveErrorRegex    = regexp.MustCompile(`.*cannot start the move operation while.*`)
-	eksaClusterResourceType     = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
+	clusterctlNetworkErrorRegex              = regexp.MustCompile(`.*failed to connect to the management cluster:.*`)
+	clusterctlMoveProvisionedInfraErrorRegex = regexp.MustCompile(`.*failed to check for provisioned infrastructure*`)
+	eksaClusterResourceType                  = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 )
 
 type ClusterManager struct {
@@ -273,7 +273,7 @@ func WithNoTimeouts() ClusterManagerOpt {
 
 func clusterctlMoveWaitForInfrastructureRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
 	// Retry both network and cluster move errors.
-	if match := (clusterctlNetworkErrorRegex.MatchString(err.Error()) || clusterctlMoveErrorRegex.MatchString(err.Error())); match {
+	if match := (clusterctlNetworkErrorRegex.MatchString(err.Error()) || clusterctlMoveProvisionedInfraErrorRegex.MatchString(err.Error())); match {
 		return true, clusterctlMoveRetryWaitTime(totalRetries)
 	}
 	return false, 0

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -99,7 +99,7 @@ type ClusterManager struct {
 
 type ClusterClient interface {
 	KubernetesClient
-	BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
+	BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveManagement(ctx context.Context, from, target *types.Cluster, clusterName string) error
 	WaitForClusterReady(ctx context.Context, cluster *types.Cluster, timeout string, clusterName string) error
 	WaitForControlPlaneAvailable(ctx context.Context, cluster *types.Cluster, timeout string, newClusterName string) error
@@ -290,7 +290,7 @@ func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait ti
 }
 
 // BackupCAPI takes backup of management cluster's resources during uograde process.
-func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error {
+func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error {
 	// Network errors, most commonly connection refused or timeout, can occur if either source
 	// cluster becomes inaccessible during the move operation.  If this occurs without retries, clusterctl
 	// abandons the move operation, and fails cluster upgrade.
@@ -301,7 +301,7 @@ func (c *ClusterManager) BackupCAPI(ctx context.Context, cluster *types.Cluster,
 
 	r := retrier.New(c.clusterctlMoveTimeout, retrier.WithRetryPolicy(clusterctlMoveRetryPolicy))
 	err := r.Retry(func() error {
-		return c.clusterClient.BackupManagement(ctx, cluster, managementStatePath)
+		return c.clusterClient.BackupManagement(ctx, cluster, managementStatePath, clusterName)
 	})
 	if err != nil {
 		return fmt.Errorf("backing up CAPI resources of management cluster before moving to bootstrap cluster: %v", err)

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1487,6 +1487,8 @@ func TestClusterManagerBackupCAPIRetrySuccess(t *testing.T) {
 func TestClusterctlWaitRetryPolicy(t *testing.T) {
 	connectionRefusedError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:53733/api?timeout=30s\": dial tcp 127.0.0.1:53733: connect: connection refused")
 	ioTimeoutError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": net/http: TLS handshake timeout")
+	infrastructureError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while cluster is still provisioning the infrastructure")
+	nodeError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while machine is still provisioning the node")
 	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
 
 	_, wait := clustermanager.ClusterctlMoveRetryPolicy(1, connectionRefusedError)
@@ -1507,6 +1509,16 @@ func TestClusterctlWaitRetryPolicy(t *testing.T) {
 	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, ioTimeoutError)
 	if wait != 10*time.Second {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, infrastructureError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for infrastructureError")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, nodeError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for nodeError")
 	}
 
 	retry, _ := clustermanager.ClusterctlMoveRetryPolicy(1, miscellaneousError)

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1457,9 +1457,9 @@ func TestClusterManagerBackupCAPISuccess(t *testing.T) {
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
-	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath)
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name)
 
-	if err := c.BackupCAPI(ctx, from, managementStatePath); err != nil {
+	if err := c.BackupCAPI(ctx, from, managementStatePath, from.Name); err != nil {
 		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }
@@ -1473,13 +1473,13 @@ func TestClusterManagerBackupCAPIRetrySuccess(t *testing.T) {
 
 	c, m := newClusterManager(t)
 	// m.client.EXPECT().BackupManagement(ctx, from, managementStatePath)
-	firstTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(errors.New("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": EOF"))
-	secondTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(nil)
+	firstTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name).Return(errors.New("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": EOF"))
+	secondTry := m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name).Return(nil)
 	gomock.InOrder(
 		firstTry,
 		secondTry,
 	)
-	if err := c.BackupCAPI(ctx, from, managementStatePath); err != nil {
+	if err := c.BackupCAPI(ctx, from, managementStatePath, from.Name); err != nil {
 		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }
@@ -1528,14 +1528,16 @@ func TestClusterctlWaitRetryPolicy(t *testing.T) {
 }
 
 func TestClusterManagerBackupCAPIError(t *testing.T) {
-	from := &types.Cluster{}
+	from := &types.Cluster{
+		Name: "from-cluster",
+	}
 
 	ctx := context.Background()
 
 	c, m := newClusterManager(t)
-	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath).Return(errors.New("backing up CAPI resources"))
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name).Return(errors.New("backing up CAPI resources"))
 
-	if err := c.BackupCAPI(ctx, from, managementStatePath); err == nil {
+	if err := c.BackupCAPI(ctx, from, managementStatePath, from.Name); err == nil {
 		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
 	}
 }

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1484,11 +1484,24 @@ func TestClusterManagerBackupCAPIRetrySuccess(t *testing.T) {
 	}
 }
 
+func TestClusterManagerBackupCAPIWaitForInfrastructureSuccess(t *testing.T) {
+	from := &types.Cluster{
+		Name: "from-cluster",
+	}
+
+	ctx := context.Background()
+
+	c, m := newClusterManager(t)
+	m.client.EXPECT().BackupManagement(ctx, from, managementStatePath, from.Name)
+
+	if err := c.BackupCAPIWaitForInfrastructure(ctx, from, managementStatePath, from.Name); err != nil {
+		t.Errorf("ClusterManager.BackupCAPI() error = %v, wantErr nil", err)
+	}
+}
+
 func TestClusterctlWaitRetryPolicy(t *testing.T) {
 	connectionRefusedError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:53733/api?timeout=30s\": dial tcp 127.0.0.1:53733: connect: connection refused")
 	ioTimeoutError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": net/http: TLS handshake timeout")
-	infrastructureError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while cluster is still provisioning the infrastructure")
-	nodeError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while machine is still provisioning the node")
 	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
 
 	_, wait := clustermanager.ClusterctlMoveRetryPolicy(1, connectionRefusedError)
@@ -1511,17 +1524,50 @@ func TestClusterctlWaitRetryPolicy(t *testing.T) {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
 	}
 
-	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, infrastructureError)
+	retry, _ := clustermanager.ClusterctlMoveRetryPolicy(1, miscellaneousError)
+	if retry != false {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't not-retry on non-network error")
+	}
+}
+
+func TestClusterctlWaitForInfrastructureRetryPolicy(t *testing.T) {
+	connectionRefusedError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:53733/api?timeout=30s\": dial tcp 127.0.0.1:53733: connect: connection refused")
+	ioTimeoutError := fmt.Errorf("Error: failed to connect to the management cluster: action failed after 9 attempts: Get \"https://127.0.0.1:61994/api?timeout=30s\": net/http: TLS handshake timeout")
+	infrastructureError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while cluster is still provisioning the infrastructure")
+	nodeError := fmt.Errorf("Error: failed to get object graph: failed to check for provisioned infrastructure: cannot start the move operation while machine is still provisioning the node")
+	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
+
+	_, wait := clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, connectionRefusedError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for connection refused")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(-1, connectionRefusedError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly protect for total retries < 0")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(2, connectionRefusedError)
+	if wait != 15*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly protect for second retry wait")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, ioTimeoutError)
+	if wait != 10*time.Second {
+		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
+	}
+
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, infrastructureError)
 	if wait != 10*time.Second {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for infrastructureError")
 	}
 
-	_, wait = clustermanager.ClusterctlMoveRetryPolicy(1, nodeError)
+	_, wait = clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, nodeError)
 	if wait != 10*time.Second {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't correctly calculate first retry wait for nodeError")
 	}
 
-	retry, _ := clustermanager.ClusterctlMoveRetryPolicy(1, miscellaneousError)
+	retry, _ := clustermanager.ClusterctlMoveWaitForInfrastructureRetryPolicy(1, miscellaneousError)
 	if retry != false {
 		t.Errorf("ClusterctlMoveRetryPolicy didn't not-retry on non-network error")
 	}

--- a/pkg/clustermanager/cluster_manager_wb_test.go
+++ b/pkg/clustermanager/cluster_manager_wb_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 var ClusterctlMoveRetryPolicy = clusterctlMoveRetryPolicy
+var ClusterctlMoveWaitForInfrastructureRetryPolicy = clusterctlMoveWaitForInfrastructureRetryPolicy
 
 func TestClusterManager_totalTimeoutForMachinesReadyWait(t *testing.T) {
 	tests := []struct {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -104,17 +104,17 @@ func (mr *MockClusterClientMockRecorder) ApplyKubeSpecFromBytesWithNamespace(arg
 }
 
 // BackupManagement mocks base method.
-func (m *MockClusterClient) BackupManagement(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+func (m *MockClusterClient) BackupManagement(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupManagement", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "BackupManagement", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BackupManagement indicates an expected call of BackupManagement.
-func (mr *MockClusterClientMockRecorder) BackupManagement(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) BackupManagement(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupManagement", reflect.TypeOf((*MockClusterClient)(nil).BackupManagement), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupManagement", reflect.TypeOf((*MockClusterClient)(nil).BackupManagement), arg0, arg1, arg2, arg3)
 }
 
 // CountMachineDeploymentReplicasReady mocks base method.

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -224,6 +225,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 	tests := []struct {
 		testName     string
 		cluster      *types.Cluster
+		setup        func(*testing.T, *clusterctlTest)
 		wantMoveArgs []interface{}
 	}{
 		{
@@ -232,21 +234,46 @@ func TestClusterctlBackupManagement(t *testing.T) {
 				Name:           clusterName,
 				KubeconfigFile: "cluster.kubeconfig",
 			},
-			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+			},
 		},
 		{
 			testName: "no kubeconfig file",
 			cluster: &types.Cluster{
 				Name: clusterName,
 			},
-			wantMoveArgs: []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", clusterName, managementClusterState), "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace}...)
+			},
+		},
+		{
+			testName: "existing backup",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
+				createTestDirectory(t, existingPath)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			tc := newClusterctlTest(t)
-			tc.e.EXPECT().Execute(tc.ctx, tt.wantMoveArgs...)
+			tc.writer, _ = tc.writer.WithDir(clusterName)
+			tc.clusterctl = executables.NewClusterctl(tc.e, tc.writer, files.NewReader())
+
+			tt.setup(t, tc)
 
 			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err != nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
@@ -257,18 +284,55 @@ func TestClusterctlBackupManagement(t *testing.T) {
 
 func TestClusterctlBackupManagementFailed(t *testing.T) {
 	managementClusterState := fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
-	tt := newClusterctlTest(t)
+	clusterName := "cluster"
 
-	cluster := &types.Cluster{
-		Name:           "cluster",
-		KubeconfigFile: "cluster.kubeconfig",
+	tests := []struct {
+		testName     string
+		cluster      *types.Cluster
+		setup        func(*testing.T, *clusterctlTest)
+		wantMoveArgs []interface{}
+	}{
+		{
+			testName: "backup failed",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+			},
+		},
+		{
+			testName: "temp backup failed",
+			cluster: &types.Cluster{
+				Name:           clusterName,
+				KubeconfigFile: "cluster.kubeconfig",
+			},
+			setup: func(t *testing.T, clusterTest *clusterctlTest) {
+				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
+				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
+				createTestDirectory(t, existingPath)
+				clusterTest.e.EXPECT().
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
+			},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			tc := newClusterctlTest(t)
+			tc.writer, _ = tc.writer.WithDir(clusterName)
+			tc.clusterctl = executables.NewClusterctl(tc.e, tc.writer, files.NewReader())
 
-	wantMoveArgs := []interface{}{"move", "--to-directory", fmt.Sprintf("%s/%s", cluster.Name, managementClusterState), "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}
+			tt.setup(t, tc)
 
-	tt.e.EXPECT().Execute(tt.ctx, wantMoveArgs...).Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
-	if err := tt.clusterctl.BackupManagement(tt.ctx, cluster, managementClusterState); err == nil {
-		t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err == nil {
+				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
+			}
+		})
 	}
 }
 
@@ -425,9 +489,64 @@ func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).NotTo(Succeed())
 }
 
+func TestReplacePath(t *testing.T) {
+	oldpath := "oldDir"
+	newpath := "newDir"
+
+	tests := []struct {
+		testName    string
+		directories []string
+		wantErr     error
+	}{
+		{
+			testName:    "replace success",
+			directories: []string{"oldDir", "newDir"},
+			wantErr:     nil,
+		},
+		{
+			testName:    "fail temp path",
+			directories: []string{"oldDir", "newDir", "newDir_temp"},
+			wantErr:     errors.New("renaming new path to temp"),
+		},
+		{
+			testName:    "fail old path",
+			directories: []string{"newDir"},
+			wantErr:     errors.New("renaming old path"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+			testpath := test.NewDirectory(t)
+
+			for _, dir := range tt.directories {
+				createTestDirectory(t, filepath.Join(testpath, dir))
+			}
+
+			err := executables.ReplacePath(filepath.Join(testpath, oldpath), filepath.Join(testpath, newpath))
+			if tt.wantErr != nil {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr.Error())))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}
+
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {
 	s.VersionsBundle = versionBundle
 })
+
+func createTestDirectory(t *testing.T, dirpath string) {
+	err := os.MkdirAll(dirpath, os.ModePerm)
+	if err != nil {
+		t.Fatalf("Could not create directory: %s", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(dirpath)
+	})
+}
 
 var versionBundle = &cluster.VersionsBundle{
 	KubeDistro: &cluster.KubeDistro{

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -237,7 +237,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 			setup: func(t *testing.T, clusterTest *clusterctlTest) {
 				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 			setup: func(t *testing.T, clusterTest *clusterctlTest) {
 				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace}...)
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
 				createTestDirectory(t, existingPath)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...)
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...)
 			},
 		},
 	}
@@ -275,7 +275,7 @@ func TestClusterctlBackupManagement(t *testing.T) {
 
 			tt.setup(t, tc)
 
-			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err != nil {
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState, clusterName); err != nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
 			}
 		})
@@ -301,7 +301,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 			setup: func(t *testing.T, clusterTest *clusterctlTest) {
 				existingPath := filepath.Join(clusterTest.writer.Dir(), managementClusterState)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", existingPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...).
 					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
 			},
 		},
@@ -316,7 +316,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 				tempPath := filepath.Join(clusterTest.writer.TempDir(), managementClusterState)
 				createTestDirectory(t, existingPath)
 				clusterTest.e.EXPECT().
-					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace}...).
+					Execute(clusterTest.ctx, []interface{}{"move", "--to-directory", tempPath, "--kubeconfig", "cluster.kubeconfig", "--namespace", constants.EksaSystemNamespace, "--filter-cluster", clusterName}...).
 					Return(bytes.Buffer{}, fmt.Errorf("error backing up management cluster resources"))
 			},
 		},
@@ -329,7 +329,7 @@ func TestClusterctlBackupManagementFailed(t *testing.T) {
 
 			tt.setup(t, tc)
 
-			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState); err == nil {
+			if err := tc.clusterctl.BackupManagement(tc.ctx, tt.cluster, managementClusterState, clusterName); err == nil {
 				t.Fatalf("Clusterctl.BackupManagement() error = %v, want nil", err)
 			}
 		})

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -18,6 +18,7 @@ type Bootstrapper interface {
 
 type ClusterManager interface {
 	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
+	BackupCAPIWaitForInfrastructure(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -17,7 +17,7 @@ type Bootstrapper interface {
 }
 
 type ClusterManager interface {
-	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath string) error
+	BackupCAPI(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error
 	CreateWorkloadCluster(ctx context.Context, managementCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) (*types.Cluster, error)
 	PauseCAPIWorkloadClusters(ctx context.Context, managementCluster *types.Cluster) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -112,17 +112,17 @@ func (mr *MockClusterManagerMockRecorder) ApplyBundles(arg0, arg1, arg2 interfac
 }
 
 // BackupCAPI mocks base method.
-func (m *MockClusterManager) BackupCAPI(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
+func (m *MockClusterManager) BackupCAPI(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupCAPI", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "BackupCAPI", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BackupCAPI indicates an expected call of BackupCAPI.
-func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2, arg3)
 }
 
 // CreateAwsIamAuthCaSecret mocks base method.

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -125,6 +125,20 @@ func (mr *MockClusterManagerMockRecorder) BackupCAPI(arg0, arg1, arg2, arg3 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPI", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPI), arg0, arg1, arg2, arg3)
 }
 
+// BackupCAPIWaitForInfrastructure mocks base method.
+func (m *MockClusterManager) BackupCAPIWaitForInfrastructure(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackupCAPIWaitForInfrastructure", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BackupCAPIWaitForInfrastructure indicates an expected call of BackupCAPIWaitForInfrastructure.
+func (mr *MockClusterManagerMockRecorder) BackupCAPIWaitForInfrastructure(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCAPIWaitForInfrastructure", reflect.TypeOf((*MockClusterManager)(nil).BackupCAPIWaitForInfrastructure), arg0, arg1, arg2, arg3)
+}
+
 // CreateAwsIamAuthCaSecret mocks base method.
 func (m *MockClusterManager) CreateAwsIamAuthCaSecret(arg0 context.Context, arg1 *types.Cluster, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -460,11 +460,16 @@ func (s *installCAPITask) Restore(ctx context.Context, commandContext *task.Comm
 }
 
 func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	// Take best effort CAPI backup of workload cluster without filter.
+	// If that errors, then take CAPI backup filtering on only workload cluster.
 	logger.Info("Backing up workload cluster's management resources before moving to bootstrap cluster")
-	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
+	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, "")
 	if err != nil {
-		commandContext.SetError(err)
-		return &CollectDiagnosticsTask{}
+		err = commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
+		if err != nil {
+			commandContext.SetError(err)
+			return &CollectDiagnosticsTask{}
+		}
 	}
 
 	logger.V(3).Info("Pausing workload clusters before moving management cluster resources to bootstrap cluster")
@@ -527,10 +532,13 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	err := commandContext.ClusterManager.UpgradeCluster(ctx, commandContext.ManagementCluster, commandContext.WorkloadCluster, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
-		logger.Info("Backing up management components from bootstrap cluster")
-		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.ManagementCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
-		if err != nil {
-			logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
+		// Take backup of bootstrap cluster capi components
+		if commandContext.BootstrapCluster != nil {
+			logger.Info("Backing up management components from bootstrap cluster")
+			err := commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.BootstrapCluster, fmt.Sprintf("bootstrap-%s", commandContext.ManagementClusterStateDir), commandContext.WorkloadCluster.Name)
+			if err != nil {
+				logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
+			}
 		}
 		return &CollectDiagnosticsTask{}
 	}

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -527,6 +527,11 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	err := commandContext.ClusterManager.UpgradeCluster(ctx, commandContext.ManagementCluster, commandContext.WorkloadCluster, commandContext.ClusterSpec, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
+		logger.Info("Backing up management components from bootstrap cluster")
+		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.BootstrapCluster, commandContext.ManagementClusterStateDir)
+		if err != nil {
+			logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
+		}
 		return &CollectDiagnosticsTask{}
 	}
 

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -461,7 +461,7 @@ func (s *installCAPITask) Restore(ctx context.Context, commandContext *task.Comm
 
 func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Backing up workload cluster's management resources before moving to bootstrap cluster")
-	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir)
+	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
@@ -528,7 +528,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 	if err != nil {
 		commandContext.SetError(err)
 		logger.Info("Backing up management components from bootstrap cluster")
-		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.BootstrapCluster, commandContext.ManagementClusterStateDir)
+		err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.ManagementCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
 		if err != nil {
 			logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
 		}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -292,9 +292,15 @@ func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	)
 }
 
-func (c *upgradeTestSetup) expectBackupManagementToBootstrapFailed() {
+func (c *upgradeTestSetup) expectBackupManagementFromCluster(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath),
+	)
+}
+
+func (c *upgradeTestSetup) expectBackupManagementFromClusterFailed(cluster *types.Cluster) {
+	gomock.InOrder(
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
 	)
 }
 
@@ -620,6 +626,7 @@ func TestUpgradeRunFailedUpgrade(t *testing.T) {
 	test.expectMoveManagementToBootstrap()
 	test.expectPrepareUpgradeWorkload(test.bootstrapCluster, test.workloadCluster)
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
+	test.expectBackupManagementFromClusterFailed(test.bootstrapCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()
@@ -643,7 +650,7 @@ func TestUpgradeRunFailedBackupManagementUpgrade(t *testing.T) {
 	test.expectPauseEKSAControllerReconcile(test.workloadCluster)
 	test.expectPauseGitOpsReconcile(test.workloadCluster)
 	test.expectCreateBootstrap()
-	test.expectBackupManagementToBootstrapFailed()
+	test.expectBackupManagementFromClusterFailed(test.managementCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()
@@ -722,6 +729,7 @@ func TestUpgradeWithCheckpointSecondRunSuccess(t *testing.T) {
 	test.expectMoveManagementToBootstrap()
 	test.expectPrepareUpgradeWorkload(test.bootstrapCluster, test.workloadCluster)
 	test.expectUpgradeWorkloadToReturn(test.bootstrapCluster, test.workloadCluster, errors.New("failed upgrading"))
+	test.expectBackupManagementFromCluster(test.bootstrapCluster)
 	test.expectSaveLogs(test.workloadCluster)
 	test.expectWriteCheckpointFile()
 	test.expectPreCoreComponentsUpgrade()

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -281,7 +281,7 @@ func (c *upgradeTestSetup) expectPrepareUpgradeWorkload(managementCluster *types
 
 func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, c.managementCluster, c.managementStatePath, c.managementCluster.Name),
 		c.clusterManager.EXPECT().PauseCAPIWorkloadClusters(c.ctx, c.managementCluster),
 		c.clusterManager.EXPECT().MoveCAPI(
 			c.ctx, c.managementCluster, c.bootstrapCluster, gomock.Any(), c.newClusterSpec, gomock.Any(),
@@ -294,13 +294,13 @@ func (c *upgradeTestSetup) expectMoveManagementToBootstrap() {
 
 func (c *upgradeTestSetup) expectBackupManagementFromCluster(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath, c.managementCluster.Name),
 	)
 }
 
 func (c *upgradeTestSetup) expectBackupManagementFromClusterFailed(cluster *types.Cluster) {
 	gomock.InOrder(
-		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath).Return(fmt.Errorf("backup management failed")),
+		c.clusterManager.EXPECT().BackupCAPI(c.ctx, cluster, c.managementStatePath, c.managementCluster.Name).Return(fmt.Errorf("backup management failed")),
 	)
 }
 


### PR DESCRIPTION
*Description of changes:*
Cherry pick of commits from main to 
- enable CAPI backup from bootstrap cluster on upgrade failures.
- add filter-cluster flags to capi backup

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

