### PR TITLE
Add aws creds validation for curated packages

### DIFF
--- a/pkg/curatedpackages/mocks/packageinstaller.go
+++ b/pkg/curatedpackages/mocks/packageinstaller.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	validations "github.com/aws/eks-anywhere/pkg/validations"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -60,6 +61,20 @@ func (m *MockPackageController) IsInstalled(ctx context.Context) bool {
 func (mr *MockPackageControllerMockRecorder) IsInstalled(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInstalled", reflect.TypeOf((*MockPackageController)(nil).IsInstalled), ctx)
+}
+
+// Validations mocks base method.
+func (m *MockPackageController) Validations() []validations.Validation {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validations")
+	ret0, _ := ret[0].([]validations.Validation)
+	return ret0
+}
+
+// Validations indicates an expected call of Validations.
+func (mr *MockPackageControllerMockRecorder) Validations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validations", reflect.TypeOf((*MockPackageController)(nil).Validations))
 }
 
 // MockPackageHandler is a mock of PackageHandler interface.

--- a/pkg/curatedpackages/packageinstaller.go
+++ b/pkg/curatedpackages/packageinstaller.go
@@ -6,12 +6,14 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/validations"
 )
 
 type PackageController interface {
 	// Enable curated packages support.
 	Enable(ctx context.Context) error
 	IsInstalled(ctx context.Context) bool
+	Validations() []validations.Validation
 }
 
 type PackageHandler interface {
@@ -85,4 +87,13 @@ func (pi *Installer) installPackages(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// Validations returns validations that the package installer can do.
+func (pi *Installer) Validations(ctx context.Context, clusterSpec *cluster.Spec) []validations.Validation {
+	if IsPackageControllerDisabled(pi.spec.Cluster) {
+		return nil
+	}
+
+	return pi.packageController.Validations()
 }

--- a/pkg/curatedpackages/validations.go
+++ b/pkg/curatedpackages/validations.go
@@ -2,7 +2,14 @@ package curatedpackages
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
 )
 
 func ValidateKubeVersion(kubeVersion string, clusterName string) error {
@@ -21,4 +28,67 @@ func ValidateKubeVersion(kubeVersion string, clusterName string) error {
 		return nil
 	}
 	return fmt.Errorf("please specify kube-version or cluster name")
+}
+
+// ValidateAWSCreds checks if the aws credentials has access to pull images from a ECR url.
+func ValidateAWSCreds(awsClientID, awsClientSecret, registryURL string) error {
+	creds := credentials.NewStaticCredentials(awsClientID, awsClientSecret, "")
+
+	region, err := getRegistryRegion(registryURL)
+	if err != nil {
+		return err
+	}
+
+	s, err := session.NewSession(&aws.Config{Credentials: creds, Region: &region})
+	if err != nil {
+		return err
+	}
+	ecrClient := ecr.New(s)
+	resp, err := ecrClient.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return err
+	}
+	authToken := resp.AuthorizationData[0].AuthorizationToken
+
+	return ValidateECRAuthToken(http.DefaultClient, *authToken, registryURL)
+}
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ValidateECRAuthToken checks if Authorization header basic authToken is valid for pull images from a ECR.
+func ValidateECRAuthToken(client httpClient, authToken string, registryURL string) error {
+	// we can also check "/v2/eks-anywhere-packages/blobs/latest" as well for ecr:GetDownloadUrlForLayer policy
+	// but manifest check should be enough for now
+	manifestPath := "/v2/eks-anywhere-packages/manifests/latest"
+
+	req, err := http.NewRequest("GET", registryURL+manifestPath, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", "Basic "+authToken)
+
+	resp2, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	bodyBytes, err := io.ReadAll(resp2.Body)
+	if resp2.StatusCode != 200 {
+		return fmt.Errorf("%s\n, %v", string(bodyBytes), err)
+	}
+
+	return nil
+}
+
+func getRegistryRegion(registryURL string) (string, error) {
+	// registryURL is in the format of https://<account_id>.dkr.ecr.<region>.amazonaws.com
+	// so we can just split on "." and take the 3rd element
+	split := strings.Split(registryURL, ".")
+	if len(split) < 4 {
+		return "", fmt.Errorf("registryURL is invalid")
+	}
+
+	return split[3], nil
 }

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -173,6 +173,7 @@ func (s *SetAndValidateTask) Run(ctx context.Context, commandContext *task.Comma
 	runner.Register(s.providerValidation(ctx, commandContext)...)
 	runner.Register(commandContext.GitOpsManager.Validations(ctx, commandContext.ClusterSpec)...)
 	runner.Register(commandContext.Validations.PreflightValidations(ctx)...)
+	runner.Register(commandContext.PackageInstaller.Validations(ctx, commandContext.ClusterSpec)...)
 
 	err := runner.Run()
 	if err != nil {

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -209,6 +209,7 @@ func (c *createTestSetup) skipInstallEksaComponents() {
 }
 
 func (c *createTestSetup) expectCuratedPackagesInstallation() {
+	c.packageInstaller.EXPECT().Validations(c.ctx, gomock.Any()).Times(1)
 	c.packageInstaller.EXPECT().InstallCuratedPackages(c.ctx).Times(1)
 }
 
@@ -288,6 +289,7 @@ func TestCreateRunAWSIamConfigFail(t *testing.T) {
 	test.clusterManager.EXPECT().CreateAwsIamAuthCaSecret(test.ctx, test.bootstrapCluster, test.clusterSpec.Cluster.Name).Return(wantError)
 	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
 	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())
+	test.packageInstaller.EXPECT().Validations(test.ctx, gomock.Any()).Times(1)
 
 	if err := test.run(); err == nil {
 		t.Fatalf("Create.Run() err = %v, want err = %v", err, wantError)
@@ -428,6 +430,7 @@ func TestCreateWorkloadClusterRunAWSIamConfigFail(t *testing.T) {
 	test.clusterManager.EXPECT().CreateAwsIamAuthCaSecret(test.ctx, test.bootstrapCluster, test.clusterSpec.Cluster.Name).Return(wantError)
 	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
 	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())
+	test.packageInstaller.EXPECT().Validations(test.ctx, gomock.Any()).Times(1)
 
 	if err := test.run(); err == nil {
 		t.Fatalf("Create.Run() err = %v, want err = %v", err, wantError)

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -79,4 +79,5 @@ type EksdUpgrader interface {
 
 type PackageInstaller interface {
 	InstallCuratedPackages(ctx context.Context)
+	Validations(ctx context.Context, clusterSpec *cluster.Spec) []validations.Validation
 }

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -861,3 +861,17 @@ func (mr *MockPackageInstallerMockRecorder) InstallCuratedPackages(arg0 interfac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallCuratedPackages", reflect.TypeOf((*MockPackageInstaller)(nil).InstallCuratedPackages), arg0)
 }
+
+// Validations mocks base method.
+func (m *MockPackageInstaller) Validations(arg0 context.Context, arg1 *cluster.Spec) []validations.Validation {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validations", arg0, arg1)
+	ret0, _ := ret[0].([]validations.Validation)
+	return ret0
+}
+
+// Validations indicates an expected call of Validations.
+func (mr *MockPackageInstallerMockRecorder) Validations(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validations", reflect.TypeOf((*MockPackageInstaller)(nil).Validations), arg0, arg1)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When user provides the AWS credential, we want to fail fast when the credential is wrong

*Testing (if applicable):* unit test and manual e2e tests. The manual tests includes following scenarios:
1. Good AWS credential is provided, validation passed.
2. Bad AWS credential is provided, validation failed.
3. No AWS credential is provided, no validation.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

