### PR TITLE
Update default CLI tools image to latest

### DIFF
--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
 
-const defaultEksaImage = "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.7.2-eks-a-v0.0.0-dev-build.1864"
+const defaultEksaImage = "public.ecr.aws/eks-anywhere/cli-tools:v0.17.0-eks-a-45"
 
 type ExecutableBuilder interface {
 	Init(ctx context.Context) (Closer, error)


### PR DESCRIPTION
*Description of changes:*
This is only used in E2E tests for convenience and only to run commands needed in the tests themselves, nothing for the normal lifecycle flows. Updating to the last version to get all dep patches and mostly because the new image is way smaller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

