### PR TITLE
CLI deprecate wl kubeconfig flag

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -141,7 +141,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithEksdInstaller().
-		WithPackageInstaller(clusterSpec, cc.installPackages, cc.managementKubeconfig).
+		WithPackageInstaller(clusterSpec, cc.installPackages, cc.clusterKubeconfig).
 		WithValidatorClients().
 		WithCreateClusterDefaulter(createCLIConfig)
 

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 
@@ -38,6 +39,10 @@ var deleteClusterCmd = &cobra.Command{
 		if err := dc.deleteCluster(cmd.Context()); err != nil {
 			return fmt.Errorf("failed to delete cluster: %v", err)
 		}
+		if uc.wConfig != "" {
+			logger.MarkFail(wConfigDeprecationMessage)
+			return errors.New("please remove the --w-config flag and use --kubeconfig instead")
+		}
 		return nil
 	},
 }
@@ -46,9 +51,13 @@ func init() {
 	deleteCmd.AddCommand(deleteClusterCmd)
 	deleteClusterCmd.Flags().StringVarP(&dc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration, required if <cluster-name> is not provided")
 	deleteClusterCmd.Flags().StringVarP(&dc.wConfig, "w-config", "w", "", "Kubeconfig file to use when deleting a workload cluster")
+	err := deleteClusterCmd.Flags().MarkDeprecated("w-config", "please use flag --kubeconfig.")
+	if err != nil {
+		log.Fatalf("Error deprecating flag as required: %v", err)
+	}
 	deleteClusterCmd.Flags().BoolVar(&dc.forceCleanup, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	hideForceCleanup(deleteClusterCmd.Flags())
-	deleteClusterCmd.Flags().StringVar(&dc.managementKubeconfig, "kubeconfig", "", "kubeconfig file pointing to a management cluster")
+	deleteClusterCmd.Flags().StringVar(&dc.clusterKubeconfig, "kubeconfig", "", "kubeconfig file pointing to a management cluster")
 	deleteClusterCmd.Flags().StringVar(&dc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 }
 
@@ -73,7 +82,7 @@ func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) err
 		return err
 	}
 
-	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.wConfig)
+	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.clusterKubeconfig)
 	if err := kubeconfig.ValidateFilename(kubeconfigPath); err != nil {
 		return err
 	}
@@ -119,21 +128,30 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	)
 
 	var cluster *types.Cluster
+	var kubeconfigFile string
 	if clusterSpec.ManagementCluster == nil {
+		kubeconfigFile = kubeconfig.FromClusterName(clusterSpec.Cluster.Name)
+		if dc.clusterKubeconfig != "" {
+			kubeconfigFile = dc.clusterKubeconfig
+		}
 		cluster = &types.Cluster{
 			Name:               clusterSpec.Cluster.Name,
-			KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
+			KubeconfigFile:     kubeconfigFile,
 			ExistingManagement: false,
 		}
 	} else {
+		kubeconfigFile = clusterSpec.ManagementCluster.KubeconfigFile
+		if dc.clusterKubeconfig != "" {
+			kubeconfigFile = dc.clusterKubeconfig
+		}
 		cluster = &types.Cluster{
 			Name:               clusterSpec.Cluster.Name,
-			KubeconfigFile:     clusterSpec.ManagementCluster.KubeconfigFile,
+			KubeconfigFile:     kubeconfigFile,
 			ExistingManagement: true,
 		}
 	}
 
-	err = deleteCluster.Run(ctx, cluster, clusterSpec, dc.forceCleanup, dc.managementKubeconfig)
+	err = deleteCluster.Run(ctx, cluster, clusterSpec, dc.forceCleanup, dc.clusterKubeconfig)
 	cleanup(deps, &err)
 	return err
 }

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -41,7 +41,7 @@ var deleteClusterCmd = &cobra.Command{
 		}
 		if uc.wConfig != "" {
 			logger.MarkFail(wConfigDeprecationMessage)
-			return errors.New("please remove the --w-config flag and use --kubeconfig instead")
+			return errors.New("--w-config is deprecated. Use --kubeconfig instead")
 		}
 		return nil
 	},

--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -22,7 +22,7 @@ const (
 https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#cluster-upgrade-fails-with-management-components-on-bootstrap-cluster`
 	forceCleanupDeprecationMessageForCreateDelete = `The flag --force-cleanup has been removed. For more information on how to troubleshoot existing bootstrap clusters, please refer to the documentation:
 https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#bootstrap-cluster-fails-to-come-up-nodes-already-exist-for-a-cluster-with-the-name`
-	wConfigDeprecationMessage = `The flag --w-config has been deprecated. Please flag --kubeconfig instead.`
+	wConfigDeprecationMessage = `The flag --w-config has been deprecated. Please use flag --kubeconfig instead.`
 )
 
 func bindFlagsToViper(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -22,6 +22,7 @@ const (
 https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#cluster-upgrade-fails-with-management-components-on-bootstrap-cluster`
 	forceCleanupDeprecationMessageForCreateDelete = `The flag --force-cleanup has been removed. For more information on how to troubleshoot existing bootstrap clusters, please refer to the documentation:
 https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#bootstrap-cluster-fails-to-come-up-nodes-already-exist-for-a-cluster-with-the-name`
+	wConfigDeprecationMessage = `The flag --w-config has been deprecated. Please flag --kubeconfig instead.`
 )
 
 func bindFlagsToViper(cmd *cobra.Command, args []string) error {
@@ -38,7 +39,7 @@ func bindFlagsToViper(cmd *cobra.Command, args []string) error {
 func applyClusterOptionFlags(flagSet *pflag.FlagSet, clusterOpt *clusterOptions) {
 	flags.String(flags.ClusterConfig, &clusterOpt.fileName, flagSet)
 	flags.String(flags.BundleOverride, &clusterOpt.bundlesOverride, flagSet)
-	flagSet.StringVar(&clusterOpt.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
+	flagSet.StringVar(&clusterOpt.clusterKubeconfig, "kubeconfig", "", "Cluster kubeconfig file")
 }
 
 func applyTinkerbellHardwareFlag(flagSet *pflag.FlagSet, pathOut *string) {

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -92,14 +92,14 @@ func buildClusterManagerOpts(t timeoutOptions, datacenterKind string) (*dependen
 
 type clusterOptions struct {
 	fileName             string
-	bundlesOverride      string
-	managementKubeconfig string
+	bundlesOverride   string
+	clusterKubeconfig string
 }
 
 func (c clusterOptions) mountDirs() []string {
 	var dirs []string
-	if c.managementKubeconfig != "" {
-		dirs = append(dirs, filepath.Dir(c.managementKubeconfig))
+	if c.clusterKubeconfig != "" {
+		dirs = append(dirs, filepath.Dir(c.clusterKubeconfig))
 	}
 
 	return dirs
@@ -138,14 +138,14 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 	}
 
 	if clusterSpec.Cluster.IsManaged() {
-		if options.managementKubeconfig == "" {
+		if options.clusterKubeconfig == "" {
 			managementKubeconfig, err := getManagementClusterKubeconfig(clusterSpec.Cluster.Spec.ManagementCluster.Name)
 			if err != nil {
 				return nil, err
 			}
-			options.managementKubeconfig = managementKubeconfig
+			options.clusterKubeconfig = managementKubeconfig
 		}
-		managementCluster, err := cluster.LoadManagement(options.managementKubeconfig)
+		managementCluster, err := cluster.LoadManagement(options.clusterKubeconfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get management cluster from kubeconfig: %v", err)
 		}

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -46,7 +46,7 @@ var supportbundleCmd = &cobra.Command{
 		}
 		if uc.wConfig != "" {
 			logger.MarkFail(wConfigDeprecationMessage)
-			return errors.New("please remove the --w-config flag and use --kubeconfig instead")
+			return errors.New("--w-config is deprecated. Use --kubeconfig instead")
 		}
 		return nil
 	},

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -22,7 +22,6 @@ import (
 type upgradeClusterOptions struct {
 	clusterOptions
 	timeoutOptions
-	wConfig               string
 	forceClean            bool
 	hardwareCSVPath       string
 	tinkerbellBootstrapIP string
@@ -55,7 +54,6 @@ func init() {
 	applyClusterOptionFlags(upgradeClusterCmd.Flags(), &uc.clusterOptions)
 	applyTimeoutFlags(upgradeClusterCmd.Flags(), &uc.timeoutOptions)
 	applyTinkerbellHardwareFlag(upgradeClusterCmd.Flags(), &uc.hardwareCSVPath)
-	upgradeClusterCmd.Flags().StringVarP(&uc.wConfig, "w-config", "w", "", "Kubeconfig file to use when upgrading a workload cluster")
 	upgradeClusterCmd.Flags().BoolVar(&uc.forceClean, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	hideForceCleanup(upgradeClusterCmd.Flags())
 	upgradeClusterCmd.Flags().StringArrayVar(&uc.skipValidations, "skip-validations", []string{}, fmt.Sprintf("Bypass upgrade validations by name. Valid arguments you can pass are --skip-validations=%s", strings.Join(upgradevalidations.SkippableValidations[:], ",")))
@@ -160,7 +158,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command) error {
 
 	workloadCluster := &types.Cluster{
 		Name:           clusterSpec.Cluster.Name,
-		KubeconfigFile: getKubeconfigPath(clusterSpec.Cluster.Name, uc.wConfig),
+		KubeconfigFile: getKubeconfigPath(clusterSpec.Cluster.Name, uc.managementKubeconfig),
 	}
 
 	var managementCluster *types.Cluster
@@ -193,7 +191,7 @@ func (uc *upgradeClusterOptions) commonValidations(ctx context.Context) (cluster
 		return nil, err
 	}
 
-	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, uc.wConfig)
+	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, uc.managementKubeconfig)
 	if err := kubeconfig.ValidateFilename(kubeconfigPath); err != nil {
 		return nil, err
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -45,7 +45,7 @@ var upgradeClusterCmd = &cobra.Command{
 		}
 		if uc.wConfig != "" {
 			logger.MarkFail(wConfigDeprecationMessage)
-			return errors.New("please remove the --w-config flag and use --kubeconfig instead")
+			return errors.New("--w-config is deprecated. Use --kubeconfig instead")
 		}
 
 		if err := uc.upgradeCluster(cmd); err != nil {
@@ -61,7 +61,7 @@ func init() {
 	applyTimeoutFlags(upgradeClusterCmd.Flags(), &uc.timeoutOptions)
 	applyTinkerbellHardwareFlag(upgradeClusterCmd.Flags(), &uc.hardwareCSVPath)
 	upgradeClusterCmd.Flags().StringVarP(&uc.wConfig, "w-config", "w", "", "Kubeconfig file to use when upgrading a workload cluster")
-	err := upgradeClusterCmd.Flags().MarkDeprecated("w-config", "please use flag --kubeconfig instead. This operation is not ")
+	err := upgradeClusterCmd.Flags().MarkDeprecated("w-config", "please use flag --kubeconfig instead.")
 	if err != nil {
 		log.Fatalf("Error deprecating flag as required: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -59,7 +59,7 @@ func init() {
 	upgradePlanClusterCmd.Flags().StringVarP(&uc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
 	upgradePlanClusterCmd.Flags().StringVar(&uc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	upgradePlanClusterCmd.Flags().StringVarP(&output, outputFlagName, "o", outputDefault, "Output format: text|json")
-	upgradePlanClusterCmd.Flags().StringVar(&uc.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
+	upgradePlanClusterCmd.Flags().StringVar(&uc.clusterKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
 	err := upgradePlanClusterCmd.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -88,7 +88,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	managementCluster := &types.Cluster{
 		Name:           newClusterSpec.Cluster.Name,
-		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.managementKubeconfig),
+		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.clusterKubeconfig),
 	}
 
 	if newClusterSpec.ManagementCluster != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -88,7 +88,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	managementCluster := &types.Cluster{
 		Name:           newClusterSpec.Cluster.Name,
-		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.wConfig),
+		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.managementKubeconfig),
 	}
 
 	if newClusterSpec.ManagementCluster != nil {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/5905

*Description of changes:*
- deprecate `wConfig` in update and delete
    - exit when use `wConfig`
- rename `wConfig` to `clusterConfig` to avoid confusion

*Testing (if applicable):*
- manual testing
    - create mgmt cluster 
    - rename cluster dir
    - use --w-config leads to error
    - use --kubeconfig to upgrade
    - use --kubeconfig to delete

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

