### PR TITLE
Set OOB mgmt data via cli flags and ENV VARS

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -101,7 +102,8 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, nil).
-		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIpCheck, dc.hardwareFileName, false, dc.tinkerbellBootstrapIP, map[string]bool{}).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: dc.hardwareFileName, IP: dc.tinkerbellBootstrapIP}).
+		WithProvider(dc.fileName, clusterSpec.Cluster, cc.skipIPCheck, false, map[string]bool{}).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithWriter().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/flags.go
+++ b/cmd/eksctl-anywhere/cmd/flags.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -25,14 +26,24 @@ https://anywhere.eks.amazonaws.com/docs/troubleshooting/troubleshooting/#bootstr
 )
 
 func bindFlagsToViper(cmd *cobra.Command, args []string) error {
-	var err error
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-		if err != nil {
+		if err := viper.BindPFlag(flag.Name, flag); err != nil {
 			return
 		}
-		err = viper.BindPFlag(flag.Name, flag)
+		viper.AutomaticEnv()
+		// Environment variables can't have dashes in them, so bind them to their equivalent
+		// keys with underscores, e.g. --hardware-csv to HARDWARE_CSV
+		viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+		// viper.AutomaticEnv() needs help with dashes in flag names.
+		if !flag.Changed && viper.IsSet(flag.Name) {
+			val := viper.Get(flag.Name)
+			if err := cmd.Flags().Set(flag.Name, fmt.Sprintf("%v", val)); err != nil {
+				return
+			}
+		}
 	})
-	return err
+
+	return nil
 }
 
 func applyClusterOptionFlags(flagSet *pflag.FlagSet, clusterOpt *clusterOptions) {

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
@@ -89,7 +90,8 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP, map[string]bool{}).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: gsbo.hardwareFileName, IP: gsbo.tinkerbellBootstrapIP}).
+		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIPCheck, false, map[string]bool{}).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -6,19 +6,22 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 )
 
 type hardwareOptions struct {
 	csvPath    string
 	outputPath string
+	config     tinkerbell.Config
 }
 
 var hOpts = &hardwareOptions{}
 
 var generateHardwareCmd = &cobra.Command{
-	Use:   "hardware",
-	Short: "Generate hardware files",
+	Use:     "hardware",
+	Short:   "Generate hardware files",
+	PreRunE: bindFlagsToViper,
 	Long: `
 Generate Kubernetes hardware YAML manifests for each Hardware entry in the source.
 `,
@@ -41,10 +44,15 @@ func init() {
 	if err := generateHardwareCmd.MarkFlagRequired(TinkerbellHardwareCSVFlagName); err != nil {
 		panic(err)
 	}
+
+	generateHardwareCmd.Flags().StringVar(&cc.tinkerbellConfig.Rufio.WebhookSecret, "webhook-secrets", "", "Comma separated list of secrets for use with the bare metal webhook provider")
+	markFlagHidden(generateHardwareCmd.Flags(), "webhook-secrets")
+	generateHardwareCmd.Flags().StringVar(&cc.tinkerbellConfig.Rufio.ConsumerURL, "consumer-url", "", "URL for the bare metal webhook consumer")
+	markFlagHidden(generateHardwareCmd.Flags(), "webhook-url")
 }
 
 func (hOpts *hardwareOptions) generateHardware(cmd *cobra.Command, args []string) error {
-	hardwareYaml, err := hardware.BuildHardwareYAML(hOpts.csvPath)
+	hardwareYaml, err := hardware.BuildHardwareYAML(hOpts.csvPath, hOpts.config.Rufio.WebhookSecret)
 	if err != nil {
 		return fmt.Errorf("building hardware yaml from csv: %v", err)
 	}

--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -174,7 +174,7 @@ func buildCliConfig(clusterSpec *cluster.Spec) *config.CliConfig {
 
 func buildCreateCliConfig(clusterOptions *createClusterOptions) (*config.CreateClusterCLIConfig, error) {
 	createCliConfig := &config.CreateClusterCLIConfig{}
-	createCliConfig.SkipCPIPCheck = clusterOptions.skipIpCheck
+	createCliConfig.SkipCPIPCheck = clusterOptions.skipIPCheck
 	if clusterOptions.noTimeouts {
 		maxTime := time.Duration(math.MaxInt64)
 		createCliConfig.NodeStartupTimeout = maxTime

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/diagnostics"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/version"
 )
 
@@ -89,7 +90,8 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 	}
 
 	deps, err := dependencies.ForSpec(ctx, clusterSpec).
-		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false, csbo.tinkerbellBootstrapIP, map[string]bool{}).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: csbo.hardwareFileName, IP: csbo.tinkerbellBootstrapIP}).
+		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIPCheck, false, map[string]bool{}).
 		WithDiagnosticBundleFactory().
 		Build(ctx)
 	if err != nil {

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -18,6 +18,7 @@ import (
 	fluxupgrader "github.com/aws/eks-anywhere/pkg/gitops/flux"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -78,7 +79,8 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 
 	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster, nil).
-		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP, map[string]bool{}).
+		WithTinkerbellConfig(tinkerbell.Config{HardwareFile: uc.hardwareCSVPath, IP: uc.tinkerbellBootstrapIP}).
+		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.forceClean, map[string]bool{}).
 		WithGitOpsFlux(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
 		WithCAPIManager().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
+++ b/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/createcluster"
@@ -18,8 +19,7 @@ import (
 
 type validateOptions struct {
 	clusterOptions
-	hardwareCSVPath       string
-	tinkerbellBootstrapIP string
+	tinkerbell tinkerbell.Config
 }
 
 var valOpt = &validateOptions{}
@@ -35,13 +35,18 @@ var validateCreateClusterCmd = &cobra.Command{
 
 func init() {
 	validateCreateCmd.AddCommand(validateCreateClusterCmd)
-	applyTinkerbellHardwareFlag(validateCreateClusterCmd.Flags(), &valOpt.hardwareCSVPath)
+	applyTinkerbellHardwareFlag(validateCreateClusterCmd.Flags(), &valOpt.tinkerbell.HardwareFile)
 	validateCreateClusterCmd.Flags().StringVarP(&valOpt.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
-	validateCreateClusterCmd.Flags().StringVar(&valOpt.tinkerbellBootstrapIP, "tinkerbell-bootstrap-ip", "", "Override the local tinkerbell IP in the bootstrap cluster")
+	validateCreateClusterCmd.Flags().StringVar(&valOpt.tinkerbell.IP, "tinkerbell-bootstrap-ip", "", "Override the local tinkerbell IP in the bootstrap cluster")
 
 	if err := validateCreateClusterCmd.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking flag as required: %v", err)
 	}
+
+	validateCreateCmd.Flags().StringVar(&cc.tinkerbellConfig.Rufio.WebhookSecret, "webhook-secrets", "", "Comma separated list of secrets for use with the bare metal webhook provider")
+	markFlagHidden(validateCreateCmd.Flags(), "webhook-secrets")
+	validateCreateCmd.Flags().StringVar(&cc.tinkerbellConfig.Rufio.ConsumerURL, "consumer-url", "", "URL for the bare metal webhook consumer")
+	markFlagHidden(validateCreateCmd.Flags(), "webhook-url")
 }
 
 func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []string) error {
@@ -53,7 +58,7 @@ func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []str
 	}
 
 	if clusterSpec.Config.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
-		if err := checkTinkerbellFlags(cmd.Flags(), valOpt.hardwareCSVPath, 0); err != nil {
+		if err := checkTinkerbellFlags(cmd.Flags(), valOpt.tinkerbell.HardwareFile, 0); err != nil {
 			return err
 		}
 	}
@@ -73,7 +78,8 @@ func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []str
 		WithWriterFolder(tmpPath).
 		WithDocker().
 		WithKubectl().
-		WithProvider(valOpt.fileName, clusterSpec.Cluster, false, valOpt.hardwareCSVPath, true, valOpt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithTinkerbellConfig(valOpt.tinkerbell).
+		WithProvider(valOpt.fileName, clusterSpec.Cluster, false, true, map[string]bool{}).
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithUnAuthKubeClient().
 		WithValidatorClients().

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/executables"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
+	tink "github.com/aws/eks-anywhere/pkg/providers/tinkerbell"
 	"github.com/aws/eks-anywhere/pkg/registrymirror"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -82,7 +83,7 @@ func TestFactoryBuildWithProvidervSphere(t *testing.T) {
 	tt := newTest(t, vsphere)
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -94,7 +95,8 @@ func TestFactoryBuildWithProviderTinkerbell(t *testing.T) {
 	tt := newTest(t, tinkerbell)
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithTinkerbellConfig(tink.Config{HardwareFile: tt.hardwareConfigFile, IP: tt.tinkerbellBootstrapIP}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -110,7 +112,7 @@ func TestFactoryBuildWithProviderSnow(t *testing.T) {
 
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())
@@ -143,7 +145,7 @@ func TestFactoryBuildWithProviderNutanix(t *testing.T) {
 
 		deps, err := dependencies.NewFactory().
 			WithLocalExecutables().
-			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+			WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 			WithNutanixValidator().
 			Build(context.Background())
 
@@ -164,7 +166,7 @@ func TestFactoryBuildWithInvalidProvider(t *testing.T) {
 
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		Build(context.Background())
 
 	tt.Expect(err).NotTo(BeNil())
@@ -209,7 +211,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithBootstrapper().
 		WithCliConfig(&tt.cliConfig).
 		WithClusterManager(tt.clusterSpec.Cluster, timeoutOpts).
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		WithGitOpsFlux(tt.clusterSpec.Cluster, tt.clusterSpec.FluxConfig, nil).
 		WithWriter().
 		WithEksdInstaller().
@@ -525,7 +527,7 @@ func TestFactoryBuildWithCNIInstallerCilium(t *testing.T) {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		Build(tt.ctx)
 	tt.Expect(err).To(BeNil())
 
@@ -547,7 +549,7 @@ func TestFactoryBuildWithCNIInstallerKindnetd(t *testing.T) {
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithLocalExecutables().
-		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}).
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, false, map[string]bool{}).
 		Build(tt.ctx)
 	tt.Expect(err).To(BeNil())
 

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc.go
@@ -87,7 +87,7 @@ func toRufioMachine(m Machine) *v1alpha1.Machine {
 	// TODO(chrisdoherty4)
 	// 	- Set the namespace to the CAPT namespace.
 	// 	- Patch through insecure TLS.
-	return &v1alpha1.Machine{
+	rufioMachine := &v1alpha1.Machine{
 		TypeMeta: newMachineTypeMeta(),
 		ObjectMeta: v1.ObjectMeta{
 			Name:      formatBMCRef(m),
@@ -104,4 +104,14 @@ func toRufioMachine(m Machine) *v1alpha1.Machine {
 			},
 		},
 	}
+	// if m.ConsumerURL != "" {
+	// 	// TODO: remove comment once reufio PR is merged
+	// 	// Set consumerURL in rufio machinespec
+	// 	rufioMachine.ProviderOptions = &v1alpha1.ProviderOptions{
+	// 		RPC: v1alpha1.RPC{
+	// 			ConsumerURL: m.Rufio.ConsumerURL,
+	// 		},
+	// 	},
+	// }
+	return rufioMachine
 }

--- a/pkg/providers/tinkerbell/hardware/catalogue_bmc_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_bmc_test.go
@@ -79,3 +79,22 @@ func TestBMCCatalogueWriter_Write(t *testing.T) {
 	g.Expect(bmcs[0].Spec.Connection.Host).To(gomega.Equal(machine.BMCIPAddress))
 	g.Expect(bmcs[0].Spec.Connection.AuthSecretRef.Name).To(gomega.ContainSubstring(machine.Hostname))
 }
+
+// func TestBMCCatalogueWriter_WriteWithConsumerURL(t *testing.T) {
+// 	g := gomega.NewWithT(t)
+
+// 	catalogue := hardware.NewCatalogue()
+// 	writer := hardware.NewBMCCatalogueWriter(catalogue)
+// 	machine := NewValidMachine()
+// 	machine.ConsumerURL = "test"
+
+// 	err := writer.Write(machine)
+// 	g.Expect(err).To(gomega.Succeed())
+
+// 	bmcs := catalogue.AllBMCs()
+// 	g.Expect(bmcs).To(gomega.HaveLen(1))
+// 	g.Expect(bmcs[0].Name).To(gomega.ContainSubstring(machine.Hostname))
+// 	g.Expect(bmcs[0].Spec.Connection.Host).To(gomega.Equal(machine.BMCIPAddress))
+// 	g.Expect(bmcs[0].Spec.Connection.AuthSecretRef.Name).To(gomega.ContainSubstring(machine.Hostname))
+// 	// g.Expect(bmcs[0].Spec.ProviderOptions.RPC.ConsumerURL).To(gomega.Equal(machine.ConsumerURL))
+// }

--- a/pkg/providers/tinkerbell/hardware/catalogue_test.go
+++ b/pkg/providers/tinkerbell/hardware/catalogue_test.go
@@ -58,7 +58,7 @@ func TestParseYAMLCatalogueWithData(t *testing.T) {
 	buffer := bufio.NewReader(bytes.NewBufferString(hardwareManifestsYAML))
 	catalogue := hardware.NewCatalogue()
 
-	err := hardware.ParseYAMLCatalogue(catalogue, buffer)
+	err := hardware.ParseYAMLCatalogue(catalogue, buffer, "")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
@@ -73,10 +73,25 @@ func TestParseYAMLCatalogueWithoutData(t *testing.T) {
 	buffer := bufio.NewReader(&buf)
 	catalogue := hardware.NewCatalogue()
 
-	err := hardware.ParseYAMLCatalogue(catalogue, buffer)
+	err := hardware.ParseYAMLCatalogue(catalogue, buffer, "")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(0))
 	g.Expect(catalogue.TotalBMCs()).To(gomega.Equal(0))
 	g.Expect(catalogue.TotalSecrets()).To(gomega.Equal(0))
+}
+
+func TestParseYAMLCatalogueWithConsumerURL(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	buffer := bufio.NewReader(bytes.NewBufferString(hardwareManifestsYAML))
+	catalogue := hardware.NewCatalogue()
+	consumerURL := "test"
+
+	err := hardware.ParseYAMLCatalogue(catalogue, buffer, consumerURL)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	g.Expect(catalogue.TotalHardware()).To(gomega.Equal(1))
+	g.Expect(catalogue.TotalBMCs()).To(gomega.Equal(1))
+	g.Expect(catalogue.TotalSecrets()).To(gomega.Equal(1))
 }

--- a/pkg/providers/tinkerbell/hardware/csv_test.go
+++ b/pkg/providers/tinkerbell/hardware/csv_test.go
@@ -147,7 +147,7 @@ func TestCSVReaderWithMissingRequiredColumns(t *testing.T) {
 func TestCSVBuildHardwareYamlFromCSV(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	hardwareYaml, err := hardware.BuildHardwareYAML("./testdata/hardware.csv")
+	hardwareYaml, err := hardware.BuildHardwareYAML("./testdata/hardware.csv", "")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(hardwareYaml).To(gomega.Equal([]byte(`apiVersion: tinkerbell.org/v1alpha1
 kind: Hardware
@@ -223,6 +223,14 @@ metadata:
   name: bmc-worker1-auth
   namespace: eksa-system
 type: kubernetes.io/basic-auth`)))
+}
+
+func TestBuildHardwareYAML(t *testing.T) {
+	g := gomega.NewWithT(t)
+	webhookSecret := "sha256"
+	_, err := hardware.BuildHardwareYAML("./testdata/hardware.csv", webhookSecret)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
 }
 
 // BufferedCSV is an in-memory CSV that satisfies io.Reader and io.Writer.

--- a/pkg/providers/tinkerbell/hardware/machine.go
+++ b/pkg/providers/tinkerbell/hardware/machine.go
@@ -27,6 +27,11 @@ type Machine struct {
 	BMCUsername  string `csv:"bmc_username, omitempty"`
 	BMCPassword  string `csv:"bmc_password, omitempty"`
 	VLANID       string `csv:"vlan_id, omitempty"`
+
+	// Rufio configurations
+	// Rufio rufio.Config `csv:"rufio, omitempty"`
+	ConsumerURL   string `csv:"consumerURL, omitempty"`
+	WebhookSecret string `csv:"webhookSecret, omitempty"`
 }
 
 // HasBMC determines if m has a BMC configuration. A BMC configuration is present if any of the BMC fields

--- a/pkg/providers/tinkerbell/hardware/translate.go
+++ b/pkg/providers/tinkerbell/hardware/translate.go
@@ -23,9 +23,9 @@ type MachineValidator interface {
 
 // TranslateAll reads entries 1 at a time from reader and writes them to writer. When reader returns io.EOF,
 // TranslateAll returns nil. Failure to return io.EOF from reader will result in an infinite loop.
-func TranslateAll(reader MachineReader, writer MachineWriter, validator MachineValidator) error {
+func TranslateAll(reader MachineReader, writer MachineWriter, validator MachineValidator, modifiers ...func(Machine) Machine) error {
 	for {
-		err := Translate(reader, writer, validator)
+		err := Translate(reader, writer, validator, modifiers...)
 		if err == io.EOF {
 			return nil
 		}
@@ -38,7 +38,7 @@ func TranslateAll(reader MachineReader, writer MachineWriter, validator MachineV
 
 // Translate reads 1 entry from reader and writes it to writer. When reader returns io.EOF Translate
 // returns io.EOF to the caller.
-func Translate(reader MachineReader, writer MachineWriter, validator MachineValidator) error {
+func Translate(reader MachineReader, writer MachineWriter, validator MachineValidator, modifiers ...func(Machine) Machine) error {
 	machine, err := reader.Read()
 	if err == io.EOF {
 		return err
@@ -46,6 +46,10 @@ func Translate(reader MachineReader, writer MachineWriter, validator MachineVali
 
 	if err != nil {
 		return fmt.Errorf("read: invalid hardware: %v", err)
+	}
+
+	for _, modify := range modifiers {
+		machine = modify(machine)
 	}
 
 	if err := validator.Validate(machine); err != nil {

--- a/pkg/providers/tinkerbell/hardware/validator.go
+++ b/pkg/providers/tinkerbell/hardware/validator.go
@@ -127,12 +127,23 @@ func StaticMachineAssertions() MachineAssertion {
 				return fmt.Errorf("BMCIPAddress: %v", err)
 			}
 
-			if m.BMCUsername == "" {
-				return newEmptyFieldError("BMCUsername")
-			}
+			// Only check if BMC username and password are set if webhook secret has not been defined
+			// We don't need to check for username and password if webhook secrets have been defined.
+			if m.WebhookSecret == "" {
+				if m.BMCUsername == "" {
+					return newEmptyFieldError("BMCUsername")
+				}
 
-			if m.BMCPassword == "" {
-				return newEmptyFieldError("BMCPassword")
+				if m.BMCPassword == "" {
+					return newEmptyFieldError("BMCPassword")
+				}
+			} else {
+				webhookSecrets := strings.Split(m.WebhookSecret, ",")
+				for _, secret := range webhookSecrets {
+					if !strings.Contains(secret, "sha256") && !strings.Contains(secret, "sha512") {
+						return fmt.Errorf("Invalid webhook secrets: %s", secret)
+					}
+				}
 			}
 		}
 

--- a/pkg/providers/tinkerbell/hardware/validator_test.go
+++ b/pkg/providers/tinkerbell/hardware/validator_test.go
@@ -214,6 +214,9 @@ func TestStaticMachineAssertions_InvalidMachines(t *testing.T) {
 		"NonIntVLAN": func(h *hardware.Machine) {
 			h.VLANID = "im not an int"
 		},
+		"InvalidWebhookSecret": func(h *hardware.Machine) {
+			h.WebhookSecret = "blah"
+		},
 	}
 
 	validate := hardware.StaticMachineAssertions()
@@ -224,6 +227,24 @@ func TestStaticMachineAssertions_InvalidMachines(t *testing.T) {
 			g.Expect(validate(machine)).To(gomega.HaveOccurred())
 		})
 	}
+}
+
+func TestStaticMachineAssertions_validWebhookSecrets(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	machine := NewValidMachine()
+	machine.WebhookSecret = "sha256, sha512"
+	validate := hardware.StaticMachineAssertions()
+	g.Expect(validate(machine)).ToNot(gomega.HaveOccurred())
+}
+
+func TestStaticMachineAssertions_invalidWebhookSecrets(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	machine := NewValidMachine()
+	machine.WebhookSecret = "blah"
+	validate := hardware.StaticMachineAssertions()
+	g.Expect(validate(machine)).To(gomega.HaveOccurred())
 }
 
 func NewValidMachine() hardware.Machine {

--- a/pkg/providers/tinkerbell/rufio/rufio.go
+++ b/pkg/providers/tinkerbell/rufio/rufio.go
@@ -1,0 +1,10 @@
+package rufio
+
+// Config is for Rufio specific configuration.
+type Config struct {
+	// WebhookSecret is the secret that will be used to sign webhook notifications in Rufio.
+	// Multiple secrets can be used by separating them with a comma.
+	WebhookSecret string
+	// ConsumerURL is the URL that will be used when sending webhook notifications in Rufio.
+	ConsumerURL string
+}

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -70,15 +70,17 @@ func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineC
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		testIP,
 		test.FakeNow,
 		forceCleanup,
 		false,
+		Config{
+			HardwareFile: hardwareFile,
+			IP:           testIP,
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -566,7 +568,7 @@ func TestPostMoveManagementToBootstrapSuccess(t *testing.T) {
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
-			provider.hardwareCSVFile = test.hardwareCSVFile
+			provider.config.HardwareFile = test.hardwareCSVFile
 			if err := provider.readCSVToCatalogue(); err != nil {
 				t.Fatalf("failed to read hardware csv: %v", err)
 			}
@@ -1400,7 +1402,7 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorBMC(t *testing.T) {
 	provider := newProvider(datacenterConfig, machineConfigs, clusterSpec.Cluster, writer, docker, helm, kubectl, forceCleanup)
 	provider.stackInstaller = stackInstaller
 	provider.providerKubectlClient = kubectl
-	provider.hardwareCSVFile = "testdata/hardware.csv"
+	provider.config.HardwareFile = "testdata/hardware.csv"
 
 	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
@@ -1965,15 +1967,17 @@ func TestTinkerbellProviderGetMachineConfigsWithMismatchedAndExternalEtcd(t *tes
 		datacenterConfig,
 		machineConfigs,
 		clusterSpec.Cluster,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		testIP,
 		test.FakeNow,
 		forceCleanup,
 		false,
+		Config{
+			HardwareFile: hardwareFile,
+			IP:           testIP,
+		},
 	)
 
 	expectedErrorMessage := fmt.Sprintf(referrencedMachineConfigsAvailabilityErrMsg, "test-etcd")
@@ -2029,15 +2033,17 @@ func TestTinkerbellProviderGetMachineConfigsWithMismatchedMachineConfig(t *testi
 		datacenterConfig,
 		machineConfigs,
 		clusterSpec.Cluster,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		testIP,
 		test.FakeNow,
 		forceCleanup,
 		false,
+		Config{
+			HardwareFile: hardwareFile,
+			IP:           testIP,
+		},
 	)
 
 	expectedErrorMessage := fmt.Sprintf(referrencedMachineConfigsAvailabilityErrMsg, "single-node-cp")

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -66,16 +66,7 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 	// If we've been given a CSV with additional hardware for the cluster, validate it and
 	// write it to the catalogue so it can be used for further processing.
 	if p.hardwareCSVIsProvided() {
-		machineCatalogueWriter := hardware.NewMachineCatalogueWriter(p.catalogue)
-
-		machines, err := hardware.NewNormalizedCSVReaderFromFile(p.hardwareCSVFile)
-		if err != nil {
-			return err
-		}
-
-		machineValidator := hardware.NewDefaultMachineValidator()
-
-		if err := hardware.TranslateAll(machines, machineCatalogueWriter, machineValidator); err != nil {
+		if err := p.readCSVToCatalogue(); err != nil {
 			return err
 		}
 	}
@@ -347,7 +338,7 @@ func (p *Provider) UpgradeNeeded(_ context.Context, _, _ *cluster.Spec, _ *types
 }
 
 func (p *Provider) hardwareCSVIsProvided() bool {
-	return p.hardwareCSVFile != ""
+	return p.config.HardwareFile != ""
 }
 
 func (p *Provider) isScaleUpDown(oldCluster *v1alpha1.Cluster, newCluster *v1alpha1.Cluster) bool {

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -595,15 +595,17 @@ func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
 		t.DatacenterConfig,
 		t.MachineConfigs,
 		t.ClusterSpec.Cluster,
-		"",
 		t.Writer,
 		t.Docker,
 		t.Helm,
 		t.KubeClient,
-		testIP,
 		test.FakeNow,
 		false,
 		false,
+		Config{
+			HardwareFile: "",
+			IP:           testIP,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -643,15 +645,17 @@ func newTinkerbellProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig
 		datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		testIP,
 		test.FakeNow,
 		forceCleanup,
 		false,
+		Config{
+			HardwareFile: hardwareFile,
+			IP:           testIP,
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -413,15 +413,17 @@ func newProvider(datacenterConfig anywherev1.TinkerbellDatacenterConfig, machine
 		&datacenterConfig,
 		machineConfigs,
 		clusterConfig,
-		hardwareFile,
 		writer,
 		docker,
 		helm,
 		kubectl,
-		"1.2.3.4",
 		test.FakeNow,
 		forceCleanup,
 		false,
+		tinkerbell.Config{
+			HardwareFile: hardwareFile,
+			IP:           "1.2.3.4",
+		},
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is the first part of adding support for the new rufio RPC provider. The RPC provider requires that webhook secret and a consumerURL defined, and the same secret and URL is used for all BMC machines. 

This PR captures the webhook secret and consumerURL via both CLI flags and env vars defined as follows:
CLI flags
`--consumer-url: URL for the bare metal webhook consumer`
`--webhook-secrets: Comma separated list of secrets for use with the rufio RPC provider`

Env vars
`CONSUMER_URL`
`WEBHOOK_SECRETS`

If the webhooks secret data is set, the validations for `BMCUsername` and `BMCPassword` not being empty will not run, and instead, a validation verifying that the webhook secrets provided are valid algorithms (currently only `sha256` and `sha512` are valid. The webhook secret data is then propogated through to a kubernetes secret the same way the BMC credentials get propogated through. 

This PR also includes framework to propagate the given consumerURL to rufio machineSpecs, but a followup pr will be required to solve some dependency issues between rufio and eks-a (mainly container-runtime)

*Testing (if applicable):*
1. Verified the bmc secret gets populated with the webhook secret as the bmc password value
2. Verified that the consumerURL gets propagated to the placeholder I have (i checked with log statements as i couldn't run with the actual rufio changes)
3. Verified that when the consumer-url and webhook-secret gets set via either cli-flag or env var, the validation for bmc username/password no longer runs, and instead
`2023-09-15T20:56:50.538Z	V0	❌ Validation failed	{"validation": "tinkerbell Provider setup is valid", "error": "Invalid webhook secrets: blah", "remediation": ""}
`

*Documentation added/planned (if applicable):*