### PR TITLE
Separate out integration tests:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,17 +422,19 @@ verify-generate: generate ## Verify if generated zz_generated.deepcopy.go files 
 		exit 1;\
 	fi
 
-
 .PHONY: test
 test: unit-test capd-test  ## Run unit and capd tests
 
+ifneq "$(INTEGRATION_TESTS_ENABLED)" "false"
+export INTEGRATION_TESTS_ENABLED = true
+endif
+
 .PHONY: unit-test
 unit-test: ## Run unit tests
-unit-test: $(SETUP_ENVTEST) 
+unit-test: $(SETUP_ENVTEST)
 unit-test: KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch $(GO_ARCH) $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 unit-test:
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GO_TEST) $(UNIT_TEST_PACKAGES) -cover -tags "$(BUILD_TAGS)" $(GO_TEST_FLAGS)
-
 
 # unit-test-patch is a convenience target that restricts test runs to modified
 # packages' tests. This is not a replacement for running the unit-test target,

--- a/controllers/cloudstack_datacenter_controller_test.go
+++ b/controllers/cloudstack_datacenter_controller_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -23,6 +24,9 @@ import (
 )
 
 func TestCloudStackDatacenterReconcilerSetupWithManager(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	client := env.Client()
 	r := controllers.NewCloudStackDatacenterReconciler(client, nil)
 
@@ -31,6 +35,9 @@ func TestCloudStackDatacenterReconcilerSetupWithManager(t *testing.T) {
 }
 
 func TestCloudStackDatacenterReconcilerSuccess(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -79,6 +86,9 @@ func TestCloudStackDatacenterReconcilerSuccess(t *testing.T) {
 }
 
 func TestCloudStackDatacenterReconcilerSetDefaultSuccess(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -146,6 +156,9 @@ func TestCloudStackDatacenterReconcilerSetDefaultSuccess(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigReconcilerDelete(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -170,6 +183,9 @@ func TestCloudstackDatacenterConfigReconcilerDelete(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigGetValidatorFailure(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -198,6 +214,9 @@ func TestCloudstackDatacenterConfigGetValidatorFailure(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigGetDatacenterFailure(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 	client := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
@@ -217,6 +236,9 @@ func TestCloudstackDatacenterConfigGetDatacenterFailure(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigGetExecConfigFailure(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -243,6 +265,9 @@ func TestCloudstackDatacenterConfigGetExecConfigFailure(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigAccountNotPresentFailure(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 	dcConfig := createCloudstackDatacenterConfig()

--- a/controllers/cloudstack_datacenter_controller_test.go
+++ b/controllers/cloudstack_datacenter_controller_test.go
@@ -3,7 +3,6 @@ package controllers_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/eks-anywhere/controllers"
+	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack"
@@ -24,9 +24,7 @@ import (
 )
 
 func TestCloudStackDatacenterReconcilerSetupWithManager(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	client := env.Client()
 	r := controllers.NewCloudStackDatacenterReconciler(client, nil)
 
@@ -35,9 +33,7 @@ func TestCloudStackDatacenterReconcilerSetupWithManager(t *testing.T) {
 }
 
 func TestCloudStackDatacenterReconcilerSuccess(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -86,9 +82,7 @@ func TestCloudStackDatacenterReconcilerSuccess(t *testing.T) {
 }
 
 func TestCloudStackDatacenterReconcilerSetDefaultSuccess(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -156,9 +150,7 @@ func TestCloudStackDatacenterReconcilerSetDefaultSuccess(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigReconcilerDelete(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -183,9 +175,7 @@ func TestCloudstackDatacenterConfigReconcilerDelete(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigGetValidatorFailure(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -214,9 +204,7 @@ func TestCloudstackDatacenterConfigGetValidatorFailure(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigGetDatacenterFailure(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 	client := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
@@ -236,9 +224,7 @@ func TestCloudstackDatacenterConfigGetDatacenterFailure(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigGetExecConfigFailure(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -265,9 +251,7 @@ func TestCloudstackDatacenterConfigGetExecConfigFailure(t *testing.T) {
 }
 
 func TestCloudstackDatacenterConfigAccountNotPresentFailure(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 	dcConfig := createCloudstackDatacenterConfig()

--- a/controllers/cluster_controller_test_test.go
+++ b/controllers/cluster_controller_test_test.go
@@ -3,7 +3,6 @@ package controllers_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -32,9 +31,7 @@ import (
 )
 
 func TestClusterReconcilerEnsureOwnerReferences(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -208,6 +205,7 @@ func TestClusterReconcilerReconcileChildObjectNotFound(t *testing.T) {
 }
 
 func TestClusterReconcilerSetupWithManager(t *testing.T) {
+	test.MarkIntegration(t)
 	client := env.Client()
 	r := controllers.NewClusterReconciler(client, newRegistryForDummyProviderReconciler(), newMockAWSIamConfigReconciler(t), newMockClusterValidator(t), nil, nil)
 

--- a/controllers/cluster_controller_test_test.go
+++ b/controllers/cluster_controller_test_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -31,6 +32,9 @@ import (
 )
 
 func TestClusterReconcilerEnsureOwnerReferences(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/controllers/nutanix_datacenter_controller_test.go
+++ b/controllers/nutanix_datacenter_controller_test.go
@@ -12,11 +12,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/eks-anywhere/controllers"
+	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/providers/nutanix"
 )
 
 func TestNutanixDatacenterConfigReconcilerSetupWithManager(t *testing.T) {
+	test.MarkIntegration(t)
 	client := env.Client()
 	r := controllers.NewNutanixDatacenterReconciler(client, nutanix.NewDefaulter())
 

--- a/controllers/snow_machineconfig_controller_test.go
+++ b/controllers/snow_machineconfig_controller_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/eks-anywhere/controllers"
 	"github.com/aws/eks-anywhere/controllers/mocks"
+	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -27,6 +28,7 @@ var (
 )
 
 func TestSnowMachineConfigReconcilerSetupWithManager(t *testing.T) {
+	test.MarkIntegration(t)
 	client := env.Client()
 	r := controllers.NewSnowMachineConfigReconciler(client, nil)
 

--- a/controllers/tinkerbell_datacenter_controller_test.go
+++ b/controllers/tinkerbell_datacenter_controller_test.go
@@ -6,9 +6,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/controllers"
+	"github.com/aws/eks-anywhere/internal/test"
 )
 
 func TestTinkerbellDatacenterReconcilerSetupWithManager(t *testing.T) {
+	test.MarkIntegration(t)
 	client := env.Client()
 	r := controllers.NewTinkerbellDatacenterReconciler(client)
 

--- a/internal/test/markers.go
+++ b/internal/test/markers.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+const IntegrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
+func MarkIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv(IntegrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", IntegrationTestEnvVar)
+	}
+}

--- a/internal/test/markers.go
+++ b/internal/test/markers.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 )
 
+// IntegrationTestEnvVar is the name of the environment variable that gates when integration tests are run.
 const IntegrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
+// MarkIntegration marks a test as an integration test.
+// Integration tests are only run when the environment variable INTEGRATION_TESTS_ENABLED is set to true.
 func MarkIntegration(t *testing.T) {
 	t.Helper()
 	if os.Getenv(IntegrationTestEnvVar) != "true" {

--- a/pkg/clients/kubernetes/runtimeclient_test.go
+++ b/pkg/clients/kubernetes/runtimeclient_test.go
@@ -3,7 +3,6 @@ package kubernetes_test
 import (
 	"context"
 	"errors"
-	"os"
 	"reflect"
 	"testing"
 
@@ -18,12 +17,8 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
-
 func TestNewRuntimeClient(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	cfg := test.UseEnvTest(t)
 	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })
@@ -57,9 +52,7 @@ func TestNewRuntimeClientInvalidRestConfig(t *testing.T) {
 }
 
 func TestNewRuntimeClientInvalidScheme(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	cfg := test.UseEnvTest(t)
 	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })

--- a/pkg/clients/kubernetes/runtimeclient_test.go
+++ b/pkg/clients/kubernetes/runtimeclient_test.go
@@ -3,6 +3,7 @@ package kubernetes_test
 import (
 	"context"
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 
@@ -17,7 +18,12 @@ import (
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 func TestNewRuntimeClient(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	cfg := test.UseEnvTest(t)
 	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })
@@ -51,6 +57,9 @@ func TestNewRuntimeClientInvalidRestConfig(t *testing.T) {
 }
 
 func TestNewRuntimeClientInvalidScheme(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	cfg := test.UseEnvTest(t)
 	rc := kubernetes.RestConfigurator(func(_ []byte) (*rest.Config, error) { return cfg, nil })

--- a/pkg/controller/clusters/controlplane_test.go
+++ b/pkg/controller/clusters/controlplane_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestReconcileControlPlaneStackedEtcd(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)
@@ -42,6 +43,7 @@ func TestReconcileControlPlaneStackedEtcd(t *testing.T) {
 }
 
 func TestReconcileControlPlaneExternalEtcdNewCluster(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)
@@ -72,6 +74,7 @@ func TestReconcileControlPlaneExternalEtcdNewCluster(t *testing.T) {
 }
 
 func TestReconcileControlPlaneExternalEtcdUpgradeWithDiff(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)
@@ -129,6 +132,7 @@ func TestReconcileControlPlaneExternalEtcdUpgradeWithDiff(t *testing.T) {
 }
 
 func TestReconcileControlPlaneExternalEtcdNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)
@@ -166,6 +170,7 @@ func TestReconcileControlPlaneExternalEtcdNotReady(t *testing.T) {
 }
 
 func TestReconcileControlPlaneExternalEtcdReadyControlPlaneUpgrade(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)
@@ -223,6 +228,7 @@ func TestReconcileControlPlaneExternalEtcdReadyControlPlaneUpgrade(t *testing.T)
 }
 
 func TestReconcileControlPlaneExternalEtcdUpgradeWithNoNamespace(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)

--- a/pkg/controller/clusters/main_test.go
+++ b/pkg/controller/clusters/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/controller/clusters/main_test.go
+++ b/pkg/controller/clusters/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/controller/clusters/workers_test.go
+++ b/pkg/controller/clusters/workers_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestReconcileWorkersSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)
@@ -66,6 +67,7 @@ func TestReconcileWorkersSuccess(t *testing.T) {
 }
 
 func TestReconcileWorkersErrorApplyingObjects(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	ctx := context.Background()
@@ -192,6 +194,7 @@ func dockerMachineTemplate(name, namespace string) *dockerv1.DockerMachineTempla
 }
 
 func TestReconcileWorkersForEKSAErrorGettingCAPICluster(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
 	ctx := context.Background()
@@ -210,6 +213,7 @@ func TestReconcileWorkersForEKSAErrorGettingCAPICluster(t *testing.T) {
 }
 
 func TestReconcileWorkersForEKSANoCAPICluster(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	ctx := context.Background()
@@ -228,6 +232,7 @@ func TestReconcileWorkersForEKSANoCAPICluster(t *testing.T) {
 }
 
 func TestReconcileWorkersForEKSASuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	c := env.Client()
 	api := envtest.NewAPIExpecter(t, c)

--- a/pkg/controller/serverside/applier_test.go
+++ b/pkg/controller/serverside/applier_test.go
@@ -3,6 +3,7 @@ package serverside_test
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -15,6 +16,9 @@ import (
 )
 
 func TestObjectApplierApplySuccess(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 	namespace := env.CreateNamespaceForTest(ctx, t)
@@ -27,6 +31,9 @@ func TestObjectApplierApplySuccess(t *testing.T) {
 }
 
 func TestObjectApplierApplyErrorFromGenerator(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -38,6 +45,9 @@ func TestObjectApplierApplyErrorFromGenerator(t *testing.T) {
 }
 
 func TestObjectApplierApplyErrorApplying(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 

--- a/pkg/controller/serverside/applier_test.go
+++ b/pkg/controller/serverside/applier_test.go
@@ -3,22 +3,20 @@ package serverside_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/controller"
 	"github.com/aws/eks-anywhere/pkg/controller/serverside"
 )
 
 func TestObjectApplierApplySuccess(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 	namespace := env.CreateNamespaceForTest(ctx, t)
@@ -31,9 +29,7 @@ func TestObjectApplierApplySuccess(t *testing.T) {
 }
 
 func TestObjectApplierApplyErrorFromGenerator(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 
@@ -45,9 +41,7 @@ func TestObjectApplierApplyErrorFromGenerator(t *testing.T) {
 }
 
 func TestObjectApplierApplyErrorApplying(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 

--- a/pkg/controller/serverside/main_test.go
+++ b/pkg/controller/serverside/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/controller/serverside/main_test.go
+++ b/pkg/controller/serverside/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/controller/serverside/reconcile_test.go
+++ b/pkg/controller/serverside/reconcile_test.go
@@ -2,7 +2,6 @@ package serverside_test
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -12,14 +11,13 @@ import (
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/controller/serverside"
 )
 
 func TestReconcileYaml(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	cluster1 := newCluster("cluster-1")
 	cluster2 := newCluster("cluster-2")
 	tests := []struct {
@@ -128,9 +126,7 @@ spec:
 }
 
 func TestReconcileUpdateObject(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	cluster1 := newCluster("cluster-1")
 
 	yaml := []byte(`apiVersion: cluster.x-k8s.io/v1beta1
@@ -200,9 +196,7 @@ spec:
 }
 
 func TestReconcileUpdateObjectError(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	cluster1 := newCluster("cluster-1")
 
 	yaml := []byte(`apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/controller/serverside/reconcile_test.go
+++ b/pkg/controller/serverside/reconcile_test.go
@@ -2,6 +2,7 @@ package serverside_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -16,6 +17,9 @@ import (
 )
 
 func TestReconcileYaml(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	cluster1 := newCluster("cluster-1")
 	cluster2 := newCluster("cluster-2")
 	tests := []struct {
@@ -124,6 +128,9 @@ spec:
 }
 
 func TestReconcileUpdateObject(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	cluster1 := newCluster("cluster-1")
 
 	yaml := []byte(`apiVersion: cluster.x-k8s.io/v1beta1
@@ -193,6 +200,9 @@ spec:
 }
 
 func TestReconcileUpdateObjectError(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	cluster1 := newCluster("cluster-1")
 
 	yaml := []byte(`apiVersion: cluster.x-k8s.io/v1beta1

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -35,7 +35,10 @@ import (
 	artifactsv1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const valueFileName = "values.yaml"
+const (
+	valueFileName         = "values.yaml"
+	integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+)
 
 //go:embed testdata/expected_all_values.yaml
 var expectedAllValues string
@@ -270,6 +273,10 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 }
 
 func TestEnableSuccess(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
+
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -304,6 +311,9 @@ func TestEnableSuccess(t *testing.T) {
 }
 
 func TestEnableSucceedInWorkloadCluster(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, tt.clusterName, tt.kubeConfig, tt.chart,
@@ -347,6 +357,9 @@ func TestEnableSucceedInWorkloadCluster(t *testing.T) {
 }
 
 func TestEnableSucceedInWorkloadClusterWhenPackageBundleControllerNotExist(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, tt.clusterName, tt.kubeConfig, tt.chart,
@@ -420,6 +433,9 @@ func getPBCFail(t *testing.T) func(context.Context, string, string, string, stri
 }
 
 func TestEnableWithProxy(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -474,6 +490,9 @@ func TestEnableWithProxy(t *testing.T) {
 }
 
 func TestEnableWithEmptyProxy(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -525,6 +544,9 @@ func TestEnableWithEmptyProxy(t *testing.T) {
 }
 
 func TestEnableFail(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -555,6 +577,9 @@ func TestEnableFail(t *testing.T) {
 }
 
 func TestEnableFailNoActiveBundle(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -585,6 +610,9 @@ func TestEnableFailNoActiveBundle(t *testing.T) {
 }
 
 func TestEnableSuccessWhenCronJobFails(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -619,6 +647,9 @@ func TestEnableSuccessWhenCronJobFails(t *testing.T) {
 }
 
 func TestIsInstalledTrue(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.kubectl.EXPECT().HasResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).Return(false, nil)
 
@@ -630,6 +661,9 @@ func TestIsInstalledTrue(t *testing.T) {
 }
 
 func TestIsInstalledFalse(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 
 		tt.kubectl.EXPECT().HasResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).
@@ -643,6 +677,9 @@ func TestIsInstalledFalse(t *testing.T) {
 }
 
 func TestEnableActiveBundleCustomTimeout(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -692,6 +729,9 @@ func TestEnableActiveBundleCustomTimeout(t *testing.T) {
 }
 
 func TestEnableActiveBundleWaitLoops(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -742,6 +782,9 @@ func getPBCLoops(t *testing.T, loops int) func(context.Context, string, string, 
 }
 
 func TestEnableActiveBundleTimesOut(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -788,6 +831,9 @@ func TestEnableActiveBundleTimesOut(t *testing.T) {
 }
 
 func TestEnableActiveBundleNamespaceTimesOut(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -845,6 +891,9 @@ func getPBCDelay(t *testing.T, delay time.Duration) func(context.Context, string
 }
 
 func TestCreateHelmOverrideValuesYaml(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		if tt.registryMirror != nil {
 			t.Setenv("REGISTRY_USERNAME", "username")
@@ -858,6 +907,9 @@ func TestCreateHelmOverrideValuesYaml(t *testing.T) {
 }
 
 func TestCreateHelmOverrideValuesYamlFail(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	_ = os.Unsetenv("REGISTRY_USERNAME")
 	_ = os.Unsetenv("REGISTRY_PASSWORD")
 	for _, tt := range newPackageControllerTests(t) {
@@ -874,6 +926,9 @@ func TestCreateHelmOverrideValuesYamlFail(t *testing.T) {
 }
 
 func TestCreateHelmOverrideValuesYamlFailWithNoWriter(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -898,6 +953,9 @@ func TestCreateHelmOverrideValuesYamlFailWithNoWriter(t *testing.T) {
 }
 
 func TestCreateHelmOverrideValuesYamlFailWithWriteError(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	ctrl := gomock.NewController(t)
 	writer := writermocks.NewMockFileWriter(ctrl)
 	for _, tt := range newPackageControllerTests(t) {
@@ -920,6 +978,9 @@ func TestCreateHelmOverrideValuesYamlFailWithWriteError(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationNil(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	sut := curatedpackages.NewPackageControllerClient(nil, nil, "billy", "", nil, nil)
 	result, err := sut.GetPackageControllerConfiguration()
@@ -928,6 +989,9 @@ func TestGetPackageControllerConfigurationNil(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationAll(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: false,
@@ -965,6 +1029,9 @@ func TestGetPackageControllerConfigurationAll(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationNothing(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: true,
@@ -979,6 +1046,9 @@ func TestGetPackageControllerConfigurationNothing(t *testing.T) {
 }
 
 func TestGetCuratedPackagesRegistriesDefaultRegion(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: true,
@@ -996,6 +1066,9 @@ func TestGetCuratedPackagesRegistriesDefaultRegion(t *testing.T) {
 }
 
 func TestGetCuratedPackagesRegistriesCustomRegion(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: true,
@@ -1013,6 +1086,9 @@ func TestGetCuratedPackagesRegistriesCustomRegion(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationError(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: false,
@@ -1030,6 +1106,9 @@ func TestGetPackageControllerConfigurationError(t *testing.T) {
 }
 
 func TestReconcileDeleteGoldenPath(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 	log := testr.New(t)
@@ -1050,6 +1129,9 @@ func TestReconcileDeleteGoldenPath(t *testing.T) {
 }
 
 func TestReconcileDeleteNamespaceErrorHandling(s *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		s.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	s.Run("ignores not found errors", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := context.Background()
@@ -1090,6 +1172,9 @@ func TestReconcileDeleteNamespaceErrorHandling(s *testing.T) {
 }
 
 func TestReconcileDeleteHelmErrorsHandling(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	g := NewWithT(t)
 	ctx := context.Background()
 	log := testr.New(t)
@@ -1115,6 +1200,9 @@ func TestReconcileDeleteHelmErrorsHandling(t *testing.T) {
 }
 
 func TestEnableFullLifecyclePath(t *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	log := testr.New(t)
 	ctrl := gomock.NewController(t)
 	k := mocks.NewMockKubectlRunner(ctrl)
@@ -1179,6 +1267,9 @@ func TestEnableFullLifecyclePath(t *testing.T) {
 }
 
 func TestGetCuratedPackagesRegistries(s *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		s.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	s.Run("substitutes a region if set", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		k := mocks.NewMockKubectlRunner(ctrl)
@@ -1266,6 +1357,9 @@ func TestGetCuratedPackagesRegistries(s *testing.T) {
 }
 
 func TestReconcile(s *testing.T) {
+	if os.Getenv(integrationTestEnvVar) != "true" {
+		s.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
+	}
 	s.Run("golden path", func(t *testing.T) {
 		ctx := context.Background()
 		log := testr.New(t)

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -35,10 +35,7 @@ import (
 	artifactsv1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const (
-	valueFileName         = "values.yaml"
-	integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
-)
+const valueFileName = "values.yaml"
 
 //go:embed testdata/expected_all_values.yaml
 var expectedAllValues string
@@ -273,9 +270,7 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 }
 
 func TestEnableSuccess(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
@@ -311,9 +306,7 @@ func TestEnableSuccess(t *testing.T) {
 }
 
 func TestEnableSucceedInWorkloadCluster(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, tt.clusterName, tt.kubeConfig, tt.chart,
@@ -357,9 +350,7 @@ func TestEnableSucceedInWorkloadCluster(t *testing.T) {
 }
 
 func TestEnableSucceedInWorkloadClusterWhenPackageBundleControllerNotExist(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, tt.clusterName, tt.kubeConfig, tt.chart,
@@ -433,9 +424,7 @@ func getPBCFail(t *testing.T) func(context.Context, string, string, string, stri
 }
 
 func TestEnableWithProxy(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -490,9 +479,7 @@ func TestEnableWithProxy(t *testing.T) {
 }
 
 func TestEnableWithEmptyProxy(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -544,9 +531,7 @@ func TestEnableWithEmptyProxy(t *testing.T) {
 }
 
 func TestEnableFail(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -577,9 +562,7 @@ func TestEnableFail(t *testing.T) {
 }
 
 func TestEnableFailNoActiveBundle(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -610,9 +593,7 @@ func TestEnableFailNoActiveBundle(t *testing.T) {
 }
 
 func TestEnableSuccessWhenCronJobFails(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -647,9 +628,7 @@ func TestEnableSuccessWhenCronJobFails(t *testing.T) {
 }
 
 func TestIsInstalledTrue(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.kubectl.EXPECT().HasResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).Return(false, nil)
 
@@ -661,9 +640,7 @@ func TestIsInstalledTrue(t *testing.T) {
 }
 
 func TestIsInstalledFalse(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 
 		tt.kubectl.EXPECT().HasResource(tt.ctx, "packageBundleController", tt.clusterName, tt.kubeConfig, constants.EksaPackagesName).
@@ -677,9 +654,7 @@ func TestIsInstalledFalse(t *testing.T) {
 }
 
 func TestEnableActiveBundleCustomTimeout(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -729,9 +704,7 @@ func TestEnableActiveBundleCustomTimeout(t *testing.T) {
 }
 
 func TestEnableActiveBundleWaitLoops(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		clusterName := fmt.Sprintf("clusterName=%s", "billy")
 		valueFilePath := filepath.Join("billy", filewriter.DefaultTmpFolder, valueFileName)
@@ -782,9 +755,7 @@ func getPBCLoops(t *testing.T, loops int) func(context.Context, string, string, 
 }
 
 func TestEnableActiveBundleTimesOut(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -831,9 +802,7 @@ func TestEnableActiveBundleTimesOut(t *testing.T) {
 }
 
 func TestEnableActiveBundleNamespaceTimesOut(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -891,9 +860,7 @@ func getPBCDelay(t *testing.T, delay time.Duration) func(context.Context, string
 }
 
 func TestCreateHelmOverrideValuesYaml(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		if tt.registryMirror != nil {
 			t.Setenv("REGISTRY_USERNAME", "username")
@@ -907,9 +874,7 @@ func TestCreateHelmOverrideValuesYaml(t *testing.T) {
 }
 
 func TestCreateHelmOverrideValuesYamlFail(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	_ = os.Unsetenv("REGISTRY_USERNAME")
 	_ = os.Unsetenv("REGISTRY_PASSWORD")
 	for _, tt := range newPackageControllerTests(t) {
@@ -926,9 +891,7 @@ func TestCreateHelmOverrideValuesYamlFail(t *testing.T) {
 }
 
 func TestCreateHelmOverrideValuesYamlFailWithNoWriter(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	for _, tt := range newPackageControllerTests(t) {
 		tt.command = curatedpackages.NewPackageControllerClient(
 			tt.chartManager, tt.kubectl, "billy", tt.kubeConfig, tt.chart,
@@ -953,9 +916,7 @@ func TestCreateHelmOverrideValuesYamlFailWithNoWriter(t *testing.T) {
 }
 
 func TestCreateHelmOverrideValuesYamlFailWithWriteError(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	ctrl := gomock.NewController(t)
 	writer := writermocks.NewMockFileWriter(ctrl)
 	for _, tt := range newPackageControllerTests(t) {
@@ -978,9 +939,7 @@ func TestCreateHelmOverrideValuesYamlFailWithWriteError(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationNil(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	sut := curatedpackages.NewPackageControllerClient(nil, nil, "billy", "", nil, nil)
 	result, err := sut.GetPackageControllerConfiguration()
@@ -989,9 +948,7 @@ func TestGetPackageControllerConfigurationNil(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationAll(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: false,
@@ -1029,9 +986,7 @@ func TestGetPackageControllerConfigurationAll(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationNothing(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: true,
@@ -1046,9 +1001,7 @@ func TestGetPackageControllerConfigurationNothing(t *testing.T) {
 }
 
 func TestGetCuratedPackagesRegistriesDefaultRegion(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: true,
@@ -1066,9 +1019,7 @@ func TestGetCuratedPackagesRegistriesDefaultRegion(t *testing.T) {
 }
 
 func TestGetCuratedPackagesRegistriesCustomRegion(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: true,
@@ -1086,9 +1037,7 @@ func TestGetCuratedPackagesRegistriesCustomRegion(t *testing.T) {
 }
 
 func TestGetPackageControllerConfigurationError(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	clusterSpec := v1alpha1.ClusterSpec{
 		Packages: &v1alpha1.PackageConfiguration{
 			Disable: false,
@@ -1106,9 +1055,7 @@ func TestGetPackageControllerConfigurationError(t *testing.T) {
 }
 
 func TestReconcileDeleteGoldenPath(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 	log := testr.New(t)
@@ -1129,9 +1076,7 @@ func TestReconcileDeleteGoldenPath(t *testing.T) {
 }
 
 func TestReconcileDeleteNamespaceErrorHandling(s *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		s.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(s)
 	s.Run("ignores not found errors", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := context.Background()
@@ -1172,9 +1117,7 @@ func TestReconcileDeleteNamespaceErrorHandling(s *testing.T) {
 }
 
 func TestReconcileDeleteHelmErrorsHandling(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	g := NewWithT(t)
 	ctx := context.Background()
 	log := testr.New(t)
@@ -1200,9 +1143,7 @@ func TestReconcileDeleteHelmErrorsHandling(t *testing.T) {
 }
 
 func TestEnableFullLifecyclePath(t *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		t.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(t)
 	log := testr.New(t)
 	ctrl := gomock.NewController(t)
 	k := mocks.NewMockKubectlRunner(ctrl)
@@ -1267,9 +1208,7 @@ func TestEnableFullLifecyclePath(t *testing.T) {
 }
 
 func TestGetCuratedPackagesRegistries(s *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		s.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(s)
 	s.Run("substitutes a region if set", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		k := mocks.NewMockKubectlRunner(ctrl)
@@ -1357,9 +1296,7 @@ func TestGetCuratedPackagesRegistries(s *testing.T) {
 }
 
 func TestReconcile(s *testing.T) {
-	if os.Getenv(integrationTestEnvVar) != "true" {
-		s.Skipf("set env var '%v=true' to run this test", integrationTestEnvVar)
-	}
+	test.MarkIntegration(s)
 	s.Run("golden path", func(t *testing.T) {
 		ctx := context.Background()
 		log := testr.New(t)

--- a/pkg/networking/cilium/reconciler/main_test.go
+++ b/pkg/networking/cilium/reconciler/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/networking/cilium/reconciler/main_test.go
+++ b/pkg/networking/cilium/reconciler/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/networking/cilium/reconciler/reconciler_test.go
+++ b/pkg/networking/cilium/reconciler/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestReconcilerReconcileInstall(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcileTest(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
@@ -50,6 +51,7 @@ func TestReconcilerReconcileInstall(t *testing.T) {
 }
 
 func TestReconcilerReconcileInstallErrorGeneratingManifest(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcileTest(t)
 	tt.templater.EXPECT().GenerateManifest(tt.ctx, tt.spec).Return(nil, errors.New("generating manifest"))
 
@@ -59,6 +61,7 @@ func TestReconcilerReconcileInstallErrorGeneratingManifest(t *testing.T) {
 }
 
 func TestReconcilerReconcileErrorYamlReconcile(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcileTest(t)
 	tt.templater.EXPECT().GenerateManifest(tt.ctx, tt.spec).Return([]byte("invalid yaml"), nil)
 
@@ -68,6 +71,7 @@ func TestReconcilerReconcileErrorYamlReconcile(t *testing.T) {
 }
 
 func TestReconcilerReconcileAlreadyUpToDate(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()
@@ -83,6 +87,7 @@ func TestReconcilerReconcileAlreadyUpToDate(t *testing.T) {
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflight(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	preflightDS := ciliumPreflightDaemonSet()
@@ -108,6 +113,7 @@ func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflight(t *testing.T) {
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorFromTemplater(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()
@@ -126,6 +132,7 @@ func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorFromTemplat
 }
 
 func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorDeletingYaml(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()
@@ -144,6 +151,7 @@ func TestReconcilerReconcileAlreadyInDesiredVersionWithPreflightErrorDeletingYam
 }
 
 func TestReconcilerReconcileUpgradeButCiliumDaemonSetNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -164,6 +172,7 @@ func TestReconcilerReconcileUpgradeButCiliumDaemonSetNotReady(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDaemonSetNotAvailable(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -186,6 +195,7 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDaemonSetNotAvailab
 }
 
 func TestReconcilerReconcileUpgradeErrorGeneratingPreflight(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -206,6 +216,7 @@ func TestReconcilerReconcileUpgradeErrorGeneratingPreflight(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDeploymentNotAvailable(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -229,6 +240,7 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightDeploymentNotAvaila
 }
 
 func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator)
@@ -252,6 +264,7 @@ func TestReconcilerReconcileUpgradeNeedsPreflightAndPreflightNotReady(t *testing
 }
 
 func TestReconcilerReconcileUpgradePreflightDaemonSetNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	tt := newReconcileTest(t).withObjects(ds, operator, ciliumPreflightDaemonSet(), ciliumPreflightDeployment())
@@ -272,6 +285,7 @@ func TestReconcilerReconcileUpgradePreflightDaemonSetNotReady(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradePreflightDeploymentSetNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	preflight := ciliumPreflightDaemonSet()
@@ -294,6 +308,7 @@ func TestReconcilerReconcileUpgradePreflightDeploymentSetNotReady(t *testing.T) 
 }
 
 func TestReconcilerReconcileUpgradeInvalidCiliumInstalledVersion(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	ds.Spec.Template.Spec.Containers[0].Image = "cilium:eksa-invalid-version"
 	operator := ciliumOperator()
@@ -320,6 +335,7 @@ func TestReconcilerReconcileUpgradeInvalidCiliumInstalledVersion(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradeErrorGeneratingManifest(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	preflight := ciliumPreflightDaemonSet()
@@ -348,6 +364,7 @@ func TestReconcilerReconcileUpgradeErrorGeneratingManifest(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradePreflightErrorYamlReconcile(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	preflight := ciliumPreflightDaemonSet()
@@ -375,6 +392,7 @@ func TestReconcilerReconcileUpgradePreflightErrorYamlReconcile(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpgradePreflightReady(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	preflight := ciliumPreflightDaemonSet()
@@ -411,6 +429,7 @@ func TestReconcilerReconcileUpgradePreflightReady(t *testing.T) {
 }
 
 func TestReconcilerReconcileUpdateConfigConfigMapEnablePolicyChange(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()
@@ -440,6 +459,7 @@ func TestReconcilerReconcileUpdateConfigConfigMapEnablePolicyChange(t *testing.T
 }
 
 func TestReconcilerReconcileSkipUpgradeWithoutCiliumInstalled(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()
@@ -467,6 +487,7 @@ func TestReconcilerReconcileSkipUpgradeWithoutCiliumInstalled(t *testing.T) {
 }
 
 func TestReconcilerReconcileSkipUpgradeWithCiliumInstalled(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()
@@ -490,6 +511,7 @@ func TestReconcilerReconcileSkipUpgradeWithCiliumInstalled(t *testing.T) {
 }
 
 func TestReconcilerReconcileSkipUpgradeWithAnnotationWithoutCilium(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcileTest(t)
 	tt.spec = test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{
@@ -510,6 +532,7 @@ func TestReconcilerReconcileSkipUpgradeWithAnnotationWithoutCilium(t *testing.T)
 }
 
 func TestReconcilerReconcileSkipUpgradeWithAnnotationWithCilium(t *testing.T) {
+	test.MarkIntegration(t)
 	ds := ciliumDaemonSet()
 	operator := ciliumOperator()
 	cm := ciliumConfigMap()

--- a/pkg/providers/cloudstack/reconciler/main_test.go
+++ b/pkg/providers/cloudstack/reconciler/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/providers/cloudstack/reconciler/main_test.go
+++ b/pkg/providers/cloudstack/reconciler/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -40,6 +40,7 @@ const (
 )
 
 func TestReconcilerReconcileSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
 	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
@@ -83,6 +84,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 }
 
 func TestReconcilerValidateDatacenterConfigRequeue(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.datacenterConfig.Status.SpecValid = false
 
@@ -103,6 +105,7 @@ func TestReconcilerValidateDatacenterConfigRequeue(t *testing.T) {
 }
 
 func TestReconcilerValidateDatacenterConfigFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.datacenterConfig.Status.SpecValid = false
 	tt.datacenterConfig.Status.FailureMessage = ptr.String("Invalid CloudStackDatacenterConfig")
@@ -123,6 +126,7 @@ func TestReconcilerValidateDatacenterConfigFail(t *testing.T) {
 }
 
 func TestReconcilerValidateMachineConfigInvalidSecret(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -138,6 +142,7 @@ func TestReconcilerValidateMachineConfigInvalidSecret(t *testing.T) {
 }
 
 func TestReconcilerValidateMachineConfigGetValidatorFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.secret)
 	tt.createAllObjs()
@@ -157,6 +162,7 @@ func TestReconcilerValidateMachineConfigGetValidatorFail(t *testing.T) {
 }
 
 func TestReconcilerValidateMachineConfigFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.secret)
 	tt.createAllObjs()
@@ -179,6 +185,7 @@ func TestReconcilerValidateMachineConfigFail(t *testing.T) {
 }
 
 func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -211,6 +218,7 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 }
 
 func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Spec.ExternalEtcdConfiguration = &anywherev1.ExternalEtcdConfiguration{
 		Count: 1,
@@ -275,6 +283,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 }
 
 func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.secret)
 	tt.createAllObjs()
@@ -332,6 +341,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 }
 
 func TestReconcileCNISuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -354,6 +364,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 }
 
 func TestReconcileCNIErrorClientRegistry(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -374,6 +385,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -419,6 +431,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersFailure(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()
@@ -438,6 +451,7 @@ func TestReconcilerReconcileWorkersFailure(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()
@@ -485,6 +499,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesFailure(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()

--- a/pkg/providers/docker/reconciler/main_test.go
+++ b/pkg/providers/docker/reconciler/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/providers/docker/reconciler/main_test.go
+++ b/pkg/providers/docker/reconciler/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/providers/docker/reconciler/reconciler_test.go
+++ b/pkg/providers/docker/reconciler/reconciler_test.go
@@ -35,6 +35,7 @@ const (
 )
 
 func TestReconcilerReconcileSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -124,6 +125,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "my-management-cluster"
 	tt.cluster.SetSelfManaged()
@@ -172,6 +174,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 }
 
 func TestReconcileCNISuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -193,6 +196,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 }
 
 func TestReconcileCNIErrorClientRegistry(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -212,6 +216,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
@@ -255,6 +260,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersErrorGeneratingSpec(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	spec := tt.buildSpec()
@@ -267,6 +273,7 @@ func TestReconcilerReconcileWorkersErrorGeneratingSpec(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "my-management-cluster"
 	tt.cluster.SetSelfManaged()
@@ -285,6 +292,7 @@ func TestReconcilerReconcileWorkerNodesFail(t *testing.T) {
 }
 
 func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	logger := test.NewNullLogger()
@@ -343,6 +351,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 }
 
 func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Spec.ExternalEtcdConfiguration = &anywherev1.ExternalEtcdConfiguration{
 		Count: 1,
@@ -404,6 +413,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	spec := tt.buildSpec()

--- a/pkg/providers/snow/reconciler/main_test.go
+++ b/pkg/providers/snow/reconciler/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/providers/snow/reconciler/main_test.go
+++ b/pkg/providers/snow/reconciler/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -34,6 +34,7 @@ const (
 )
 
 func TestReconcilerReconcileSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
 	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
@@ -65,6 +66,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "my-management-cluster"
 	tt.cluster.SetSelfManaged()
@@ -120,6 +122,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 }
 
 func TestReconcilerValidateMachineConfigsInvalidWorkerMachineConfig(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.machineConfigWorker.Status.SpecValid = false
 	m := "Something wrong"
@@ -138,6 +141,7 @@ func TestReconcilerValidateMachineConfigsInvalidWorkerMachineConfig(t *testing.T
 }
 
 func TestReconcilerValidateMachineConfigsInvalidControlPlaneMachineConfig(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.machineConfigControlPlane.Status.SpecValid = false
 	m := "Something wrong"
@@ -156,6 +160,7 @@ func TestReconcilerValidateMachineConfigsInvalidControlPlaneMachineConfig(t *tes
 }
 
 func TestReconcilerValidateMachineConfigsMachineConfigNotValidated(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.machineConfigWorker.Status.SpecValid = false
 	tt.withFakeClient()
@@ -169,6 +174,7 @@ func TestReconcilerValidateMachineConfigsMachineConfigNotValidated(t *testing.T)
 }
 
 func TestReconcilerReconcileWorkers(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
@@ -185,6 +191,7 @@ func TestReconcilerReconcileWorkers(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlane(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -222,6 +229,7 @@ func TestReconcilerReconcileControlPlane(t *testing.T) {
 }
 
 func TestReconcilerCheckControlPlaneReadyItIsReady(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
@@ -238,6 +246,7 @@ func TestReconcilerCheckControlPlaneReadyItIsReady(t *testing.T) {
 }
 
 func TestReconcilerReconcileCNISuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -259,6 +268,7 @@ func TestReconcilerReconcileCNISuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileCNIErrorClientRegistry(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	tinkerbellv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -141,6 +142,7 @@ func AssertHookRetrievableWithoutProxy(spec *ClusterSpec) error {
 	transport.Proxy = nil
 	client := &http.Client{
 		Transport: transport,
+		Timeout:   time.Second * 5,
 	}
 
 	resp, err := client.Get(spec.DatacenterConfig.Spec.HookImagesURLPath)

--- a/pkg/providers/tinkerbell/hardware/csv_test.go
+++ b/pkg/providers/tinkerbell/hardware/csv_test.go
@@ -149,7 +149,7 @@ func TestCSVBuildHardwareYamlFromCSV(t *testing.T) {
 
 	hardwareYaml, err := hardware.BuildHardwareYAML("./testdata/hardware.csv")
 	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(hardwareYaml).To(gomega.Equal([]byte(`apiVersion: tinkerbell.org/v1alpha1
+	g.Expect(string(hardwareYaml)).To(gomega.Equal(string([]byte(`apiVersion: tinkerbell.org/v1alpha1
 kind: Hardware
 metadata:
   labels:
@@ -222,7 +222,7 @@ metadata:
     clusterctl.cluster.x-k8s.io/move: "true"
   name: bmc-worker1-auth
   namespace: eksa-system
-type: kubernetes.io/basic-auth`)))
+type: kubernetes.io/basic-auth`))))
 }
 
 // BufferedCSV is an in-memory CSV that satisfies io.Reader and io.Writer.

--- a/pkg/providers/tinkerbell/reconciler/main_test.go
+++ b/pkg/providers/tinkerbell/reconciler/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/providers/tinkerbell/reconciler/main_test.go
+++ b/pkg/providers/tinkerbell/reconciler/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -40,6 +40,7 @@ const (
 )
 
 func TestReconcilerGenerateSpec(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	logger := test.NewNullLogger()
@@ -54,6 +55,7 @@ func TestReconcilerGenerateSpec(t *testing.T) {
 }
 
 func TestReconcilerReconcileSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -82,6 +84,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 }
 
 func TestReconcilerValidateDatacenterConfigSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -93,6 +96,7 @@ func TestReconcilerValidateDatacenterConfigSuccess(t *testing.T) {
 }
 
 func TestReconcilerValidateDatacenterConfigMissingManagementCluster(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Spec.ManagementCluster.Name = "nonexistent-management-cluster"
 	tt.withFakeClient()
@@ -107,6 +111,7 @@ func TestReconcilerValidateDatacenterConfigMissingManagementCluster(t *testing.T
 }
 
 func TestReconcilerValidateDatacenterConfigMissingManagementDatacenter(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.managementCluster.Spec.DatacenterRef.Name = "nonexistent-datacenter"
 	tt.withFakeClient()
@@ -121,6 +126,7 @@ func TestReconcilerValidateDatacenterConfigMissingManagementDatacenter(t *testin
 }
 
 func TestReconcilerValidateDatacenterConfigIpMismatch(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	managementDatacenterConfig := dataCenter(func(d *anywherev1.TinkerbellDatacenterConfig) {
 		d.Name = "ip-mismatch-datacenter"
@@ -140,6 +146,7 @@ func TestReconcilerValidateDatacenterConfigIpMismatch(t *testing.T) {
 }
 
 func TestReconcileCNISuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -163,6 +170,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 }
 
 func TestReconcileCNIErrorClientRegistry(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -183,6 +191,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneScaleSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 
 	tt.createAllObjs()
@@ -215,6 +224,7 @@ func TestReconcilerReconcileControlPlaneScaleSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	scope := tt.buildScope()
@@ -250,6 +260,7 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneSuccessRegistryMirrorAuthentication(t *testing.T) {
+	test.MarkIntegration(t)
 	t.Setenv("REGISTRY_USERNAME", "username")
 	t.Setenv("REGISTRY_PASSWORD", "password")
 	tt := newReconcilerTest(t)
@@ -294,6 +305,7 @@ func TestReconcilerReconcileControlPlaneSuccessRegistryMirrorAuthentication(t *t
 }
 
 func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	scope := tt.buildScope()
@@ -310,6 +322,7 @@ func TestReconcilerReconcileControlPlaneFailure(t *testing.T) {
 }
 
 func TestReconcilerValidateClusterSpecValidationFailedDatacenterConfig(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 
 	logger := test.NewNullLogger()
@@ -331,6 +344,7 @@ func TestReconcilerValidateClusterSpecValidationFailedDatacenterConfig(t *testin
 }
 
 func TestReconcilerValidateClusterSpecValidationFailedOSFamily(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 
 	logger := test.NewNullLogger()
@@ -352,6 +366,7 @@ func TestReconcilerValidateClusterSpecValidationFailedOSFamily(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()
@@ -403,6 +418,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersScaleSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -449,6 +465,7 @@ func TestReconcilerReconcileWorkersScaleSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
@@ -500,6 +517,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesFailure(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "mgmt-cluster"
 	tt.cluster.SetSelfManaged()
@@ -519,6 +537,7 @@ func TestReconcilerReconcileWorkerNodesFailure(t *testing.T) {
 }
 
 func TestReconcilerValidateHardwareCountNewClusterFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 
@@ -538,6 +557,7 @@ func TestReconcilerValidateHardwareCountNewClusterFail(t *testing.T) {
 }
 
 func TestReconcilerValidateHardwareCountRollingUpdateFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -558,6 +578,7 @@ func TestReconcilerValidateHardwareCountRollingUpdateFail(t *testing.T) {
 }
 
 func TestReconcilerValidateHardwareScalingUpdateFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -579,6 +600,7 @@ func TestReconcilerValidateHardwareScalingUpdateFail(t *testing.T) {
 }
 
 func TestReconcilerValidateHardwareNoHardware(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 
@@ -598,6 +620,7 @@ func TestReconcilerValidateHardwareNoHardware(t *testing.T) {
 }
 
 func TestReconcilerValidateRufioMachinesFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 
@@ -657,6 +680,7 @@ func TestReconcilerValidateRufioMachinesFail(t *testing.T) {
 }
 
 func TestReconcilerDetectOperationK8sVersionUpgrade(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -672,6 +696,7 @@ func TestReconcilerDetectOperationK8sVersionUpgrade(t *testing.T) {
 }
 
 func TestReconcilerDetectOperationExistingWorkerNodeGroupScaleUpdate(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -687,6 +712,7 @@ func TestReconcilerDetectOperationExistingWorkerNodeGroupScaleUpdate(t *testing.
 }
 
 func TestReconcilerDetectOperationNewWorkerNodeGroupScaleUpdate(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -712,6 +738,7 @@ func TestReconcilerDetectOperationNewWorkerNodeGroupScaleUpdate(t *testing.T) {
 }
 
 func TestReconcilerDetectOperationNoChanges(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 
@@ -726,6 +753,7 @@ func TestReconcilerDetectOperationNoChanges(t *testing.T) {
 }
 
 func TestReconcilerDetectOperationNewCluster(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 	logger := test.NewNullLogger()
@@ -740,6 +768,7 @@ func TestReconcilerDetectOperationNewCluster(t *testing.T) {
 }
 
 func TestReconcilerDetectOperationFail(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.client = fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
 	_, err := tt.reconciler().DetectOperation(tt.ctx, test.NewNullLogger(), &reconciler.Scope{ClusterSpec: &clusterspec.Spec{Config: &clusterspec.Config{Cluster: &anywherev1.Cluster{}}}})

--- a/pkg/providers/vsphere/reconciler/main_test.go
+++ b/pkg/providers/vsphere/reconciler/main_test.go
@@ -7,8 +7,12 @@ import (
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
 
+const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
+
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	if os.Getenv(integrationTestEnvVar) == "true" {
+		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	}
 }

--- a/pkg/providers/vsphere/reconciler/main_test.go
+++ b/pkg/providers/vsphere/reconciler/main_test.go
@@ -4,15 +4,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
 )
-
-const integrationTestEnvVar = "INTEGRATION_TESTS_ENABLED"
 
 var env *envtest.Environment
 
 func TestMain(m *testing.M) {
-	if os.Getenv(integrationTestEnvVar) == "true" {
+	if os.Getenv(test.IntegrationTestEnvVar) == "true" {
 		os.Exit(envtest.RunWithEnvironment(m, envtest.WithAssignment(&env)))
+	} else {
+		os.Exit(m.Run())
 	}
 }

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -45,6 +45,7 @@ const (
 )
 
 func TestReconcilerReconcileSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	// We want to check that the cluster status is cleaned up if validations are passed
 	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
@@ -82,6 +83,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.cluster.Name = "my-management-cluster"
 	tt.cluster.SetSelfManaged()
@@ -135,6 +137,7 @@ func TestReconcilerReconcileWorkerNodesSuccess(t *testing.T) {
 }
 
 func TestReconcilerFailToSetUpMachineConfigCP(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 	tt.withFakeClient()
@@ -152,6 +155,7 @@ func TestReconcilerFailToSetUpMachineConfigCP(t *testing.T) {
 }
 
 func TestSetupEnvVars(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -166,6 +170,7 @@ func TestSetupEnvVars(t *testing.T) {
 }
 
 func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
@@ -198,6 +203,7 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 }
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
@@ -214,6 +220,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 }
 
 func TestReconcilerReconcileInvalidDatacenterConfig(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 	tt.datacenterConfig.Status.SpecValid = false
@@ -230,6 +237,7 @@ func TestReconcilerReconcileInvalidDatacenterConfig(t *testing.T) {
 }
 
 func TestReconcilerDatacenterConfigNotValidated(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 	tt.datacenterConfig.Status.SpecValid = false
@@ -244,6 +252,7 @@ func TestReconcilerDatacenterConfigNotValidated(t *testing.T) {
 }
 
 func TestReconcileCNISuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -265,6 +274,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 }
 
 func TestReconcileCNIErrorClientRegistry(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.withFakeClient()
 
@@ -284,6 +294,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 }
 
 func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
+	test.MarkIntegration(t)
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()
 


### PR DESCRIPTION
*Issue #, if available:*
#5364

*Description of changes:*
Without breaking any Make goals, this allows specifying an env var (`INTEGRATION_TESTS_ENABLED`) that will cause any test that uses [`envtest`](https://book.kubebuilder.io/reference/envtest.html) to either run or not. By default, `make unit-test` will run all tests that use `envtest`. i.e. `INTEGRATION_TESTS_ENABLED=true`. To disable tests that use `envtest`, set `INTEGRATION_TESTS_ENABLED=false`.

For example, with `make`, to disable `envtest` tests run:
`INTEGRATION_TESTS_ENABLED=false make unit-test`

When running `go` directly, the default behavior is to not run any `envtest` tests.
`go test ./...` is the same as `INTEGRATION_TESTS_ENABLED=false go test ./...`

To enable `envtest` with `go` directly, you'll need to start `envtest` and then run: `INTEGRATION_TESTS_ENABLED=true go test ./...`

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

