### PR TITLE
Fix regex for make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,9 +397,9 @@ clean: ## Clean up resources created by make targets
 	rm -rf ./pkg/providers/vsphere/Test*
 	rm -rf ./pkg/providers/tinkerbell/stack/TestTinkerbellStackInstall*
 ifeq ($(UNAME), Darwin)
-	  find -E . -depth -type d -regex '.*\/Test.*-[0-9]{9}\/.*' -exec rm -rf {} \;
+	  find -E . -depth -type d -regex '.*\/Test.*-[0-9]{10}[\/]?.*' -exec rm -rf {} \;
 else
-	  find . -depth -type d -regextype posix-egrep -regex '.*\/Test.*-[0-9]{9}\/.*' -exec rm -rf {} \;
+	  find . -depth -type d -regextype posix-egrep -regex '.*\/Test.*-[0-9]{10}[\/]?.*' -exec rm -rf {} \;
 endif
 	rm -rf ./manager/bin/*
 	rm -rf ./hack/tools/bin


### PR DESCRIPTION
*Description of changes:*
The current regex in `make clean` doesn't delete the `Test...` folders created for unit-tests.
This PR updates the regex to `.*\/Test.*-[0-9]{10}[\/]?.*` which matches the following folders created during unit tests.

```bash
./pkg/providers/cloudstack/TestSetupAndValidateSSHAuthorizedKeyEmptyCP-2071519390/generated
./pkg/providers/cloudstack/TestSetupAndValidateSSHAuthorizedKeyEmptyCP-2071519390
```
Here's the regex matching example https://rubular.com/r/pBaXKbK9yzTPKO

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

