### PR TITLE
Validate all cloudstack machine configs in webhook

### DIFF
--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
@@ -58,11 +58,6 @@ func (r *CloudStackMachineConfig) ValidateUpdate(old runtime.Object) error {
 		return nil
 	}
 
-	if oldCloudStackMachineConfig.IsManagement() {
-		cloudstackmachineconfiglog.Info("Machine config is associated with workload cluster", "name", oldCloudStackMachineConfig.Name)
-		return nil
-	}
-
 	// This is only needed for the webhook, which is why it is separate from the Validate method
 	if err := r.ValidateUsers(); err != nil {
 		return apierrors.NewInvalid(GroupVersion.WithKind(CloudStackMachineConfigKind).GroupKind(),

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook_test.go
@@ -454,18 +454,6 @@ func TestWorkloadCloudStackMachineValidateUpdateSshAuthorizedKeyMutable(t *testi
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementCloudStackMachineValidateUpdateSshUsernameMutable(t *testing.T) {
-	vOld := cloudstackMachineConfig()
-	vOld.SetControlPlane()
-	vOld.SetManagement("test-cluster")
-	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
-	c := vOld.DeepCopy()
-
-	c.Spec.Users[0].Name = "Andy"
-	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
-}
-
 func TestWorkloadCloudStackMachineValidateUpdateSshUsernameMutable(t *testing.T) {
 	vOld := cloudstackMachineConfig()
 	vOld.SetControlPlane()


### PR DESCRIPTION
Until now, any machine config belonging to a workload cluster was
skipping all webhook validations. All existing validations apply to both
management and workload cluster machine configs, so there is no need to
make a distinction here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

