### PR TITLE
Fix bare metal upgrade with custom pod CIDR

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -405,6 +405,12 @@ func (s *Installer) Upgrade(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		},
 		hegel: map[string]interface{}{
 			image: bundle.TinkerbellStack.Hegel.URI,
+			env: []map[string]string{
+				{
+					"name":  "HEGEL_TRUSTED_PROXIES",
+					"value": s.podCidrRange,
+				},
+			},
 		},
 		boots: map[string]interface{}{
 			image: bundle.TinkerbellStack.Boots.URI,

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -148,13 +148,7 @@ func (s *Installer) Install(ctx context.Context, bundle releasev1alpha1.Tinkerbe
 		option(s)
 	}
 
-	bootEnv := []map[string]string{}
-	for k, v := range s.getBootsEnv(bundle.TinkerbellStack, tinkerbellIP) {
-		bootEnv = append(bootEnv, map[string]string{
-			"name":  k,
-			"value": v,
-		})
-	}
+	bootEnv := s.getBootsEnv(bundle.TinkerbellStack, tinkerbellIP)
 
 	osiePath, err := getURIDir(bundle.TinkerbellStack.Hook.Initramfs.Amd.URI)
 	if err != nil {
@@ -260,8 +254,8 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 		"-e", fmt.Sprintf("BOOTS_KUBE_NAMESPACE=%v", s.namespace),
 	}
 
-	for name, value := range s.getBootsEnv(bundle, tinkServerIP) {
-		flags = append(flags, "-e", fmt.Sprintf("%s=%s", name, value))
+	for _, e := range s.getBootsEnv(bundle, tinkServerIP) {
+		flags = append(flags, "-e", fmt.Sprintf("%s=%s", e["name"], e["value"]))
 	}
 
 	osiePath, err := getURIDir(bundle.Hook.Initramfs.Amd.URI)
@@ -285,30 +279,39 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 	return nil
 }
 
-func (s *Installer) getBootsEnv(bundle releasev1alpha1.TinkerbellStackBundle, tinkServerIP string) map[string]string {
-	bootsEnv := map[string]string{
-		"DATA_MODEL_VERSION":        "kubernetes",
-		"TINKERBELL_TLS":            "false",
-		"TINKERBELL_GRPC_AUTHORITY": fmt.Sprintf("%s:%s", tinkServerIP, grpcPort),
+func (s *Installer) getBootsEnv(bundle releasev1alpha1.TinkerbellStackBundle, tinkServerIP string) []map[string]string {
+	env := []map[string]string{
+		toEnvEntry("DATA_MODEL_VERSION", "kubernetes"),
+		toEnvEntry("TINKERBELL_TLS", "false"),
+		toEnvEntry("TINKERBELL_GRPC_AUTHORITY", fmt.Sprintf("%s:%s", tinkServerIP, grpcPort)),
 	}
 
 	extraKernelArgs := fmt.Sprintf("tink_worker_image=%s", s.localRegistryURL(bundle.Tink.TinkWorker.URI))
+
 	if s.registryMirror != nil {
 		localRegistry := s.registryMirror.BaseRegistry
 		extraKernelArgs = fmt.Sprintf("%s insecure_registries=%s", extraKernelArgs, localRegistry)
 		if s.registryMirror.Auth {
 			username, password, _ := config.ReadCredentials()
-			bootsEnv["REGISTRY_USERNAME"] = username
-			bootsEnv["REGISTRY_PASSWORD"] = password
+			env = append(env,
+				toEnvEntry("REGISTRY_USERNAME", username),
+				toEnvEntry("REGISTRY_PASSWORD", password))
 		}
 	}
+
 	if s.proxyConfig != nil {
 		noProxy := strings.Join(s.proxyConfig.NoProxy, ",")
 		extraKernelArgs = fmt.Sprintf("%s HTTP_PROXY=%s HTTPS_PROXY=%s NO_PROXY=%s", extraKernelArgs, s.proxyConfig.HttpProxy, s.proxyConfig.HttpsProxy, noProxy)
 	}
-	bootsEnv["BOOTS_EXTRA_KERNEL_ARGS"] = extraKernelArgs
 
-	return bootsEnv
+	return append(env, toEnvEntry("BOOTS_EXTRA_KERNEL_ARGS", extraKernelArgs))
+}
+
+func toEnvEntry(k, v string) map[string]string {
+	return map[string]string{
+		"name":  k,
+		"value": v,
+	}
 }
 
 // UninstallLocal currently removes local docker container running Boots.
@@ -378,13 +381,7 @@ func (s *Installer) authenticateHelmRegistry(ctx context.Context) error {
 func (s *Installer) Upgrade(ctx context.Context, bundle releasev1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig string, hookOverride string) error {
 	logger.V(6).Info("Upgrading Tinkerbell helm chart")
 
-	bootEnv := []map[string]string{}
-	for k, v := range s.getBootsEnv(bundle.TinkerbellStack, tinkerbellIP) {
-		bootEnv = append(bootEnv, map[string]string{
-			"name":  k,
-			"value": v,
-		})
-	}
+	bootEnv := s.getBootsEnv(bundle.TinkerbellStack, tinkerbellIP)
 
 	osiePath, err := getURIDir(bundle.TinkerbellStack.Hook.Initramfs.Amd.URI)
 	if err != nil {

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -16,6 +16,9 @@ createNamespace: false
 envoy:
   image: public.ecr.aws/eks-anywhere/envoy:latest
 hegel:
+  env:
+  - name: HEGEL_TRUSTED_PROXIES
+    value: 192.168.0.0/16
   image: public.ecr.aws/eks-anywhere/hegel:latest
 kubevip:
   image: public.ecr.aws/eks-anywhere/kube-vip:latest
@@ -25,4 +28,5 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -1,8 +1,7 @@
 boots:
   args:
   - -dhcp-addr=0.0.0.0:67
-  - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
-  deploy: true
+  - -osie-path-override=https://my-local-web-server/hook
   env:
   - name: DATA_MODEL_VERSION
     value: kubernetes
@@ -11,22 +10,18 @@ boots:
   - name: TINKERBELL_GRPC_AUTHORITY
     value: 1.2.3.4:42113
   - name: BOOTS_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
+    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest HTTP_PROXY=1.2.3.4
+      HTTPS_PROXY=1.2.3.4 NO_PROXY=localhost,.svc
   image: public.ecr.aws/eks-anywhere/boots:latest
-createNamespace: true
+createNamespace: false
 envoy:
-  deploy: false
-  externalIp: 1.2.3.4
   image: public.ecr.aws/eks-anywhere/envoy:latest
 hegel:
   env:
   - name: HEGEL_TRUSTED_PROXIES
     value: 192.168.0.0/16
   image: public.ecr.aws/eks-anywhere/hegel:latest
-  port:
-    hostPortEnabled: false
 kubevip:
-  deploy: false
   image: public.ecr.aws/eks-anywhere/kube-vip:latest
 namespace: eksa-system
 rufio:
@@ -36,5 +31,3 @@ tinkController:
 tinkServer:
   args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
-  port:
-    hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: false
   env:
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
   - name: TINKERBELL_GRPC_AUTHORITY
     value: 1.2.3.4:42113
   - name: BOOTS_EXTRA_KERNEL_ARGS
     value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: false
   env:
-  - name: TINKERBELL_GRPC_AUTHORITY
-    value: 1.2.3.4:42113
-  - name: BOOTS_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   - name: DATA_MODEL_VERSION
     value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
+  - name: TINKERBELL_GRPC_AUTHORITY
+    value: 1.2.3.4:42113
+  - name: BOOTS_EXTRA_KERNEL_ARGS
+    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_envoy_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_envoy_enabled_false.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
-  - name: TINKERBELL_GRPC_AUTHORITY
-    value: 1.2.3.4:42113
-  - name: BOOTS_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   - name: DATA_MODEL_VERSION
     value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
+  - name: TINKERBELL_GRPC_AUTHORITY
+    value: 1.2.3.4:42113
+  - name: BOOTS_EXTRA_KERNEL_ARGS
+    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_envoy_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_envoy_enabled_true.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
-  - name: TINKERBELL_GRPC_AUTHORITY
-    value: 1.2.3.4:42113
-  - name: BOOTS_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   - name: DATA_MODEL_VERSION
     value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
+  - name: TINKERBELL_GRPC_AUTHORITY
+    value: 1.2.3.4:42113
+  - name: BOOTS_EXTRA_KERNEL_ARGS
+    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
   - name: TINKERBELL_GRPC_AUTHORITY
     value: 1.2.3.4:42113
   - name: BOOTS_EXTRA_KERNEL_ARGS
     value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
   - name: TINKERBELL_GRPC_AUTHORITY
     value: 1.2.3.4:42113
   - name: BOOTS_EXTRA_KERNEL_ARGS
     value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
   - name: TINKERBELL_GRPC_AUTHORITY
     value: 1.2.3.4:42113
   - name: BOOTS_EXTRA_KERNEL_ARGS
     value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_namespace_create_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_namespace_create_false.yaml
@@ -4,14 +4,14 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
-  - name: TINKERBELL_GRPC_AUTHORITY
-    value: 1.2.3.4:42113
-  - name: BOOTS_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   - name: DATA_MODEL_VERSION
     value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
+  - name: TINKERBELL_GRPC_AUTHORITY
+    value: 1.2.3.4:42113
+  - name: BOOTS_EXTRA_KERNEL_ARGS
+    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -34,8 +34,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -4,18 +4,15 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
   - name: TINKERBELL_GRPC_AUTHORITY
     value: 1.2.3.4:42113
-  - name: HTTP_PROXY
-    value: "1.2.3.4:3128"
-  - name: HTTP_PROXY
-    value: "1.2.3.4:3128"
   - name: BOOTS_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=1.2.3.4:443/custom/eks-anywhere/tink-worker:latest insecure_registries=1.2.3.4:443
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
+    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest HTTP_PROXY=1.2.3.4:3128
+      HTTPS_PROXY=1.2.3.4:3128 NO_PROXY=
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -38,8 +35,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -4,6 +4,8 @@ boots:
   - -osie-path-override=https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
   deploy: true
   env:
+  - name: DATA_MODEL_VERSION
+    value: kubernetes
   - name: TINKERBELL_TLS
     value: "false"
   - name: TINKERBELL_GRPC_AUTHORITY
@@ -14,8 +16,6 @@ boots:
     value: password
   - name: BOOTS_EXTRA_KERNEL_ARGS
     value: tink_worker_image=1.2.3.4:443/custom/eks-anywhere/tink-worker:latest insecure_registries=1.2.3.4:443
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: false
 envoy:
@@ -38,8 +38,7 @@ rufio:
 tinkController:
   image: public.ecr.aws/eks-anywhere/tink-controller:latest
 tinkServer:
-  args:
-  - --tls=false
+  args: []
   image: public.ecr.aws/eks-anywhere/tink-server:latest
   port:
     hostPortEnabled: false

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/rufiounreleased"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -365,13 +364,17 @@ func (p *Provider) PreCoreComponentsUpgrade(
 ) error {
 	// When a workload cluster the cluster object could be nil. Noop if it is.
 	if cluster == nil {
-		logger.V(4).Info("Cluster object is nil, assuming it is a workload cluster with no " +
-			"Tinkerbell stack to upgrade")
 		return nil
 	}
 
 	if clusterSpec == nil {
 		return errors.New("cluster spec is nil")
+	}
+
+	// PreCoreComponentsUpgrade can be called for workload clusters. Ensure we only attempt to
+	// upgrade the stack if we're upgrading a management cluster.
+	if clusterSpec.Cluster.IsManaged() {
+		return nil
 	}
 
 	versionsBundle := clusterSpec.RootVersionsBundle()


### PR DESCRIPTION
Closes #6442.

When upgrading bare metal clusters that use a custom pod CIDR Hegel looses the pod CIDR as a trusted proxy. It can be caused by either an upgrade of the management cluster or upgrade of a workload cluster. 

The problem stems from trusted proxies not being included in the values when upgrading the Tinkerbell helm chart and incorrectly identifying the need to upgrade when upgrading workload clusters.

This change has undergone extensive manual testing with both management and workload cluster creations and upgrades (scale ups and downs). 

Additionally, I found a programmer error in our unit tests where we incorrect deserialized YAML into map data structures which resulted in the comparison of 2 empty maps. Correcting the error revealed numerous unit test failures. I reworked some parts of the code to bring about determinism and avoid re-writing tests to accommodate for the determinism due to the time pressure. I'll circle back and rework some of the code to tidy it up in a subsequent PR.