### PR TITLE
Waiting for control plane to be fully upgraded 

### DIFF
--- a/pkg/clusterapi/constants.go
+++ b/pkg/clusterapi/constants.go
@@ -4,4 +4,5 @@ import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 const (
 	ControlPlaneReadyCondition clusterv1.ConditionType = "ControlPlaneReady"
+	ReadyCondition             clusterv1.ConditionType = "Ready"
 )

--- a/pkg/controller/clusters/clusterapi.go
+++ b/pkg/controller/clusters/clusterapi.go
@@ -11,13 +11,40 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/controller"
+	"github.com/aws/eks-anywhere/pkg/features"
 )
 
-// CheckControlPlaneReady is a controller helper to check whether a CAPI cluster CP for
-// an eks-a cluster is ready or not. This is intended to be used from cluster reconcilers
+// CheckControlPlaneReady is a controller helper to check whether KCP object for
+// the cluster is ready or not. This is intended to be used from cluster reconcilers
 // due its signature and that it returns controller results with appropriate wait times whenever
 // the cluster is not ready.
 func CheckControlPlaneReady(ctx context.Context, client client.Client, log logr.Logger, cluster *anywherev1.Cluster) (controller.Result, error) {
+	if features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
+		kcp, err := controller.GetKubeadmControlPlane(ctx, client, cluster)
+		if err != nil {
+			return controller.Result{}, err
+		}
+
+		if kcp == nil {
+			log.Info("KCP does not exist yet, requeuing")
+			return controller.ResultWithRequeue(5 * time.Second), nil
+		}
+
+		// We make sure to check that the status is up to date before using it
+		if kcp.Status.ObservedGeneration != kcp.ObjectMeta.Generation {
+			log.Info("KCP information is outdated, requeing")
+			return controller.ResultWithRequeue(5 * time.Second), nil
+		}
+
+		if !conditions.IsTrue(kcp, clusterapi.ReadyCondition) {
+			log.Info("KCP is not ready yet, requeing")
+			return controller.ResultWithRequeue(30 * time.Second), nil
+		}
+
+		log.Info("KCP is ready")
+		return controller.Result{}, nil
+	}
+
 	capiCluster, err := controller.GetCAPICluster(ctx, client, cluster)
 	if err != nil {
 		return controller.Result{}, err


### PR DESCRIPTION
*Issue #, if available:*
A part of kindless upgrade task for management cluster: https://github.com/aws/eks-anywhere/blob/main/designs/kindless-upgrades.md#waiting-for-control-plane-to-be-fully-upgraded

*Description of changes:*
There a race condition where the status of the CAPI cluster is not updated fast enough after updating the KCP. Thus, before upgrading other components like CNI, worker nodes wait for CP to be fully upgraded before upgrading other components of the cluster. Now the controller will look at the KCP object instead of CAPI cluster to avoid outdated status reports. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

