### PR TITLE
Try to fix file reader proxy flaky test

### DIFF
--- a/pkg/files/reader_test.go
+++ b/pkg/files/reader_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -117,6 +118,7 @@ func TestReaderReadFileHTTPSProxySuccess(t *testing.T) {
 	hostMappings := map[string]string{fakeServerHost: serverHost}
 	proxy := newProxyServer(t, hostMappings)
 
+	os.Unsetenv("HTTP_PROXY")
 	t.Setenv("HTTPS_PROXY", proxy.URL)
 
 	r := files.NewReader(
@@ -157,7 +159,7 @@ type proxyServer struct {
 
 func newProxyServer(tb testing.TB, hostMappings map[string]string) *proxyServer {
 	proxyServer := &proxyServer{
-		proxy: newProxy(hostMappings),
+		proxy: newProxy(hostMappings, tb),
 	}
 	proxyServer.Server = httptest.NewServer(http.HandlerFunc(proxyServer.handleProxy))
 
@@ -176,12 +178,14 @@ type proxy struct {
 	// hostMappings allows to map the dst host in the CONNECT
 	// request to a different host.
 	hostMappings map[string]string
+	tb           testing.TB
 }
 
-func newProxy(hostMappings map[string]string) *proxy {
+func newProxy(hostMappings map[string]string, tb testing.TB) *proxy {
 	return &proxy{
 		proxied:      map[string]int{},
 		hostMappings: hostMappings,
+		tb:           tb,
 	}
 }
 
@@ -200,10 +204,10 @@ func (p *proxy) tunnelConnection(w http.ResponseWriter, r *http.Request) {
 	}
 	destConn, err := net.DialTimeout("tcp", host, 2*time.Second)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		http.Error(w, fmt.Sprintf("opening TCP connection to proxied host %s: %s", host, err), http.StatusServiceUnavailable)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	defer destConn.Close()
 
 	h, ok := w.(http.Hijacker)
 	if !ok {
@@ -211,9 +215,31 @@ func (p *proxy) tunnelConnection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientConn, _, err := h.Hijack()
+	// This might be too early if we can't hijack the connection
+	// But we can't use ResponseWriter after the hijack
+	// and doing it manually is too difficult
+	w.WriteHeader(http.StatusOK)
+
+	clientConn, hijackedConnData, err := h.Hijack()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		http.Error(w, fmt.Sprintf("hijacking the connection in proxy: %s", err), http.StatusServiceUnavailable)
+		return
+	}
+	defer clientConn.Close()
+
+	// Read more from the client. Include the connection buffer if
+	// it contains data.
+	orgReader := io.Reader(clientConn)
+	if hijackedConnData.Reader.Buffered() > 0 {
+		p.tb.Logf("Looks like there is unread data in the buffer: %d bytes", hijackedConnData.Reader.Buffered())
+		orgReader = io.MultiReader(hijackedConnData, clientConn)
+	}
+
+	if hijackedConnData.Reader.Buffered() > 0 {
+		if _, err := io.Copy(destConn, hijackedConnData); err != nil {
+			p.tb.Errorf("Error writing client unprocessed data: %s", err)
+			return
+		}
 	}
 
 	p.countRequest(host)
@@ -221,17 +247,15 @@ func (p *proxy) tunnelConnection(w http.ResponseWriter, r *http.Request) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
-		pipe(w, destConn, clientConn)
+		p.pipe(destConn, orgReader)
 		wg.Done()
 	}()
 	go func() {
-		pipe(w, clientConn, destConn)
+		p.pipe(clientConn, destConn)
 		wg.Done()
 	}()
 
 	wg.Wait()
-	destConn.Close()
-	clientConn.Close()
 }
 
 // countRequest increases the proxied counter for the given host.
@@ -250,8 +274,8 @@ func (p *proxy) countForHost(host string) int {
 	return p.proxied[host]
 }
 
-func pipe(w http.ResponseWriter, destination io.WriteCloser, source io.ReadCloser) {
+func (p *proxy) pipe(destination io.Writer, source io.Reader) {
 	if _, err := io.Copy(destination, source); err != nil {
-		http.Error(w, fmt.Sprintf("piping: %s", err), http.StatusInternalServerError)
+		p.tb.Errorf("Error piping: %s", err)
 	}
 }


### PR DESCRIPTION
*Description of changes:*
I'm not completely sure this will fix this issue because I'm not completely sure what the actual issue is. But at least this should provide more info through test logs plus it handles an edge case where the connection had some buffered read data before we hijack it.

If this keeps failing and I'm not able to figure out the issue, I'll just delete the test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

