### PR TITLE
Enable Kindless management cluster upgrade for vSphere provider

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -115,6 +116,13 @@ func NewClusterE2ETest(t T, provider Provider, opts ...ClusterE2ETestOpt) *Clust
 		clusterFillers:        make([]api.ClusterFiller, 0),
 		KubectlClient:         buildKubectl(t),
 		eksaBinaryLocation:    defaultEksaBinaryLocation,
+	}
+
+	// For kindless management upgrade task
+	// Remove this once we remove feature flag for ExpSelfManagedAPIUpgrade.
+	if provider.Name() == constants.VSphereProviderName {
+		opts = append(opts, WithEnvVar(features.ExperimentalSelfManagedClusterUpgradeGate, "true"))
+		opts = append(opts, WithEnvVar(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true"))
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enables Kindless management cluster upgrade for vSphere provider. The feature is under feature flag so it won't impact the current upgrade process for other providers.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

