### PR TITLE
Terminate ec2 instance runner after e2e tests

### DIFF
--- a/internal/test/e2e/testRunner.go
+++ b/internal/test/e2e/testRunner.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_ssm "github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v2"
@@ -229,7 +230,13 @@ func (v *VSphereTestRunner) decommInstance(c instanceRunConf) error {
 	return nil
 }
 
-func (v *Ec2TestRunner) decommInstance(c instanceRunConf) error {
+func (e *Ec2TestRunner) decommInstance(c instanceRunConf) error {
+	runnerName := getTestRunnerName(e.logger, c.jobId)
+	e.logger.V(1).Info("Terminating ec2 Test Runner instance", "instanceID", e.InstanceID, "runner", runnerName)
+	if err := ec2.TerminateEc2Instances(c.session, aws.StringSlice([]string{e.InstanceID})); err != nil {
+		return fmt.Errorf("terminating instance %s for runner %s: %w", e.InstanceID, runnerName, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description of changes
Instead of waiting for the job to clean the up, we now terminate the instance immediately. All logs and tests artifacts should already be uploaded by this time, that should be our tool to debug tests.

The main benefit here is we avoid lingering instances that might still be running something (like a kind cluster) that could keep hitting the infra APIs, which could overwhelm them if too many are doing that at the same time. This gets even worse when they overlap with the next test run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

