### PR TITLE
Fix Modular k8s Skew Validation

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -486,7 +486,7 @@ func ValidateWorkerKubernetesVersionSkew(new, old *Cluster) field.ErrorList {
 	for _, nodeGroupNewSpec := range new.Spec.WorkerNodeGroupConfigurations {
 		newVersion := nodeGroupNewSpec.KubernetesVersion
 
-		if newVersion != nil && nodeGroupNewSpec.MachineGroupRef.Kind == TinkerbellMachineConfigKind {
+		if newVersion != nil && new.Spec.DatacenterRef.Kind == TinkerbellDatacenterKind {
 			allErrs = append(allErrs, field.Forbidden(path, "worker node group level kubernetesVersion is not supported for Tinkerbell"))
 			return allErrs
 		}

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -2186,14 +2186,10 @@ func TestValidateWorkerVersionBlockTinkerbell(t *testing.T) {
 	newCluster := baseCluster()
 	newCluster.Spec.KubernetesVersion = kube119
 	newCluster.Spec.WorkerNodeGroupConfigurations[0].KubernetesVersion = &kube119
-	newCluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Kind = v1alpha1.TinkerbellMachineConfigKind
+	newCluster.Spec.DatacenterRef.Kind = v1alpha1.TinkerbellDatacenterKind
 	newWorker := v1alpha1.WorkerNodeGroupConfiguration{
-		Name:  "md-1",
-		Count: ptr.Int(1),
-		MachineGroupRef: &v1alpha1.Ref{
-			Kind: v1alpha1.TinkerbellMachineConfigKind,
-			Name: "eksa-unit-test",
-		},
+		Name:              "md-1",
+		Count:             ptr.Int(1),
 		KubernetesVersion: &kube119,
 	}
 	newCluster.Spec.WorkerNodeGroupConfigurations = append(newCluster.Spec.WorkerNodeGroupConfigurations, newWorker)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Check DatacenterRef Kind instead of MachineGroupRef Kind to block Tinkerbell modular k8s since docker configs don't have MachineConfigs.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

