### PR TITLE
[release-0.16] Remove mgmt bundlesRef validation

### DIFF
--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -90,27 +90,3 @@ func ValidateManagementClusterName(ctx context.Context, k KubectlClient, mgmtClu
 	}
 	return nil
 }
-
-// ValidateManagementClusterBundlesVersion checks if management cluster's bundle version
-// is greater than or equal to the bundle version used to upgrade a workload cluster.
-func ValidateManagementClusterBundlesVersion(ctx context.Context, k KubectlClient, mgmtCluster *types.Cluster, workload *cluster.Spec) error {
-	cluster, err := k.GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name)
-	if err != nil {
-		return err
-	}
-
-	if cluster.Spec.BundlesRef == nil {
-		return fmt.Errorf("management cluster bundlesRef cannot be nil")
-	}
-
-	mgmtBundles, err := k.GetBundles(ctx, mgmtCluster.KubeconfigFile, cluster.Spec.BundlesRef.Name, cluster.Spec.BundlesRef.Namespace)
-	if err != nil {
-		return err
-	}
-
-	if mgmtBundles.Spec.Number < workload.Bundles.Spec.Number {
-		return fmt.Errorf("cannot upgrade workload cluster with bundle spec.number %d while management cluster %s is on older bundle spec.number %d", workload.Bundles.Spec.Number, mgmtCluster.Name, mgmtBundles.Spec.Number)
-	}
-
-	return nil
-}

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -82,13 +82,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 					Err: validations.ValidateManagementClusterName(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec.Cluster.Spec.ManagementCluster.Name),
 				}
 			},
-			func() *validations.ValidationResult {
-				return &validations.ValidationResult{
-					Name:        "validate management cluster bundle version compatibility",
-					Remediation: fmt.Sprintf("upgrade management cluster %s before creating workload cluster %s", v.Opts.Spec.Cluster.ManagedBy(), v.Opts.WorkloadCluster.Name),
-					Err:         validations.ValidateManagementClusterBundlesVersion(ctx, k, v.Opts.ManagementCluster, v.Opts.Spec),
-				}
-			},
 		)
 	}
 

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
-	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type preflightValidationsTest struct {
@@ -79,18 +78,10 @@ func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
 		},
 	}
 
-	mgmtBundle := &releasev1alpha1.Bundles{
-		Spec: releasev1alpha1.BundlesSpec{
-			Number: tt.c.Opts.Spec.Bundles.Spec.Number + 1,
-		},
-	}
-
 	tt.k.EXPECT().GetClusters(tt.ctx, tt.c.Opts.WorkloadCluster).Return(nil, nil)
 	tt.k.EXPECT().ValidateClustersCRD(tt.ctx, tt.c.Opts.WorkloadCluster).Return(nil)
 	tt.k.EXPECT().ValidateEKSAClustersCRD(tt.ctx, tt.c.Opts.WorkloadCluster).Return(nil)
 	tt.k.EXPECT().GetEksaCluster(tt.ctx, tt.c.Opts.ManagementCluster, mgmtClusterName).Return(mgmt, nil)
-	tt.k.EXPECT().GetEksaCluster(tt.ctx, tt.c.Opts.ManagementCluster, mgmtClusterName).Return(mgmt, nil)
-	tt.k.EXPECT().GetBundles(tt.ctx, tt.c.Opts.ManagementCluster.KubeconfigFile, mgmt.Spec.BundlesRef.Name, mgmt.Spec.BundlesRef.Namespace).Return(mgmtBundle, nil)
 
 	tt.Expect(validations.ProcessValidationResults(tt.c.PreflightValidations(tt.ctx))).To(Succeed())
 }

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -93,18 +93,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 		},
 	}
 
-	if u.Opts.Spec.Cluster.IsManaged() {
-		upgradeValidations = append(
-			upgradeValidations,
-			func() *validations.ValidationResult {
-				return &validations.ValidationResult{
-					Name:        "validate management cluster bundle version compatibility",
-					Remediation: fmt.Sprintf("upgrade management cluster %s before upgrading workload cluster %s", u.Opts.Spec.Cluster.ManagedBy(), u.Opts.WorkloadCluster.Name),
-					Err:         validations.ValidateManagementClusterBundlesVersion(ctx, k, u.Opts.ManagementCluster, u.Opts.Spec),
-				}
-			})
-	}
-
 	if !u.Opts.SkippedValidations[PDB] {
 		upgradeValidations = append(
 			upgradeValidations,

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
 	"github.com/aws/eks-anywhere/pkg/validations/upgradevalidations"
-	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const (
@@ -1185,11 +1184,6 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 					GitVersion: tc.clusterVersion,
 				},
 			}
-			bundlesResponse := &releasev1alpha1.Bundles{
-				Spec: releasev1alpha1.BundlesSpec{
-					Number: 28,
-				},
-			}
 
 			provider.EXPECT().DatacenterConfig(clusterSpec).Return(existingProviderSpec).MaxTimes(1)
 			provider.EXPECT().ValidateNewSpec(ctx, workloadCluster, clusterSpec).Return(nil).MaxTimes(1)
@@ -1201,10 +1195,6 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 			k.EXPECT().ValidateClustersCRD(ctx, workloadCluster).Return(tc.crdResponse)
 			k.EXPECT().GetClusters(ctx, workloadCluster).Return(tc.getClusterResponse, nil)
 			k.EXPECT().GetEksaCluster(ctx, workloadCluster, clusterSpec.Cluster.Name).Return(existingClusterSpec.Cluster, nil)
-			if opts.Spec.Cluster.IsManaged() {
-				k.EXPECT().GetEksaCluster(ctx, workloadCluster, workloadCluster.Name).Return(existingClusterSpec.Cluster, nil)
-				k.EXPECT().GetBundles(ctx, workloadCluster.KubeconfigFile, existingClusterSpec.Cluster.Spec.BundlesRef.Name, existingClusterSpec.Cluster.Spec.BundlesRef.Namespace).Return(bundlesResponse, nil)
-			}
 			k.EXPECT().GetEksaGitOpsConfig(ctx, clusterSpec.Cluster.Spec.GitOpsRef.Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.GitOpsConfig, nil).MaxTimes(1)
 			k.EXPECT().GetEksaOIDCConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[1].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.OIDCConfig, nil).MaxTimes(1)
 			k.EXPECT().GetEksaAWSIamConfig(ctx, clusterSpec.Cluster.Spec.IdentityProviderRefs[0].Name, gomock.Any(), gomock.Any()).Return(existingClusterSpec.AWSIamConfig, nil).MaxTimes(1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove validation that checks if mgmt cluster's bundle is compatible with workload cluster's bundle to enable 0.17 mgmt clusters with 0.16 workload clusters.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

