### PR TITLE
Update API upgrade test to specify use appropriate templates

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -4107,10 +4107,7 @@ func TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI(t *t
 	)
 	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
 	managementCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube123),
-		),
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 	)
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
 	wc := framework.NewClusterE2ETest(
@@ -4123,14 +4120,15 @@ func TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI(t *t
 		api.ClusterToConfigFiller(
 			api.WithManagementCluster(managementCluster.ClusterName),
 		),
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 	)
 	test.WithWorkloadClusters(wc)
 
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		cloudstack.WithRedhat124(),
+		v1alpha1.Kube124,
+		framework.RedHat8,
 	)
 }
 
@@ -4147,11 +4145,7 @@ func TestCloudStackKubernetesRedHat123to124UpgradeFromLatestMinorReleaseGitHubFl
 	)
 	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
 	managementCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube123),
-		),
-
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 		framework.WithFluxGithubConfig(),
 	)
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
@@ -4168,7 +4162,7 @@ func TestCloudStackKubernetesRedHat123to124UpgradeFromLatestMinorReleaseGitHubFl
 		api.ClusterToConfigFiller(
 			api.WithManagementCluster(managementCluster.ClusterName),
 		),
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 		framework.WithFluxGithubConfig(),
 	)
 	test.WithWorkloadClusters(wc)
@@ -4176,7 +4170,8 @@ func TestCloudStackKubernetesRedHat123to124UpgradeFromLatestMinorReleaseGitHubFl
 	runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(
 		test,
 		release,
-		cloudstack.WithRedhat124(),
+		v1alpha1.Kube124,
+		framework.RedHat8,
 	)
 }
 

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1027,7 +1027,8 @@ func TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI(t *testing.T) 
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		api.ClusterToConfigFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
+		v1alpha1.Kube124,
+		"",
 	)
 }
 

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2715,12 +2715,8 @@ func TestVSphereKubernetes123to124UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		api.JoinClusterConfigFillers(
-			provider.WithBottleRocket124(),
-			api.VSphereToConfigFiller(
-				provider.Bottlerocket124Template(), // Set the template so it doesn't get autoimported
-			),
-		),
+		v1alpha1.Kube124,
+		framework.Bottlerocket1,
 	)
 }
 

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -18,14 +18,15 @@ import (
 )
 
 func validationsForExpectedObjects() []clusterf.StateValidation {
-	mediumRetier := retrier.NewWithMaxRetries(120, 5*time.Second)
-	longRetier := retrier.NewWithMaxRetries(120, 10*time.Second)
+	mediumRetier := retrier.New(10 * time.Minute)
+	longRetier := retrier.New(30 * time.Minute)
 	return []clusterf.StateValidation{
-		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateClusterReady),
 		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateEKSAObjects),
 		clusterf.RetriableStateValidation(longRetier, validations.ValidateControlPlaneNodes),
 		clusterf.RetriableStateValidation(longRetier, validations.ValidateWorkerNodes),
 		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateCilium),
+		// This should be checked last as the Cluster should only be ready after all the other validations pass.
+		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateClusterReady),
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This CR updates from latest release API tests to:
1. Update the workload cluster config machines templates before creating the cluster with the old bundle.  

At the step of creating a new workload cluster with the old Eksa version, the test may fail validating template tags (particularly for vSphere)) if the old bundle is using a different eksd tags. So, we need to also update the workload cluster machine templates with a template appropriate for the Kubernetes version and the old release. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

