### PR TITLE
Retrieve management cluster namespace instead of assuming workload cluster namespace

### DIFF
--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -152,7 +152,7 @@ func (p *Provider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpe
 			return err
 		}
 
-		managementDatacenterConfig, err := p.providerKubectlClient.GetEksaTinkerbellDatacenterConfig(ctx, managementClusterSpec.Spec.DatacenterRef.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace)
+		managementDatacenterConfig, err := p.providerKubectlClient.GetEksaTinkerbellDatacenterConfig(ctx, managementClusterSpec.Spec.DatacenterRef.Name, clusterSpec.ManagementCluster.KubeconfigFile, managementClusterSpec.Namespace)
 		if err != nil {
 			return fmt.Errorf("getting TinkerbellIP of management cluster: %s", err)
 		}

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -1058,6 +1058,55 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	assert.NoError(t, err, "No error should be returned")
 }
 
+func TestSetupAndValidateCreateWorkloadClusterDifferentNamespaceSuccess(t *testing.T) {
+	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
+	mockCtrl := gomock.NewController(t)
+	docker := stackmocks.NewMockDocker(mockCtrl)
+	helm := stackmocks.NewMockHelm(mockCtrl)
+	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
+	writer := filewritermocks.NewMockFileWriter(mockCtrl)
+
+	forceCleanup := false
+
+	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+	datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+	managementCluster := clusterSpec.Cluster.DeepCopy()
+	managementCluster.Namespace = "different-namespace"
+	ctx := context.Background()
+
+	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
+	provider.stackInstaller = stackInstaller
+
+	stackInstaller.EXPECT().CleanupLocalBoots(ctx, forceCleanup)
+	provider.providerKubectlClient = kubectl
+
+	clusterSpec.Cluster.SetManagedBy("management-cluster")
+	clusterSpec.ManagementCluster = &types.Cluster{
+		Name:               "management-cluster",
+		KubeconfigFile:     "kc.kubeconfig",
+		ExistingManagement: true,
+	}
+	for _, config := range machineConfigs {
+		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
+	}
+	kubectl.EXPECT().SearchTinkerbellDatacenterConfig(ctx, datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, clusterSpec.Cluster.Namespace).Return([]*v1alpha1.TinkerbellDatacenterConfig{}, nil)
+
+	kubectl.EXPECT().GetUnprovisionedTinkerbellHardware(ctx, clusterSpec.ManagementCluster.KubeconfigFile, constants.EksaSystemNamespace).Return([]tinkv1alpha1.Hardware{}, nil)
+	kubectl.EXPECT().GetProvisionedTinkerbellHardware(ctx, clusterSpec.ManagementCluster.KubeconfigFile, constants.EksaSystemNamespace).Return([]tinkv1alpha1.Hardware{}, nil)
+	kubectl.EXPECT().GetEksaCluster(ctx, clusterSpec.ManagementCluster, clusterSpec.ManagementCluster.Name).Return(managementCluster, nil)
+	kubectl.EXPECT().GetEksaTinkerbellDatacenterConfig(ctx, datacenterConfig.Name, clusterSpec.ManagementCluster.KubeconfigFile, managementCluster.Namespace).Return(datacenterConfig, nil)
+	kubectl.EXPECT().ApplyKubeSpecFromBytesForce(ctx, clusterSpec.ManagementCluster, gomock.Any())
+	kubectl.EXPECT().WaitForRufioMachines(ctx, clusterSpec.ManagementCluster, "5m", "Contactable", constants.EksaSystemNamespace)
+
+	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
+	if err != nil {
+		t.Fatalf("unexpected failure %v", err)
+	}
+	assert.NoError(t, err, "No error should be returned")
+}
+
 func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T) {
 	clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
 	mockCtrl := gomock.NewController(t)

--- a/pkg/validations/createvalidations/gitops.go
+++ b/pkg/validations/createvalidations/gitops.go
@@ -46,13 +46,13 @@ func validateGitOpsConfig(ctx context.Context, k validations.KubectlClient, clus
 		return fmt.Errorf("fetching gitOpsConfig in cluster: %v", err)
 	}
 
-	mgmtCluster := &v1alpha1.Cluster{}
-	if err := k.GetObject(ctx, clusterResourceType, clusterSpec.Cluster.ManagedBy(), clusterSpec.Cluster.Namespace, cluster.KubeconfigFile, mgmtCluster); err != nil {
+	mgmtCluster, err := k.GetEksaCluster(ctx, clusterSpec.ManagementCluster, clusterSpec.Cluster.ManagedBy())
+	if err != nil {
 		return err
 	}
 
 	mgmtGitOpsConfig := &v1alpha1.GitOpsConfig{}
-	if err := k.GetObject(ctx, gitOpsConfigResourceType, mgmtCluster.Spec.GitOpsRef.Name, clusterSpec.Cluster.Namespace, cluster.KubeconfigFile, mgmtGitOpsConfig); err != nil {
+	if err := k.GetObject(ctx, gitOpsConfigResourceType, mgmtCluster.Spec.GitOpsRef.Name, mgmtCluster.Namespace, cluster.KubeconfigFile, mgmtGitOpsConfig); err != nil {
 		return err
 	}
 
@@ -83,8 +83,8 @@ func validateFluxConfig(ctx context.Context, k validations.KubectlClient, cluste
 		return fmt.Errorf("fetching fluxConfig in cluster: %v", err)
 	}
 
-	mgmtCluster := &v1alpha1.Cluster{}
-	if err := k.GetObject(ctx, clusterResourceType, clusterSpec.Cluster.ManagedBy(), clusterSpec.Cluster.Namespace, cluster.KubeconfigFile, mgmtCluster); err != nil {
+	mgmtCluster, err := k.GetEksaCluster(ctx, clusterSpec.ManagementCluster, clusterSpec.Cluster.ManagedBy())
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Builds off of #6414, however there are a few places outside of the controller where we make this assumption as well, which the `GetEksaCluster` function solves for.

*Testing (if applicable):*
unit testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

