### PR TITLE
Remove kubebuilder root tags from unreleased Rufio CRDs to avoid generating deepcopy

### DIFF
--- a/pkg/providers/tinkerbell/rufiounreleased/baseboardmanagement.go
+++ b/pkg/providers/tinkerbell/rufiounreleased/baseboardmanagement.go
@@ -165,7 +165,6 @@ type BaseboardManagementRef struct {
 	Namespace string `json:"namespace"`
 }
 
-//+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=baseboardmanagements,scope=Namespaced,categories=tinkerbell,singular=baseboardmanagement,shortName=bm
 
@@ -177,8 +176,6 @@ type BaseboardManagement struct {
 	Spec   BaseboardManagementSpec   `json:"spec,omitempty"`
 	Status BaseboardManagementStatus `json:"status,omitempty"`
 }
-
-//+kubebuilder:object:root=true
 
 // BaseboardManagementList contains a list of BaseboardManagement.
 type BaseboardManagementList struct {


### PR DESCRIPTION
*Description of changes:*
If you run `make generate` currently, it generates `pkg/providers/tinkerbell/rufiounreleased/zz_generated.deepcopy.go` which isn't needed. This PR removes the `//+kubebuilder:object:root=true` annotations from this file so `controller-gen` doesn't generate this file anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

