### PR TITLE
Create cluster failure support bundle logs

### DIFF
--- a/pkg/workflows/diagnostics.go
+++ b/pkg/workflows/diagnostics.go
@@ -3,7 +3,6 @@ package workflows
 import (
 	"context"
 
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
 )
@@ -55,7 +54,7 @@ func (s *CollectWorkloadClusterDiagnosticsTask) Name() string {
 func (s *CollectMgmtClusterDiagnosticsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("collecting management cluster diagnostics")
 	mgmt := commandContext.BootstrapCluster
-	if features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
+	if mgmt == nil {
 		mgmt = commandContext.ManagementCluster
 	}
 


### PR DESCRIPTION
*Description of changes:*
For create cluster we need `commandContext.BootstrapCluster` value for collecting support bundle in case of failure and with the new upgrade management changes we need `commandContext.ManagementCluster` value for collecting the support bundle. This PR accommodates both the scenarios.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

