### PR TITLE
Add ability to list clusters across namespaces for validating management cluster name

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -367,6 +367,7 @@ func (r *ClusterReconciler) preClusterProviderReconcile(ctx context.Context, log
 	}
 	if cluster.IsManaged() {
 		if err := r.clusterValidator.ValidateManagementClusterName(ctx, log, cluster); err != nil {
+			log.Error(err, "Invalid cluster configuration")
 			cluster.SetFailure(anywherev1.ManagementClusterRefInvalidReason, err.Error())
 			return controller.Result{}, err
 		}
@@ -570,12 +571,14 @@ func aggregatedGeneration(config *c.Config) int64 {
 }
 
 func getManagementCluster(ctx context.Context, clus *anywherev1.Cluster, client client.Client) (*anywherev1.Cluster, error) {
-	mgmtCluster := &anywherev1.Cluster{}
-	if err := client.Get(ctx, types.NamespacedName{Name: clus.ManagedBy(), Namespace: clus.Namespace}, mgmtCluster); err != nil {
-		if apierrors.IsNotFound(err) {
-			failureMessage := fmt.Sprintf("Management cluster %s does not exist", clus.Spec.ManagementCluster.Name)
-			clus.SetFailure(anywherev1.ManagementClusterRefInvalidReason, failureMessage)
-		}
+	mgmtCluster, err := clusters.FetchManagementEksaCluster(ctx, client, clus)
+	if apierrors.IsNotFound(err) {
+		clus.SetFailure(
+			anywherev1.ManagementClusterRefInvalidReason,
+			fmt.Sprintf("Management cluster %s does not exist", clus.Spec.ManagementCluster.Name),
+		)
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/manager/main.go
+++ b/manager/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/aws/eks-anywhere/controllers"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/features"
 	snowv1 "github.com/aws/eks-anywhere/pkg/providers/snow/api/v1beta1"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -142,6 +143,12 @@ func main() {
 	setupChecks(setupLog, mgr)
 	//+kubebuilder:scaffold:builder
 
+	// Adding this indexer to allow for listing Cluster objects by name if they are in different namespaces.
+	if err := mgr.GetFieldIndexer().
+		IndexField(ctx, &anywherev1.Cluster{}, "metadata.name", clientutil.ClusterNameIndexer); err != nil {
+		setupLog.Error(err, "unable to create index for Cluster name")
+		os.Exit(1)
+	}
 	setupLog.Info("Starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/pkg/controller/clientutil/indexers.go
+++ b/pkg/controller/clientutil/indexers.go
@@ -1,0 +1,19 @@
+package clientutil
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// ClusterNameIndexer is an indexer for controller to list Cluster objects based on name.
+func ClusterNameIndexer(obj client.Object) []string {
+	cluster, ok := obj.(*anywherev1.Cluster)
+	if !ok {
+		panic(fmt.Errorf("indexer function for type %T's metadata.name field received"+
+			" object of type %T, this should never happen", anywherev1.Cluster{}, obj))
+	}
+	return []string{cluster.Name}
+}

--- a/pkg/controller/clientutil/indexers_test.go
+++ b/pkg/controller/clientutil/indexers_test.go
@@ -1,0 +1,34 @@
+package clientutil_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
+)
+
+func TestClusterNameIndexerValid(t *testing.T) {
+	g := NewWithT(t)
+	c := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cluster",
+		},
+	}
+	name := clientutil.ClusterNameIndexer(c)
+	g.Expect(name[0]).To(Equal(c.Name))
+}
+
+func TestClusterNameIndexerFail(t *testing.T) {
+	g := NewWithT(t)
+	c := &v1alpha1.VSphereDatacenterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cluster",
+		},
+	}
+	g.Expect(func() {
+		clientutil.ClusterNameIndexer(c)
+	}).To(Panic())
+}

--- a/pkg/controller/clusters/management.go
+++ b/pkg/controller/clusters/management.go
@@ -1,0 +1,45 @@
+package clusters
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// FetchManagementEksaCluster returns the management cluster object for a given workload Cluster.
+// If we are unable to find the management cluster using the same namespace as the current cluster, we will attempt
+// to get a list of the clusters with that name across all the namespaces. If we find multiple, which usually should
+// not happen as these clusters get mapped to a cluster-api cluster object in the eksa-system namespace, then we
+// also error on that because it is not possible to have multiple resources with the same name within a namespace.
+func FetchManagementEksaCluster(ctx context.Context, cli client.Client, cluster *v1alpha1.Cluster) (*v1alpha1.Cluster, error) {
+	mgmtCluster := &v1alpha1.Cluster{}
+	mgmtClusterKey := client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      cluster.ManagedBy(),
+	}
+	err := cli.Get(ctx, mgmtClusterKey, mgmtCluster)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if apierrors.IsNotFound(err) {
+		// Save error returned from Get if we don't end up finding the cluster through List as it won't return an error
+		notFoundErr := errors.Wrapf(err, "unable to retrieve management cluster %s", cluster.Spec.ManagementCluster.Name)
+		clusterList := &v1alpha1.ClusterList{}
+		if err = cli.List(ctx, clusterList,
+			client.MatchingFields{"metadata.name": cluster.Spec.ManagementCluster.Name}); err != nil {
+			return nil, errors.Wrapf(err, "unable to retrieve management cluster %s", cluster.Spec.ManagementCluster.Name)
+		}
+		if len(clusterList.Items) == 0 {
+			return nil, notFoundErr
+		}
+		if len(clusterList.Items) > 1 {
+			return nil, errors.Errorf("found multiple clusters with the name %s", cluster.Spec.ManagementCluster.Name)
+		}
+		mgmtCluster = &clusterList.Items[0]
+	}
+	return mgmtCluster, nil
+}

--- a/pkg/controller/clusters/validations_test.go
+++ b/pkg/controller/clusters/validations_test.go
@@ -15,6 +15,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/controller/clusters"
 )
 
@@ -35,7 +36,19 @@ func TestValidateManagementClusterNameSuccess(t *testing.T) {
 	tt := newClusterValidatorTest(t)
 
 	objs := []runtime.Object{tt.cluster, tt.managementCluster}
-	cb := fake.NewClientBuilder()
+	cb := fakeClientBuilder()
+	cl := cb.WithRuntimeObjects(objs...).Build()
+
+	validator := clusters.NewClusterValidator(cl)
+	tt.Expect(validator.ValidateManagementClusterName(context.Background(), tt.logger, tt.cluster)).To(BeNil())
+}
+
+func TestValidateManagementClusterNameDifferentNamespaceSuccess(t *testing.T) {
+	tt := newClusterValidatorTest(t)
+	tt.managementCluster.Namespace = "different-namespace"
+
+	objs := []runtime.Object{tt.cluster, tt.managementCluster}
+	cb := fakeClientBuilder()
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	validator := clusters.NewClusterValidator(cl)
@@ -47,12 +60,28 @@ func TestValidateManagementClusterNameMissing(t *testing.T) {
 
 	tt.cluster.Spec.ManagementCluster.Name = "missing"
 	objs := []runtime.Object{tt.cluster, tt.managementCluster}
-	cb := fake.NewClientBuilder()
+	cb := fakeClientBuilder()
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	validator := clusters.NewClusterValidator(cl)
-	tt.Expect(validator.ValidateManagementClusterName(context.Background(), tt.logger, tt.cluster)).
-		To(MatchError(errors.New("unable to retrieve management cluster missing: clusters.anywhere.eks.amazonaws.com \"missing\" not found")))
+	err := validator.ValidateManagementClusterName(context.Background(), tt.logger, tt.cluster)
+	tt.Expect(err.Error()).
+		To(Equal("unable to retrieve management cluster missing: clusters.anywhere.eks.amazonaws.com \"missing\" not found"))
+}
+
+func TestValidateManagementClusterNameMultiple(t *testing.T) {
+	tt := newClusterValidatorTest(t)
+
+	tt.managementCluster.Namespace = "different-namespace-1"
+	managementCluster2 := tt.managementCluster.DeepCopy()
+	managementCluster2.Namespace = "different-namespace-2"
+	objs := []runtime.Object{tt.cluster, tt.managementCluster, managementCluster2}
+	cb := fakeClientBuilder()
+	cl := cb.WithRuntimeObjects(objs...).Build()
+
+	validator := clusters.NewClusterValidator(cl)
+	err := validator.ValidateManagementClusterName(context.Background(), tt.logger, tt.cluster)
+	tt.Expect(err.Error()).To(Equal("found multiple clusters with the name my-management-cluster"))
 }
 
 func TestValidateManagementClusterNameInvalid(t *testing.T) {
@@ -60,7 +89,7 @@ func TestValidateManagementClusterNameInvalid(t *testing.T) {
 
 	tt.managementCluster.SetManagedBy("differentCluster")
 	objs := []runtime.Object{tt.cluster, tt.managementCluster}
-	cb := fake.NewClientBuilder()
+	cb := fakeClientBuilder()
 	cl := cb.WithRuntimeObjects(objs...).Build()
 
 	validator := clusters.NewClusterValidator(cl)
@@ -104,4 +133,8 @@ func newClusterValidatorTest(t *testing.T) *clusterValidatorTest {
 		cluster:           cluster,
 		managementCluster: managementCluster,
 	}
+}
+
+func fakeClientBuilder() *fake.ClientBuilder {
+	return fake.NewClientBuilder().WithIndex(&anywherev1.Cluster{}, "metadata.name", clientutil.ClusterNameIndexer)
 }

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -303,12 +303,7 @@ func (r *Reconciler) validateTinkerbellIPMatch(ctx context.Context, clusterSpec 
 	if clusterSpec.Cluster.IsManaged() {
 
 		// for workload cluster tinkerbell IP must match management cluster tinkerbell IP
-		managementClusterSpec := &anywherev1.Cluster{}
-
-		err := r.client.Get(ctx, client.ObjectKey{
-			Namespace: clusterSpec.Cluster.Namespace,
-			Name:      clusterSpec.Cluster.Spec.ManagementCluster.Name,
-		}, managementClusterSpec)
+		managementClusterSpec, err := clusters.FetchManagementEksaCluster(ctx, r.client, clusterSpec.Cluster)
 		if err != nil {
 			return err
 		}
@@ -316,7 +311,7 @@ func (r *Reconciler) validateTinkerbellIPMatch(ctx context.Context, clusterSpec 
 		managementDatacenterConfig := &anywherev1.TinkerbellDatacenterConfig{}
 
 		err = r.client.Get(ctx, client.ObjectKey{
-			Namespace: clusterSpec.Cluster.Namespace,
+			Namespace: managementClusterSpec.Namespace,
 			Name:      managementClusterSpec.Spec.DatacenterRef.Name,
 		}, managementDatacenterConfig)
 		if err != nil {

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -747,7 +747,10 @@ func TestReconcilerDetectOperationFail(t *testing.T) {
 }
 
 func (tt *reconcilerTest) withFakeClient() {
-	tt.client = fake.NewClientBuilder().WithObjects(clientutil.ObjectsToClientObjects(tt.allObjs())...).Build()
+	tt.client = fake.NewClientBuilder().
+		WithIndex(&anywherev1.Cluster{}, "metadata.name", clientutil.ClusterNameIndexer).
+		WithObjects(clientutil.ObjectsToClientObjects(tt.allObjs())...).
+		Build()
 }
 
 func (tt *reconcilerTest) reconciler() *reconciler.Reconciler {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently we make an assumption in our management cluster name validation for our workload cluster that both clusters exist in the same namespace. However, it is possible that the management cluster and the workload cluster are created in different namespaces. This is also how we get the cluster object through the CLI: https://github.com/aws/eks-anywhere/blob/2347399db3b997eddc9e2e770af1c1ef19bd6ccb/pkg/executables/kubectl.go#L1500

We are keeping the current check of getting the cluster based on the same namespace, but if we don't find it, we will fall back to looking for the cluster using the list api. If we still don't find the cluster or it errors out, we will tell the user that we were unable to find the cluster as we did before. If we find multiple clusters, which should not be possible as the cluster-api cluster resources can't have the same name in the `eksa-system` namespace, we will throw an error too. Once we get past these validations, we will return the cluster in the different namespace. 

Since the list api for controller-runtime needs an index to look off of, we need to add an indexer based on the cluster name to do the lookup, otherwise it would fail with the following error:
```
List on GroupVersionKind anywhere.eks.amazonaws.com/v1alpha1, Kind=Cluster specifies selector on field metadata.name, but no index with name metadata.name has been registered for GroupVersionKind anywhere.eks.amazonaws.com/v1alpha1, Kind=Cluster
```

I followed the approach listed in https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#setup to set up the indexer. There is also another approach using the cache to set it up listed here https://stackoverflow.com/questions/57083221/list-custom-resources-from-caching-client-with-custom-fieldselector, but I am unsure what the real difference is between both approaches so I went with the former.

*Testing (if applicable):*
unit testing
functional testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

