### PR TITLE
Error out when management kubeconfig is not present for workload cluster operations

### DIFF
--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -138,8 +138,9 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 	}
 
 	if clusterSpec.Cluster.IsManaged() && options.managementKubeconfig == "" {
-		if kubeconfig.FromEnvironment() != "" {
-			options.managementKubeconfig = kubeconfig.FromEnvironment()
+		envKubeconfig := kubeconfig.FromEnvironment()
+		if envKubeconfig != "" {
+			options.managementKubeconfig = envKubeconfig
 		} else {
 			// check if kubeconfig for management cluster exists locally
 			managementKubeconfigPath := kubeconfig.FromClusterName(clusterSpec.Cluster.Spec.ManagementCluster.Name)


### PR DESCRIPTION
When management cluster kubeconfig is not set during workload cluster create/upgrade, eks-a doesn't fail and incorrectly sets management cluster to same as workload cluster when `clusterspec.ManagementCluster` value is nil which is determined based on kubeconfig file being explicitly passed or set as env variable. This change tries to additionally find the kubeconfig file locally if the env variable is not set for kubeconfig and errors out when not able to find any valid kubeconfig file.  

*Issue #, if available:*


*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

