### PR TITLE
Prevent bare metal machine config references from changing to existing machine configs

### DIFF
--- a/pkg/collection/set.go
+++ b/pkg/collection/set.go
@@ -48,8 +48,8 @@ func (s Set[T]) ToSlice() []T {
 	return keys
 }
 
-// MapSet allows to map a collection to a Set using a closure to extract
-// the values of type T.
+// MapSet converts c to a new set. f is used to extract the value for representing each element
+// of c.
 func MapSet[G any, T comparable](c []G, f func(G) T) Set[T] {
 	s := NewSet[T]()
 	for _, element := range c {

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -925,7 +925,7 @@ func TestProvider_ValidateNewSpec_NewWorkerNodeGroup(t *testing.T) {
 
 	// Add an extra worker node group to the desired configuration with its associated machine
 	// config. The machine configs are plumbed in via the Tinkerbell provider constructor func.
-	newMachineCfgName := "additiona-machine-config"
+	newMachineCfgName := "additional-machine-config"
 	newWorkerNodeGroupName := "additional-worker-node-group"
 	desiredWorkerNodeGroups := &desiredClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations
 	*desiredWorkerNodeGroups = append(*desiredWorkerNodeGroups, v1alpha1.WorkerNodeGroupConfiguration{

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -201,7 +201,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 			workerResponse:     nil,
 			nodeResponse:       nil,
 			crdResponse:        nil,
-			wantErr:            composeError("spec.TinkerbellIP is immutable. Previous value 4.5.6.7,   New value 1.2.3.4"),
+			wantErr:            composeError("spec.tinkerbellIP is immutable; previous = 4.5.6.7, new = 1.2.3.4"),
 			modifyDatacenterFunc: func(s *anywherev1.TinkerbellDatacenterConfig) {
 				s.Spec.TinkerbellIP = "4.5.6.7"
 			},


### PR DESCRIPTION
Closes #6633.

In bare metal clusters users shouldn't be able to change machine configs. However, EKS-A incorrectly allowed users to change the machine config references to existing machine configs.