### PR TITLE
Kindless upgrade changes for vSphere & CloudStack provider

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -202,8 +202,8 @@ func (c *Config) ChildObjects() []kubernetes.Object {
 // ClusterAndChildren returns all kubernetes objects in the cluster Config.
 // It's equivalent to appending the Cluster to the result of ChildObjects.
 func (c *Config) ClusterAndChildren() []kubernetes.Object {
-	objs := c.ChildObjects()
-	return append(objs, c.Cluster)
+	objs := []kubernetes.Object{c.Cluster}
+	return append(objs, c.ChildObjects()...)
 }
 
 func appendIfNotNil(objs []kubernetes.Object, elems ...kubernetes.Object) []kubernetes.Object {

--- a/pkg/cluster/wait.go
+++ b/pkg/cluster/wait.go
@@ -17,6 +17,26 @@ import (
 // or the retrier timeouts. If observedGeneration is not equal to generation,
 // the condition is considered false regardless of the status value.
 func WaitForCondition(ctx context.Context, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, conditionType anywherev1.ConditionType) error {
+	return WaitFor(ctx, client, cluster, retrier, func(c *anywherev1.Cluster) error {
+		condition := conditions.Get(c, conditionType)
+		if condition == nil {
+			return fmt.Errorf("cluster doesn't yet have condition %s", conditionType)
+		}
+
+		if condition.Status != corev1.ConditionTrue {
+			return fmt.Errorf("cluster condition %s is %s: %s", conditionType, condition.Status, condition.Message)
+		}
+		return nil
+	})
+}
+
+// Matcher matches the given condition.
+type Matcher func(*anywherev1.Cluster) error
+
+// WaitFor gets the cluster object from the client
+// checks for generation and observedGeneration condition
+// matches condition and returns error if the condition is not met.
+func WaitFor(ctx context.Context, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, matcher Matcher) error {
 	return retrier.Retry(func() error {
 		c := &anywherev1.Cluster{}
 
@@ -35,15 +55,6 @@ func WaitForCondition(ctx context.Context, client kubernetes.Reader, cluster *an
 			return fmt.Errorf("cluster generation (%d) and observedGeneration (%d) differ", generation, observedGeneration)
 		}
 
-		condition := conditions.Get(c, conditionType)
-		if condition == nil {
-			return fmt.Errorf("cluster doesn't yet have condition %s", conditionType)
-		}
-
-		if condition.Status != corev1.ConditionTrue {
-			return fmt.Errorf("cluster condition %s is %s: %s", conditionType, condition.Status, condition.Message)
-		}
-
-		return nil
+		return matcher(c)
 	})
 }

--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -607,7 +607,7 @@ func cloudstackMachineTemplate(name string) *cloudstackv1.CloudStackMachineTempl
 			Template: cloudstackv1.CloudStackMachineTemplateResource{
 				Spec: cloudstackv1.CloudStackMachineSpec{
 					Template: cloudstackv1.CloudStackResourceIdentifier{
-						Name: "centos7-k8s-118",
+						Name: "kubernetes_1_21",
 					},
 					Offering: cloudstackv1.CloudStackResourceIdentifier{
 						Name: "m4-large",

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -54,11 +54,12 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	remoteClient := env.Client()
 
 	spec := tt.buildSpec()
-	tt.ipValidator.EXPECT().ValidateControlPlaneIP(tt.ctx, logger, spec).Return(controller.Result{}, nil)
+	tt.ipValidator.EXPECT().ValidateControlPlaneIP(tt.ctx, logger, tt.buildSpec()).Return(controller.Result{}, nil)
 	tt.remoteClientRegistry.EXPECT().GetClient(
 		tt.ctx, client.ObjectKey{Name: "workload-cluster", Namespace: constants.EksaSystemNamespace},
 	).Return(remoteClient, nil).Times(1)
-	tt.cniReconciler.EXPECT().Reconcile(tt.ctx, logger, remoteClient, tt.buildSpec())
+
+	tt.cniReconciler.EXPECT().Reconcile(tt.ctx, logger, remoteClient, spec)
 	ctrl := gomock.NewController(t)
 	validator := cloudstack.NewMockProviderValidator(ctrl)
 	tt.validatorRegistry.EXPECT().Get(tt.execConfig).Return(validator, nil).Times(1)
@@ -587,6 +588,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 
 	machineConfigCP := machineConfig(func(m *anywherev1.CloudStackMachineConfig) {
 		m.Name = "cp-machine-config"
+		m.Spec.Template.Name = "kubernetes-1-22"
 		m.Spec.Users = append(m.Spec.Users,
 			anywherev1.UserConfiguration{
 				Name:              "user",
@@ -595,6 +597,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 	})
 	machineConfigWN := machineConfig(func(m *anywherev1.CloudStackMachineConfig) {
 		m.Name = "worker-machine-config"
+		m.Spec.Template.Name = "kubernetes-1-22"
 		m.Spec.Users = append(m.Spec.Users,
 			anywherev1.UserConfiguration{
 				Name:              "user",

--- a/pkg/providers/cloudstack/testdata/cluster_main.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main.yaml
@@ -65,7 +65,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -90,7 +90,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -118,7 +118,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/pkg/providers/cloudstack/testdata/cluster_main_with_cp_node_labels.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main_with_cp_node_labels.yaml
@@ -64,7 +64,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -87,7 +87,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -115,7 +115,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/pkg/providers/cloudstack/testdata/cluster_main_with_node_labels.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main_with_node_labels.yaml
@@ -64,7 +64,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -89,7 +89,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -114,7 +114,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_autoscaling_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_autoscaling_md.yaml
@@ -124,7 +124,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -454,7 +454,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -485,6 +485,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_md.yaml
@@ -121,7 +121,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -454,7 +454,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -485,6 +485,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -121,7 +121,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -440,7 +440,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -470,6 +470,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_md.yaml
@@ -107,7 +107,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -454,7 +454,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -485,6 +485,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes fixes for below 3 issues,
1. Validates Cloudstack template name and kubernetes version from the controller side and waits for both to match for further reconciliation.
2. Since we have seperated ETCD and CP reconciliation, it waits for ETCD to be ready before marking ControlPlaneReady to true.
3. From the CLI side during management cluster upgrade, waits for Cluster FailureMessage to be nil before waiting for other condition to met.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

