### PR TITLE
Add apply server side to the k8s client interface

### DIFF
--- a/internal/test/kubernetes.go
+++ b/internal/test/kubernetes.go
@@ -1,6 +1,9 @@
 package test
 
 import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -10,9 +13,33 @@ import (
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 )
 
+// testKubeClient implements a kubernetes.Client that uses
+// a fake client.Client under the hood. It reimplements server-side
+// apply since Fake client doesn't support it.
+type testKubeClient struct {
+	kubernetes.Client
+	fakeClient client.Client
+}
+
+// ApplyServerSide creates or patches and object using server side logic.
+// Giving the limitations of the fake client, we implement a fake server side apply
+// using a simplified version, using a raw update if the object exists and create
+// otherwise.
+func (t *testKubeClient) ApplyServerSide(ctx context.Context, fieldManager string, obj kubernetes.Object, opts ...kubernetes.ApplyServerSideOption) error {
+	err := t.fakeClient.Update(ctx, obj)
+	if apierrors.IsNotFound(err) {
+		return t.fakeClient.Create(ctx, obj)
+	}
+
+	return err
+}
+
 // NewKubeClient builds a new kubernetes.Client by using client.Client.
 func NewKubeClient(client client.Client) kubernetes.Client {
-	return clientutil.NewKubeClient(client)
+	return &testKubeClient{
+		fakeClient: client,
+		Client:     clientutil.NewKubeClient(client),
+	}
 }
 
 // NewFakeKubeClient returns a kubernetes.Client that uses a fake client.Client under the hood.

--- a/pkg/clients/kubernetes/client.go
+++ b/pkg/clients/kubernetes/client.go
@@ -36,6 +36,9 @@ type Writer interface {
 	// Update updates the given obj in the Kubernetes cluster.
 	Update(ctx context.Context, obj Object) error
 
+	// ApplyServerSide creates or patches and object using server side logic.
+	ApplyServerSide(ctx context.Context, fieldManager string, obj Object, opts ...ApplyServerSideOption) error
+
 	// Delete deletes the given obj from Kubernetes cluster.
 	Delete(ctx context.Context, obj Object) error
 
@@ -69,5 +72,26 @@ func (o *DeleteAllOfOptions) ApplyToDeleteAllOf(do *DeleteAllOfOptions) {
 	}
 	if o.Namespace != "" {
 		do.Namespace = o.Namespace
+	}
+}
+
+// ApplyServerSideOption is some configuration that modifies options for an apply request.
+type ApplyServerSideOption interface {
+	ApplyToApplyServerSide(*ApplyServerSideOptions)
+}
+
+// ApplyServerSideOptions contains options for server side apply requests.
+type ApplyServerSideOptions struct {
+	// ForceOwnership indicates that in case of conflicts with server-side apply,
+	// the client should acquire ownership of the conflicting field.
+	ForceOwnership bool
+}
+
+var _ ApplyServerSideOption = ApplyServerSideOptions{}
+
+// ApplyToApplyServerSide implements ApplyServerSideOption.
+func (o ApplyServerSideOptions) ApplyToApplyServerSide(do *ApplyServerSideOptions) {
+	if o.ForceOwnership {
+		do.ForceOwnership = true
 	}
 }

--- a/pkg/clients/kubernetes/kubeconfig.go
+++ b/pkg/clients/kubernetes/kubeconfig.go
@@ -40,6 +40,11 @@ func (c *KubeconfigClient) Update(ctx context.Context, obj Object) error {
 	return c.client.Update(ctx, c.kubeconfig, obj)
 }
 
+// ApplyServerSide creates or patches and object using server side logic.
+func (c *KubeconfigClient) ApplyServerSide(ctx context.Context, fieldManager string, obj Object, opts ...ApplyServerSideOption) error {
+	return c.client.ApplyServerSide(ctx, c.kubeconfig, fieldManager, obj, opts...)
+}
+
 // Delete deletes the given obj from Kubernetes cluster.
 func (c *KubeconfigClient) Delete(ctx context.Context, obj Object) error {
 	return c.client.Delete(ctx, c.kubeconfig, obj)

--- a/pkg/clients/kubernetes/kubeconfig_test.go
+++ b/pkg/clients/kubernetes/kubeconfig_test.go
@@ -93,6 +93,29 @@ func TestKubeconfigClientUpdate(t *testing.T) {
 	g.Expect(kc.Update(ctx, obj)).To(Succeed())
 }
 
+func TestKubeconfigClientApplyServerSide(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	kubectl := mocks.NewMockKubectl(ctrl)
+	fieldManager := "my-manager"
+	kubeconfig := "k.kubeconfig"
+	obj := &corev1.Pod{}
+
+	opts := kubernetes.KubectlApplyOptions{
+		ServerSide:   true,
+		FieldManager: fieldManager,
+	}
+	kubectl.EXPECT().Apply(ctx, kubeconfig, obj, opts)
+
+	c := kubernetes.NewUnAuthClient(kubectl)
+	g.Expect(c.Init()).To(Succeed())
+	kc, err := c.BuildClientFromKubeconfig(kubeconfig)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(kc.ApplyServerSide(ctx, fieldManager, obj)).To(Succeed())
+}
+
 func TestKubeconfigClientDelete(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/pkg/clients/kubernetes/kubectl.go
+++ b/pkg/clients/kubernetes/kubectl.go
@@ -11,7 +11,7 @@ type Kubectl interface {
 	Get(ctx context.Context, resourceType, kubeconfig string, obj runtime.Object, opts ...KubectlGetOption) error
 	Create(ctx context.Context, kubeconfig string, obj runtime.Object) error
 	Replace(ctx context.Context, kubeconfig string, obj runtime.Object) error
-	Apply(ctx context.Context, kubeconfig string, obj runtime.Object) error
+	Apply(ctx context.Context, kubeconfig string, obj runtime.Object, opts ...KubectlApplyOption) error
 	Delete(ctx context.Context, resourceType, kubeconfig string, opts ...KubectlDeleteOption) error
 }
 
@@ -51,7 +51,43 @@ func (o *KubectlGetOptions) ApplyToGet(kgo *KubectlGetOptions) {
 	}
 }
 
-// KubectlDeleteOption is some configuration that modifies options for a get request.
+// KubectlApplyOption is some configuration that modifies options for an apply command.
+type KubectlApplyOption interface {
+	// ApplyToApply applies this configuration to the given apply options.
+	ApplyToApply(*KubectlApplyOptions)
+}
+
+// KubectlApplyOptions contains options for apply command.
+type KubectlApplyOptions struct {
+	// ServerSide configures kubectl so apply runs in the server instead of the client.
+	ServerSide bool
+
+	// ForceOwnership indicates that in case of conflicts with server-side apply,
+	// kubectl should acquire ownership of the conflicting field.
+	ForceOwnership bool
+
+	// FieldManager sets the field owner name for the given server-side apply.
+	FieldManager string
+}
+
+var _ KubectlApplyOption = KubectlApplyOptions{}
+
+// ApplyToApply applies this configuration to the given apply options.
+func (o KubectlApplyOptions) ApplyToApply(kao *KubectlApplyOptions) {
+	if o.ServerSide {
+		kao.ServerSide = true
+	}
+
+	if o.ForceOwnership {
+		kao.ForceOwnership = true
+	}
+
+	if o.FieldManager != "" {
+		kao.FieldManager = o.FieldManager
+	}
+}
+
+// KubectlDeleteOption is some configuration that modifies options for a delete command.
 type KubectlDeleteOption interface {
 	// ApplyToDelete applies this configuration to the given delete options.
 	ApplyToDelete(*KubectlDeleteOptions)

--- a/pkg/clients/kubernetes/kubectl_test.go
+++ b/pkg/clients/kubernetes/kubectl_test.go
@@ -179,3 +179,66 @@ func TestKubectlDeleteOptionsApplyToDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestKubectlApplyOptionsApplyToApply(t *testing.T) {
+	tests := []struct {
+		name             string
+		option, in, want *kubernetes.KubectlApplyOptions
+	}{
+		{
+			name:   "empty",
+			option: &kubernetes.KubectlApplyOptions{},
+			in:     &kubernetes.KubectlApplyOptions{},
+			want:   &kubernetes.KubectlApplyOptions{},
+		},
+		{
+			name: "serverside",
+			option: &kubernetes.KubectlApplyOptions{
+				ServerSide: true,
+			},
+			in: &kubernetes.KubectlApplyOptions{
+				FieldManager: "a",
+			},
+			want: &kubernetes.KubectlApplyOptions{
+				ServerSide:   true,
+				FieldManager: "a",
+			},
+		},
+		{
+			name: "force ownership",
+			option: &kubernetes.KubectlApplyOptions{
+				ForceOwnership: true,
+			},
+			in: &kubernetes.KubectlApplyOptions{
+				FieldManager: "a",
+			},
+			want: &kubernetes.KubectlApplyOptions{
+				ForceOwnership: true,
+				FieldManager:   "a",
+			},
+		},
+		{
+			name: "field manager",
+			option: &kubernetes.KubectlApplyOptions{
+				FieldManager: "a",
+			},
+			in: &kubernetes.KubectlApplyOptions{
+				FieldManager:   "b",
+				ServerSide:     true,
+				ForceOwnership: true,
+			},
+			want: &kubernetes.KubectlApplyOptions{
+				FieldManager:   "a",
+				ServerSide:     true,
+				ForceOwnership: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			tt.option.ApplyToApply(tt.in)
+			g.Expect(tt.in).To(BeComparableTo(tt.want))
+		})
+	}
+}

--- a/pkg/clients/kubernetes/mocks/client.go
+++ b/pkg/clients/kubernetes/mocks/client.go
@@ -35,6 +35,25 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// ApplyServerSide mocks base method.
+func (m *MockClient) ApplyServerSide(ctx context.Context, fieldManager string, obj kubernetes.Object, opts ...kubernetes.ApplyServerSideOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, fieldManager, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ApplyServerSide", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyServerSide indicates an expected call of ApplyServerSide.
+func (mr *MockClientMockRecorder) ApplyServerSide(ctx, fieldManager, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, fieldManager, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyServerSide", reflect.TypeOf((*MockClient)(nil).ApplyServerSide), varargs...)
+}
+
 // Create mocks base method.
 func (m *MockClient) Create(ctx context.Context, obj kubernetes.Object) error {
 	m.ctrl.T.Helper()
@@ -198,6 +217,25 @@ func (m *MockWriter) EXPECT() *MockWriterMockRecorder {
 	return m.recorder
 }
 
+// ApplyServerSide mocks base method.
+func (m *MockWriter) ApplyServerSide(ctx context.Context, fieldManager string, obj kubernetes.Object, opts ...kubernetes.ApplyServerSideOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, fieldManager, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ApplyServerSide", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyServerSide indicates an expected call of ApplyServerSide.
+func (mr *MockWriterMockRecorder) ApplyServerSide(ctx, fieldManager, obj interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, fieldManager, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyServerSide", reflect.TypeOf((*MockWriter)(nil).ApplyServerSide), varargs...)
+}
+
 // Create mocks base method.
 func (m *MockWriter) Create(ctx context.Context, obj kubernetes.Object) error {
 	m.ctrl.T.Helper()
@@ -292,4 +330,39 @@ func (m *MockDeleteAllOfOption) ApplyToDeleteAllOf(arg0 *kubernetes.DeleteAllOfO
 func (mr *MockDeleteAllOfOptionMockRecorder) ApplyToDeleteAllOf(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyToDeleteAllOf", reflect.TypeOf((*MockDeleteAllOfOption)(nil).ApplyToDeleteAllOf), arg0)
+}
+
+// MockApplyServerSideOption is a mock of ApplyServerSideOption interface.
+type MockApplyServerSideOption struct {
+	ctrl     *gomock.Controller
+	recorder *MockApplyServerSideOptionMockRecorder
+}
+
+// MockApplyServerSideOptionMockRecorder is the mock recorder for MockApplyServerSideOption.
+type MockApplyServerSideOptionMockRecorder struct {
+	mock *MockApplyServerSideOption
+}
+
+// NewMockApplyServerSideOption creates a new mock instance.
+func NewMockApplyServerSideOption(ctrl *gomock.Controller) *MockApplyServerSideOption {
+	mock := &MockApplyServerSideOption{ctrl: ctrl}
+	mock.recorder = &MockApplyServerSideOptionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockApplyServerSideOption) EXPECT() *MockApplyServerSideOptionMockRecorder {
+	return m.recorder
+}
+
+// ApplyToApplyServerSide mocks base method.
+func (m *MockApplyServerSideOption) ApplyToApplyServerSide(arg0 *kubernetes.ApplyServerSideOptions) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ApplyToApplyServerSide", arg0)
+}
+
+// ApplyToApplyServerSide indicates an expected call of ApplyToApplyServerSide.
+func (mr *MockApplyServerSideOptionMockRecorder) ApplyToApplyServerSide(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyToApplyServerSide", reflect.TypeOf((*MockApplyServerSideOption)(nil).ApplyToApplyServerSide), arg0)
 }

--- a/pkg/clients/kubernetes/mocks/kubectl.go
+++ b/pkg/clients/kubernetes/mocks/kubectl.go
@@ -37,17 +37,22 @@ func (m *MockKubectl) EXPECT() *MockKubectlMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockKubectl) Apply(ctx context.Context, kubeconfig string, obj runtime.Object) error {
+func (m *MockKubectl) Apply(ctx context.Context, kubeconfig string, obj runtime.Object, opts ...kubernetes.KubectlApplyOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", ctx, kubeconfig, obj)
+	varargs := []interface{}{ctx, kubeconfig, obj}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Apply", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockKubectlMockRecorder) Apply(ctx, kubeconfig, obj interface{}) *gomock.Call {
+func (mr *MockKubectlMockRecorder) Apply(ctx, kubeconfig, obj interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockKubectl)(nil).Apply), ctx, kubeconfig, obj)
+	varargs := append([]interface{}{ctx, kubeconfig, obj}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockKubectl)(nil).Apply), varargs...)
 }
 
 // Create mocks base method.
@@ -149,6 +154,41 @@ func (m *MockKubectlGetOption) ApplyToGet(arg0 *kubernetes.KubectlGetOptions) {
 func (mr *MockKubectlGetOptionMockRecorder) ApplyToGet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyToGet", reflect.TypeOf((*MockKubectlGetOption)(nil).ApplyToGet), arg0)
+}
+
+// MockKubectlApplyOption is a mock of KubectlApplyOption interface.
+type MockKubectlApplyOption struct {
+	ctrl     *gomock.Controller
+	recorder *MockKubectlApplyOptionMockRecorder
+}
+
+// MockKubectlApplyOptionMockRecorder is the mock recorder for MockKubectlApplyOption.
+type MockKubectlApplyOptionMockRecorder struct {
+	mock *MockKubectlApplyOption
+}
+
+// NewMockKubectlApplyOption creates a new mock instance.
+func NewMockKubectlApplyOption(ctrl *gomock.Controller) *MockKubectlApplyOption {
+	mock := &MockKubectlApplyOption{ctrl: ctrl}
+	mock.recorder = &MockKubectlApplyOptionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockKubectlApplyOption) EXPECT() *MockKubectlApplyOptionMockRecorder {
+	return m.recorder
+}
+
+// ApplyToApply mocks base method.
+func (m *MockKubectlApplyOption) ApplyToApply(arg0 *kubernetes.KubectlApplyOptions) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ApplyToApply", arg0)
+}
+
+// ApplyToApply indicates an expected call of ApplyToApply.
+func (mr *MockKubectlApplyOptionMockRecorder) ApplyToApply(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyToApply", reflect.TypeOf((*MockKubectlApplyOption)(nil).ApplyToApply), arg0)
 }
 
 // MockKubectlDeleteOption is a mock of KubectlDeleteOption interface.

--- a/pkg/clients/kubernetes/unauth.go
+++ b/pkg/clients/kubernetes/unauth.go
@@ -61,6 +61,24 @@ func (c *UnAuthClient) Apply(ctx context.Context, kubeconfig string, obj runtime
 	return c.kubectl.Apply(ctx, kubeconfig, obj)
 }
 
+// ApplyServerSide creates or patches and object using server side logic.
+func (c *UnAuthClient) ApplyServerSide(ctx context.Context, kubeconfig, fieldManager string, obj Object, opts ...ApplyServerSideOption) error {
+	o := &ApplyServerSideOptions{}
+	for _, opt := range opts {
+		opt.ApplyToApplyServerSide(o)
+	}
+
+	ko := KubectlApplyOptions{
+		ServerSide:   true,
+		FieldManager: fieldManager,
+	}
+	if o.ForceOwnership {
+		ko.ForceOwnership = o.ForceOwnership
+	}
+
+	return c.kubectl.Apply(ctx, kubeconfig, obj, ko)
+}
+
 // List retrieves list of objects. On a successful call, Items field
 // in the list will be populated with the result returned from the server.
 func (c *UnAuthClient) List(ctx context.Context, kubeconfig string, list ObjectList) error {

--- a/pkg/clustermanager/client.go
+++ b/pkg/clustermanager/client.go
@@ -6,12 +6,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 // KubernetesClient allows to interact with the k8s api server.
 type KubernetesClient interface {
-	Apply(ctx context.Context, kubeconfigPath string, obj runtime.Object) error
+	Apply(ctx context.Context, kubeconfigPath string, obj runtime.Object, opts ...kubernetes.KubectlApplyOption) error
 	ApplyKubeSpecFromBytes(ctx context.Context, cluster *types.Cluster, data []byte) error
 	ApplyKubeSpecFromBytesWithNamespace(ctx context.Context, cluster *types.Cluster, data []byte, namespace string) error
 	ApplyKubeSpecFromBytesForce(ctx context.Context, cluster *types.Cluster, data []byte) error

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -48,17 +48,22 @@ func (m *MockClusterClient) EXPECT() *MockClusterClientMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockClusterClient) Apply(arg0 context.Context, arg1 string, arg2 runtime.Object) error {
+func (m *MockClusterClient) Apply(arg0 context.Context, arg1 string, arg2 runtime.Object, arg3 ...kubernetes.KubectlApplyOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Apply", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockClusterClientMockRecorder) Apply(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) Apply(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClusterClient)(nil).Apply), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClusterClient)(nil).Apply), varargs...)
 }
 
 // ApplyKubeSpecFromBytes mocks base method.
@@ -1003,17 +1008,22 @@ func (m *MockKubernetesClient) EXPECT() *MockKubernetesClientMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockKubernetesClient) Apply(arg0 context.Context, arg1 string, arg2 runtime.Object) error {
+func (m *MockKubernetesClient) Apply(arg0 context.Context, arg1 string, arg2 runtime.Object, arg3 ...kubernetes.KubectlApplyOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Apply", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockKubernetesClientMockRecorder) Apply(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKubernetesClientMockRecorder) Apply(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockKubernetesClient)(nil).Apply), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockKubernetesClient)(nil).Apply), varargs...)
 }
 
 // ApplyKubeSpecFromBytes mocks base method.

--- a/pkg/clustermanager/retrier_client.go
+++ b/pkg/clustermanager/retrier_client.go
@@ -34,10 +34,10 @@ func (c *RetrierClient) ApplyKubeSpecFromBytes(ctx context.Context, cluster *typ
 }
 
 // Apply creates/updates an object against the api server following a client side apply mechanism.
-func (c *RetrierClient) Apply(ctx context.Context, kubeconfigPath string, obj runtime.Object) error {
+func (c *RetrierClient) Apply(ctx context.Context, kubeconfigPath string, obj runtime.Object, opts ...kubernetes.KubectlApplyOption) error {
 	return c.retrier.Retry(
 		func() error {
-			return c.ClusterClient.Apply(ctx, kubeconfigPath, obj)
+			return c.ClusterClient.Apply(ctx, kubeconfigPath, obj, opts...)
 		},
 	)
 }

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -2307,12 +2307,30 @@ func deleteParams(resourceType, kubeconfig string, o *kubernetes.KubectlDeleteOp
 	return params
 }
 
-func (k *Kubectl) Apply(ctx context.Context, kubeconfig string, obj runtime.Object) error {
+// Apply creates the resource or it updates if it already exists.
+func (k *Kubectl) Apply(ctx context.Context, kubeconfig string, obj runtime.Object, opts ...kubernetes.KubectlApplyOption) error {
+	o := &kubernetes.KubectlApplyOptions{}
+	for _, opt := range opts {
+		opt.ApplyToApply(o)
+	}
+
 	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return fmt.Errorf("marshalling object: %v", err)
 	}
-	if _, err := k.ExecuteWithStdin(ctx, b, "apply", "-f", "-", "--kubeconfig", kubeconfig); err != nil {
+
+	params := []string{"apply", "-f", "-", "--kubeconfig", kubeconfig}
+	if o.FieldManager != "" {
+		params = append(params, "--field-manager", o.FieldManager)
+	}
+	if o.ServerSide {
+		params = append(params, "--server-side")
+	}
+	if o.ForceOwnership {
+		params = append(params, "--force-conflicts")
+	}
+
+	if _, err := k.ExecuteWithStdin(ctx, b, params...); err != nil {
 		return fmt.Errorf("applying object with kubectl: %v", err)
 	}
 	return nil

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -3138,19 +3138,65 @@ func TestWaitForRufioMachines(t *testing.T) {
 }
 
 func TestKubectlApply(t *testing.T) {
-	t.Parallel()
-	tt := newKubectlTest(t)
-	secret := &corev1.Secret{}
-	b, err := yaml.Marshal(secret)
-	tt.Expect(err).To(Succeed())
+	kubeconfig := "myconfig.kubeconfig"
+	testCases := []struct {
+		name                  string
+		opts                  []kubernetes.KubectlApplyOption
+		expectedCommandParams []string
+	}{
+		{
+			name:                  "no opts",
+			expectedCommandParams: []string{"apply", "-f", "-", "--kubeconfig", kubeconfig},
+		},
+		{
+			name: "with field manager",
+			opts: []kubernetes.KubectlApplyOption{
+				kubernetes.KubectlApplyOptions{
+					FieldManager: "my-manager",
+				},
+			},
+			expectedCommandParams: []string{"apply", "-f", "-", "--kubeconfig", kubeconfig, "--field-manager", "my-manager"},
+		},
+		{
+			name: "with server side and force ownership",
+			opts: []kubernetes.KubectlApplyOption{
+				kubernetes.KubectlApplyOptions{
+					ServerSide:     true,
+					ForceOwnership: true,
+				},
+			},
+			expectedCommandParams: []string{"apply", "-f", "-", "--kubeconfig", kubeconfig, "--server-side", "--force-conflicts"},
+		},
+		{
+			name: "with server side and field manager",
+			opts: []kubernetes.KubectlApplyOption{
+				kubernetes.KubectlApplyOptions{
+					ServerSide:   true,
+					FieldManager: "my-manager",
+				},
+			},
+			expectedCommandParams: []string{"apply", "-f", "-", "--kubeconfig", kubeconfig, "--field-manager", "my-manager", "--server-side"},
+		},
+	}
+	for _, tCase := range testCases {
+		tc := tCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tt := newKubectlTest(t)
+			tt.kubeconfig = kubeconfig
+			secret := &corev1.Secret{}
+			b, err := yaml.Marshal(secret)
+			tt.Expect(err).To(Succeed())
 
-	tt.e.EXPECT().ExecuteWithStdin(
-		tt.ctx,
-		b,
-		"apply", "-f", "-", "--kubeconfig", tt.kubeconfig,
-	).Return(bytes.Buffer{}, nil)
+			tt.e.EXPECT().ExecuteWithStdin(
+				tt.ctx,
+				b,
+				tc.expectedCommandParams,
+			).Return(bytes.Buffer{}, nil)
 
-	tt.Expect(tt.k.Apply(tt.ctx, tt.kubeconfig, secret)).To(Succeed())
+			tt.Expect(tt.k.Apply(tt.ctx, tt.kubeconfig, secret, tc.opts...)).To(Succeed())
+		})
+	}
 }
 
 func TestKubectlListObjects(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
This allows code shared between the CLI (where the a kubectl wrapper is used) and the controller (where the controller-runtime client.Client is used) to leverage server side apply.

Part of the kindless upgrades work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

