### PR TITLE
Add extra logs and increase verbosity of upgrade command for e2e tests

### DIFF
--- a/pkg/cluster/wait.go
+++ b/pkg/cluster/wait.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
@@ -16,8 +17,8 @@ import (
 // WaitForCondition blocks until either the cluster has this condition as True
 // or the retrier timeouts. If observedGeneration is not equal to generation,
 // the condition is considered false regardless of the status value.
-func WaitForCondition(ctx context.Context, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, conditionType anywherev1.ConditionType) error {
-	return WaitFor(ctx, client, cluster, retrier, func(c *anywherev1.Cluster) error {
+func WaitForCondition(ctx context.Context, log logr.Logger, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, conditionType anywherev1.ConditionType) error {
+	return WaitFor(ctx, log, client, cluster, retrier, func(c *anywherev1.Cluster) error {
 		condition := conditions.Get(c, conditionType)
 		if condition == nil {
 			return fmt.Errorf("cluster doesn't yet have condition %s", conditionType)
@@ -36,7 +37,7 @@ type Matcher func(*anywherev1.Cluster) error
 // WaitFor gets the cluster object from the client
 // checks for generation and observedGeneration condition
 // matches condition and returns error if the condition is not met.
-func WaitFor(ctx context.Context, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, matcher Matcher) error {
+func WaitFor(ctx context.Context, log logr.Logger, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, matcher Matcher) error {
 	return retrier.Retry(func() error {
 		c := &anywherev1.Cluster{}
 
@@ -51,6 +52,9 @@ func WaitFor(ctx context.Context, client kubernetes.Reader, cluster *anywherev1.
 
 		observedGeneration := c.Status.ObservedGeneration
 		generation := c.Generation
+
+		log.V(9).Info("Cluster generation and observedGeneration", "Generation", generation, "ObservedGeneration", observedGeneration)
+
 		if observedGeneration != generation {
 			return fmt.Errorf("cluster generation (%d) and observedGeneration (%d) differ", generation, observedGeneration)
 		}

--- a/pkg/cluster/wait_test.go
+++ b/pkg/cluster/wait_test.go
@@ -145,7 +145,7 @@ func TestWaitForCondition(t *testing.T) {
 			g := NewWithT(t)
 			client := test.NewFakeKubeClient(tt.currentCluster)
 
-			gotErr := cluster.WaitForCondition(ctx, client, tt.clusterInput, tt.retrier, tt.condition)
+			gotErr := cluster.WaitForCondition(ctx, test.NewNullLogger(), client, tt.clusterInput, tt.retrier, tt.condition)
 			if tt.wantErr != "" {
 				g.Expect(gotErr).To(MatchError(tt.wantErr))
 			} else {
@@ -254,7 +254,7 @@ func TestWaitFor(t *testing.T) {
 			g := NewWithT(t)
 			client := test.NewFakeKubeClient(tt.currentCluster)
 
-			gotErr := cluster.WaitFor(ctx, client, tt.clusterInput, tt.retrier, tt.matcher)
+			gotErr := cluster.WaitFor(ctx, test.NewNullLogger(), client, tt.clusterInput, tt.retrier, tt.matcher)
 			if tt.wantErr != "" {
 				g.Expect(gotErr).To(MatchError(tt.wantErr))
 			} else {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -844,7 +844,7 @@ func (e *ClusterE2ETest) upgradeCluster(clusterOpts []ClusterE2ETestOpt, command
 
 // UpgradeCluster runs the CLI upgrade command.
 func (e *ClusterE2ETest) UpgradeCluster(commandOpts ...CommandOpt) {
-	upgradeClusterArgs := []string{"upgrade", "cluster", "-f", e.ClusterConfigLocation, "-v", "4"}
+	upgradeClusterArgs := []string{"upgrade", "cluster", "-f", e.ClusterConfigLocation, "-v", "9"}
 	if getBundlesOverride() == "true" {
 		upgradeClusterArgs = append(upgradeClusterArgs, "--bundles-override", defaultBundleReleaseManifestFile)
 	}


### PR DESCRIPTION
*Description of changes:*
Increase the verbosity of upgrade command for e2e tests and added logs for debugging e2e tests failures.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

