### PR TITLE
Patch the inability to add worker node groups in bare metal clusters

### DIFF
--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -22,7 +22,7 @@ type Spec struct {
 }
 
 func (s *Spec) DeepCopy() *Spec {
-	return &Spec{
+	ns := &Spec{
 		Config:          s.Config.DeepCopy(),
 		OIDCConfig:      s.OIDCConfig.DeepCopy(),
 		AWSIamConfig:    s.AWSIamConfig.DeepCopy(),
@@ -30,6 +30,12 @@ func (s *Spec) DeepCopy() *Spec {
 		VersionsBundles: deepCopyVersionsBundles(s.VersionsBundles),
 		EKSARelease:     s.EKSARelease.DeepCopy(),
 	}
+
+	if s.ManagementCluster != nil {
+		ns.ManagementCluster = s.ManagementCluster.DeepCopy()
+	}
+
+	return ns
 }
 
 type VersionsBundle struct {

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 

--- a/pkg/collection/convert.go
+++ b/pkg/collection/convert.go
@@ -1,0 +1,21 @@
+package collection
+
+// ToMap is a utility function that converts the slice s to a map using key to retrieve map
+// keys.
+func ToMap[K comparable, V any](s []V, key func(V) K) map[K]V {
+	m := make(map[K]V)
+	for _, elem := range s {
+		m[key(elem)] = elem
+	}
+	return m
+}
+
+// ToSlice is a utility function that converts the map m to a slice of m's values. The returned
+// slices order is undefined.
+func ToSlice[K comparable, V any](m map[K]V) []V {
+	s := make([]V, 0, len(m))
+	for _, v := range m {
+		s = append(s, v)
+	}
+	return s
+}

--- a/pkg/collection/convert_test.go
+++ b/pkg/collection/convert_test.go
@@ -1,0 +1,56 @@
+package collection_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/collection"
+)
+
+func TestToMap(t *testing.T) {
+	type Elem struct {
+		Name  string
+		Value int
+	}
+	elems := []Elem{
+		{Name: "4", Value: 4},
+		{Name: "3", Value: 3},
+		{Name: "1", Value: 1},
+	}
+
+	m := collection.ToMap(elems, func(e Elem) string { return e.Name })
+
+	for _, e := range elems {
+		if v, present := m[e.Name]; !present || v.Value != e.Value {
+			t.Fatalf("Missing elements: %#v", e)
+		}
+	}
+}
+
+func TestToSlice(t *testing.T) {
+	type Elem struct {
+		Name  string
+		Value int
+	}
+	elems := map[string]Elem{
+		"4": {Name: "4", Value: 4},
+		"5": {Name: "5", Value: 5},
+		"2": {Name: "2", Value: 2},
+	}
+
+	s := collection.ToSlice(elems)
+
+	contains := func(s []Elem, e Elem) bool {
+		for _, v := range s {
+			if v == e {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, e := range elems {
+		if !contains(s, e) {
+			t.Fatalf("Missing elements: %#v", e)
+		}
+	}
+}

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -8,6 +8,15 @@ type Cluster struct {
 	ExistingManagement bool // true is the cluster has EKS Anywhere management components
 }
 
+// DeepCopy creates a new in-memory copy of c.
+func (c *Cluster) DeepCopy() *Cluster {
+	return &Cluster{
+		Name:               c.Name,
+		KubeconfigFile:     c.KubeconfigFile,
+		ExistingManagement: c.ExistingManagement,
+	}
+}
+
 type InfrastructureBundle struct {
 	FolderName string
 	Manifests  []v1alpha1.Manifest


### PR DESCRIPTION
Closes #6615 

When adding worker node groups we were erroring out indicating you cannot add or remove machine configs. This change ensures a worker node group with a new machine config can be added to a cluster spec.