### PR TITLE
Add omitempty to bundlesRef

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -98,7 +98,7 @@ type ClusterSpecGenerate struct {
 	Packages                    *PackageConfiguration        `json:"packages,omitempty"`
 	// BundlesRef contains a reference to the Bundles containing the desired dependencies for the cluster.
 	// DEPRECATED: Use EksaVersion instead.
-	BundlesRef         *BundlesRef         `json:"bundlesRef"`
+	BundlesRef         *BundlesRef         `json:"bundlesRef,omitempty"`
 	EksaVersion        *EksaVersion        `json:"eksaVersion,omitempty"`
 	MachineHealthCheck *MachineHealthCheck `json:"machineHealthCheck,omitempty"`
 }

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mycluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mycluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mycluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
@@ -4,7 +4,6 @@ metadata:
   name: testcluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/gitops/flux/files_test.go
+++ b/pkg/gitops/flux/files_test.go
@@ -23,7 +23,6 @@ metadata:
   name: test-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-default-path-management.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-default-path-management.yaml
@@ -4,7 +4,6 @@ metadata:
   name: management-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-default-path-workload.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-default-path-workload.yaml
@@ -6,7 +6,6 @@ metadata:
   name: workload-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-user-provided-path.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-user-provided-path.yaml
@@ -4,7 +4,6 @@ metadata:
   name: management-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}


### PR DESCRIPTION
*Description of changes:*
Add `omitempty` tag to `bundlesRef` so it doesn't show up in `generate clusterconfig` command 

*Testing (if applicable):*
Before:
```yaml
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: Cluster
metadata:
  name: docker
spec:
  bundlesRef: null
  clusterNetwork:
    cniConfig:
      cilium: {}
    pods:
      cidrBlocks:
      - 192.168.0.0/16
    services:
      cidrBlocks:
      - 10.96.0.0/12
  controlPlaneConfiguration:
    count: 1
  datacenterRef:
    kind: DockerDatacenterConfig
    name: docker
  externalEtcdConfiguration:
    count: 1
  kubernetesVersion: "1.27"
  managementCluster:
    name: docker
  workerNodeGroupConfigurations:
  - count: 1
    name: md-0
```

After:
```yaml
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: Cluster
metadata:
  name: docker
spec:
  clusterNetwork:
    cniConfig:
      cilium: {}
    pods:
      cidrBlocks:
      - 192.168.0.0/16
    services:
      cidrBlocks:
      - 10.96.0.0/12
  controlPlaneConfiguration:
    count: 1
  datacenterRef:
    kind: DockerDatacenterConfig
    name: docker
  externalEtcdConfiguration:
    count: 1
  kubernetesVersion: "1.27"
  managementCluster:
    name: docker
  workerNodeGroupConfigurations:
  - count: 1
    name: md-0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

