### PR TITLE
Revert docker tests to use cilium instead of kindnetd

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -83,15 +83,6 @@ func WithCiliumSkipUpgrade() ClusterFiller {
 	}
 }
 
-// WithKindnetd configures the cluster to use the Kindnetd cni.
-func WithKindnetd() ClusterFiller {
-	return func(cluster *anywherev1.Cluster) {
-		cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
-			Kindnetd: &anywherev1.KindnetdConfig{},
-		}
-	}
-}
-
 func WithClusterNamespace(ns string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Namespace = ns

--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -141,7 +141,3 @@ skipped_tests:
 - TestTinkerbellKubernetes123BottleRocketCuratedPackagesPrometheusSimpleFlow
 # Conformance
 - TestSnowKubernetes123ThreeWorkersConformanceFlow
-
-#Docker
-#Skipping because upgrade from latest minor release with cilium is currently broken for docker and the controller does not support kindnet.
-- TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -740,7 +740,6 @@ func TestDockerKubernetes124UpgradeFromLatestMinorRelease(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKindnetd()),
 	)
 	runUpgradeFromReleaseFlow(
 		test,
@@ -759,7 +758,6 @@ func TestDockerKubernetes123to124UpgradeFromLatestMinorRelease(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKindnetd()),
 	)
 	runUpgradeFromReleaseFlow(
 		test,
@@ -779,7 +777,6 @@ func TestDockerKubernetes124to125UpgradeFromLatestMinorRelease(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKindnetd()),
 	)
 	runUpgradeFromReleaseFlow(
 		test,
@@ -799,7 +796,6 @@ func TestDockerKubernetes125to126UpgradeFromLatestMinorRelease(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKindnetd()),
 	)
 	runUpgradeFromReleaseFlow(
 		test,
@@ -819,7 +815,6 @@ func TestDockerKubernetes126to127UpgradeFromLatestMinorRelease(t *testing.T) {
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKindnetd()),
 	)
 	runUpgradeFromReleaseFlow(
 		test,
@@ -839,7 +834,6 @@ func TestDockerKubernetes126to127GithubFluxEnabledUpgradeFromLatestMinorRelease(
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKindnetd()),
 	)
 	runUpgradeWithFluxFromReleaseFlow(
 		test,
@@ -851,9 +845,7 @@ func TestDockerKubernetes126to127GithubFluxEnabledUpgradeFromLatestMinorRelease(
 
 func TestDockerKubernetes126WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewDocker(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube126, api.ClusterToConfigFiller(
-		api.WithKindnetd(),
-	))
+	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube126)
 }
 
 func TestDockerKubernetes124UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates docker tests from using kindnetd to cilium again. This change was original made in [this](https://github.com/aws/eks-anywhere/pull/6296) PR due to issues upgrading from the latest release, specifically with docker.

*Testing (if applicable):*
I ran some of the affected e2e tests locally and they all succeeded.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

