### PR TITLE
Source Bottlerocket artifacts from new upload location

### DIFF
--- a/release/pkg/assets/archives/archives.go
+++ b/release/pkg/assets/archives/archives.go
@@ -53,7 +53,7 @@ func EksDistroArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assett
 
 	if rc.DevRelease || rc.ReleaseEnvironment == "development" {
 		sourceS3Key = fmt.Sprintf("%s.%s", archive.OSName, imageExtension)
-		sourceS3Prefix = fmt.Sprintf("%s/%s/%s/%s/%s", projectPath, eksDReleaseChannel, archive.Format, archive.OSName, latestPath)
+		sourceS3Prefix = fmt.Sprintf("%s/%s/%s/%s/%s/%s", projectPath, eksDReleaseChannel, archive.Format, archive.OSName, archive.OSVersion, latestPath)
 	} else {
 		sourceS3Key = fmt.Sprintf("%s-%s-eks-d-%s-%s-eks-a-%d-%s.%s",
 			archive.OSName,

--- a/release/pkg/assets/archives/archives_test.go
+++ b/release/pkg/assets/archives/archives_test.go
@@ -125,12 +125,13 @@ func TestGenerateArchiveAssets(t *testing.T) {
 			archive: &assettypes.Archive{
 				Name:                "baz",
 				OSName:              "lorem",
+				OSVersion:           "v1.2.3",
 				Format:              "ova",
 				ArchiveS3PathGetter: EksDistroArtifactPathGetter,
 			},
 			wantArchiveArtifact: &releasetypes.ArchiveArtifact{
 				SourceS3Key:       "lorem.ova",
-				SourceS3Prefix:    "projects/foo/bar/1-21/ova/lorem/latest",
+				SourceS3Prefix:    "projects/foo/bar/1-21/ova/lorem/v1.2.3/latest",
 				ArtifactPath:      "artifacts/baz-ova/1-21",
 				ReleaseName:       "lorem-1.21.9-eks-d-1-21-8-eks-a-v0.0.0-dev-build.0-amd64.ova",
 				ReleaseS3Path:     "artifacts/v0.0.0-dev-build.0/eks-distro/ova/1-21/1-21-8",

--- a/release/pkg/assets/config/bundle_release.go
+++ b/release/pkg/assets/config/bundle_release.go
@@ -599,18 +599,21 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			{
 				Name:                "eks-distro",
 				OSName:              "bottlerocket",
+				OSVersion:           "1",
 				Format:              "ami",
 				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
 			},
 			{
 				Name:                "eks-distro",
 				OSName:              "bottlerocket",
+				OSVersion:           "1",
 				Format:              "ova",
 				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
 			},
 			{
 				Name:                "eks-distro",
 				OSName:              "bottlerocket",
+				OSVersion:           "1",
 				Format:              "raw",
 				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
 			},

--- a/release/pkg/assets/types/types.go
+++ b/release/pkg/assets/types/types.go
@@ -44,6 +44,7 @@ type Archive struct {
 	Name                 string
 	Format               string
 	OSName               string
+	OSVersion            string
 	ArchitectureOverride string
 	ArchiveS3PathGetter  ArchiveS3PathGenerator
 }

--- a/release/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/pkg/test/testdata/main-bundle-release.yaml
@@ -37,18 +37,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:a1b07272379f62ed857c3dd29e0624773a634eec24716c249e7d2fc8b6ef98ec
+        imageDigest: sha256:2a81ceb8d2f40c1573d2358398da97c12d516888a702e710ea46d0ef5380e5a3
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:104b9e8def8f9cb07b77d407f774a1d731ef785dd880007cec68d0003d7f1900
+        imageDigest: sha256:551be0f7ec17780e766e2ed9d8162b9a65c9f455d32f32aa095f1c5ba5c32118
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4
       kubeadmBootstrap:
         arch:
         - amd64
@@ -823,18 +823,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:a1b07272379f62ed857c3dd29e0624773a634eec24716c249e7d2fc8b6ef98ec
+        imageDigest: sha256:2a81ceb8d2f40c1573d2358398da97c12d516888a702e710ea46d0ef5380e5a3
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:104b9e8def8f9cb07b77d407f774a1d731ef785dd880007cec68d0003d7f1900
+        imageDigest: sha256:551be0f7ec17780e766e2ed9d8162b9a65c9f455d32f32aa095f1c5ba5c32118
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4
       kubeadmBootstrap:
         arch:
         - amd64
@@ -1609,18 +1609,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:a1b07272379f62ed857c3dd29e0624773a634eec24716c249e7d2fc8b6ef98ec
+        imageDigest: sha256:2a81ceb8d2f40c1573d2358398da97c12d516888a702e710ea46d0ef5380e5a3
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:104b9e8def8f9cb07b77d407f774a1d731ef785dd880007cec68d0003d7f1900
+        imageDigest: sha256:551be0f7ec17780e766e2ed9d8162b9a65c9f455d32f32aa095f1c5ba5c32118
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4
       kubeadmBootstrap:
         arch:
         - amd64
@@ -2368,18 +2368,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:a1b07272379f62ed857c3dd29e0624773a634eec24716c249e7d2fc8b6ef98ec
+        imageDigest: sha256:2a81ceb8d2f40c1573d2358398da97c12d516888a702e710ea46d0ef5380e5a3
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:104b9e8def8f9cb07b77d407f774a1d731ef785dd880007cec68d0003d7f1900
+        imageDigest: sha256:551be0f7ec17780e766e2ed9d8162b9a65c9f455d32f32aa095f1c5ba5c32118
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4
       kubeadmBootstrap:
         arch:
         - amd64
@@ -3127,18 +3127,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:a1b07272379f62ed857c3dd29e0624773a634eec24716c249e7d2fc8b6ef98ec
+        imageDigest: sha256:2a81ceb8d2f40c1573d2358398da97c12d516888a702e710ea46d0ef5380e5a3
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:104b9e8def8f9cb07b77d407f774a1d731ef785dd880007cec68d0003d7f1900
+        imageDigest: sha256:551be0f7ec17780e766e2ed9d8162b9a65c9f455d32f32aa095f1c5ba5c32118
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4
       kubeadmBootstrap:
         arch:
         - amd64
@@ -3886,18 +3886,18 @@ spec:
         arch:
         - amd64
         description: Container image for bottlerocket-admin image
-        imageDigest: sha256:a1b07272379f62ed857c3dd29e0624773a634eec24716c249e7d2fc8b6ef98ec
+        imageDigest: sha256:2a81ceb8d2f40c1573d2358398da97c12d516888a702e710ea46d0ef5380e5a3
         name: bottlerocket-admin
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.10.2
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.0
       control:
         arch:
         - amd64
         description: Container image for bottlerocket-control image
-        imageDigest: sha256:104b9e8def8f9cb07b77d407f774a1d731ef785dd880007cec68d0003d7f1900
+        imageDigest: sha256:551be0f7ec17780e766e2ed9d8162b9a65c9f455d32f32aa095f1c5ba5c32118
         name: bottlerocket-control
         os: linux
-        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.3
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.4
       kubeadmBootstrap:
         arch:
         - amd64


### PR DESCRIPTION
We upload Bottlerocket OS images to an OS version folder and we need to source it from the same folder during dev and staging releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

