### PR TITLE
Fix upgrade from latest minor release API tests

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1378,7 +1378,7 @@ func TestClusterReconcilerPackagesInstall(s *testing.T) {
 }
 
 func TestClusterReconcilerValidateManagementEksaVersionFail(t *testing.T) {
-	lower := anywherev1.EksaVersion("v0.0.0")
+	lower := anywherev1.EksaVersion("v0.1.0")
 	higher := anywherev1.EksaVersion("v0.5.0")
 	config, _ := baseTestVsphereCluster()
 	config.Cluster.Name = "test-cluster"

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -106,6 +106,9 @@ type ClusterSpecGenerate struct {
 // EksaVersion is the semver identifying the release of eks-a used to populate the cluster components.
 type EksaVersion string
 
+// DevBuildVersion is the version string for the dev build of EKS-A.
+const DevBuildVersion = "v0.0.0-dev"
+
 // Equal checks if two EksaVersions are equal.
 func (n *EksaVersion) Equal(o *EksaVersion) bool {
 	if n == o {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -32,8 +32,6 @@ import (
 
 const supportedMinorVersionIncrement int64 = 1
 
-var devBuild, _ = semver.New("v0.0.0-dev")
-
 // log is for logging in this package.
 var clusterlog = logf.Log.WithName("cluster-resource")
 
@@ -151,7 +149,8 @@ func ValidateEksaVersionSkew(new, old *Cluster) field.ErrorList {
 		return allErrs
 	}
 
-	if newEksaVersion.SamePatch(devBuild) {
+	devBuildVersion, _ := semver.New(DevBuildVersion)
+	if newEksaVersion.SamePatch(devBuildVersion) {
 		return nil
 	}
 

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -150,6 +150,11 @@ func ValidateManagementEksaVersion(mgmtCluster, cluster *v1alpha1.Cluster) error
 		return err
 	}
 
+	devBuildVersion, _ := semver.New(v1alpha1.DevBuildVersion)
+	if mVersion.SamePatch(devBuildVersion) {
+		return nil
+	}
+
 	if wVersion.GreaterThan(mVersion) {
 		errMsg := fmt.Sprintf("cannot upgrade workload cluster to %v while management cluster is an older version: %v", wVersion, mVersion)
 		reason := v1alpha1.EksaVersionInvalidReason

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -438,6 +438,7 @@ func TestValidateManagementClusterEksaVersion(t *testing.T) {
 	v := test.DevEksaVersion()
 	uv := anywherev1.EksaVersion("v0.1.0")
 	badVersion := anywherev1.EksaVersion("invalid")
+
 	tests := []struct {
 		name              string
 		wantErr           error
@@ -448,6 +449,12 @@ func TestValidateManagementClusterEksaVersion(t *testing.T) {
 			name:              "Success",
 			wantErr:           nil,
 			version:           &v,
+			managementVersion: &v,
+		},
+		{
+			name:              "Management with dev build version and workload with release version",
+			wantErr:           nil,
+			version:           &uv,
 			managementVersion: &v,
 		},
 		{

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -103,8 +103,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		wc.UpdateClusterConfig(
 			api.ClusterToConfigFiller(
-				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
-				api.WithEksaVersion(nil),
+				api.WithEksaVersion(oldCluster.Spec.EksaVersion),
 			),
 		)
 		wc.ApplyClusterManifest()
@@ -155,7 +154,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		test.PushWorkloadClusterToGit(wc,
 			api.ClusterToConfigFiller(
-				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
+				api.WithEksaVersion(oldCluster.Spec.EksaVersion),
 				api.WithEksaVersion(nil),
 			),
 		)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses two issues with the API upgrade from latest minor release tests:
1. These tests have a step where they create a new workload cluster after upgrading from latest minor release using the old bundle. After recent changes added to the latest minor release 0.17, the `bundleRef` on clusters is null so the test hits a nil pointer trying to use and panics. This PR fixes the test run flow to use the EksaVersion field instead of the BundleRef field to test creating clusters with an older bundle.
2. After fixing the above issue, the control plane on the new cluster still fails to come up due to a failure in the controller :

```
...
    failureMessage: 'cannot upgrade workload cluster to v0.17.0 while management cluster
      is an older version: v0.0.0'
    failureReason: EksaVersionInvalid
```
    
It's blocked by a validation that ensures the management cluster version is not an older version than the workload cluster. This issue was previous fix for the webhook in [this](https://github.com/aws/eks-anywhere/pull/6551) PR by skipping the validation when the upgraded version is a dev build. However, there is similar validation in the controller that was missed. This PR fixes the issue by applying the same solution to the validation run in the controller

*Testing (if applicable):*
- Build controller image locally
- Pushed it to a personal ECR repository
- Ran the `TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI` locally with bundle override on upgrade from latest minor release to use the new controller.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

