### PR TITLE
cloudstack cluster/dc/mc should use same namespace

### DIFF
--- a/pkg/cluster/testdata/cluster_tinkerbell_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_tinkerbell_1_19.yaml
@@ -22,16 +22,12 @@ spec:
   datacenterRef:
     kind: TinkerbellDatacenterConfig
     name: test
-  externalEtcdConfiguration:
-    count: 1
-    machineGroupRef:
-      name: test-cp
-      kind: TinkerbellMachineConfig
   kubernetesVersion: "1.19"
   managementCluster:
     name: test
   workerNodeGroupConfigurations:
     - count: 1
+      name: md-0
       machineGroupRef:
         name: test-md
         kind: TinkerbellMachineConfig

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -25,6 +24,24 @@ func tinkerbellEntry() *ConfigManagerEntry {
 			processTinkerbellDatacenter,
 			machineConfigsProcessor(processTinkerbellMachineConfig),
 			processTinkerbellTemplateConfigs,
+		},
+		Validations: []Validation{
+			func(c *Config) error {
+				if c.TinkerbellDatacenter != nil {
+					if err := validateSameNamespace(c, c.TinkerbellDatacenter); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			func(c *Config) error {
+				for _, t := range c.TinkerbellMachineConfigs {
+					if err := validateSameNamespace(c, t); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
 		},
 	}
 }

--- a/pkg/cluster/tinkerbell_test.go
+++ b/pkg/cluster/tinkerbell_test.go
@@ -47,6 +47,7 @@ func TestParseConfigFromFileTinkerbellCluster(t *testing.T) {
 				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						Count: ptr.Int(1),
+						Name:  "md-0",
 						MachineGroupRef: &anywherev1.Ref{
 							Kind: "TinkerbellMachineConfig",
 							Name: "test-md",
@@ -67,13 +68,6 @@ func TestParseConfigFromFileTinkerbellCluster(t *testing.T) {
 						CidrBlocks: []string{"10.96.0.0/12"},
 					},
 					CNI: "cilium",
-				},
-				ExternalEtcdConfiguration: &anywherev1.ExternalEtcdConfiguration{
-					Count: 1,
-					MachineGroupRef: &anywherev1.Ref{
-						Kind: "TinkerbellMachineConfig",
-						Name: "test-cp",
-					},
 				},
 				ManagementCluster: anywherev1.ManagementCluster{Name: "test"},
 			},


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/6452

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

