### PR TITLE
Fix to fetch the correct prev minor release for e2e tests 

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -1143,3 +1143,33 @@ func (g *Govc) SetGroupRoleOnObject(ctx context.Context, principal string, role 
 
 	return nil
 }
+
+type resourcePoolInfo struct {
+	resourcePoolIdentifier resourcePool
+}
+
+type resourcePool struct {
+	CPUUsage    string
+	CPULimit    string
+	MemoryUsage string
+	MemoryLimit string
+}
+
+// ResourcePoolInfo returns the pool info for the provided resource pool.
+func (g *Govc) ResourcePoolInfo(ctx context.Context, datacenter, resourcepool string, args ...string) (resourcePool, error) {
+	params := []string{"pool.info", "-dc", datacenter, "-vm", resourcepool, "-json"}
+	params = append(params, args...)
+	response, err := g.exec(ctx, params...)
+	if err != nil {
+		return resourcePool{}, fmt.Errorf("getting resource pool information: %v", err)
+	}
+	var resourcePoolInfoResponse resourcePoolInfo
+	err = yaml.Unmarshal(response.Bytes(), &resourcePoolInfoResponse)
+	if err != nil {
+		return resourcePool{}, fmt.Errorf("unmarshalling devices info: %v", err)
+	}
+
+	return resourcePoolInfoResponse.resourcePoolIdentifier, nil
+}
+
+func validateMemoryAnd

--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -40,8 +39,6 @@ const (
 	DeployOptsFile       = "deploy-opts.json"
 	disk1                = "Hard disk 1"
 	disk2                = "Hard disk 2"
-	cpuAvailable         = "CPU_Available"
-	memoryAvailable      = "Memory_Available"
 )
 
 var requiredEnvs = []string{govcUsernameKey, govcPasswordKey, govcURLKey, govcInsecure, govcDatacenterKey}
@@ -1145,78 +1142,4 @@ func (g *Govc) SetGroupRoleOnObject(ctx context.Context, principal string, role 
 	}
 
 	return nil
-}
-
-type resourcePoolInfo struct {
-	resourcePoolIdentifier *resourcePool
-}
-
-type resourcePool struct {
-	CPUUsage    string
-	CPULimit    string
-	memoryUsage string
-	memoryLimit string
-}
-
-// ResourcePoolInfo returns the pool info for the provided resource pool.
-func (g *Govc) ResourcePoolInfo(ctx context.Context, datacenter, resourcepool string, args ...string) (map[string]int, error) {
-	params := []string{"pool.info", "-dc", datacenter, resourcepool}
-	params = append(params, args...)
-	response, err := g.exec(ctx, params...)
-	if err != nil {
-		return nil, fmt.Errorf("getting resource pool information: %v", err)
-	}
-	var resourcePoolInfoResponse resourcePoolInfo
-	err = yaml.Unmarshal(response.Bytes(), &resourcePoolInfoResponse)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling devices info: %v", err)
-	}
-	poolInfo, err := getPoolInfo(resourcePoolInfoResponse.resourcePoolIdentifier)
-	if err != nil {
-	
-	}
-	return poolInfo, nil
-}
-
-// func validateMemoryAnd
-func getPoolInfo(rp *resourcePool) (map[string]int, error) {
-	CPUUsed, err := getValueFromString(rp.CPUUsage)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to obtain CPU usage for resource pool %s: %v", rp.CPUUsage, err)
-	}
-	CPULimit, err := getValueFromString(rp.CPULimit)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to obtain CPU limit for resource pool %s: %v", rp.CPULimit, err)
-	}
-	memoryUsed, err := getValueFromString(rp.memoryUsage)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to obtain memory usage for resource pool %s: %v", rp.CPULimit, err)
-	}
-	memoryLimit, err := getValueFromString(rp.memoryLimit)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to obtain memory limit for resource pool %s: %v", rp.CPULimit, err)
-	}
-	poolInfo := make(map[string]int)
-	if memoryLimit != -1 {
-		poolInfo[memoryAvailable] = memoryLimit - memoryUsed
-	} else {
-		poolInfo[memoryAvailable] = -1
-	}
-	if CPULimit != -1 {
-		poolInfo[cpuAvailable] = CPULimit - CPUUsed
-	} else {
-		poolInfo[cpuAvailable] = -1
-	}
-	return poolInfo, nil
-}
-
-func getValueFromString(str string) (int, error) {
-	splitResponse := strings.Split(str, " ")
-	nonNumericRegex := regexp.MustCompile(`[^0-9- ]+`)
-	cleanedString := nonNumericRegex.ReplaceAllString(splitResponse[0], "")
-	numValue, err := strconv.Atoi(cleanedString)
-	if err != nil {
-		return 0, err
-	}
-	return numValue, nil
 }

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/semver"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -25,14 +24,8 @@ func latestMinorRelease(t testing.TB) *releasev1.EksARelease {
 
 func prevLatestMinorRelease(t testing.TB) *releasev1.EksARelease {
 	t.Helper()
-	currLatestRelease := latestMinorRelease(t)
-
-	semCurrLatestRel, err := semver.New(currLatestRelease.Version)
-	if err != nil {
-		t.Fatal(err)
-	}
 	// Fetch the previous latest minor release for workload creation For ex. curr latest release 15.x prev latest minor release: 14.x
-	prevLatestRel, err := framework.GetPreviousMinorReleaseFromVersion(semCurrLatestRel)
+	prevLatestRel, err := framework.GetPreviousMinorReleaseFromTestBranch()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/framework/release_versions.go
+++ b/test/framework/release_versions.go
@@ -62,16 +62,16 @@ func GetPreviousMinorReleaseFromTestBranch() (*releasev1alpha1.EksARelease, erro
 	// For release branch just return the latest minor release
 	if testBranch != "main" {
 		return latestMinorRelease, nil
-	} else {
-		semLatestMinorRelease, err := semver.New(latestMinorRelease.Version)
-		if err != nil {
-			return nil, err
-		}
-		prevLatestMinorRelease, err = GetPreviousMinorReleaseFromVersion(semLatestMinorRelease)
-		if err != nil {
-			return nil, err
-		}
 	}
+	semLatestMinorRelease, err := semver.New(latestMinorRelease.Version)
+	if err != nil {
+		return nil, err
+	}
+	prevLatestMinorRelease, err = GetPreviousMinorReleaseFromVersion(semLatestMinorRelease)
+	if err != nil {
+		return nil, err
+	}
+
 	return prevLatestMinorRelease, nil
 }
 

--- a/test/framework/release_versions.go
+++ b/test/framework/release_versions.go
@@ -45,6 +45,36 @@ func GetLatestMinorReleaseFromTestBranch() (*releasev1alpha1.EksARelease, error)
 	return GetPreviousMinorReleaseFromVersion(testBranchFirstSemver)
 }
 
+// GetPreviousMinorReleaseFromTestBranch inspects the T_BRANCH_NAME environment variable for a
+// branch to retrieve the previous latest minor released CLI version. If T_BRANCH_NAME is main, it returns
+// the previous minor version which is one minor version below the latest minor version that is released.
+//
+// If T_BRANCH_NAME is not main, it expects it to be of the format release-<major>.<minor>
+// and will use the <major>.<minor> to retrieve the previous minor release. For example, if the
+// release branch is release-0.2 it will retrieve the latest 0.1 release.
+func GetPreviousMinorReleaseFromTestBranch() (*releasev1alpha1.EksARelease, error) {
+	testBranch := testBranch()
+	var prevLatestMinorRelease *releasev1alpha1.EksARelease
+	latestMinorRelease, err := GetLatestMinorReleaseFromTestBranch()
+	if err != nil {
+		return nil, fmt.Errorf("getting latest minor release: %v", err)
+	}
+	// For release branch just return the latest minor release
+	if testBranch != "main" {
+		return latestMinorRelease, nil
+	} else {
+		semLatestMinorRelease, err := semver.New(latestMinorRelease.Version)
+		if err != nil {
+			return nil, err
+		}
+		prevLatestMinorRelease, err = GetPreviousMinorReleaseFromVersion(semLatestMinorRelease)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return prevLatestMinorRelease, nil
+}
+
 // EKSAVersionForTestBinary returns the "future" EKS-A version for the tested binary based on the TEST_BRANCH name.
 // For main, it returns the next minor version.
 // For a release branch, it returns the next path version for that release minor version.


### PR DESCRIPTION
*Issue #, if available:*
When workload cluster creation with previous eksa-version e2e test is run against release branch, the test incorrectly fetches 2 minor versions below the current release branch. For ex., when run against release-0.17 it fetches 15.x eks-a version while the correct previous version should be 16.x.This change fixes the logic to fetch the right latest minor version when run against both main and release branches. 

   
*Description of changes:*

*Testing (if applicable):*
Ran the e2e test locally against both main and release branch.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

