### PR TITLE
Add retries for TLS handshake timeout on kubectl waits

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -91,7 +91,7 @@ var (
 	eksaPackagesBundleControllerType     = fmt.Sprintf("packagebundlecontroller.%s", packagesv1.GroupVersion.Group)
 	eksaPackageBundlesType               = fmt.Sprintf("packagebundles.%s", packagesv1.GroupVersion.Group)
 	kubectlConnectionRefusedRegex        = regexp.MustCompile("The connection to the server .* was refused")
-	kubectlIoTimeoutRegex                = regexp.MustCompile("Unable to connect to the server.*i/o timeout.*")
+	kubectlConnectionTimeoutRegex        = regexp.MustCompile("Unable to connect to the server.*timeout.*")
 )
 
 type Kubectl struct {
@@ -568,7 +568,7 @@ func (k *Kubectl) kubectlWaitRetryPolicy(totalRetries int, err error) (retry boo
 	if match := kubectlConnectionRefusedRegex.MatchString(err.Error()); match {
 		return true, waitTime
 	}
-	if match := kubectlIoTimeoutRegex.MatchString(err.Error()); match {
+	if match := kubectlConnectionTimeoutRegex.MatchString(err.Error()); match {
 		return true, waitTime
 	}
 	return false, 0

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -453,6 +453,7 @@ func TestKubectlWaitRetryPolicy(t *testing.T) {
 	t.Parallel()
 	connectionRefusedError := fmt.Errorf("The connection to the server 127.0.0.1:56789 was refused")
 	ioTimeoutError := fmt.Errorf("Unable to connect to the server 127.0.0.1:56789, i/o timeout\n")
+	tlsHandshakeError := fmt.Errorf("Unable to connect to the server: net/http: TLS handshake timeout")
 	miscellaneousError := fmt.Errorf("Some other random miscellaneous error")
 
 	k := executables.NewKubectl(nil)
@@ -475,6 +476,11 @@ func TestKubectlWaitRetryPolicy(t *testing.T) {
 	_, wait = executables.KubectlWaitRetryPolicy(k, 1, ioTimeoutError)
 	if wait != 10*time.Second {
 		t.Errorf("kubectlWaitRetryPolicy didn't correctly calculate first retry wait for ioTimeout")
+	}
+
+	_, wait = executables.KubectlWaitRetryPolicy(k, 1, tlsHandshakeError)
+	if wait != 10*time.Second {
+		t.Errorf("kubectlWaitRetryPolicy didn't correctly calculate first retry wait for tls handshake error")
 	}
 
 	retry, _ := executables.KubectlWaitRetryPolicy(k, 1, miscellaneousError)


### PR DESCRIPTION
*Description of changes:*
Kubectl waits already have a retry policy which checks for both connection refused and IO timeouts. This change updates the regex to also include a tls handshake timeout so that the policy and retry on such occurrences.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

