### PR TITLE
Rename ControlPlaneVersionsBundle to RootVersionsBundle

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deprecated_importimages.go
+++ b/cmd/eksctl-anywhere/cmd/deprecated_importimages.go
@@ -76,7 +76,7 @@ func importImages(ctx context.Context, clusterSpecPath string) error {
 
 	de := executables.BuildDockerExecutable()
 
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 	executableBuilder, closer, err := executables.InitInDockerExecutablesBuilder(ctx, bundle.Eksa.CliTools.VersionedImage())
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)

--- a/pkg/awsiamauth/template.go
+++ b/pkg/awsiamauth/template.go
@@ -38,7 +38,7 @@ func (t *TemplateBuilder) GenerateManifest(clusterSpec *cluster.Spec, clusterID 
 		clusterIDValue = clusterID.String()
 	}
 
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 
 	data := map[string]interface{}{
 		"image":              bundle.KubeDistro.AwsIamAuthImage.VersionedImage(),

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -168,8 +168,8 @@ func (s *Spec) VersionsBundle(version eksav1alpha1.KubernetesVersion) *VersionsB
 	return vb
 }
 
-// ControlPlaneVersionsBundle returns a VersionsBundle for the top level kubernetes version.
-func (s *Spec) ControlPlaneVersionsBundle() *VersionsBundle {
+// RootVersionsBundle returns a VersionsBundle for the Cluster objects root Kubernetes versions.
+func (s *Spec) RootVersionsBundle() *VersionsBundle {
 	return s.VersionsBundle(s.Cluster.Spec.KubernetesVersion)
 }
 
@@ -178,7 +178,7 @@ func (s *Spec) WorkerNodeGroupVersionsBundle(w eksav1alpha1.WorkerNodeGroupConfi
 	if w.KubernetesVersion != nil {
 		return s.VersionsBundle(*w.KubernetesVersion)
 	}
-	return s.ControlPlaneVersionsBundle()
+	return s.RootVersionsBundle()
 }
 
 func buildKubeDistro(eksd *eksdv1alpha1.Release) (*KubeDistro, error) {

--- a/pkg/cluster/spec_test.go
+++ b/pkg/cluster/spec_test.go
@@ -205,7 +205,7 @@ func TestBundlesRefDefaulter(t *testing.T) {
 }
 
 func validateSpecFromSimpleBundle(t *testing.T, gotSpec *cluster.Spec) {
-	VersionsBundle := gotSpec.ControlPlaneVersionsBundle()
+	VersionsBundle := gotSpec.RootVersionsBundle()
 	validateVersionedRepo(t, VersionsBundle.KubeDistro.Kubernetes, "public.ecr.aws/eks-distro/kubernetes", "v1.19.8-eks-1-19-4")
 	validateVersionedRepo(t, VersionsBundle.KubeDistro.CoreDNS, "public.ecr.aws/eks-distro/coredns", "v1.8.0-eks-1-19-4")
 	validateVersionedRepo(t, VersionsBundle.KubeDistro.Etcd, "public.ecr.aws/eks-distro/etcd-io", "v3.4.14-eks-1-19-4")

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -126,7 +126,7 @@ func Cluster(clusterSpec *cluster.Spec, infrastructureObject, controlPlaneObject
 
 func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObject) (*controlplanev1.KubeadmControlPlane, error) {
 	replicas := int32(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Count)
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/clusterapi/bottlerocket_test.go
+++ b/pkg/clusterapi/bottlerocket_test.go
@@ -77,7 +77,7 @@ func TestSetBottlerocketInKubeadmControlPlane(t *testing.T) {
 	)
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.CertificatesDir = "/var/lib/kubeadm/pki"
 
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 
 	clusterapi.SetBottlerocketInKubeadmControlPlane(got, bundle)
@@ -91,7 +91,7 @@ func TestSetBottlerocketAdminContainerImageInKubeadmControlPlane(t *testing.T) {
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = adminContainer
 	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = adminContainer
 
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 
 	clusterapi.SetBottlerocketAdminContainerImageInKubeadmControlPlane(got, bundle)
@@ -105,7 +105,7 @@ func TestSetBottlerocketControlContainerImageInKubeadmControlPlane(t *testing.T)
 	want.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = controlContainer
 	want.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = controlContainer
 
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 
 	clusterapi.SetBottlerocketControlContainerImageInKubeadmControlPlane(got, bundle)
@@ -120,7 +120,7 @@ func TestSetBottlerocketInKubeadmConfigTemplate(t *testing.T) {
 	want.Spec.Template.Spec.JoinConfiguration.BottlerocketBootstrap = bootstrap
 	want.Spec.Template.Spec.JoinConfiguration.Pause = pause
 
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 
 	clusterapi.SetBottlerocketInKubeadmConfigTemplate(got, bundle)
@@ -133,7 +133,7 @@ func TestSetBottlerocketAdminContainerImageInKubeadmConfigTemplate(t *testing.T)
 	want := got.DeepCopy()
 	want.Spec.Template.Spec.JoinConfiguration.BottlerocketAdmin = adminContainer
 
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 
 	clusterapi.SetBottlerocketAdminContainerImageInKubeadmConfigTemplate(got, bundle)
@@ -146,7 +146,7 @@ func TestSetBottlerocketControlContainerImageInKubeadmConfigTemplate(t *testing.
 	want := got.DeepCopy()
 	want.Spec.Template.Spec.JoinConfiguration.BottlerocketControl = controlContainer
 
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 
 	clusterapi.SetBottlerocketControlContainerImageInKubeadmConfigTemplate(got, bundle)
@@ -163,7 +163,7 @@ func TestSetBottlerocketInEtcdCluster(t *testing.T) {
 		BootstrapImage: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
 		PauseImage:     "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
 	}
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 	clusterapi.SetBottlerocketInEtcdCluster(got, bundle)
 	g.Expect(got).To(Equal(want))
@@ -179,7 +179,7 @@ func TestSetBottlerocketAdminContainerImageInEtcdCluster(t *testing.T) {
 	}
 	want := got.DeepCopy()
 	want.Spec.EtcdadmConfigSpec.BottlerocketConfig.AdminImage = "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1"
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 	clusterapi.SetBottlerocketAdminContainerImageInEtcdCluster(got, bundle.BottleRocketHostContainers.Admin)
 	g.Expect(got).To(Equal(want))
@@ -195,7 +195,7 @@ func TestSetBottlerocketControlContainerImageInEtcdCluster(t *testing.T) {
 	}
 	want := got.DeepCopy()
 	want.Spec.EtcdadmConfigSpec.BottlerocketConfig.ControlImage = "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1"
-	bundle := g.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := g.clusterSpec.RootVersionsBundle()
 	g.Expect(bundle).ToNot(BeNil())
 	clusterapi.SetBottlerocketControlContainerImageInEtcdCluster(got, bundle.BottleRocketHostContainers.Control)
 	g.Expect(got).To(Equal(want))

--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -75,8 +75,8 @@ func capiChangeDiff(currentSpec, newSpec *cluster.Spec, provider providers.Provi
 	changeDiff := &CAPIChangeDiff{}
 	componentChanged := false
 
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 
 	if currentVersionsBundle.CertManager.Version != newVersionsBundle.CertManager.Version {
 		changeDiff.CertManager = &types.ComponentChangeDiff{

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -746,8 +746,8 @@ func (c *ClusterManager) EKSAClusterSpecChanged(ctx context.Context, clus *types
 }
 
 func compareEKSAClusterSpec(ctx context.Context, currentClusterSpec, newClusterSpec *cluster.Spec) (bool, error) {
-	newVersionsBundle := newClusterSpec.ControlPlaneVersionsBundle()
-	oldVersionsBundle := currentClusterSpec.ControlPlaneVersionsBundle()
+	newVersionsBundle := newClusterSpec.RootVersionsBundle()
+	oldVersionsBundle := currentClusterSpec.RootVersionsBundle()
 
 	if oldVersionsBundle.EksD.Name != newVersionsBundle.EksD.Name {
 		logger.V(3).Info("New eks-d release detected")

--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -98,8 +98,8 @@ func (i *EKSAInstaller) Upgrade(ctx context.Context, log logr.Logger, c *types.C
 		return nil, nil
 	}
 	log.V(1).Info("Starting EKS-A components upgrade")
-	oldVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	oldVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	oldVersion := oldVersionsBundle.Eksa.Version
 	newVersion := newVersionsBundle.Eksa.Version
 	if err := i.Install(ctx, log, c, newSpec); err != nil {
@@ -185,7 +185,7 @@ func fullLifeCycleControllerForProvider(cluster *anywherev1.Cluster) bool {
 }
 
 func (g *EKSAComponentGenerator) parseEKSAComponentsSpec(spec *cluster.Spec) (*eksaComponents, error) {
-	bundle := spec.ControlPlaneVersionsBundle()
+	bundle := spec.RootVersionsBundle()
 	componentsManifest, err := bundles.ReadManifest(g.reader, bundle.Eksa.Components)
 	if err != nil {
 		return nil, fmt.Errorf("loading manifest for eksa components: %v", err)
@@ -233,8 +233,8 @@ func (c *eksaComponents) BuildFromParsed(lookup yamlutil.ObjectLookup) error {
 
 // EksaChangeDiff computes the version diff in eksa components between two specs.
 func EksaChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
-	oldVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	oldVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 
 	if oldVersionsBundle.Eksa.Version != newVersionsBundle.Eksa.Version {
 		return &types.ChangeDiff{

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -128,7 +128,7 @@ func (d *Dependencies) Close(ctx context.Context) error {
 }
 
 func ForSpec(ctx context.Context, clusterSpec *cluster.Spec) *Factory {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	eksaToolsImage := versionsBundle.Eksa.CliTools
 	return NewFactory().
 		UseExecutableImage(eksaToolsImage.VersionedImage()).
@@ -1247,7 +1247,7 @@ func (f *Factory) WithPackageControllerClient(spec *cluster.Spec, kubeConfig str
 		if err != nil {
 			return err
 		}
-		bundle := spec.ControlPlaneVersionsBundle()
+		bundle := spec.RootVersionsBundle()
 		if bundle == nil {
 			return fmt.Errorf("could not find VersionsBundle")
 		}

--- a/pkg/eksd/upgrader.go
+++ b/pkg/eksd/upgrader.go
@@ -38,8 +38,8 @@ func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentS
 }
 
 func EksdChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.EksD.Name != newVersionsBundle.EksD.Name {
 		logger.V(1).Info("EKS-D change diff ", "oldVersion ", currentVersionsBundle.EksD.Name, "newVersion ", newVersionsBundle.EksD.Name)
 		return &types.ChangeDiff{

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -64,7 +64,7 @@ func imageRepository(image v1alpha1.Image) string {
 // used by cluster api to install components.
 // See: https://cluster-api.sigs.k8s.io/clusterctl/configuration.html
 func (c *Clusterctl) buildOverridesLayer(clusterSpec *cluster.Spec, clusterName string, provider providers.Provider) error {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	// Adding cluster name to path temporarily following suggestion.
 	//
@@ -249,7 +249,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluste
 
 func (c *Clusterctl) buildConfig(clusterSpec *cluster.Spec, clusterName string, provider providers.Provider) (*clusterctlConfiguration, error) {
 	t := templater.New(c.writer)
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	path, err := os.Getwd()
 	if err != nil {

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -180,7 +180,7 @@ func (k *Kind) DeleteBootstrapCluster(ctx context.Context, cluster *types.Cluste
 }
 
 func (k *Kind) setupExecConfig(clusterSpec *cluster.Spec) error {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	k.execConfig = &kindExecConfig{
 		KindImage:            registryMirror.ReplaceRegistry(versionsBundle.EksD.KindNode.VersionedImage()),

--- a/pkg/gitops/flux/files.go
+++ b/pkg/gitops/flux/files.go
@@ -150,7 +150,7 @@ func (g *FileGenerator) WriteFluxSync() error {
 }
 
 func (g *FileGenerator) WriteFluxPatch(clusterSpec *cluster.Spec) error {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	values := map[string]string{
 		"Namespace":                   clusterSpec.FluxConfig.Spec.SystemNamespace,
 		"SourceControllerImage":       versionsBundle.Flux.SourceController.VersionedImage(),

--- a/pkg/gitops/flux/upgrader.go
+++ b/pkg/gitops/flux/upgrader.go
@@ -53,8 +53,8 @@ func FluxChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 		logger.V(1).Info("Skipping Flux upgrades, GitOps not enabled")
 		return nil
 	}
-	oldVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	oldVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	oldVersion := oldVersionsBundle.Flux.Version
 	newVersion := newVersionsBundle.Flux.Version
 	if oldVersion != newVersion {

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -40,7 +40,7 @@ func NewTemplater(helm Helm) *Templater {
 }
 
 func (t *Templater) GenerateUpgradePreflightManifest(ctx context.Context, spec *cluster.Spec) ([]byte, error) {
-	versionsBundle := spec.ControlPlaneVersionsBundle()
+	versionsBundle := spec.RootVersionsBundle()
 	v := templateValues(spec, versionsBundle)
 	v.set(true, "preflight", "enabled")
 	v.set(versionsBundle.Cilium.Cilium.Image(), "preflight", "image", "repository")
@@ -131,7 +131,7 @@ func WithPolicyAllowedNamespaces(namespaces []string) ManifestOpt {
 }
 
 func (t *Templater) GenerateManifest(ctx context.Context, spec *cluster.Spec, opts ...ManifestOpt) ([]byte, error) {
-	versionsBundle := spec.ControlPlaneVersionsBundle()
+	versionsBundle := spec.RootVersionsBundle()
 	kubeVersion, err := getKubeVersionString(spec, versionsBundle)
 	if err != nil {
 		return nil, err

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -318,7 +318,7 @@ func TestTemplaterGenerateManifestUpgradeSameKubernetesVersionSuccess(t *testing
 	tt := newtemplaterTest(t)
 	tt.expectHelmTemplateWith(eqMap(wantUpgradeValues()), "1.22").Return(tt.manifest, nil)
 
-	vb := tt.currentSpec.ControlPlaneVersionsBundle()
+	vb := tt.currentSpec.RootVersionsBundle()
 
 	oldCiliumVersion, err := semver.New(vb.Cilium.Version)
 	tt.Expect(err).NotTo(HaveOccurred())
@@ -334,7 +334,7 @@ func TestTemplaterGenerateManifestUpgradeNewKubernetesVersionSuccess(t *testing.
 	tt := newtemplaterTest(t)
 	tt.expectHelmTemplateWith(eqMap(wantUpgradeValues()), "1.21").Return(tt.manifest, nil)
 
-	vb := tt.currentSpec.ControlPlaneVersionsBundle()
+	vb := tt.currentSpec.RootVersionsBundle()
 	oldCiliumVersion, err := semver.New(vb.Cilium.Version)
 	tt.Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -142,7 +142,7 @@ func BuildUpgradePlan(installation *Installation, clusterSpec *cluster.Spec) Upg
 }
 
 func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) VersionedComponentUpgradePlan {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	dsImage := versionsBundle.Cilium.Cilium.VersionedImage()
 	info := VersionedComponentUpgradePlan{
 		NewImage: dsImage,
@@ -171,7 +171,7 @@ func daemonSetUpgradePlan(ds *appsv1.DaemonSet, clusterSpec *cluster.Spec) Versi
 }
 
 func operatorUpgradePlan(operator *appsv1.Deployment, clusterSpec *cluster.Spec) VersionedComponentUpgradePlan {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	newImage := versionsBundle.Cilium.Operator.VersionedImage()
 	info := VersionedComponentUpgradePlan{
 		NewImage: newImage,

--- a/pkg/networking/cilium/upgrader.go
+++ b/pkg/networking/cilium/upgrader.go
@@ -83,7 +83,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentS
 		return nil, fmt.Errorf("failed deleting cilium preflight check: %v", err)
 	}
 
-	versionsBundle := currentSpec.ControlPlaneVersionsBundle()
+	versionsBundle := currentSpec.RootVersionsBundle()
 
 	logger.V(3).Info("Generating Cilium upgrade manifest")
 	currentKubeVersion, err := getKubeVersionString(currentSpec, versionsBundle)
@@ -143,8 +143,8 @@ func (u *Upgrader) waitForCilium(ctx context.Context, cluster *types.Cluster) er
 }
 
 func ciliumChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Cilium.Version == newVersionsBundle.Cilium.Version {
 		return nil
 	}

--- a/pkg/networking/kindnetd/manifest.go
+++ b/pkg/networking/kindnetd/manifest.go
@@ -17,7 +17,7 @@ import (
 )
 
 func generateManifest(reader manifests.FileReader, clusterSpec *cluster.Spec) ([]byte, error) {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	kindnetdManifest, err := bundles.ReadManifest(reader, versionsBundle.Kindnetd.Manifest)
 	if err != nil {
 		return nil, fmt.Errorf("can't load kindnetd manifest: %v", err)

--- a/pkg/networking/kindnetd/upgrader.go
+++ b/pkg/networking/kindnetd/upgrader.go
@@ -45,8 +45,8 @@ func (u Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSp
 }
 
 func kindnetdChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Kindnetd.Version == newVersionsBundle.Kindnetd.Version {
 		return nil
 	}

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -203,8 +203,8 @@ func (p *cloudstackProvider) ValidateNewSpec(ctx context.Context, cluster *types
 }
 
 func (p *cloudstackProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.CloudStack.Version == newVersionsBundle.CloudStack.Version {
 		return nil
 	}
@@ -812,7 +812,7 @@ func (p *cloudstackProvider) BootstrapSetup(ctx context.Context, clusterConfig *
 }
 
 func (p *cloudstackProvider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	return versionsBundle.CloudStack.Version
 }
 
@@ -833,7 +833,7 @@ func (p *cloudstackProvider) GetDeployments() map[string][]string {
 }
 
 func (p *cloudstackProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	folderName := fmt.Sprintf("infrastructure-cloudstack/%s/", versionsBundle.CloudStack.Version)
 
 	infraBundle := types.InfrastructureBundle{

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -1081,7 +1081,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 			}
 			assert.Equal(t, "infrastructure-cloudstack/v0.1.0/", infraBundle.FolderName, "Incorrect folder name")
 			assert.Equal(t, len(infraBundle.Manifests), 2, "Wrong number of files in the infrastructure bundle")
-			bundle := tt.clusterSpec.ControlPlaneVersionsBundle()
+			bundle := tt.clusterSpec.RootVersionsBundle()
 			wantManifests := []releasev1alpha1.Manifest{
 				bundle.CloudStack.Components,
 				bundle.CloudStack.Metadata,

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -100,7 +100,7 @@ func (cs *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 // nolint:gocyclo
 func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, error) {
 	datacenterConfigSpec := clusterSpec.CloudStackDatacenter.Spec
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	format := "cloud-config"
 	host, port, err := getValidControlPlaneHostPort(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -232,7 +232,7 @@ func kubeletCgroupDriverExtraArgs(kubeVersion v1alpha1.KubernetesVersion) (clust
 }
 
 func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, error) {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
@@ -541,7 +541,7 @@ func getUpdatedKubeConfigContent(content *[]byte, dockerLbPort string) {
 }
 
 func (p *provider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	return versionsBundle.Docker.Version
 }
 
@@ -560,7 +560,7 @@ func (p *provider) GetDeployments() map[string][]string {
 }
 
 func (p *provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	folderName := fmt.Sprintf("infrastructure-docker/%s/", versionsBundle.Docker.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -588,8 +588,8 @@ func (p *provider) ValidateNewSpec(_ context.Context, _ *types.Cluster, _ *clust
 }
 
 func (p *provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Docker.Version == newVersionsBundle.Docker.Version {
 		return nil
 	}

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -522,7 +522,7 @@ func (p *Provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 
 // Version returns the nutanix version from the VersionsBundle.
 func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	return versionsBundle.Nutanix.Version
 }
 
@@ -546,7 +546,7 @@ func (p *Provider) GetDeployments() map[string][]string {
 }
 
 func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	manifests := []releasev1alpha1.Manifest{
 		versionsBundle.Nutanix.Components,
 		versionsBundle.Nutanix.Metadata,
@@ -612,8 +612,8 @@ func (p *Provider) ValidateNewSpec(_ context.Context, _ *types.Cluster, _ *clust
 }
 
 func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Nutanix.Version == newVersionsBundle.Nutanix.Version {
 		return nil
 	}

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -150,7 +150,7 @@ func buildTemplateMapCP(
 	controlPlaneMachineSpec v1alpha1.NutanixMachineConfigSpec,
 	etcdMachineSpec v1alpha1.NutanixMachineConfigSpec,
 ) (map[string]interface{}, error) {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	format := "cloud-config"
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -41,7 +41,7 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 		return nil, fmt.Errorf("generating KubeadmControlPlane: %v", err)
 	}
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	if err := clusterapi.SetKubeVipInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host, versionsBundle.Snow.KubeVip.VersionedImage()); err != nil {
 		return nil, fmt.Errorf("setting kube-vip: %v", err)
@@ -102,7 +102,7 @@ func KubeadmConfigTemplate(log logr.Logger, clusterSpec *cluster.Spec, workerNod
 		return nil, fmt.Errorf("generating KubeadmConfigTemplate: %v", err)
 	}
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	joinConfigKubeletExtraArg := kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
@@ -148,7 +148,7 @@ func machineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig v1alpha1
 func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTemplate *snowv1.AWSSnowMachineTemplate) *etcdv1.EtcdadmCluster {
 	etcd := clusterapi.EtcdadmCluster(clusterSpec, snowMachineTemplate)
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	machineConfig := clusterSpec.SnowMachineConfig(clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name)
 	osFamily := machineConfig.OSFamily()

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -190,7 +190,7 @@ func (p *SnowProvider) UpdateKubeConfig(content *[]byte, clusterName string) err
 }
 
 func (p *SnowProvider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	return versionsBundle.Snow.Version
 }
 
@@ -199,7 +199,7 @@ func (p *SnowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, err
 	envMap[snowCredentialsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCredentialsKey])
 	envMap[snowCertsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCertificatesKey])
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	envMap["SNOW_CONTROLLER_IMAGE"] = versionsBundle.Snow.Manager.VersionedImage()
 
@@ -213,7 +213,7 @@ func (p *SnowProvider) GetDeployments() map[string][]string {
 }
 
 func (p *SnowProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	folderName := fmt.Sprintf("infrastructure-snow/%s/", versionsBundle.Snow.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -251,8 +251,8 @@ func (p *SnowProvider) ValidateNewSpec(ctx context.Context, cluster *types.Clust
 }
 
 func (p *SnowProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Snow.Version == newVersionsBundle.Snow.Version {
 		return nil
 	}
@@ -334,8 +334,8 @@ func (p *SnowProvider) validateUpgradeRolloutStrategy(clusterSpec *cluster.Spec)
 // to trigger a cluster upgrade or not.
 // TODO: revert the change once cluster.BuildSpec is used in cluster_manager to replace the deprecated cluster.BuildSpecForCluster
 func (p *SnowProvider) UpgradeNeeded(ctx context.Context, newSpec, oldSpec *cluster.Spec, c *types.Cluster) (bool, error) {
-	oldVersionBundle := oldSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	oldVersionBundle := oldSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if !bundleImagesEqual(newVersionsBundle.Snow, oldVersionBundle.Snow) {
 		return true, nil
 	}

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -991,7 +991,7 @@ func TestVersion(t *testing.T) {
 
 func TestGetInfrastructureBundle(t *testing.T) {
 	tt := newSnowTest(t)
-	bundle := tt.clusterSpec.ControlPlaneVersionsBundle()
+	bundle := tt.clusterSpec.RootVersionsBundle()
 	want := &types.InfrastructureBundle{
 		FolderName: "infrastructure-snow/v1.0.2/",
 		Manifests: []releasev1alpha1.Manifest{

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -28,7 +28,7 @@ func (p *Provider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.Bootstr
 func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	logger.V(4).Info("Installing Tinkerbell stack on bootstrap cluster")
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	err := p.stackInstaller.Install(
 		ctx,
@@ -76,7 +76,7 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 		logger.Info("Warning: Skipping load balancer deployment. Please install and configure a load balancer once the cluster is created.")
 	}
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	err := p.stackInstaller.Install(
 		ctx,

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -65,7 +65,7 @@ func NewTemplateBuilder(datacenterSpec *v1alpha1.TinkerbellDatacenterConfigSpec,
 
 func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	cpTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[tb.controlPlaneMachineSpec.TemplateRef.Name]
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 
 func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error) {
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 		workerNodeMachineSpec := tb.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name]
 		wTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[workerNodeMachineSpec.TemplateRef.Name]
@@ -362,7 +362,7 @@ func buildTemplateMapCP(
 	etcdTemplateOverride string,
 	datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec,
 ) (map[string]interface{}, error) {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	format := "cloud-config"
 
 	apiServerExtraArgs := clusterapi.OIDCToExtraArgs(clusterSpec.OIDCConfig).

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -208,7 +208,7 @@ func (p *Provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 }
 
 func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	return versionsBundle.Tinkerbell.Version
 }
 
@@ -243,7 +243,7 @@ func (p *Provider) GetDeployments() map[string][]string {
 }
 
 func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	folderName := fmt.Sprintf("infrastructure-tinkerbell/%s/", versionsBundle.Tinkerbell.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -295,8 +295,8 @@ func (p *Provider) MachineConfigs(_ *cluster.Spec) []providers.MachineConfig {
 }
 
 func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Tinkerbell.Version == newVersionsBundle.Tinkerbell.Version {
 		return nil
 	}

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -416,7 +416,7 @@ func TestPreCAPIInstallOnBootstrapSuccess(t *testing.T) {
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 	provider.stackInstaller = stackInstaller
 
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 
 	stackInstaller.EXPECT().Install(
 		ctx,
@@ -453,7 +453,7 @@ func TestPostWorkloadInitSuccess(t *testing.T) {
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 	provider.stackInstaller = stackInstaller
 
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 
 	stackInstaller.EXPECT().Install(
 		ctx,

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -374,7 +374,7 @@ func (p *Provider) PreCoreComponentsUpgrade(
 		return errors.New("cluster spec is nil")
 	}
 
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 
 	// Attempt the upgrade. This should upgrade the stack in the mangement cluster by updating
 	// images, installing new CRDs and possibly removing old ones.

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -72,7 +72,7 @@ func TestProviderPreCoreComponentsUpgrade_StackUpgradeError(t *testing.T) {
 	tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
 	expect := "foobar"
-	bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+	bundle := tconfig.ClusterSpec.RootVersionsBundle()
 	tconfig.Installer.EXPECT().
 		Upgrade(
 			gomock.Any(),
@@ -97,7 +97,7 @@ func TestProviderPreCoreComponentsUpgrade_StackUpgradeError(t *testing.T) {
 func TestProviderPreCoreComponentsUpgrade_HasBaseboardManagementCRDError(t *testing.T) {
 	tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
-	bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+	bundle := tconfig.ClusterSpec.RootVersionsBundle()
 
 	tconfig.Installer.EXPECT().
 		Upgrade(
@@ -132,7 +132,7 @@ func TestProviderPreCoreComponentsUpgrade_HasBaseboardManagementCRDError(t *test
 func TestProviderPreCoreComponentsUpgrade_NoBaseboardManagementCRD(t *testing.T) {
 	tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
-	bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+	bundle := tconfig.ClusterSpec.RootVersionsBundle()
 
 	tconfig.Installer.EXPECT().
 		Upgrade(
@@ -441,7 +441,7 @@ func TestProviderPreCoreComponentsUpgrade_RufioConversions(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tconfig := NewPreCoreComponentsUpgradeTestConfig(t)
 
-			bundle := tconfig.ClusterSpec.ControlPlaneVersionsBundle()
+			bundle := tconfig.ClusterSpec.RootVersionsBundle()
 
 			// Configure the mocks to successfully upgrade the Tinkerbell stack using the installer
 			// and identify the need to convert deprecated Rufio custom resources.
@@ -613,7 +613,7 @@ func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
 
 // WithStackUpgrade configures t mocks to get successfully reach Rufio CRD conversion.
 func (t *PreCoreComponentsUpgradeTestConfig) WithStackUpgrade() *PreCoreComponentsUpgradeTestConfig {
-	bundle := t.ClusterSpec.ControlPlaneVersionsBundle()
+	bundle := t.ClusterSpec.RootVersionsBundle()
 
 	t.Installer.EXPECT().
 		Upgrade(

--- a/pkg/providers/vsphere/defaults.go
+++ b/pkg/providers/vsphere/defaults.go
@@ -94,7 +94,7 @@ func (d *Defaulter) setWorkerDefaultTemplateIfMissing(ctx context.Context, spec 
 func (d *Defaulter) setDefaultTemplateIfMissing(ctx context.Context, spec *Spec, m *anywherev1.VSphereMachineConfig) error {
 	if m.Spec.Template == "" {
 		logger.V(1).Info("VSphereMachineConfig template is not set. Using default template.")
-		versionsBundle := spec.ControlPlaneVersionsBundle()
+		versionsBundle := spec.RootVersionsBundle()
 		if err := d.setupDefaultTemplate(ctx, spec, m, versionsBundle); err != nil {
 			return err
 		}

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -124,7 +124,7 @@ func buildTemplateMapCP(
 	datacenterSpec anywherev1.VSphereDatacenterConfigSpec,
 	controlPlaneMachineSpec, etcdMachineSpec anywherev1.VSphereMachineConfigSpec,
 ) (map[string]interface{}, error) {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	format := "cloud-config"
 	etcdExtraArgs := clusterapi.SecureEtcdTlsCipherSuitesExtraArgs()
 	sharedExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -890,7 +890,7 @@ func (p *vsphereProvider) PostWorkloadInit(ctx context.Context, cluster *types.C
 }
 
 func (p *vsphereProvider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	return versionsBundle.VSphere.Version
 }
 
@@ -913,7 +913,7 @@ func (p *vsphereProvider) GetDeployments() map[string][]string {
 }
 
 func (p *vsphereProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.ControlPlaneVersionsBundle()
+	versionsBundle := clusterSpec.RootVersionsBundle()
 	folderName := fmt.Sprintf("infrastructure-vsphere/%s/", versionsBundle.VSphere.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -1099,8 +1099,8 @@ func (p *vsphereProvider) secretContentsChanged(ctx context.Context, workloadClu
 }
 
 func (p *vsphereProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.VSphere.Version == newVersionsBundle.VSphere.Version {
 		return nil
 	}
@@ -1121,8 +1121,8 @@ func cpiResourceSetName(clusterSpec *cluster.Spec) string {
 }
 
 func (p *vsphereProvider) UpgradeNeeded(ctx context.Context, newSpec, currentSpec *cluster.Spec, c *types.Cluster) (bool, error) {
-	currentVersionsBundle := currentSpec.ControlPlaneVersionsBundle()
-	newVersionsBundle := newSpec.ControlPlaneVersionsBundle()
+	currentVersionsBundle := currentSpec.RootVersionsBundle()
+	newVersionsBundle := newSpec.RootVersionsBundle()
 	newV, oldV := newVersionsBundle.VSphere, currentVersionsBundle.VSphere
 
 	if newV.Manager.ImageDigest != oldV.Manager.ImageDigest ||
@@ -1199,7 +1199,7 @@ func (p *vsphereProvider) applyEthtoolDaemonSet(ctx context.Context, cluster *ty
 		}
 	}
 	logger.V(4).Info("Applying vsphere-disable-udp-offload daemonset")
-	bundle := clusterSpec.ControlPlaneVersionsBundle()
+	bundle := clusterSpec.RootVersionsBundle()
 	values := map[string]interface{}{
 		"eksaSystemNamespace": constants.EksaSystemNamespace,
 		"kindNodeImage":       bundle.EksD.KindNode.VersionedImage(),

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2901,7 +2901,7 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 			}
 			assert.Equal(t, "infrastructure-vsphere/v0.7.8/", infraBundle.FolderName, "Incorrect folder name")
 			assert.Equal(t, len(infraBundle.Manifests), 3, "Wrong number of files in the infrastructure bundle")
-			bundle := tt.clusterSpec.ControlPlaneVersionsBundle()
+			bundle := tt.clusterSpec.RootVersionsBundle()
 			wantManifests := []releasev1alpha1.Manifest{
 				bundle.VSphere.Components,
 				bundle.VSphere.Metadata,


### PR DESCRIPTION
Our API doesn't contain a control plane version bundle. This method, used extensively throughout the code base, creates a little confusion so warrants a rename.