### PR TITLE
Revert 6580 cherry pick 6576 to release 0.17

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1378,7 +1378,7 @@ func TestClusterReconcilerPackagesInstall(s *testing.T) {
 }
 
 func TestClusterReconcilerValidateManagementEksaVersionFail(t *testing.T) {
-	lower := anywherev1.EksaVersion("v0.1.0")
+	lower := anywherev1.EksaVersion("v0.0.0")
 	higher := anywherev1.EksaVersion("v0.5.0")
 	config, _ := baseTestVsphereCluster()
 	config.Cluster.Name = "test-cluster"

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -105,9 +105,6 @@ type ClusterSpecGenerate struct {
 // EksaVersion is the semver identifying the release of eks-a used to populate the cluster components.
 type EksaVersion string
 
-// DevBuildVersion is the version string for the dev build of EKS-A.
-const DevBuildVersion = "v0.0.0-dev"
-
 // Equal checks if two EksaVersions are equal.
 func (n *EksaVersion) Equal(o *EksaVersion) bool {
 	if n == o {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -32,6 +32,8 @@ import (
 
 const supportedMinorVersionIncrement int64 = 1
 
+var devBuild, _ = semver.New("v0.0.0-dev")
+
 // log is for logging in this package.
 var clusterlog = logf.Log.WithName("cluster-resource")
 
@@ -145,8 +147,7 @@ func ValidateEksaVersionSkew(new, old *Cluster) field.ErrorList {
 		return allErrs
 	}
 
-	devBuildVersion, _ := semver.New(DevBuildVersion)
-	if newEksaVersion.SamePatch(devBuildVersion) {
+	if newEksaVersion.SamePatch(devBuild) {
 		return nil
 	}
 

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -149,11 +149,6 @@ func ValidateManagementEksaVersion(mgmtCluster, cluster *v1alpha1.Cluster) error
 		return err
 	}
 
-	devBuildVersion, _ := semver.New(v1alpha1.DevBuildVersion)
-	if mVersion.SamePatch(devBuildVersion) {
-		return nil
-	}
-
 	if wVersion.GreaterThan(mVersion) {
 		errMsg := fmt.Sprintf("cannot upgrade workload cluster to %v while management cluster is an older version: %v", wVersion, mVersion)
 		reason := v1alpha1.EksaVersionInvalidReason

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -437,7 +437,6 @@ func TestValidateManagementClusterEksaVersion(t *testing.T) {
 	v := test.DevEksaVersion()
 	uv := anywherev1.EksaVersion("v0.1.0")
 	badVersion := anywherev1.EksaVersion("invalid")
-
 	tests := []struct {
 		name              string
 		wantErr           error
@@ -448,12 +447,6 @@ func TestValidateManagementClusterEksaVersion(t *testing.T) {
 			name:              "Success",
 			wantErr:           nil,
 			version:           &v,
-			managementVersion: &v,
-		},
-		{
-			name:              "Management with dev build version and workload with release version",
-			wantErr:           nil,
-			version:           &uv,
 			managementVersion: &v,
 		},
 		{

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -103,7 +103,8 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		wc.UpdateClusterConfig(
 			api.ClusterToConfigFiller(
-				api.WithEksaVersion(oldCluster.Spec.EksaVersion),
+				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
+				api.WithEksaVersion(nil),
 			),
 		)
 		wc.ApplyClusterManifest()
@@ -154,7 +155,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		test.PushWorkloadClusterToGit(wc,
 			api.ClusterToConfigFiller(
-				api.WithEksaVersion(oldCluster.Spec.EksaVersion),
+				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
 				api.WithEksaVersion(nil),
 			),
 		)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This patch never applied to release 0.17. Originally, a patch was made such due to encountering an error upgrading from latest minor release in the controller on main.

```
status:
    failureMessage: 'cannot upgrade workload cluster to v0.17.0 while management cluster is an older version: v0.0.0'
    failureReason: EksaVersionInvalid
```

It only happened when trying to create a new cluster with the old bundle, but the old cluster created from the latest minor release will not have an EksaVersion, only BundlesRef.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

