### PR TITLE
Enable kindless upgrades in controller from CLI

### DIFF
--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -18,6 +18,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -160,7 +161,13 @@ func setManagerEnvVars(d *appsv1.Deployment, spec *cluster.Spec) {
 }
 
 func managerEnabledGates(spec *cluster.Spec) []string {
-	return nil
+	g := []string{}
+	// TODO(pjshah): remove this feature flag after we implement kindless upgrade managaement feature for all the providers.
+	if features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
+		g = append(g, features.ExperimentalSelfManagedClusterUpgradeGate)
+	}
+
+	return g
 }
 
 func fullLifeCycleControllerForProvider(cluster *anywherev1.Cluster) bool {

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -2,6 +2,7 @@ package clustermanager_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -17,6 +18,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clustermanager"
 	"github.com/aws/eks-anywhere/pkg/clustermanager/mocks"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -211,9 +213,22 @@ func TestSetManagerFlags(t *testing.T) {
 			spec:       test.NewClusterSpec(),
 			want:       deployment(),
 		},
+		{
+			name:           "kindless upgrades, feature flag enabled",
+			deployment:     deployment(),
+			spec:           test.NewClusterSpec(),
+			featureEnvVars: []string{features.ExperimentalSelfManagedClusterUpgradeEnvVar},
+			want: deployment(func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].Args = []string{
+					"--feature-gates=ExpSelfManagedAPIUpgrade=true",
+				}
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar)
+			features.ClearCache()
 			for _, e := range tt.featureEnvVars {
 				t.Setenv(e, "true")
 			}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,7 +7,7 @@ const (
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
 
 	ExperimentalSelfManagedClusterUpgradeEnvVar = "EXP_SELF_MANAGED_API_UPGRADE"
-	experimentalSelfManagedClusterUpgradeGate   = "ExpSelfManagedAPIUpgrade"
+	ExperimentalSelfManagedClusterUpgradeGate   = "ExpSelfManagedAPIUpgrade"
 )
 
 func FeedGates(featureGates []string) {
@@ -34,7 +34,7 @@ func ExperimentalSelfManagedClusterUpgrade() Feature {
 		Name: "[EXPERIMENTAL] Upgrade self-managed clusters through the API",
 		IsActive: globalFeatures.isActiveForEnvVarOrGate(
 			ExperimentalSelfManagedClusterUpgradeEnvVar,
-			experimentalSelfManagedClusterUpgradeGate,
+			ExperimentalSelfManagedClusterUpgradeGate,
 		),
 	}
 }


### PR DESCRIPTION
*Description of changes:*
If the envvar is set when the CLI installs the controller, pass the feature flag so the controller allows kindless upgrades.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

