### PR TITLE
Add generate TinkerbellTemplateConfig command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/flags"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/awsiamauth"
 	"github.com/aws/eks-anywhere/pkg/clustermanager"
@@ -50,16 +50,14 @@ func init() {
 	applyClusterOptionFlags(createClusterCmd.Flags(), &cc.clusterOptions)
 	applyTimeoutFlags(createClusterCmd.Flags(), &cc.timeoutOptions)
 	applyTinkerbellHardwareFlag(createClusterCmd.Flags(), &cc.hardwareCSVPath)
-	createClusterCmd.Flags().StringVar(&cc.tinkerbellBootstrapIP, "tinkerbell-bootstrap-ip", "", "Override the local tinkerbell IP in the bootstrap cluster")
+	flags.String(flags.TinkerbellBootstrapIP, &cc.tinkerbellBootstrapIP, createClusterCmd.Flags())
 	createClusterCmd.Flags().BoolVar(&cc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	hideForceCleanup(createClusterCmd.Flags())
 	createClusterCmd.Flags().BoolVar(&cc.skipIpCheck, "skip-ip-check", false, "Skip check for whether cluster control plane ip is in use")
 	createClusterCmd.Flags().StringVar(&cc.installPackages, "install-packages", "", "Location of curated packages configuration files to install to the cluster")
 	createClusterCmd.Flags().StringArrayVar(&cc.skipValidations, "skip-validations", []string{}, fmt.Sprintf("Bypass create validations by name. Valid arguments you can pass are --skip-validations=%s", strings.Join(createvalidations.SkippableValidations[:], ",")))
 
-	if err := createClusterCmd.MarkFlagRequired("filename"); err != nil {
-		log.Fatalf("Error marking flag as required: %v", err)
-	}
+	flags.MarkRequired(createClusterCmd.Flags(), flags.ClusterConfig.Name)
 }
 
 func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) error {

--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/flags"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
@@ -35,8 +36,8 @@ func bindFlagsToViper(cmd *cobra.Command, args []string) error {
 }
 
 func applyClusterOptionFlags(flagSet *pflag.FlagSet, clusterOpt *clusterOptions) {
-	flagSet.StringVarP(&clusterOpt.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
-	flagSet.StringVar(&clusterOpt.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
+	flags.String(flags.ClusterConfig, &clusterOpt.fileName, flagSet)
+	flags.String(flags.BundleOverride, &clusterOpt.bundlesOverride, flagSet)
 	flagSet.StringVar(&clusterOpt.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
 }
 

--- a/cmd/eksctl-anywhere/cmd/flags/cluster.go
+++ b/cmd/eksctl-anywhere/cmd/flags/cluster.go
@@ -1,0 +1,15 @@
+package flags
+
+// ClusterConfig is the path to a cluster specification YAML.
+var ClusterConfig = Flag[string]{
+	Name:  "filename",
+	Short: "f",
+	Usage: "Path that contains a cluster configuration",
+}
+
+// BundleOverride is a path to a bundles manifest YAML that will be used in-place of the cluster
+// specifications bundle override.
+var BundleOverride = Flag[string]{
+	Name:  "bundles-override",
+	Usage: "A path to a custom bundles manifest",
+}

--- a/cmd/eksctl-anywhere/cmd/flags/flag.go
+++ b/cmd/eksctl-anywhere/cmd/flags/flag.go
@@ -1,0 +1,23 @@
+package flags
+
+import "github.com/spf13/pflag"
+
+// Flag defines a CLI flag.
+type Flag[T any] struct {
+	Name    string
+	Short   string
+	Usage   string
+	Default T
+}
+
+// String applies f to fs and writes the value to dst.
+func String(f Flag[string], dst *string, fs *pflag.FlagSet) {
+	switch {
+	// With short form
+	case f.Short != "":
+		fs.StringVarP(dst, f.Name, f.Short, f.Default, f.Usage)
+	// Without short form
+	default:
+		fs.StringVar(dst, f.Name, f.Default, f.Usage)
+	}
+}

--- a/cmd/eksctl-anywhere/cmd/flags/require.go
+++ b/cmd/eksctl-anywhere/cmd/flags/require.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MarkRequired is a helper to mark flags required on cmd. If a flag does not exist, it panics.
-func MarkRequired(set *pflag.FlagSet, flags []string) {
+func MarkRequired(set *pflag.FlagSet, flags ...string) {
 	for _, flag := range flags {
 		if err := cobra.MarkFlagRequired(set, flag); err != nil {
 			panic(err)

--- a/cmd/eksctl-anywhere/cmd/flags/require.go
+++ b/cmd/eksctl-anywhere/cmd/flags/require.go
@@ -1,0 +1,15 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// MarkRequired is a helper to mark flags required on cmd. If a flag does not exist, it panics.
+func MarkRequired(set *pflag.FlagSet, flags []string) {
+	for _, flag := range flags {
+		if err := cobra.MarkFlagRequired(set, flag); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/cmd/eksctl-anywhere/cmd/flags/require_test.go
+++ b/cmd/eksctl-anywhere/cmd/flags/require_test.go
@@ -77,7 +77,7 @@ func TestMarkRequired(t *testing.T) {
 			// so we need to parse the args using the flag set before calling it.
 			_ = cmd.Flags().Parse(tc.Args)
 
-			flags.MarkRequired(cmd.Flags(), required)
+			flags.MarkRequired(cmd.Flags(), required...)
 
 			err := cmd.ValidateRequiredFlags()
 
@@ -109,7 +109,7 @@ func TestMarkRequired_FlagDoesNotExist(t *testing.T) {
 	}()
 
 	flgs := pflag.NewFlagSet("", pflag.ContinueOnError)
-	flags.MarkRequired(flgs, []string{"does-not-exist"})
+	flags.MarkRequired(flgs, "does-not-exist")
 }
 
 func nopPflag(name string) pflag.Flag {

--- a/cmd/eksctl-anywhere/cmd/flags/require_test.go
+++ b/cmd/eksctl-anywhere/cmd/flags/require_test.go
@@ -1,0 +1,127 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/flags"
+)
+
+func TestMarkRequired(t *testing.T) {
+	type flag struct {
+		Pflag   pflag.Flag
+		Require bool
+	}
+
+	for _, tc := range []struct {
+		Name        string
+		Flags       []flag
+		Args        []string
+		ExpectError string
+	}{
+		{
+			Name:  "RequiredFlagPresent",
+			Flags: []flag{{Pflag: nopPflag("foo"), Require: true}},
+			Args:  []string{"--foo=."},
+		},
+		{
+			Name:        "RequiredFlagNotPresent",
+			Flags:       []flag{{Pflag: nopPflag("foo"), Require: true}},
+			ExpectError: "required flag(s) \"foo\" not set",
+		},
+		{
+			Name: "MultipleRequiredFlagsPresent",
+			Flags: []flag{
+				{Pflag: nopPflag("foo"), Require: true},
+				{Pflag: nopPflag("bar"), Require: true},
+			},
+			Args: []string{"--foo=.", "--bar=."},
+		},
+		{
+			Name: "MultipleRequiredFlagsNotPresent",
+			Flags: []flag{
+				{Pflag: nopPflag("foo"), Require: true},
+				{Pflag: nopPflag("bar"), Require: true},
+			},
+			// A bug in cobra causes
+			ExpectError: "required flag(s) \"bar\", \"foo\" not set",
+		},
+		{
+			Name: "NoRequiredFlags",
+			Flags: []flag{
+				{Pflag: nopPflag("foo")},
+				{Pflag: nopPflag("bar")},
+			},
+			Args: []string{"--foo=."},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+
+			// Cache required flags so we can call the function under test.
+			var required []string
+
+			// Add all flags.
+			for _, flg := range tc.Flags {
+				flg := flg
+				cmd.Flags().AddFlag(&flg.Pflag)
+
+				if flg.Require {
+					required = append(required, flg.Pflag.Name)
+				}
+			}
+
+			// The cmd.ValidateRequiredFlags() operates on the flag set as opposed to cmd internals
+			// so we need to parse the args using the flag set before calling it.
+			_ = cmd.Flags().Parse(tc.Args)
+
+			flags.MarkRequired(cmd.Flags(), required)
+
+			err := cmd.ValidateRequiredFlags()
+
+			// We expect an error but we received nothing.
+			if tc.ExpectError != "" && err == nil {
+				t.Error("Expected error but received nil")
+			}
+
+			// We don't expect an error but we received something.
+			if tc.ExpectError == "" && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// We expect an error but its not what we expected.
+			if tc.ExpectError != "" && tc.ExpectError != err.Error() {
+				t.Errorf("Expected: %v\nReceived: %v\n", tc.ExpectError, err)
+			}
+		})
+	}
+}
+
+func TestMarkRequired_FlagDoesNotExist(t *testing.T) {
+	defer func() {
+		// We expect the panic called in flags.MarkRequired() to pass a non-nil value so we can
+		// test for that here.
+		if recover() == nil {
+			t.Error("no panic received")
+		}
+	}()
+
+	flgs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.MarkRequired(flgs, []string{"does-not-exist"})
+}
+
+func nopPflag(name string) pflag.Flag {
+	return pflag.Flag{
+		Name:        name,
+		Value:       nopValue{},
+		Annotations: map[string][]string{},
+	}
+}
+
+type nopValue struct{}
+
+func (nopValue) String() string   { return "" }
+func (nopValue) Set(string) error { return nil }
+func (nopValue) Type() string     { return "" }

--- a/cmd/eksctl-anywhere/cmd/flags/tinkerbell.go
+++ b/cmd/eksctl-anywhere/cmd/flags/tinkerbell.go
@@ -1,0 +1,8 @@
+package flags
+
+// TinkerbellBootstrapIP is used to override the Tinkerbell IP for serving a Tinkerbell stack
+// from an admin machine.
+var TinkerbellBootstrapIP = Flag[string]{
+	Name:  "tinkerbell-bootstrap-ip",
+	Usage: "The IP used to expose the Tinkerbell stack from the bootstrap cluster",
+}

--- a/cmd/eksctl-anywhere/cmd/generate.go
+++ b/cmd/eksctl-anywhere/cmd/generate.go
@@ -12,4 +12,5 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
+	generateCmd.AddCommand(NewGenerateTinkerbellTemplateConfig())
 }

--- a/cmd/eksctl-anywhere/cmd/generate_tinkerbell_template_config.go
+++ b/cmd/eksctl-anywhere/cmd/generate_tinkerbell_template_config.go
@@ -41,13 +41,10 @@ func NewGenerateTinkerbellTemplateConfig() *cobra.Command {
 
 	// Configure the flagset. Some of these flags are duplicated from other parts of the cmd code
 	// for consistency but their descriptions may vary because of the commands use-case.
-	flgs := pflag.NewFlagSet("tinkerbelltemplateconfig", pflag.ExitOnError)
-	flgs.StringVarP(&opts.fileName, "filename", "f", "",
-		"A path to the EKS Anywhere cluster specification")
-	flgs.StringVar(&opts.bundlesOverride, "bundles-override", "",
-		"A path to a custom bundles manifest")
-	flgs.StringVar(&opts.BootstrapTinkerbellIP, "tinkerbell-bootstrap-ip", "",
-		"The IP used to expose the Tinkerbell stack from the bootstrap cluster")
+	flgs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.String(flags.ClusterConfig, &opts.fileName, flgs)
+	flags.String(flags.BundleOverride, &opts.bundlesOverride, flgs)
+	flags.String(flags.TinkerbellBootstrapIP, &opts.BootstrapTinkerbellIP, flgs)
 
 	cmd := &cobra.Command{
 		Use:     "tinkerbelltemplateconfig",
@@ -57,7 +54,7 @@ func NewGenerateTinkerbellTemplateConfig() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// When the bootstrap IP is unspecified attempt to derive it from IPs assigned to the
 			// primary interface.
-			if f := flgs.Lookup("tinkerbell-bootstrap-ip"); !f.Changed {
+			if f := flgs.Lookup(flags.TinkerbellBootstrapIP.Name); !f.Changed {
 				bootstrapIP, err := networkutils.GetLocalIP()
 				if err != nil {
 					return fmt.Errorf("tinkerbell bootstrap ip: %v", err)
@@ -115,7 +112,6 @@ func NewGenerateTinkerbellTemplateConfig() *cobra.Command {
 
 	// Configure the commands flags.
 	cmd.Flags().AddFlagSet(flgs)
-	flags.MarkRequired(cmd.Flags(), []string{"filename", "tinkerbell-bootstrap-ip"})
 
 	return cmd
 }

--- a/cmd/eksctl-anywhere/cmd/generate_tinkerbell_template_config.go
+++ b/cmd/eksctl-anywhere/cmd/generate_tinkerbell_template_config.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/flags"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
+	"github.com/aws/eks-anywhere/pkg/utils/yaml"
+)
+
+const shortGenerateTinkerbellTemplateConfigHelp = "Generate TinkerbellTemplateConfig objects"
+
+const longGenerateTinkerbellTemplateConfigHelp = `Generate TinkerbellTemplateConfig objects for your cluster specification.
+
+The TinkerbellTemplateConfig is part of an EKS Anywhere bare metal cluster 
+specification. When no template config is specified on TinkerbellMachineConfig
+objects, EKS Anywhere generates the template config internally. The template 
+config defines the actions for provisioning a bare metal host such as streaming 
+an OS image to disk. Actions vary based on the OS - see the EKS Anywhere 
+documentation for more details on the individual actions.
+
+The template config include it in your bare metal cluster specification and
+reference it in the TinkerbellMachineConfig object using the .spec.templateRef
+field.
+`
+
+// NewGenerateTinkerbellTemplateConfig creates a command that will generate a TinkerbellTemplateConfig
+// using the cluster configuration.
+func NewGenerateTinkerbellTemplateConfig() *cobra.Command {
+	var opts struct {
+		clusterOptions
+		BootstrapTinkerbellIP string
+	}
+
+	// Configure the flagset. Some of these flags are duplicated from other parts of the cmd code
+	// for consistency but their descriptions may vary because of the commands use-case.
+	flgs := pflag.NewFlagSet("tinkerbelltemplateconfig", pflag.ExitOnError)
+	flgs.StringVarP(&opts.fileName, "filename", "f", "",
+		"A path to the EKS Anywhere cluster specification")
+	flgs.StringVar(&opts.bundlesOverride, "bundles-override", "",
+		"A path to a custom bundles manifest")
+	flgs.StringVar(&opts.BootstrapTinkerbellIP, "tinkerbell-bootstrap-ip", "",
+		"The IP used to expose the Tinkerbell stack from the bootstrap cluster")
+
+	cmd := &cobra.Command{
+		Use:     "tinkerbelltemplateconfig",
+		Short:   shortGenerateTinkerbellTemplateConfigHelp,
+		Long:    longGenerateTinkerbellTemplateConfigHelp,
+		Aliases: []string{"ttc"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// When the bootstrap IP is unspecified attempt to derive it from IPs assigned to the
+			// primary interface.
+			if f := flgs.Lookup("tinkerbell-bootstrap-ip"); !f.Changed {
+				bootstrapIP, err := networkutils.GetLocalIP()
+				if err != nil {
+					return fmt.Errorf("tinkerbell bootstrap ip: %v", err)
+				}
+				opts.BootstrapTinkerbellIP = bootstrapIP.String()
+			}
+
+			// Validation logic called by newClusterSpec arbitrarily logs warnings. Until it can
+			// be refactored we need to redirect logging such that the output is swallowed.
+			if err := logger.Init(logger.Options{
+				Level: -1,
+			}); err != nil {
+				return err
+			}
+
+			cs, err := newClusterSpec(opts.clusterOptions)
+
+			// Reset the logger before evaluating anything in-case logic higher up the call path
+			// needs the logger.
+			if err := logger.Init(logger.Options{
+				Level: viper.GetInt("verbosity"),
+			}); err != nil {
+				return err
+			}
+
+			// Handle the newClusterSpec() error.
+			if err != nil {
+				return err
+			}
+
+			// Generating the TinkerbellTemplateConfig requires the OS family to ensure the right
+			// actions are produced. The OS family is specified per TinkerbellMachineConfig,
+			// therefore is specified in multiple places (control plane and worker node groups).
+			// However, we only support single OS family clusters so validation should error out
+			// earlier if they aren't the same. This means we can use the control plane machine
+			// configs OS family.
+			controlPlaneMachineConfigName := cs.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+			controlPlaneMachineConfig := cs.TinkerbellMachineConfigs[controlPlaneMachineConfigName]
+			osFamily := controlPlaneMachineConfig.OSFamily()
+
+			// For modular upgrades the version bundle is retrieve per worker node group. However,
+			// because Tinkerbell action images are the same for every Kubernetes version within
+			// the same bundle manifest, its OK to just use the root version bundle.
+			bundle := *cs.RootVersionsBundle().VersionsBundle
+
+			osImageURL := cs.TinkerbellDatacenter.Spec.OSImageURL
+			tinkerbellIP := cs.TinkerbellDatacenter.Spec.TinkerbellIP
+
+			cfg := v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(cs.Cluster, bundle, osImageURL,
+				opts.BootstrapTinkerbellIP, tinkerbellIP, osFamily)
+
+			return yaml.NewK8sEncoder(os.Stdout).Encode(cfg)
+		},
+	}
+
+	// Configure the commands flags.
+	cmd.Flags().AddFlagSet(flgs)
+	flags.MarkRequired(cmd.Flags(), []string{"filename", "tinkerbell-bootstrap-ip"})
+
+	return cmd
+}

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/flags"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
@@ -60,9 +60,7 @@ func init() {
 	hideForceCleanup(upgradeClusterCmd.Flags())
 	upgradeClusterCmd.Flags().StringArrayVar(&uc.skipValidations, "skip-validations", []string{}, fmt.Sprintf("Bypass upgrade validations by name. Valid arguments you can pass are --skip-validations=%s", strings.Join(upgradevalidations.SkippableValidations[:], ",")))
 
-	if err := upgradeClusterCmd.MarkFlagRequired("filename"); err != nil {
-		log.Fatalf("Error marking flag as required: %v", err)
-	}
+	flags.MarkRequired(createClusterCmd.Flags(), flags.ClusterConfig.Name)
 }
 
 func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {

--- a/pkg/utils/yaml/kubernetes.go
+++ b/pkg/utils/yaml/kubernetes.go
@@ -1,0 +1,29 @@
+package yaml
+
+import (
+	"io"
+
+	"sigs.k8s.io/yaml"
+)
+
+// K8sEncoder leverages the Kubernetes YAML package (sigs.k8s.io/yaml) to provide an Encoder data
+// structure that is friendlier to the io package.
+type K8sEncoder struct {
+	out io.Writer
+}
+
+// NewK8sEncoder creates a K8sEncoder instance that writes to out.
+func NewK8sEncoder(out io.Writer) K8sEncoder {
+	return K8sEncoder{out}
+}
+
+// Encode marshals v into YAML and writes it to e's output stream.
+func (e K8sEncoder) Encode(v any) error {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	_, err = e.out.Write(b)
+	return err
+}


### PR DESCRIPTION
Closes #3588.

**Summary**
In Tinkerbell clusters users can customize the provisioning steps by specifying their own TinkerbellTemplateConfig as part of the cluster spec. However, to date its been difficult for users to determine what set of default actions are used as EKS-A generates the TinkerbellTemplateConfig when unspecified (default behavior).

This command generates a TinkerbellTemplateConfig using the users cluster spec giving them a functional template.

```
eksctl anywhere generate tinkerbelltemplateconfig -f <cluster spec path>
```

**Future work**
Further refactoring is necessary around flag names to deduplicate flag name strings. Some refactoring in validation logic is necessary to decouple output of warnings from the validation logic.

In addition to this new command, or as part of `generate clusterconfig` command, we would like a way to update the cluster spec - including the template reference fields - to use the newly generated template.