### PR TITLE
Allow to configure gitOps during kindless management cluster

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -334,7 +334,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		}
 	}
 
-	if !new.Spec.GitOpsRef.Equal(old.Spec.GitOpsRef) {
+	if !new.Spec.GitOpsRef.Equal(old.Spec.GitOpsRef) && !old.IsSelfManaged() {
 		allErrs = append(
 			allErrs,
 			field.Forbidden(specPath.Child("GitOpsRef"), fmt.Sprintf("field is immutable %v", new.Spec.GitOpsRef)))

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -692,8 +692,19 @@ func TestClusterValidateUpdateGitOpsRefImmutableNilEqual(t *testing.T) {
 	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
 }
 
+func TestClusterValidateUpdateGitOpsRefMutableManagementCluster(t *testing.T) {
+	cOld := baseCluster()
+	cOld.Spec.GitOpsRef = nil
+	c := cOld.DeepCopy()
+	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test2", Kind: "GitOpsConfig"}
+
+	g := NewWithT(t)
+	g.Expect(c.ValidateUpdate(cOld)).To(Succeed())
+}
+
 func TestClusterValidateUpdateGitOpsRefImmutable(t *testing.T) {
 	cOld := baseCluster()
+	cOld.SetManagedBy("management-cluster")
 	cOld.Spec.GitOpsRef = &v1alpha1.Ref{}
 	c := cOld.DeepCopy()
 	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test2", Kind: "GitOpsConfig2"}
@@ -704,6 +715,7 @@ func TestClusterValidateUpdateGitOpsRefImmutable(t *testing.T) {
 
 func TestClusterValidateUpdateGitOpsRefImmutableName(t *testing.T) {
 	cOld := baseCluster()
+	cOld.SetManagedBy("management-cluster")
 	cOld.Spec.GitOpsRef = &v1alpha1.Ref{
 		Name: "test1", Kind: "GitOpsConfig",
 	}
@@ -716,6 +728,7 @@ func TestClusterValidateUpdateGitOpsRefImmutableName(t *testing.T) {
 
 func TestClusterValidateUpdateGitOpsRefImmutableKind(t *testing.T) {
 	cOld := baseCluster()
+	cOld.SetManagedBy("management-cluster")
 	cOld.Spec.GitOpsRef = &v1alpha1.Ref{
 		Name: "test", Kind: "GitOpsConfig1",
 	}
@@ -728,6 +741,7 @@ func TestClusterValidateUpdateGitOpsRefImmutableKind(t *testing.T) {
 
 func TestClusterValidateUpdateGitOpsRefOldNilImmutable(t *testing.T) {
 	cOld := baseCluster()
+	cOld.SetManagedBy("management-cluster")
 	cOld.Spec.GitOpsRef = nil
 
 	c := cOld.DeepCopy()
@@ -739,6 +753,7 @@ func TestClusterValidateUpdateGitOpsRefOldNilImmutable(t *testing.T) {
 
 func TestClusterValidateUpdateGitOpsRefNewNilImmutable(t *testing.T) {
 	cOld := baseCluster()
+	cOld.SetManagedBy("management-cluster")
 	cOld.Spec.GitOpsRef = &v1alpha1.Ref{
 		Name: "test", Kind: "GitOpsConfig",
 	}


### PR DESCRIPTION
*Description of changes:*
We don't allow to configure gitOps for management cluster upgrade. For kindless management upgrade flow, we use controller to upgrade our cluster so this PR allows configuring gitOps for the management cluster if the kindless feature is enabled.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

