### PR TITLE
Control plane scale up shows misleading error meessage in EKSA cloudstack #1741

### DIFF
--- a/pkg/validations/upgradevalidations/immutable_fields.go
+++ b/pkg/validations/upgradevalidations/immutable_fields.go
@@ -43,6 +43,10 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		return fmt.Errorf("spec.controlPlaneConfiguration.endpoint is immutable")
 	}
 
+	if nSpec.ControlPlaneConfiguration.Count != oSpec.ControlPlaneConfiguration.Count {
+		return fmt.Errorf("spec.controlPlaneConfiguration.count is immutable")
+	}
+
 	/* compare all clusterNetwork fields individually, since we do allow updating updating fields for configuring plugins such as CiliumConfig through the cli*/
 	if !nSpec.ClusterNetwork.Pods.Equal(&oSpec.ClusterNetwork.Pods) {
 		return fmt.Errorf("spec.clusterNetwork.Pods is immutable")


### PR DESCRIPTION
Control plane scale up shows misleading error meessage in EKSA cloudstack
*Issue #, if available:*
1741

*Description of changes:*
Added a validation check to check for control plane count

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

