### PR TITLE
Add helper to wait for cluster condition

### DIFF
--- a/pkg/cluster/wait.go
+++ b/pkg/cluster/wait.go
@@ -1,0 +1,42 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/retrier"
+)
+
+// WaitForCondition blocks until either the cluster has this condition as True
+// or the retrier timeouts. If observedGeneration is not equal to generation,
+// the condition is considered false regardless of the status value.
+func WaitForCondition(ctx context.Context, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, conditionType anywherev1.ConditionType) error {
+	return retrier.Retry(func() error {
+		c := &anywherev1.Cluster{}
+		if err := client.Get(ctx, cluster.Name, cluster.Namespace, c); err != nil {
+			return err
+		}
+
+		observedGeneration := c.Status.ObservedGeneration
+		generation := c.Generation
+		if observedGeneration != generation {
+			return errors.Errorf("cluster generation (%d) and observedGeneration (%d) differ", generation, observedGeneration)
+		}
+
+		condition := conditions.Get(c, conditionType)
+		if condition == nil {
+			return errors.Errorf("cluster doesn't yet have condition %s", conditionType)
+		}
+
+		if condition.Status != corev1.ConditionTrue {
+			return errors.Errorf("cluster condition %s is %s: %s", conditionType, condition.Status, condition.Message)
+		}
+
+		return nil
+	})
+}

--- a/pkg/cluster/wait_test.go
+++ b/pkg/cluster/wait_test.go
@@ -1,0 +1,156 @@
+package cluster_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/retrier"
+)
+
+func TestWaitForCondition(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		clusterInput, currentCluster *anywherev1.Cluster
+		condition                    anywherev1.ConditionType
+		retrier                      *retrier.Retrier
+		wantErr                      string
+	}{
+		{
+			name: "cluster does not exist",
+			clusterInput: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-c",
+					Namespace: "my-n",
+				},
+			},
+			currentCluster: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-cluster",
+					Namespace: "my-n",
+				},
+			},
+			retrier: retrier.NewWithMaxRetries(1, 0),
+			wantErr: "clusters.anywhere.eks.amazonaws.com \"my-c\" not found",
+		},
+		{
+			name: "observed generation not updated",
+			clusterInput: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-c",
+					Namespace: "my-n",
+				},
+			},
+			currentCluster: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "my-c",
+					Namespace:  "my-n",
+					Generation: 5,
+				},
+				Status: anywherev1.ClusterStatus{
+					ObservedGeneration: 4,
+				},
+			},
+			retrier: retrier.NewWithMaxRetries(1, 0),
+			wantErr: "cluster generation (5) and observedGeneration (4) differ",
+		},
+		{
+			name: "no condition",
+			clusterInput: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-c",
+					Namespace: "my-n",
+				},
+			},
+			currentCluster: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "my-c",
+					Namespace:  "my-n",
+					Generation: 5,
+				},
+				Status: anywherev1.ClusterStatus{
+					ObservedGeneration: 5,
+				},
+			},
+			retrier:   retrier.NewWithMaxRetries(1, 0),
+			condition: anywherev1.ControlPlaneReadyCondition,
+			wantErr:   "cluster doesn't yet have condition ControlPlaneReady",
+		},
+		{
+			name: "condition is False",
+			clusterInput: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-c",
+					Namespace: "my-n",
+				},
+			},
+			currentCluster: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "my-c",
+					Namespace:  "my-n",
+					Generation: 5,
+				},
+				Status: anywherev1.ClusterStatus{
+					ObservedGeneration: 5,
+					Conditions: []anywherev1.Condition{
+						{
+							Type:    anywherev1.ControlPlaneReadyCondition,
+							Status:  "False",
+							Message: "CP is being rolled out",
+						},
+					},
+				},
+			},
+			retrier:   retrier.NewWithMaxRetries(1, 0),
+			condition: anywherev1.ControlPlaneReadyCondition,
+			wantErr:   "cluster condition ControlPlaneReady is False: CP is being rolled out",
+		},
+		{
+			name: "condition is True",
+			clusterInput: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-c",
+					Namespace: "my-n",
+				},
+			},
+			currentCluster: &anywherev1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "my-c",
+					Namespace:  "my-n",
+					Generation: 5,
+				},
+				Status: anywherev1.ClusterStatus{
+					ObservedGeneration: 5,
+					Conditions: []anywherev1.Condition{
+						{
+							Type:   anywherev1.ControlPlaneReadyCondition,
+							Status: "True",
+						},
+					},
+				},
+			},
+			retrier:   retrier.NewWithMaxRetries(1, 0),
+			condition: anywherev1.ControlPlaneReadyCondition,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			g := NewWithT(t)
+			client := test.NewFakeKubeClient(tt.currentCluster)
+
+			gotErr := cluster.WaitForCondition(ctx, client, tt.clusterInput, tt.retrier, tt.condition)
+			if tt.wantErr != "" {
+				g.Expect(gotErr).To(MatchError(tt.wantErr))
+			} else {
+				g.Expect(gotErr).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Helpful tool when waiting for an eksa cluster condition in the CLI. Will be used for kindless upgrades, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

