### PR TITLE
Add Chris Splinter to docs OWNERS

### DIFF
--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,8 +1,10 @@
 approvers:
 - chrisnegus
+- csplinter
 - rothgar
 reviewers:
 - chrisnegus
+- csplinter
 - rothgar
 labels:
 - documentation


### PR DESCRIPTION
Adding csplinter to docs OWNERS file.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

