### PR TITLE
Fix checkpoint test to not fail at etcd rolling out

### DIFF
--- a/internal/pkg/api/vsphere.go
+++ b/internal/pkg/api/vsphere.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"os"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -132,6 +133,17 @@ func WithResourcePoolForAllMachines(value string) VSphereFiller {
 	return func(config VSphereConfig) {
 		for _, m := range config.machineConfigs {
 			m.Spec.ResourcePool = value
+		}
+	}
+}
+
+// WithResourcePoolforCPMachines sets the resource pool for control plane machines to the specified value.
+func WithResourcePoolforCPMachines(value string) VSphereFiller {
+	return func(config VSphereConfig) {
+		for _, m := range config.machineConfigs {
+			if strings.HasSuffix(m.Name, "-cp") {
+				m.Spec.ResourcePool = value
+			}
 		}
 	}
 }

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2322,9 +2322,9 @@ func TestVSphereKubernetes126UbuntuTo127UpgradeWithCheckpoint(t *testing.T) {
 	)
 
 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Ubuntu127Template(), api.WithResourcePoolForAllMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "false"))
+		provider.WithProviderUpgrade(provider.Ubuntu127Template(), api.WithResourcePoolforCPMachines(vsphereInvalidResourcePoolUpdateVar)), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "false"))
 
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+	commandOpts := []framework.CommandOpt{framework.WithControlPlaneWaitTimeout("10m")}
 
 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)), framework.ExpectFailure(false),
 		provider.WithProviderUpgrade(provider.Ubuntu127Template(), api.WithResourcePoolForAllMachines(os.Getenv(vsphereResourcePoolVar))), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupVmsVar, "true"))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Test fails at waiting for external etcd to be ready because of the 2X replicas hard limit on etcd. This changes the checkpoint test to not fail at etcd rolling out but at cp rolling out to avoid the test timing out waiting for external etcd to be ready when more etcd nodes cannot be rolled out.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


