### PR TITLE
Ignore node taints when scheduling Cilium preflight daemonset

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -50,24 +50,6 @@ func (t *Templater) GenerateUpgradePreflightManifest(ctx context.Context, spec *
 
 	tolerationsList := []map[string]string{
 		{
-			"key":    "node.kubernetes.io/not-ready",
-			"effect": "NoSchedule",
-		},
-		{
-			"key":    "node-role.kubernetes.io/master",
-			"effect": "NoSchedule",
-		},
-		{
-			"key":    "node-role.kubernetes.io/control-plane",
-			"effect": "NoSchedule",
-		},
-		{
-			"key":    "node.cloudprovider.kubernetes.io/uninitialized",
-			"effect": "NoSchedule",
-			"value":  "true",
-		},
-		{
-			"key":      "CriticalAddonsOnly",
 			"operator": "Exists",
 		},
 	}

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -135,24 +135,6 @@ func TestTemplaterGenerateUpgradePreflightManifestSuccess(t *testing.T) {
 			},
 			"tolerations": []map[string]string{
 				{
-					"key":    "node.kubernetes.io/not-ready",
-					"effect": "NoSchedule",
-				},
-				{
-					"key":    "node-role.kubernetes.io/master",
-					"effect": "NoSchedule",
-				},
-				{
-					"key":    "node-role.kubernetes.io/control-plane",
-					"effect": "NoSchedule",
-				},
-				{
-					"key":    "node.cloudprovider.kubernetes.io/uninitialized",
-					"effect": "NoSchedule",
-					"value":  "true",
-				},
-				{
-					"key":      "CriticalAddonsOnly",
 					"operator": "Exists",
 				},
 			},
@@ -445,7 +427,7 @@ func TestTemplaterGenerateManifestForSingleNodeCluster(t *testing.T) {
 
 	tt.h.EXPECT().
 		Template(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ interface{}, _ interface{}, _ interface{}, _ interface{}, values map[string]interface{}, _ interface{}) ([]byte, error) {
+		DoAndReturn(func(_, _, _, _ interface{}, values map[string]interface{}, _ interface{}) ([]byte, error) {
 			tt.Expect(reflect.ValueOf(values["operator"]).MapIndex(reflect.ValueOf("replicas")).Interface().(int)).To(Equal(1))
 			return tt.manifest, nil
 		})


### PR DESCRIPTION
The Cilium preflight DaemonSet is a part of Cilium Helm charts and is installed to act as helper during Cilium upgrades. Since it's a DaemonSet, it will target all nodes to schedule pods on, and tolerates some well-known taints defined [here](https://github.com/aws/eks-anywhere/blob/main/pkg/networking/cilium/templater.go#L51-L73) (this list is a modified version of [upstream's list](https://github.com/cilium/cilium/blob/v1.12.11/install/kubernetes/cilium/values.yaml#L1917-L1926) that includes the toleration to the `node-role.kubernetes.io/control-plane`  taint). However if a user configures taints in their EKS-A cluster config, then this preflight DaemonSet will not be able to schedule pods on those nodes since it only tolerates the static list of taints above. Thus cluster upgrades will fail during the preflight validation phase when trying to upgrade a cluster with taints.

This PR sets the tolerations such that the preflight DaemonSet gets scheduled on all nodes regardless of the taints on that node.

From Kubernetes [docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/):
> An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

