### PR TITLE
Fix incorrect k8s version in vSphere E2E

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2683,7 +2683,7 @@ func TestVSphereKubernetes123to124UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 		api.VSphereToConfigFiller(
 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
 		),
-		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube124, framework.Bottlerocket1, release),
+		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube123, framework.Bottlerocket1, release),
 	)
 
 	test.WithWorkloadClusters(wc)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes incorrect kubernetes version in `TestVSphereKubernetes123to124UpgradeFromLatestMinorReleaseBottleRocketAPI`

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


