### PR TITLE
Fix vSphere template tags validation

### DIFF
--- a/pkg/providers/vsphere/validator_test.go
+++ b/pkg/providers/vsphere/validator_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/govmomi"
 	"github.com/aws/eks-anywhere/pkg/govmomi/mocks"
 	govcmocks "github.com/aws/eks-anywhere/pkg/providers/vsphere/mocks"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 func TestValidatorValidatePrivs(t *testing.T) {
@@ -137,17 +138,18 @@ func TestValidatorValidatePrivsBadJson(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring(errMsg)))
 }
 
-func clusterSpec() Spec {
+func clusterSpec(opts ...func(*Spec)) *Spec {
 	cpMachineConfig := &v1alpha1.VSphereMachineConfig{
 		Spec: v1alpha1.VSphereMachineConfigSpec{
 			Datastore:    "datastore",
 			ResourcePool: "pool",
 			Folder:       "folder",
 			Template:     "temp",
+			OSFamily:     v1alpha1.Bottlerocket,
 		},
 	}
 
-	return Spec{
+	s := &Spec{
 		Spec: &cluster.Spec{
 			Config: &cluster.Config{
 				VSphereDatacenter: &v1alpha1.VSphereDatacenterConfig{
@@ -166,11 +168,27 @@ func clusterSpec() Spec {
 								Name: "test-cp",
 							},
 						},
+						KubernetesVersion: v1alpha1.Kube127,
+					},
+				},
+			},
+			VersionsBundles: map[v1alpha1.KubernetesVersion]*cluster.VersionsBundle{
+				v1alpha1.Kube127: {
+					VersionsBundle: &releasev1.VersionsBundle{
+						EksD: releasev1.EksDRelease{
+							Name: "ekd-d-1-27",
+						},
 					},
 				},
 			},
 		},
 	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
 }
 
 func TestValidatorValidateVsphereUserPrivsError(t *testing.T) {
@@ -190,7 +208,7 @@ func TestValidatorValidateVsphereUserPrivsError(t *testing.T) {
 
 	g := NewWithT(t)
 
-	err := v.validateVsphereUserPrivs(ctx, &spec)
+	err := v.validateVsphereUserPrivs(ctx, spec)
 	g.Expect(err).To(MatchError(ContainSubstring("error")))
 }
 
@@ -231,7 +249,7 @@ func TestValidatorValidateVsphereCPUserPrivsError(t *testing.T) {
 	vscb.EXPECT().Build(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), spec.VSphereDatacenter.Spec.Datacenter).Return(nil, fmt.Errorf("error"))
 	g := NewWithT(t)
 
-	err = v.validateVsphereUserPrivs(ctx, &spec)
+	err = v.validateVsphereUserPrivs(ctx, spec)
 	g.Expect(err).To(MatchError(ContainSubstring("error")))
 }
 
@@ -406,6 +424,181 @@ func TestValidateBRHardDiskSize(t *testing.T) {
 				gt.Expect(err).To(BeNil())
 			} else {
 				gt.Expect(err.Error()).To(Equal(tt.wantErr.Error()))
+			}
+		})
+	}
+}
+
+func TestValidator_validateTemplates(t *testing.T) {
+	type template struct {
+		name string
+		tags []string
+	}
+	testCases := []struct {
+		name      string
+		spec      *Spec
+		templates []template
+		wantErr   string
+	}{
+		{
+			name:    "template cp does not exist",
+			spec:    clusterSpec(),
+			wantErr: "template <temp> not found. Has the template been imported?",
+		},
+		{
+			name: "template etcd does not exist",
+			spec: clusterSpec(
+				func(s *Spec) {
+					s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
+						MachineGroupRef: &v1alpha1.Ref{
+							Name: "etcd-machine",
+						},
+					}
+
+					s.VSphereMachineConfigs["etcd-machine"] = &v1alpha1.VSphereMachineConfig{
+						Spec: v1alpha1.VSphereMachineConfigSpec{
+							Template: "etcd-template",
+							OSFamily: v1alpha1.Bottlerocket,
+						},
+					}
+				},
+			),
+			templates: []template{
+				{
+					name: "temp",
+					tags: []string{"eksdRelease:ekd-d-1-27", "os:bottlerocket"},
+				},
+			},
+			wantErr: "template <etcd-template> not found. Has the template been imported?",
+		},
+		{
+			name: "template cp is missing tag",
+			spec: clusterSpec(),
+			templates: []template{
+				{
+					name: "temp",
+					tags: []string{"eksdRelease:ekd-d-1-28", "os:bottlerocket"},
+				},
+			},
+			wantErr: "template temp is missing tag eksdRelease:ekd-d-1-27",
+		},
+		{
+			name: "template etcd is missing tag",
+			spec: clusterSpec(
+				func(s *Spec) {
+					s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
+						MachineGroupRef: &v1alpha1.Ref{
+							Name: "etcd-machine",
+						},
+					}
+
+					s.VSphereMachineConfigs["etcd-machine"] = &v1alpha1.VSphereMachineConfig{
+						Spec: v1alpha1.VSphereMachineConfigSpec{
+							Template: "etcd-template",
+							OSFamily: v1alpha1.Bottlerocket,
+						},
+					}
+				},
+			),
+			templates: []template{
+				{
+					name: "temp",
+					tags: []string{"eksdRelease:ekd-d-1-27", "os:bottlerocket"},
+				},
+				{
+					name: "etcd-template",
+					tags: []string{"eksdRelease:ekd-d-1-28", "os:bottlerocket"},
+				},
+			},
+			wantErr: "template etcd-template is missing tag eksdRelease:ekd-d-1-27",
+		},
+		{
+			name: "template worker does not exist",
+			spec: clusterSpec(
+				func(s *Spec) {
+					s.Cluster.Spec.WorkerNodeGroupConfigurations = append(s.Cluster.Spec.WorkerNodeGroupConfigurations,
+						v1alpha1.WorkerNodeGroupConfiguration{
+							Name: "w-1",
+							MachineGroupRef: &v1alpha1.Ref{
+								Name: "w-1",
+							},
+						})
+
+					s.VSphereMachineConfigs["w-1"] = &v1alpha1.VSphereMachineConfig{
+						Spec: v1alpha1.VSphereMachineConfigSpec{
+							Template: "worker-template",
+							OSFamily: v1alpha1.Bottlerocket,
+						},
+					}
+				},
+			),
+			templates: []template{
+				{
+					name: "temp",
+					tags: []string{"eksdRelease:ekd-d-1-27", "os:bottlerocket"},
+				},
+			},
+			wantErr: "template <worker-template> not found. Has the template been imported?",
+		},
+		{
+			name: "template worker is missing tag",
+			spec: clusterSpec(
+				func(s *Spec) {
+					s.Cluster.Spec.WorkerNodeGroupConfigurations = append(s.Cluster.Spec.WorkerNodeGroupConfigurations,
+						v1alpha1.WorkerNodeGroupConfiguration{
+							Name: "w-1",
+							MachineGroupRef: &v1alpha1.Ref{
+								Name: "w-1",
+							},
+						})
+
+					s.VSphereMachineConfigs["w-1"] = &v1alpha1.VSphereMachineConfig{
+						Spec: v1alpha1.VSphereMachineConfigSpec{
+							Template: "worker-template",
+							OSFamily: v1alpha1.Bottlerocket,
+						},
+					}
+				},
+			),
+			templates: []template{
+				{
+					name: "temp",
+					tags: []string{"eksdRelease:ekd-d-1-27", "os:bottlerocket"},
+				},
+				{
+					name: "worker-template",
+					tags: []string{"eksdRelease:ekd-d-1-28", "os:bottlerocket"},
+				},
+			},
+			wantErr: "template worker-template is missing tag eksdRelease:ekd-d-1-27",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			ctrl := gomock.NewController(t)
+			govc := govcmocks.NewMockProviderGovcClient(ctrl)
+
+			datacenter := tc.spec.VSphereDatacenter.Spec.Datacenter
+
+			for _, t := range tc.templates {
+				govc.EXPECT().SearchTemplate(ctx, datacenter, t.name).Return(t.name, nil).AnyTimes()
+				govc.EXPECT().GetTags(ctx, t.name).Return(t.tags, nil).AnyTimes()
+			}
+			// allow search for any template and by default return not found
+			govc.EXPECT().SearchTemplate(ctx, datacenter, gomock.Any()).Return("", nil).AnyTimes()
+
+			v := Validator{
+				govc: govc,
+			}
+
+			gotErr := v.validateTemplates(ctx, tc.spec)
+			if tc.wantErr != "" {
+				g.Expect(gotErr).To(MatchError(ContainSubstring(tc.wantErr)))
+			} else {
+				g.Expect(gotErr).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -2332,7 +2332,8 @@ func TestSetupAndValidateCreateClusterFullCloneDiskGiBLessThan20TemplateDiskSize
 
 	tt.govc.EXPECT().GetVMDiskSizeInGB(tt.ctx, template, tt.clusterSpec.VSphereDatacenter.Spec.Datacenter)
 	tt.govc.EXPECT().TemplateHasSnapshot(tt.ctx, template).Return(false, nil)
-	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, template).Return(template, nil)
+	tt.govc.EXPECT().SearchTemplate(tt.ctx, tt.datacenterConfig.Spec.Datacenter, template).Return(template, nil).Times(2) // One for defaults and another time for template validation
+	tt.govc.EXPECT().GetTags(tt.ctx, template).Return([]string{"eksdRelease:kubernetes-1-21-eks-4", "os:ubuntu"}, nil)
 	tt.govc.EXPECT().ListTags(tt.ctx)
 	tt.govc.EXPECT().GetWorkloadAvailableSpace(tt.ctx, tt.clusterSpec.VSphereMachineConfigs[controlPlaneMachineConfigName].Spec.Datastore).Return(100.0, nil)
 	tt.ipValidator.EXPECT().ValidateControlPlaneIPUniqueness(tt.cluster)


### PR DESCRIPTION
*Description of changes:*
Old code was not validating templates for etcd or CP, only for workers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

