### PR TITLE
Fix custom HookOS docs typing error

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
+++ b/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
@@ -178,7 +178,7 @@ For more information on Tinkerbell’s Hook Installation Environment, see the [T
 1. Start a local registry:
 
     ```bash
-    docker run -d -p 5000:5000 -—name registry registry:2
+    docker run -d -p 5000:5000 --name registry registry:2
     ```
 
 1. Compile by running the following in the root of the repo:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
There is a typo in the command line, so an error occurs when copying.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

