### PR TITLE
Verify the condition matches certain amount of times kindless upgrade

### DIFF
--- a/pkg/cluster/wait.go
+++ b/pkg/cluster/wait.go
@@ -17,8 +17,9 @@ import (
 // WaitForCondition blocks until either the cluster has this condition as True
 // or the retrier timeouts. If observedGeneration is not equal to generation,
 // the condition is considered false regardless of the status value.
-func WaitForCondition(ctx context.Context, log logr.Logger, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, conditionType anywherev1.ConditionType) error {
-	return WaitFor(ctx, log, client, cluster, retrier, func(c *anywherev1.Cluster) error {
+// total field is to check the total number of times the given condition is met for consistency.
+func WaitForCondition(ctx context.Context, log logr.Logger, client kubernetes.Reader, cluster *anywherev1.Cluster, total int, retrier *retrier.Retrier, conditionType anywherev1.ConditionType) error {
+	return WaitFor(ctx, log, client, cluster, total, retrier, func(c *anywherev1.Cluster) error {
 		condition := conditions.Get(c, conditionType)
 		if condition == nil {
 			return fmt.Errorf("cluster doesn't yet have condition %s", conditionType)
@@ -37,7 +38,8 @@ type Matcher func(*anywherev1.Cluster) error
 // WaitFor gets the cluster object from the client
 // checks for generation and observedGeneration condition
 // matches condition and returns error if the condition is not met.
-func WaitFor(ctx context.Context, log logr.Logger, client kubernetes.Reader, cluster *anywherev1.Cluster, retrier *retrier.Retrier, matcher Matcher) error {
+func WaitFor(ctx context.Context, log logr.Logger, client kubernetes.Reader, cluster *anywherev1.Cluster, total int, retrier *retrier.Retrier, matcher Matcher) error {
+	count := 0
 	return retrier.Retry(func() error {
 		c := &anywherev1.Cluster{}
 
@@ -59,6 +61,20 @@ func WaitFor(ctx context.Context, log logr.Logger, client kubernetes.Reader, clu
 			return fmt.Errorf("cluster generation (%d) and observedGeneration (%d) differ", generation, observedGeneration)
 		}
 
-		return matcher(c)
+		if err := matcher(c); err != nil {
+			count = 0
+			return err
+		}
+
+		count++
+		// total field is to check the total number of times the given condition is met.
+		// for ex, the total is set to 5 and we want to check certain condition is met
+		// we check the condition is met for 5 times to make sure the given behavior is consistent.
+		if count < total {
+			return fmt.Errorf("cluster has reached to expected condition in %d/%d times", count, total)
+		}
+
+		// when the count matches total number it returns without error
+		return nil
 	})
 }

--- a/pkg/clustermanager/applier_test.go
+++ b/pkg/clustermanager/applier_test.go
@@ -151,6 +151,7 @@ func TestApplierRunCClusterUpdatedWithCNINotManaged(t *testing.T) {
 	tt.markClusterReady(tt.spec.Cluster)
 	a := clustermanager.NewApplier(tt.log, tt.clientFactory,
 		clustermanager.WithApplierWaitForClusterReconcile(0),
+		clustermanager.WithApplierWaitForFailureMessage(0),
 	)
 
 	tt.Expect(a.Run(tt.ctx, tt.spec, tt.mgmtCluster)).To(Succeed())
@@ -184,7 +185,8 @@ func TestApplierRunFailureMessage(t *testing.T) {
 	tt.updateFailureMessage(tt.spec.Cluster, "error")
 	tt.startFakeController()
 	a := clustermanager.NewApplier(tt.log, tt.clientFactory,
-		clustermanager.WithApplierRetryBackOff(time.Millisecond),
+		clustermanager.WithApplierRetryBackOff(0),
+		clustermanager.WithApplierWaitForFailureMessage(0),
 	)
 
 	tt.Expect(a.Run(tt.ctx, tt.spec, tt.mgmtCluster)).To(MatchError(ContainSubstring("cluster has a validation error that doesn't seem transient")))
@@ -195,6 +197,7 @@ func TestApplierRunControlPlaneNotReady(t *testing.T) {
 	tt.buildClient()
 	a := clustermanager.NewApplier(tt.log, tt.clientFactory,
 		clustermanager.WithApplierWaitForClusterReconcile(0),
+		clustermanager.WithApplierWaitForFailureMessage(0),
 	)
 
 	tt.Expect(a.Run(tt.ctx, tt.spec, tt.mgmtCluster)).To(MatchError(ContainSubstring("waiting for cluster's control plane to be ready")))
@@ -206,6 +209,7 @@ func TestApplierRunCNINotConfigured(t *testing.T) {
 	tt.markCPReady(tt.spec.Cluster)
 	a := clustermanager.NewApplier(tt.log, tt.clientFactory,
 		clustermanager.WithApplierWaitForClusterReconcile(0),
+		clustermanager.WithApplierWaitForFailureMessage(0),
 	)
 
 	tt.Expect(a.Run(tt.ctx, tt.spec, tt.mgmtCluster)).To(MatchError(ContainSubstring("waiting for cluster's CNI to be configured")))
@@ -218,6 +222,7 @@ func TestApplierRunWorkersNotReady(t *testing.T) {
 	tt.markCNIConfigured(tt.spec.Cluster)
 	a := clustermanager.NewApplier(tt.log, tt.clientFactory,
 		clustermanager.WithApplierWaitForClusterReconcile(0),
+		clustermanager.WithApplierWaitForFailureMessage(0),
 	)
 
 	tt.Expect(a.Run(tt.ctx, tt.spec, tt.mgmtCluster)).To(MatchError(ContainSubstring("waiting for cluster's workers to be ready")))
@@ -231,6 +236,7 @@ func TestApplierRunClusterNotReady(t *testing.T) {
 	tt.markWorkersReady(tt.spec.Cluster)
 	a := clustermanager.NewApplier(tt.log, tt.clientFactory,
 		clustermanager.WithApplierWaitForClusterReconcile(0),
+		clustermanager.WithApplierWaitForFailureMessage(0),
 	)
 
 	tt.Expect(a.Run(tt.ctx, tt.spec, tt.mgmtCluster)).To(MatchError(ContainSubstring("waiting for cluster to be ready")))


### PR DESCRIPTION
*Description of changes:*
With the new kindless upgrade management task we have seen an error message like `kubernetes version v1.25.13-eks-a6e69b0 does not match expected version 1.26`. CLI relies on cluster status object field to decide on cluster upgrade process. This error happens due to cluster status field not being upgraded immediately due to certain race condition or just due to the lag. To fix these issues we have added a check to verify the conditions certain amount of times before moving to the next steps.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

