### PR TITLE
Use Full Template Path in Tag Validation

### DIFF
--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -200,11 +200,12 @@ func (v *Validator) validateTemplates(ctx context.Context, spec *Spec) error {
 	for template, requiredTags := range tagsForTemplates {
 		datacenter := spec.VSphereDatacenter.Spec.Datacenter
 
-		if err := v.validateTemplatePresence(ctx, datacenter, template); err != nil {
+		templatePath, err := v.getTemplatePath(ctx, datacenter, template)
+		if err != nil {
 			return err
 		}
 
-		if err := v.validateTemplateTags(ctx, template, requiredTags); err != nil {
+		if err := v.validateTemplateTags(ctx, templatePath, requiredTags); err != nil {
 			return err
 		}
 	}
@@ -212,17 +213,17 @@ func (v *Validator) validateTemplates(ctx context.Context, spec *Spec) error {
 	return nil
 }
 
-func (v *Validator) validateTemplatePresence(ctx context.Context, datacenter, templatePath string) error {
+func (v *Validator) getTemplatePath(ctx context.Context, datacenter, templatePath string) (string, error) {
 	templateFullPath, err := v.govc.SearchTemplate(ctx, datacenter, templatePath)
 	if err != nil {
-		return fmt.Errorf("validating template: %v", err)
+		return "", fmt.Errorf("validating template: %v", err)
 	}
 
 	if len(templateFullPath) <= 0 {
-		return fmt.Errorf("template <%s> not found. Has the template been imported?", templatePath)
+		return "", fmt.Errorf("template <%s> not found. Has the template been imported?", templatePath)
 	}
 
-	return nil
+	return templateFullPath, nil
 }
 
 func (v *Validator) validateTemplateTags(ctx context.Context, templatePath string, requiredTags []string) error {

--- a/pkg/providers/vsphere/validator_test.go
+++ b/pkg/providers/vsphere/validator_test.go
@@ -328,6 +328,26 @@ func TestValidatorValidateMachineConfigTagsExistTagDoesNotExist(t *testing.T) {
 	g.Expect(err).To(Not(BeNil()))
 }
 
+func TestValidatorValidateMachineConfigTemplateDoesNotExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	govc := govcmocks.NewMockProviderGovcClient(ctrl)
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	v := Validator{
+		govc: govc,
+	}
+
+	govc.EXPECT().SearchTemplate(ctx, "", "").Return("", nil)
+
+	_, err := v.getTemplatePath(ctx, "", "")
+	g.Expect(err).To(Not(BeNil()))
+
+	govc.EXPECT().SearchTemplate(ctx, "", "").Return("", fmt.Errorf("not found"))
+	_, err = v.getTemplatePath(ctx, "", "")
+	g.Expect(err).To(MatchError("validating template: not found"))
+}
+
 func TestValidateBRHardDiskSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	govc := govcmocks.NewMockProviderGovcClient(ctrl)

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -416,7 +416,7 @@ func (v *VSphere) WithBottleRocket123() api.ClusterConfigFiller {
 // WithBottleRocket124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
 // as well as the right botllerocket template and osFamily for all VSphereMachineConfigs.
 func (v *VSphere) WithBottleRocket124() api.ClusterConfigFiller {
-	return v.WithKubeVersionAndOS(anywherev1.Kube123, Bottlerocket1, nil)
+	return v.WithKubeVersionAndOS(anywherev1.Kube124, Bottlerocket1, nil)
 }
 
 // CleanupVMs deletes all the VMs owned by the test EKS-A cluster. It satisfies the test framework Provider.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1636

*Description of changes:*
Pass the full template path when validating template tags instead of just the name.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

