### PR TITLE
Add credential provider package to bundle release yaml

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1782,6 +1782,35 @@ spec:
                       type: object
                     packageController:
                       properties:
+                        credentialProviderPackage:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         helmChart:
                           properties:
                             arch:
@@ -1872,6 +1901,7 @@ spec:
                         version:
                           type: string
                       required:
+                      - credentialProviderPackage
                       - packageController
                       - tokenRefresher
                       type: object

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1950,6 +1950,35 @@ spec:
                       type: object
                     packageController:
                       properties:
+                        credentialProviderPackage:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         helmChart:
                           properties:
                             arch:
@@ -2040,6 +2069,7 @@ spec:
                         version:
                           type: string
                       required:
+                      - credentialProviderPackage
                       - packageController
                       - tokenRefresher
                       type: object

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -197,9 +197,9 @@ type VSphereBundle struct {
 	Metadata             Manifest `json:"metadata"`
 	ClusterTemplate      Manifest `json:"clusterTemplate"`
 	// This field has been deprecated
-	Driver               *Image    `json:"driver,omitempty"`
+	Driver *Image `json:"driver,omitempty"`
 	// This field has been deprecated
-	Syncer               *Image    `json:"syncer,omitempty"`
+	Syncer *Image `json:"syncer,omitempty"`
 }
 
 type DockerBundle struct {
@@ -242,10 +242,11 @@ type FluxBundle struct {
 }
 
 type PackageBundle struct {
-	Version        string `json:"version,omitempty"`
-	Controller     Image  `json:"packageController"`
-	TokenRefresher Image  `json:"tokenRefresher"`
-	HelmChart      Image  `json:"helmChart,omitempty"`
+	Version                   string `json:"version,omitempty"`
+	Controller                Image  `json:"packageController"`
+	TokenRefresher            Image  `json:"tokenRefresher"`
+	CredentialProviderPackage Image  `json:"credentialProviderPackage"`
+	HelmChart                 Image  `json:"helmChart,omitempty"`
 }
 
 type EksaBundle struct {

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1782,6 +1782,35 @@ spec:
                       type: object
                     packageController:
                       properties:
+                        credentialProviderPackage:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
+                              type: string
+                          type: object
                         helmChart:
                           properties:
                             arch:
@@ -1872,6 +1901,7 @@ spec:
                         version:
                           type: string
                       required:
+                      - credentialProviderPackage
                       - packageController
                       - tokenRefresher
                       type: object

--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -402,6 +402,9 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				RepoName: "ecr-token-refresher",
 			},
 			{
+				RepoName: "credential-provider-package",
+			},
+			{
 				AssetName:            "eks-anywhere-packages-helm",
 				RepoName:             "eks-anywhere-packages",
 				TrimVersionSignifier: true,

--- a/release/pkg/bundles/package-controller.go
+++ b/release/pkg/bundles/package-controller.go
@@ -33,8 +33,9 @@ import (
 
 func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]string) (anywherev1alpha1.PackageBundle, error) {
 	artifacts := map[string][]releasetypes.Artifact{
-		"eks-anywhere-packages": r.BundleArtifactsTable["eks-anywhere-packages"],
-		"ecr-token-refresher":   r.BundleArtifactsTable["ecr-token-refresher"],
+		"eks-anywhere-packages":       r.BundleArtifactsTable["eks-anywhere-packages"],
+		"ecr-token-refresher":         r.BundleArtifactsTable["ecr-token-refresher"],
+		"credential-provider-package": r.BundleArtifactsTable["credential-provider-package"],
 	}
 	sortedComponentNames := bundleutils.SortArtifactsMap(artifacts)
 
@@ -173,10 +174,11 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 	}
 
 	bundle := anywherev1alpha1.PackageBundle{
-		Version:        version,
-		Controller:     bundleImageArtifacts["eks-anywhere-packages"],
-		TokenRefresher: bundleImageArtifacts["ecr-token-refresher"],
-		HelmChart:      bundleImageArtifacts["eks-anywhere-packages-helm"],
+		Version:                   version,
+		Controller:                bundleImageArtifacts["eks-anywhere-packages"],
+		TokenRefresher:            bundleImageArtifacts["ecr-token-refresher"],
+		CredentialProviderPackage: bundleImageArtifacts["credential-provider-package"],
+		HelmChart:                 bundleImageArtifacts["eks-anywhere-packages-helm"],
 	}
 	return bundle, nil
 }

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -483,6 +483,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
       version: v1.2.3+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -1260,6 +1269,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
       version: v1.2.3+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -2010,6 +2028,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
       version: v1.2.3+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -2760,6 +2787,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
       version: v1.2.3+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -3510,6 +3546,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.3/metadata.yaml
       version: v1.2.3+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/release/pkg/test/testdata/release-0.16-bundle-release.yaml
+++ b/release/pkg/test/testdata/release-0.16-bundle-release.yaml
@@ -483,6 +483,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
       version: v1.2.1+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-release-0.16-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -1260,6 +1269,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
       version: v1.2.1+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-release-0.16-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -2010,6 +2028,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
       version: v1.2.1+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-release-0.16-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -2760,6 +2787,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
       version: v1.2.1+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-release-0.16-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -3510,6 +3546,15 @@ spec:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.16-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.1/metadata.yaml
       version: v1.2.1+abcdef1
     packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/release-container-registry/credential-provider-package:v0.3.10-eks-a-v0.0.0-dev-release-0.16-build.1
       helmChart:
         description: Helm chart for eks-anywhere-packages
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef


### PR DESCRIPTION
*Issue #, if available:* credential-provider-package is missing in eksa bundle-release.yaml

*Description of changes:*

*Testing (if applicable):* unit test "bundle_release_test.go"

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

