### PR TITLE
Add a RoutingMode option to cniConfig

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -77,6 +77,12 @@ spec:
                               allowed between pods. Accepted values are default, always,
                               never.
                             type: string
+                          routingMode:
+                            description: RoutingMode indicates the routing tunnel
+                              mode to use for Cilium. Accepted values are overlay
+                              (geneve tunnel with overlay) or direct (tunneling disabled
+                              with direct routing) Defaults to overlay.
+                            type: string
                           skipUpgrade:
                             description: SkipUpgrade indicicates that Cilium maintenance
                               should be skipped during upgrades. This can be used

--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -73,22 +73,21 @@ spec:
                               values are a valid interface name or interface prefix.
                             type: string
                           ipv4NativeRoutingCIDR:
-                            description: When RoutingMode is set to direct this flag
-                              allows too explicitly specify the IPv4 CIDR for native
-                              routing. When specified, Cilium assumes networking for
-                              this CIDR is preconfigured and hands traffic destined
-                              for that range to the Linux network stack without applying
-                              any SNAT. If this is not set autoDirectNodeRoutes will
-                              be set to true
+                            description: IPv4NativeRoutingCIDR specifies the CIDR
+                              to use when RoutingMode is set to direct. When specified,
+                              Cilium assumes networking for this CIDR is preconfigured
+                              and hands traffic destined for that range to the Linux
+                              network stack without applying any SNAT. If this is
+                              not set autoDirectNodeRoutes will be set to true
                             type: string
                           ipv6NativeRoutingCIDR:
-                            description: When RoutingMode is set to direct this flag
-                              allows too explicitly specify the IPv6 CIDR for native
-                              routing. When specified, Cilium assumes networking for
-                              this CIDR is preconfigured and hands traffic destined
-                              for that range to the Linux network stack without applying
-                              any SNAT. If this is not set autoDirectNodeRoutes will
-                              be set to true
+                            description: IPv6NativeRoutingCIDR specifies the IPv6
+                              CIDR to use when RoutingMode is set to direct. When
+                              specified, Cilium assumes networking for this CIDR is
+                              preconfigured and hands traffic destined for that range
+                              to the Linux network stack without applying any SNAT.
+                              If this is not set autoDirectNodeRoutes will be set
+                              to true
                             type: string
                           policyEnforcementMode:
                             description: PolicyEnforcementMode determines communication

--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -72,6 +72,24 @@ spec:
                               network interfaces are used for masquerading. Accepted
                               values are a valid interface name or interface prefix.
                             type: string
+                          ipv4NativeRoutingCIDR:
+                            description: When RoutingMode is set to direct this flag
+                              allows too explicitly specify the IPv4 CIDR for native
+                              routing. When specified, Cilium assumes networking for
+                              this CIDR is preconfigured and hands traffic destined
+                              for that range to the Linux network stack without applying
+                              any SNAT. If this is not set autoDirectNodeRoutes will
+                              be set to true
+                            type: string
+                          ipv6NativeRoutingCIDR:
+                            description: When RoutingMode is set to direct this flag
+                              allows too explicitly specify the IPv6 CIDR for native
+                              routing. When specified, Cilium assumes networking for
+                              this CIDR is preconfigured and hands traffic destined
+                              for that range to the Linux network stack without applying
+                              any SNAT. If this is not set autoDirectNodeRoutes will
+                              be set to true
+                            type: string
                           policyEnforcementMode:
                             description: PolicyEnforcementMode determines communication
                               allowed between pods. Accepted values are default, always,

--- a/docs/content/en/docs/getting-started/optional/cni.md
+++ b/docs/content/en/docs/getting-started/optional/cni.md
@@ -164,6 +164,29 @@ spec:
         egressMasqueradeInterfaces: "eth0"
 ```
 
+### RoutingMode option for Cilium plugin
+
+By default all traffic is sent by Cilium over Geneve tunneling on the network. The `routingMode` option allows users to switch to [native routing](https://docs.cilium.io/en/v1.12/concepts/networking/routing/#native-routing) instead. 
+
+This field can be set as follows:
+```yaml
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: my-cluster-name
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+    cniConfig:
+      cilium: 
+        routingMode: "direct"
+```
+
 ### Use a custom CNI
 
 EKS Anywhere can be configured to skip EKS Anywhere's default Cilium CNI upgrades via the `skipUpgrade` field. 

--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -83,6 +83,16 @@ func WithCiliumSkipUpgrade() ClusterFiller {
 	}
 }
 
+// WithCiliumRoutingMode sets the tunnel mode with the provided mode option to use.
+func WithCiliumRoutingMode(mode anywherev1.CiliumRoutingMode) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.ClusterNetwork.CNIConfig == nil {
+			c.Spec.ClusterNetwork.CNIConfig = &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}}
+		}
+		c.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode = mode
+	}
+}
+
 func WithClusterNamespace(ns string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Namespace = ns

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -626,6 +626,10 @@ func (n *CiliumConfig) Equal(o *CiliumConfig) bool {
 		return false
 	}
 
+	if n.RoutingMode != o.RoutingMode {
+		return false
+	}
+
 	oSkipUpgradeIsFalse := o.SkipUpgrade == nil || !*o.SkipUpgrade
 	nSkipUpgradeIsFalse := n.SkipUpgrade == nil || !*n.SkipUpgrade
 
@@ -825,6 +829,8 @@ type CNI string
 
 type CiliumPolicyEnforcementMode string
 
+type CiliumRoutingMode string
+
 type CNIConfig struct {
 	Cilium   *CiliumConfig   `json:"cilium,omitempty"`
 	Kindnetd *KindnetdConfig `json:"kindnetd,omitempty"`
@@ -847,6 +853,12 @@ type CiliumConfig struct {
 	// be used when operators wish to self manage the Cilium installation.
 	// +optional
 	SkipUpgrade *bool `json:"skipUpgrade,omitempty"`
+
+	// RoutingMode indicates the routing tunnel mode to use for Cilium. Accepted values are overlay (geneve tunnel with overlay)
+	// or direct (tunneling disabled with direct routing)
+	// Defaults to overlay.
+	// +optional
+	RoutingMode CiliumRoutingMode `json:"routingMode,omitempty"`
 }
 
 // IsManaged returns true if SkipUpgrade is nil or false indicating EKS-A is responsible for
@@ -879,6 +891,11 @@ var validCiliumPolicyEnforcementModes = map[CiliumPolicyEnforcementMode]bool{
 	CiliumPolicyModeDefault: true,
 	CiliumPolicyModeNever:   true,
 }
+
+const (
+	CiliumRoutingModeOverlay CiliumRoutingMode = "overlay"
+	CiliumRoutingModeDirect  CiliumRoutingMode = "direct"
+)
 
 // FailureReasonType is a type for defining failure reasons.
 type FailureReasonType string

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -859,6 +859,24 @@ type CiliumConfig struct {
 	// Defaults to overlay.
 	// +optional
 	RoutingMode CiliumRoutingMode `json:"routingMode,omitempty"`
+
+	// When RoutingMode is set to direct this flag allows too explicitly specify the
+	// IPv4 CIDR for native routing.
+	// When specified, Cilium assumes networking for this CIDR is preconfigured and
+	// hands traffic destined for that range to the Linux network stack without
+	// applying any SNAT.
+	// If this is not set autoDirectNodeRoutes will be set to true
+	// +optional
+	IPv4NativeRoutingCIDR string `json:"ipv4NativeRoutingCIDR,omitempty"`
+
+	// When RoutingMode is set to direct this flag allows too explicitly specify the
+	// IPv6 CIDR for native routing.
+	// When specified, Cilium assumes networking for this CIDR is preconfigured and
+	// hands traffic destined for that range to the Linux network stack without
+	// applying any SNAT.
+	// If this is not set autoDirectNodeRoutes will be set to true
+	// +optional
+	IPv6NativeRoutingCIDR string `json:"ipv6NativeRoutingCIDR,omitempty"`
 }
 
 // IsManaged returns true if SkipUpgrade is nil or false indicating EKS-A is responsible for

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -841,6 +841,7 @@ func (n *CNIConfig) IsManaged() bool {
 	return n != nil && (n.Kindnetd != nil || n.Cilium != nil && n.Cilium.IsManaged())
 }
 
+// CiliumConfig contains configuration specific to the Cilium CNI.
 type CiliumConfig struct {
 	// PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.
 	PolicyEnforcementMode CiliumPolicyEnforcementMode `json:"policyEnforcementMode,omitempty"`
@@ -860,8 +861,7 @@ type CiliumConfig struct {
 	// +optional
 	RoutingMode CiliumRoutingMode `json:"routingMode,omitempty"`
 
-	// When RoutingMode is set to direct this flag allows too explicitly specify the
-	// IPv4 CIDR for native routing.
+	// IPv4NativeRoutingCIDR specifies the CIDR to use when RoutingMode is set to direct.
 	// When specified, Cilium assumes networking for this CIDR is preconfigured and
 	// hands traffic destined for that range to the Linux network stack without
 	// applying any SNAT.
@@ -869,8 +869,7 @@ type CiliumConfig struct {
 	// +optional
 	IPv4NativeRoutingCIDR string `json:"ipv4NativeRoutingCIDR,omitempty"`
 
-	// When RoutingMode is set to direct this flag allows too explicitly specify the
-	// IPv6 CIDR for native routing.
+	// IPv6NativeRoutingCIDR specifies the IPv6 CIDR to use when RoutingMode is set to direct.
 	// When specified, Cilium assumes networking for this CIDR is preconfigured and
 	// hands traffic destined for that range to the Linux network stack without
 	// applying any SNAT.
@@ -885,12 +884,18 @@ func (n *CiliumConfig) IsManaged() bool {
 	return n.SkipUpgrade == nil || !*n.SkipUpgrade
 }
 
+// KindnetdConfig contains configuration specific to the Kindnetd CNI.
 type KindnetdConfig struct{}
 
 const (
-	Cilium           CNI = "cilium"
+	// Cilium is the EKS-A Cilium.
+	Cilium CNI = "cilium"
+
+	// CiliumEnterprise is Isovalents Cilium.
 	CiliumEnterprise CNI = "cilium-enterprise"
-	Kindnetd         CNI = "kindnetd"
+
+	// Kindnetd is the CNI shipped with KinD.
+	Kindnetd CNI = "kindnetd"
 )
 
 var validCNIs = map[CNI]struct{}{
@@ -898,6 +903,7 @@ var validCNIs = map[CNI]struct{}{
 	Kindnetd: {},
 }
 
+// Policy enforcement modes for Cilium.
 const (
 	CiliumPolicyModeDefault CiliumPolicyEnforcementMode = "default"
 	CiliumPolicyModeAlways  CiliumPolicyEnforcementMode = "always"
@@ -910,6 +916,7 @@ var validCiliumPolicyEnforcementModes = map[CiliumPolicyEnforcementMode]bool{
 	CiliumPolicyModeNever:   true,
 }
 
+// Routing modes for Cilium.
 const (
 	CiliumRoutingModeOverlay CiliumRoutingMode = "overlay"
 	CiliumRoutingModeDirect  CiliumRoutingMode = "direct"

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -237,6 +237,11 @@ func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) 
 		val["egressMasqueradeInterfaces"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.EgressMasqueradeInterfaces
 	}
 
+	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode == anywherev1.CiliumRoutingModeDirect {
+		val["tunnel"] = "disabled"
+		val["routingMode"] = "native"
+	}
+
 	return val
 }
 

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -239,7 +239,14 @@ func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) 
 
 	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode == anywherev1.CiliumRoutingModeDirect {
 		val["tunnel"] = "disabled"
-		val["routingMode"] = "native"
+
+		if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv4NativeRoutingCIDR == "" &&
+			spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv6NativeRoutingCIDR == "" {
+			val["autoDirectNodeRoutes"] = "true"
+		} else {
+			val["ipv4NativeRoutingCIDR"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv4NativeRoutingCIDR
+			val["ipv6NativeRoutingCIDR"] = spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv6NativeRoutingCIDR
+		}
 	}
 
 	return val

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -278,6 +278,44 @@ func TestTemplaterGenerateManifestEgressMasqueradeInterfacesSuccess(t *testing.T
 	tt.Expect(tt.t.GenerateManifest(tt.ctx, tt.spec)).To(Equal(tt.manifest), "templater.GenerateManifest() should return right manifest")
 }
 
+func TestTemplaterGenerateManifestTunnelModeSuccess(t *testing.T) {
+	wantValues := map[string]interface{}{
+		"cni": map[string]interface{}{
+			"chainingMode": "portmap",
+		},
+		"ipam": map[string]interface{}{
+			"mode": "kubernetes",
+		},
+		"identityAllocationMode": "crd",
+		"prometheus": map[string]interface{}{
+			"enabled": true,
+		},
+		"rollOutCiliumPods": true,
+		"tunnel":            "disabled",
+		"routingMode":       "native",
+		"image": map[string]interface{}{
+			"repository": "public.ecr.aws/isovalent/cilium",
+			"tag":        "v1.9.11-eksa.1",
+		},
+		"operator": map[string]interface{}{
+			"image": map[string]interface{}{
+				"repository": "public.ecr.aws/isovalent/operator",
+				"tag":        "v1.9.11-eksa.1",
+			},
+			"prometheus": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}
+
+	tt := newtemplaterTest(t)
+	tt.spec.Cluster.Spec.ManagementCluster.Name = "managed"
+	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode = v1alpha1.CiliumRoutingModeDirect
+	tt.expectHelmTemplateWith(eqMap(wantValues), "1.22").Return(tt.manifest, nil)
+
+	tt.Expect(tt.t.GenerateManifest(tt.ctx, tt.spec)).To(Equal(tt.manifest), "templater.GenerateManifest() should return right manifest")
+}
+
 func TestTemplaterGenerateManifestError(t *testing.T) {
 	expectedAttempts := 2
 	tt := newtemplaterTest(t)

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -278,7 +278,7 @@ func TestTemplaterGenerateManifestEgressMasqueradeInterfacesSuccess(t *testing.T
 	tt.Expect(tt.t.GenerateManifest(tt.ctx, tt.spec)).To(Equal(tt.manifest), "templater.GenerateManifest() should return right manifest")
 }
 
-func TestTemplaterGenerateManifestTunnelModeSuccess(t *testing.T) {
+func TestTemplaterGenerateManifestDirectRouteModeSuccess(t *testing.T) {
 	wantValues := map[string]interface{}{
 		"cni": map[string]interface{}{
 			"chainingMode": "portmap",
@@ -290,9 +290,9 @@ func TestTemplaterGenerateManifestTunnelModeSuccess(t *testing.T) {
 		"prometheus": map[string]interface{}{
 			"enabled": true,
 		},
-		"rollOutCiliumPods": true,
-		"tunnel":            "disabled",
-		"routingMode":       "native",
+		"rollOutCiliumPods":    true,
+		"tunnel":               "disabled",
+		"autoDirectNodeRoutes": "true",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -311,6 +311,47 @@ func TestTemplaterGenerateManifestTunnelModeSuccess(t *testing.T) {
 	tt := newtemplaterTest(t)
 	tt.spec.Cluster.Spec.ManagementCluster.Name = "managed"
 	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode = v1alpha1.CiliumRoutingModeDirect
+	tt.expectHelmTemplateWith(eqMap(wantValues), "1.22").Return(tt.manifest, nil)
+
+	tt.Expect(tt.t.GenerateManifest(tt.ctx, tt.spec)).To(Equal(tt.manifest), "templater.GenerateManifest() should return right manifest")
+}
+
+func TestTemplaterGenerateManifestDirectModeManualIPCIDRSuccess(t *testing.T) {
+	wantValues := map[string]interface{}{
+		"cni": map[string]interface{}{
+			"chainingMode": "portmap",
+		},
+		"ipam": map[string]interface{}{
+			"mode": "kubernetes",
+		},
+		"identityAllocationMode": "crd",
+		"prometheus": map[string]interface{}{
+			"enabled": true,
+		},
+		"rollOutCiliumPods":     true,
+		"tunnel":                "disabled",
+		"ipv4NativeRoutingCIDR": "192.168.0.0/24",
+		"ipv6NativeRoutingCIDR": "2001:db8::/32",
+		"image": map[string]interface{}{
+			"repository": "public.ecr.aws/isovalent/cilium",
+			"tag":        "v1.9.11-eksa.1",
+		},
+		"operator": map[string]interface{}{
+			"image": map[string]interface{}{
+				"repository": "public.ecr.aws/isovalent/operator",
+				"tag":        "v1.9.11-eksa.1",
+			},
+			"prometheus": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}
+
+	tt := newtemplaterTest(t)
+	tt.spec.Cluster.Spec.ManagementCluster.Name = "managed"
+	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode = v1alpha1.CiliumRoutingModeDirect
+	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv4NativeRoutingCIDR = "192.168.0.0/24"
+	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv6NativeRoutingCIDR = "2001:db8::/32"
 	tt.expectHelmTemplateWith(eqMap(wantValues), "1.22").Return(tt.manifest, nil)
 
 	tt.Expect(tt.t.GenerateManifest(tt.ctx, tt.spec)).To(Equal(tt.manifest), "templater.GenerateManifest() should return right manifest")


### PR DESCRIPTION
Fixes  #3182

*Description of changes:* This adds two routing modes for CIlium to use in the CNI configuration. Tunneled keeps the default geneve tunnel mode.
Direct adds a no tunnel mode with native as routing mode

*Documentation added/planned (if applicable):* Added a part explaining the option and linking to Cilium documentation to the `cni.md` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

