### PR TITLE
Fix Tinkerbell preflights to account for bundles changes

### DIFF
--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -146,7 +146,8 @@ func (p *Provider) validateAvailableHardwareForUpgrade(ctx context.Context, curr
 	)
 
 	rollingUpgrade := false
-	if currentSpec.Cluster.Spec.KubernetesVersion != newClusterSpec.Cluster.Spec.KubernetesVersion {
+	if currentSpec.Cluster.Spec.KubernetesVersion != newClusterSpec.Cluster.Spec.KubernetesVersion ||
+		currentSpec.Bundles.Spec.Number != newClusterSpec.Bundles.Spec.Number {
 		clusterSpecValidator.Register(ExtraHardwareAvailableAssertionForRollingUpgrade(p.catalogue))
 		rollingUpgrade = true
 	}


### PR DESCRIPTION
*Description of changes:*
The bundle changes trigger a rolling upgrades but Tinkerbell currently doesn't account for them during preflights which causes the upgrade to fail if a bundle change happened alongside a scaling operation.
This PR adds a preflight to detect bundle changes and marks those also as a trigger for rolling upgrades.
So if a scaling operation happens along with bundle changes, the CLI will fail out early in preflights.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

