### PR TITLE
[release-0.17] update api upgrade test to specifically use apropropriate templates

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -40,9 +40,9 @@ func WithKubernetesVersion(v anywherev1.KubernetesVersion) ClusterFiller {
 }
 
 // WithBundlesRef sets BundlesRef with the provided name to use.
-func WithBundlesRef(name string, namespace string, apiVersion string) ClusterFiller {
+func WithBundlesRef(bundlesRef *anywherev1.BundlesRef) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
-		c.Spec.BundlesRef = &anywherev1.BundlesRef{Name: name, Namespace: namespace, APIVersion: apiVersion}
+		c.Spec.BundlesRef = bundlesRef
 	}
 }
 

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -4112,10 +4112,7 @@ func TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI(t *t
 	)
 	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
 	managementCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube123),
-		),
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 	)
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
 	wc := framework.NewClusterE2ETest(
@@ -4129,14 +4126,15 @@ func TestCloudStackKubernetesRedHat123To124UpgradeFromLatestMinorReleaseAPI(t *t
 		api.ClusterToConfigFiller(
 			api.WithManagementCluster(managementCluster.ClusterName),
 		),
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 	)
 	test.WithWorkloadClusters(wc)
 
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		cloudstack.WithRedhat124(),
+		v1alpha1.Kube124,
+		framework.RedHat8,
 	)
 }
 
@@ -4153,11 +4151,7 @@ func TestCloudStackKubernetesRedHat123to124UpgradeFromLatestMinorReleaseGitHubFl
 	)
 	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
 	managementCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube123),
-		),
-
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 		framework.WithFluxGithubConfig(),
 	)
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
@@ -4174,7 +4168,7 @@ func TestCloudStackKubernetesRedHat123to124UpgradeFromLatestMinorReleaseGitHubFl
 		api.ClusterToConfigFiller(
 			api.WithManagementCluster(managementCluster.ClusterName),
 		),
-		cloudstack.WithRedhat123(),
+		cloudstack.WithKubeVersionAndOS(v1alpha1.Kube123, framework.RedHat8, release),
 		framework.WithFluxGithubConfig(),
 	)
 	test.WithWorkloadClusters(wc)
@@ -4182,7 +4176,8 @@ func TestCloudStackKubernetesRedHat123to124UpgradeFromLatestMinorReleaseGitHubFl
 	runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(
 		test,
 		release,
-		cloudstack.WithRedhat124(),
+		v1alpha1.Kube124,
+		framework.RedHat8,
 	)
 }
 

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1027,7 +1027,8 @@ func TestDockerKubernetes123to124UpgradeFromLatestMinorReleaseAPI(t *testing.T) 
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		api.ClusterToConfigFiller(api.WithKubernetesVersion(v1alpha1.Kube124)),
+		v1alpha1.Kube124,
+		"",
 	)
 }
 

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -58,7 +58,8 @@ func runUpgradeWithFluxFromReleaseFlow(test *framework.ClusterE2ETest, latestRel
 	test.DeleteCluster()
 }
 
-func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETest, release *releasev1.EksARelease, upgradeChanges api.ClusterConfigFiller) {
+func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETest, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion, os framework.OS) {
+	provider := test.ManagementCluster.Provider
 	test.CreateManagementCluster(framework.ExecuteWithEksaRelease(release))
 
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
@@ -69,7 +70,9 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 
 	oldCluster := test.ManagementCluster.GetEKSACluster()
 
-	test.ManagementCluster.UpdateClusterConfig(upgradeChanges)
+	test.ManagementCluster.UpdateClusterConfig(
+		provider.WithKubeVersionAndOS(kubeVersion, os, nil),
+	)
 	test.ManagementCluster.UpgradeCluster()
 	test.ManagementCluster.ValidateCluster(test.ManagementCluster.ClusterConfig.Cluster.Spec.KubernetesVersion)
 	test.ManagementCluster.StopIfFailed()
@@ -79,8 +82,9 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 	// Upgrade bundle workload clusters now because they still have the old versions of the bundle.
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		wc.UpdateClusterConfig(
-			api.JoinClusterConfigFillers(upgradeChanges),
+			provider.WithKubeVersionAndOS(kubeVersion, os, nil),
 			api.ClusterToConfigFiller(
+				api.WithBundlesRef(nil),
 				api.WithEksaVersion(cluster.Spec.EksaVersion),
 			),
 		)
@@ -95,8 +99,9 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 	// Create workload cluster with old bundle
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		wc.UpdateClusterConfig(
+			provider.WithKubeVersionAndOS(kubeVersion, os, release),
 			api.ClusterToConfigFiller(
-				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
+				api.WithBundlesRef(oldCluster.Spec.BundlesRef),
 				api.WithEksaVersion(nil),
 			),
 		)
@@ -112,7 +117,8 @@ func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETes
 	test.DeleteManagementCluster()
 }
 
-func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.MulticlusterE2ETest, release *releasev1.EksARelease, upgradeChanges api.ClusterConfigFiller) {
+func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.MulticlusterE2ETest, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion, os framework.OS) {
+	provider := test.ManagementCluster.Provider
 	test.CreateManagementCluster(framework.ExecuteWithEksaRelease(release))
 
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
@@ -123,18 +129,21 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 
 	oldCluster := test.ManagementCluster.GetEKSACluster()
 
-	test.ManagementCluster.UpdateClusterConfig(upgradeChanges)
+	test.ManagementCluster.UpdateClusterConfig(
+		provider.WithKubeVersionAndOS(kubeVersion, os, nil),
+	)
 	test.ManagementCluster.UpgradeCluster()
 	test.ManagementCluster.ValidateCluster(test.ManagementCluster.ClusterConfig.Cluster.Spec.KubernetesVersion)
 	test.ManagementCluster.StopIfFailed()
 
 	cluster := test.ManagementCluster.GetEKSACluster()
 
-	// Upgrade bundle workload clusters now because they still have the old versions of the bundle.
+	// Upgrade bundle workload clusters now using the new EksaVersion
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		test.PushWorkloadClusterToGit(wc,
-			api.JoinClusterConfigFillers(upgradeChanges),
+			provider.WithKubeVersionAndOS(kubeVersion, os, nil),
 			api.ClusterToConfigFiller(
+				api.WithBundlesRef(nil),
 				api.WithEksaVersion(cluster.Spec.EksaVersion),
 			),
 		)
@@ -144,11 +153,12 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 		wc.ValidateClusterDelete()
 	})
 
-	// Create workload cluster with old bundle
+	// Create workload cluster with the old EksaVersion
 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
 		test.PushWorkloadClusterToGit(wc,
+			provider.WithKubeVersionAndOS(kubeVersion, os, release),
 			api.ClusterToConfigFiller(
-				api.WithBundlesRef(oldCluster.Spec.BundlesRef.Name, oldCluster.Spec.BundlesRef.Namespace, oldCluster.Spec.BundlesRef.APIVersion),
+				api.WithBundlesRef(oldCluster.Spec.BundlesRef),
 				api.WithEksaVersion(nil),
 			),
 		)

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2691,12 +2691,8 @@ func TestVSphereKubernetes123to124UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 	runMulticlusterUpgradeFromReleaseFlowAPI(
 		test,
 		release,
-		api.JoinClusterConfigFillers(
-			provider.WithBottleRocket124(),
-			api.VSphereToConfigFiller(
-				provider.Bottlerocket124Template(), // Set the template so it doesn't get autoimported
-			),
-		),
+		v1alpha1.Kube124,
+		framework.Bottlerocket1,
 	)
 }
 

--- a/test/framework/clustervalidator.go
+++ b/test/framework/clustervalidator.go
@@ -18,14 +18,15 @@ import (
 )
 
 func validationsForExpectedObjects() []clusterf.StateValidation {
-	mediumRetier := retrier.NewWithMaxRetries(120, 5*time.Second)
-	longRetier := retrier.NewWithMaxRetries(120, 10*time.Second)
+	mediumRetier := retrier.New(10 * time.Minute)
+	longRetier := retrier.New(30 * time.Minute)
 	return []clusterf.StateValidation{
-		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateClusterReady),
 		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateEKSAObjects),
 		clusterf.RetriableStateValidation(longRetier, validations.ValidateControlPlaneNodes),
 		clusterf.RetriableStateValidation(longRetier, validations.ValidateWorkerNodes),
 		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateCilium),
+		// This should be checked last as the Cluster should only be ready after all the other validations pass.
+		clusterf.RetriableStateValidation(mediumRetier, validations.ValidateClusterReady),
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Manual cherry pick of #6656 

The upgrade from latest minor release tests on this branch can't use EksaVersion for the creating the workload cluster with the old bundle, because it does not exist in 0.16.5. So we must use bundlesRef

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

