### PR TITLE
Get previous disk usage only from existing machine configs

### DIFF
--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -471,12 +471,14 @@ type datastoreUsage struct {
 }
 
 func (p *vsphereProvider) getPrevMachineConfigDatastoreUsage(ctx context.Context, machineConfig *v1alpha1.VSphereMachineConfig, cluster *types.Cluster, count int) (diskGiB float64, err error) {
-	em, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, machineConfig.Name, cluster.KubeconfigFile, machineConfig.GetNamespace())
-	if err != nil {
-		return 0, err
-	}
-	if em != nil {
-		return float64(em.Spec.DiskGiB * count), nil
+	if count > 0 {
+		em, err := p.providerKubectlClient.GetEksaVSphereMachineConfig(ctx, machineConfig.Name, cluster.KubeconfigFile, machineConfig.GetNamespace())
+		if err != nil {
+			return 0, err
+		}
+		if em != nil {
+			return float64(em.Spec.DiskGiB * count), nil
+		}
 	}
 	return 0, nil
 }


### PR DESCRIPTION
During upgrade of an EKS-A vSphere cluster, one of the preflight checks we do is to validate whether the cumulative disk size requirements of the `VSphereMachineConfig`s can be met by the vCenter datastore. For this, we get the previous disk size requirement for each `VSphereMachineConfig` and then add it to the value in the new cluster config, and we sum this value across all `VSphereMachineConfigs` and compare it to the available space in the datastore. The previous disk usage is obtained by performing a `kubectl get` call on the `VSphereMachineConfig` object in the old cluster, but we are also doing this for newly added `VSphereMachineConfig` which don't exist on the old cluster, which leads to errors like
```bash
Error: "Validation failed {"validation": "vsphere provider validation", "error": "validating vsphere machine configs datastore usage: calculating datastore usage: getting eksa vsphere cluster Error from server (NotFound): [vspheremachineconfigs.anywhere.eks.amazonaws.com](http://vspheremachineconfigs.anywhere.eks.amazonaws.com/) \"new-vsphere-machine-config\" not found\n", "remediation": ""}"
```
We should try to fetch the object only if the previous count of the corresponding `WorkerNodeConfiguration` is greater than 0, which indicates that the `VSphereMachineConfig` exists on the old cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

