### PR TITLE
Revert "CLI deprecate wl kubeconfig flag"

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -141,7 +141,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		WithEksdInstaller().
-		WithPackageInstaller(clusterSpec, cc.installPackages, cc.clusterKubeconfig).
+		WithPackageInstaller(clusterSpec, cc.installPackages, cc.managementKubeconfig).
 		WithValidatorClients().
 		WithCreateClusterDefaulter(createCLIConfig)
 

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 
@@ -39,10 +38,6 @@ var deleteClusterCmd = &cobra.Command{
 		if err := dc.deleteCluster(cmd.Context()); err != nil {
 			return fmt.Errorf("failed to delete cluster: %v", err)
 		}
-		if uc.wConfig != "" {
-			logger.MarkFail(wConfigDeprecationMessage)
-			return errors.New("--w-config is deprecated. Use --kubeconfig instead")
-		}
 		return nil
 	},
 }
@@ -51,13 +46,9 @@ func init() {
 	deleteCmd.AddCommand(deleteClusterCmd)
 	deleteClusterCmd.Flags().StringVarP(&dc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration, required if <cluster-name> is not provided")
 	deleteClusterCmd.Flags().StringVarP(&dc.wConfig, "w-config", "w", "", "Kubeconfig file to use when deleting a workload cluster")
-	err := deleteClusterCmd.Flags().MarkDeprecated("w-config", "please use flag --kubeconfig.")
-	if err != nil {
-		log.Fatalf("Error deprecating flag as required: %v", err)
-	}
 	deleteClusterCmd.Flags().BoolVar(&dc.forceCleanup, "force-cleanup", false, "Force deletion of previously created bootstrap cluster")
 	hideForceCleanup(deleteClusterCmd.Flags())
-	deleteClusterCmd.Flags().StringVar(&dc.clusterKubeconfig, "kubeconfig", "", "kubeconfig file pointing to a management cluster")
+	deleteClusterCmd.Flags().StringVar(&dc.managementKubeconfig, "kubeconfig", "", "kubeconfig file pointing to a management cluster")
 	deleteClusterCmd.Flags().StringVar(&dc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 }
 
@@ -82,7 +73,7 @@ func (dc *deleteClusterOptions) validate(ctx context.Context, args []string) err
 		return err
 	}
 
-	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.clusterKubeconfig)
+	kubeconfigPath := getKubeconfigPath(clusterConfig.Name, dc.wConfig)
 	if err := kubeconfig.ValidateFilename(kubeconfigPath); err != nil {
 		return err
 	}
@@ -128,30 +119,21 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 	)
 
 	var cluster *types.Cluster
-	var kubeconfigFile string
 	if clusterSpec.ManagementCluster == nil {
-		kubeconfigFile = kubeconfig.FromClusterName(clusterSpec.Cluster.Name)
-		if dc.clusterKubeconfig != "" {
-			kubeconfigFile = dc.clusterKubeconfig
-		}
 		cluster = &types.Cluster{
 			Name:               clusterSpec.Cluster.Name,
-			KubeconfigFile:     kubeconfigFile,
+			KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 			ExistingManagement: false,
 		}
 	} else {
-		kubeconfigFile = clusterSpec.ManagementCluster.KubeconfigFile
-		if dc.clusterKubeconfig != "" {
-			kubeconfigFile = dc.clusterKubeconfig
-		}
 		cluster = &types.Cluster{
 			Name:               clusterSpec.Cluster.Name,
-			KubeconfigFile:     kubeconfigFile,
+			KubeconfigFile:     clusterSpec.ManagementCluster.KubeconfigFile,
 			ExistingManagement: true,
 		}
 	}
 
-	err = deleteCluster.Run(ctx, cluster, clusterSpec, dc.forceCleanup, dc.clusterKubeconfig)
+	err = deleteCluster.Run(ctx, cluster, clusterSpec, dc.forceCleanup, dc.managementKubeconfig)
 	cleanup(deps, &err)
 	return err
 }

--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -22,7 +22,6 @@ const (
 https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#cluster-upgrade-fails-with-management-components-on-bootstrap-cluster`
 	forceCleanupDeprecationMessageForCreateDelete = `The flag --force-cleanup has been removed. For more information on how to troubleshoot existing bootstrap clusters, please refer to the documentation:
 https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#bootstrap-cluster-fails-to-come-up-nodes-already-exist-for-a-cluster-with-the-name`
-	wConfigDeprecationMessage = `The flag --w-config has been deprecated. Please use flag --kubeconfig instead.`
 )
 
 func bindFlagsToViper(cmd *cobra.Command, args []string) error {
@@ -39,7 +38,7 @@ func bindFlagsToViper(cmd *cobra.Command, args []string) error {
 func applyClusterOptionFlags(flagSet *pflag.FlagSet, clusterOpt *clusterOptions) {
 	flags.String(flags.ClusterConfig, &clusterOpt.fileName, flagSet)
 	flags.String(flags.BundleOverride, &clusterOpt.bundlesOverride, flagSet)
-	flagSet.StringVar(&clusterOpt.clusterKubeconfig, "kubeconfig", "", "Cluster kubeconfig file")
+	flagSet.StringVar(&clusterOpt.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
 }
 
 func applyTinkerbellHardwareFlag(flagSet *pflag.FlagSet, pathOut *string) {

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -92,14 +92,14 @@ func buildClusterManagerOpts(t timeoutOptions, datacenterKind string) (*dependen
 
 type clusterOptions struct {
 	fileName             string
-	bundlesOverride   string
-	clusterKubeconfig string
+	bundlesOverride      string
+	managementKubeconfig string
 }
 
 func (c clusterOptions) mountDirs() []string {
 	var dirs []string
-	if c.clusterKubeconfig != "" {
-		dirs = append(dirs, filepath.Dir(c.clusterKubeconfig))
+	if c.managementKubeconfig != "" {
+		dirs = append(dirs, filepath.Dir(c.managementKubeconfig))
 	}
 
 	return dirs
@@ -138,14 +138,14 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 	}
 
 	if clusterSpec.Cluster.IsManaged() {
-		if options.clusterKubeconfig == "" {
+		if options.managementKubeconfig == "" {
 			managementKubeconfig, err := getManagementClusterKubeconfig(clusterSpec.Cluster.Spec.ManagementCluster.Name)
 			if err != nil {
 				return nil, err
 			}
-			options.clusterKubeconfig = managementKubeconfig
+			options.managementKubeconfig = managementKubeconfig
 		}
-		managementCluster, err := cluster.LoadManagement(options.clusterKubeconfig)
+		managementCluster, err := cluster.LoadManagement(options.managementKubeconfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get management cluster from kubeconfig: %v", err)
 		}

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -14,14 +13,12 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 type createSupportBundleOptions struct {
 	fileName              string
 	wConfig               string
-	clusterKubeconfig     string
 	since                 string
 	sinceTime             string
 	bundleConfig          string
@@ -44,10 +41,6 @@ var supportbundleCmd = &cobra.Command{
 		if err := csbo.createBundle(cmd.Context(), csbo.since, csbo.sinceTime, csbo.bundleConfig); err != nil {
 			return fmt.Errorf("failed to create support bundle: %v", err)
 		}
-		if uc.wConfig != "" {
-			logger.MarkFail(wConfigDeprecationMessage)
-			return errors.New("--w-config is deprecated. Use --kubeconfig instead")
-		}
 		return nil
 	},
 }
@@ -58,13 +51,8 @@ func init() {
 	supportbundleCmd.Flags().StringVarP(&csbo.since, "since", "", "", "Collect pod logs in the latest duration like 5s, 2m, or 3h.")
 	supportbundleCmd.Flags().StringVarP(&csbo.bundleConfig, "bundle-config", "", "", "Bundle Config file to use when generating support bundle")
 	supportbundleCmd.Flags().StringVarP(&csbo.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
-	supportbundleCmd.Flags().StringVarP(&csbo.wConfig, "w-config", "w", "", "Kubeconfig file pointing to a cluster")
-	err := supportbundleCmd.Flags().MarkDeprecated("w-config", "please use flag --kubeconfig.")
-	if err != nil {
-		log.Fatalf("Error deprecating flag as required: %v", err)
-	}
-	supportbundleCmd.Flags().StringVarP(&csbo.clusterKubeconfig, "kubeconfig", "", "", "Cluster kubeconfig file")
-	err = supportbundleCmd.MarkFlagRequired("filename")
+	supportbundleCmd.Flags().StringVarP(&csbo.wConfig, "w-config", "w", "", "Kubeconfig file to use when creating support bundle for a workload cluster")
+	err := supportbundleCmd.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
@@ -109,7 +97,7 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	}
 	defer close(ctx, deps)
 
-	supportBundle, err := deps.DignosticCollectorFactory.DiagnosticBundle(clusterSpec, deps.Provider, getKubeconfigPath(clusterSpec.Cluster.Name, csbo.clusterKubeconfig), bundleConfig)
+	supportBundle, err := deps.DignosticCollectorFactory.DiagnosticBundle(clusterSpec, deps.Provider, getKubeconfigPath(clusterSpec.Cluster.Name, csbo.wConfig), bundleConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse collector: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -59,7 +59,7 @@ func init() {
 	upgradePlanClusterCmd.Flags().StringVarP(&uc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
 	upgradePlanClusterCmd.Flags().StringVar(&uc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
 	upgradePlanClusterCmd.Flags().StringVarP(&output, outputFlagName, "o", outputDefault, "Output format: text|json")
-	upgradePlanClusterCmd.Flags().StringVar(&uc.clusterKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
+	upgradePlanClusterCmd.Flags().StringVar(&uc.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
 	err := upgradePlanClusterCmd.MarkFlagRequired("filename")
 	if err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
@@ -88,7 +88,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	managementCluster := &types.Cluster{
 		Name:           newClusterSpec.Cluster.Name,
-		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.clusterKubeconfig),
+		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.wConfig),
 	}
 
 	if newClusterSpec.ManagementCluster != nil {


### PR DESCRIPTION
Reverts aws/eks-anywhere#6573

We found w-config is at least used in cilium and IAM, so we better not deprecate it.
The bug can be fixed by using kubeconfig instead of w-config in [validation](https://github.com/aws/eks-anywhere/blob/3df940e33d3126d87922927217080bbdb52230a1/cmd/eksctl-anywhere/cmd/upgradecluster.go#L194). Or we should validate both kubeconfig and w-config if they are not empty