### PR TITLE
static pod kube-vip and externalTrafficPolicy: Local

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -255,6 +255,8 @@ spec:
                 # When there is no worker node, make kube-vip in control-plane nodes watch
               - name: svc_enable
                 value: "true"
+              - name: svc_election
+                value: "true"
 {{- end }}
               image: {{ .kubeVipImage }}
               imagePullPolicy: IfNotPresent

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -99,6 +99,8 @@ spec:
                 # When there is no worker node, make kube-vip in control-plane nodes watch
               - name: svc_enable
                 value: "true"
+              - name: svc_election
+                value: "true"
               image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.581
               imagePullPolicy: IfNotPresent
               name: kube-vip


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In scenarios where you create a cluster of size > 1 and where the control plane and worker nodes are all together this fixes an issue with k8s services interoperating properly with static pod deployment of kube-vip when the service uses `externalTrafficPolicy: Local`

*Testing (if applicable):*
Built the cli with this change and tested using the bare metal provider.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

