### PR TITLE
fix upgrade from latest e2e

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -32,6 +32,8 @@ import (
 
 const supportedMinorVersionIncrement int64 = 1
 
+var devBuild, _ = semver.New("v0.0.0-dev")
+
 // log is for logging in this package.
 var clusterlog = logf.Log.WithName("cluster-resource")
 
@@ -147,6 +149,10 @@ func ValidateEksaVersionSkew(new, old *Cluster) field.ErrorList {
 			allErrs,
 			field.Invalid(eksaVersionPath, new.Spec.EksaVersion, "EksaVersion is not a valid semver"))
 		return allErrs
+	}
+
+	if newEksaVersion.SamePatch(devBuild) {
+		return nil
 	}
 
 	majorVersionDifference := int64(newEksaVersion.Major) - int64(oldEksaVersion.Major)

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -898,6 +898,13 @@ func TestClusterValidateUpdateEksaVersionSkew(t *testing.T) {
 			allow:          true,
 		},
 		{
+			name:           "allow upgrade from release to dev with prerelease metadata",
+			wantErr:        "",
+			upgradeVersion: v1alpha1.EksaVersion("v0.0.0-dev-release-0.17"),
+			oldVersion:     v1alpha1.EksaVersion("v0.17.0"),
+			allow:          true,
+		},
+		{
 			name:           "success",
 			wantErr:        "",
 			upgradeVersion: v1alpha1.EksaVersion("v0.2.0"),

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -880,21 +880,28 @@ func TestClusterValidateUpdateEksaVersionSkew(t *testing.T) {
 		{
 			name:           "allow downgrade",
 			wantErr:        "",
-			upgradeVersion: v1alpha1.EksaVersion("v0.0.0"),
-			oldVersion:     v1alpha1.EksaVersion("v0.1.0"),
+			upgradeVersion: v1alpha1.EksaVersion("v0.1.0"),
+			oldVersion:     v1alpha1.EksaVersion("v0.2.0"),
 			allow:          true,
 		},
 		{
 			name:           "forbid downgrade",
 			wantErr:        "cannot downgrade",
+			upgradeVersion: v1alpha1.EksaVersion("v0.1.0"),
+			oldVersion:     v1alpha1.EksaVersion("v0.2.0"),
+		},
+		{
+			name:           "allow upgrade from release to dev",
+			wantErr:        "",
 			upgradeVersion: v1alpha1.EksaVersion("v0.0.0"),
-			oldVersion:     v1alpha1.EksaVersion("v0.1.0"),
+			oldVersion:     v1alpha1.EksaVersion("v0.17.0"),
+			allow:          true,
 		},
 		{
 			name:           "success",
 			wantErr:        "",
-			upgradeVersion: v1alpha1.EksaVersion("v0.1.0"),
-			oldVersion:     v1alpha1.EksaVersion("v0.0.0"),
+			upgradeVersion: v1alpha1.EksaVersion("v0.2.0"),
+			oldVersion:     v1alpha1.EksaVersion("v0.1.0"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -356,8 +356,9 @@ func TestValidateEksaVersion(t *testing.T) {
 }
 
 func TestValidateEksaVersionSkew(t *testing.T) {
-	v := test.DevEksaVersion()
-	uv := anywherev1.EksaVersion("v0.1.0")
+	v := anywherev1.EksaVersion("v0.1.0")
+	uv := anywherev1.EksaVersion("v0.2.0")
+	devVersion := test.DevEksaVersion()
 	badVersion := anywherev1.EksaVersion("invalid")
 	tests := []struct {
 		name           string
@@ -385,7 +386,7 @@ func TestValidateEksaVersionSkew(t *testing.T) {
 		},
 		{
 			name:           "Fail",
-			wantErr:        fmt.Errorf("spec.EksaVersion: Invalid value: \"v0.0.0-dev\": cannot downgrade from v0.1.0 to v0.0.0: EksaVersion upgrades must be incremental"),
+			wantErr:        fmt.Errorf("spec.EksaVersion: Invalid value: \"v0.1.0\": cannot downgrade from v0.2.0 to v0.1.0: EksaVersion upgrades must be incremental"),
 			version:        &uv,
 			upgradeVersion: &v,
 		},
@@ -400,6 +401,12 @@ func TestValidateEksaVersionSkew(t *testing.T) {
 			wantErr:        nil,
 			version:        &uv,
 			upgradeVersion: nil,
+		},
+		{
+			name:           "Upgrade to dev build success",
+			wantErr:        nil,
+			version:        &uv,
+			upgradeVersion: &devVersion,
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Preflight validations currently see upgrading from a release build to dev build as a downgrade. This change lets you upgrade with a dev build in this scenario. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

