### PR TITLE
Update CLI to apply resources to using regular kubectl apply instead of with force

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -1359,7 +1359,7 @@ func (c *ClusterManager) resumeReconcileForCluster(ctx context.Context, clusterC
 }
 
 func (c *ClusterManager) applyResource(ctx context.Context, cluster *types.Cluster, resourcesSpec []byte) error {
-	err := c.clusterClient.ApplyKubeSpecFromBytesForce(ctx, cluster, resourcesSpec)
+	err := c.clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, resourcesSpec)
 	if err != nil {
 		return fmt.Errorf("applying eks-a spec: %v", err)
 	}

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -1781,7 +1781,7 @@ func TestClusterManagerCreateEKSAResourcesSuccess(t *testing.T) {
 
 	c, m := newClusterManager(t)
 
-	m.client.EXPECT().ApplyKubeSpecFromBytesForce(ctx, tt.cluster, gomock.Any())
+	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, tt.cluster, gomock.Any())
 	// ApplyKubeSpecFromBytes is called twice. Once for Bundles and again for EKSARelease.
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, tt.cluster, gomock.Any()).MaxTimes(2)
 	m.client.EXPECT().ApplyKubeSpecFromBytesWithNamespace(ctx, tt.cluster, gomock.Any(), gomock.Any()).MaxTimes(2)
@@ -1834,7 +1834,7 @@ func TestClusterManagerCreateEKSAResourcesFailureBundles(t *testing.T) {
 	c := clustermanager.New(cf, client, m.networking, m.writer, m.diagnosticsFactory, m.awsIamAuth, m.eksaComponents)
 
 	m.client.EXPECT().CreateNamespaceIfNotPresent(ctx, gomock.Any(), tt.clusterSpec.Cluster.Namespace).Return(nil)
-	m.client.EXPECT().ApplyKubeSpecFromBytesForce(ctx, gomock.Any(), gomock.Any()).Return(nil)
+	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, gomock.Any(), gomock.Any()).Return(errors.New(""))
 	tt.Expect(c.CreateEKSAResources(ctx, tt.cluster, tt.clusterSpec, datacenterConfig, machineConfigs)).NotTo(Succeed())
 }
@@ -1866,7 +1866,7 @@ func TestClusterManagerCreateEKSAResourcesFailureEKSARelease(t *testing.T) {
 	c := clustermanager.New(cf, client, m.networking, m.writer, m.diagnosticsFactory, m.awsIamAuth, m.eksaComponents)
 
 	m.client.EXPECT().CreateNamespaceIfNotPresent(ctx, gomock.Any(), tt.clusterSpec.Cluster.Namespace).Return(nil)
-	m.client.EXPECT().ApplyKubeSpecFromBytesForce(ctx, gomock.Any(), gomock.Any()).Return(nil)
+	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	m.client.EXPECT().ApplyKubeSpecFromBytes(ctx, gomock.Any(), gomock.Any()).Return(errors.New(""))
 	tt.Expect(c.CreateEKSAResources(ctx, tt.cluster, tt.clusterSpec, datacenterConfig, machineConfigs)).NotTo(Succeed())


### PR DESCRIPTION
*Issue #, if available:*
#6453 

*Description of changes:*

This PR addresses the issue where the CLI stalls on create/upgrade if it encounters a validation error at the point of force "Applying eksa yaml resources to cluster" near the end of cluster creation or upgrade, where it will stall indefinitely until it eventually times out. This is proposing opting to use a regular client side `kubectl apply` operation instead of the current client side`kubectl apply --force`, so that such issues are raised earlier and handle properly in the web-hooks

Normally, the `k --force apply` would delete the resource and just recreate it, but instead it the CLI gets stuck. This is because there is a finalizer on the Cluster object resecource. Typically, the `eksa-controller-manager` controls deletion of this resource using the finalizer once the dependent objects have been cleaned up, however, the controller short circuits with an error before it gets to point where it removes the finalizer for management clusters. It throws an error saying `deleting self-managed clusters is not supported` instead, which is intended behavior. Currently, this seems to happen for only management clusters.

So far, this situation has primarily been observed when upgrading a cluster using GitOps Flux, but it can be present when not using GitOps Flux as well. Here are two cases in which we’ve encountered this problem:

**Case 1**

When upgrading from the latest minor release to v0.17.0, the CLI stalled while "Applying eksa yaml resources to cluster". In this case, both the newly added eksaVersion field and the bundlesRef were populated in submission to the kube-apiserver, however, there is a web-hook validation that does not allow both to be set at the same time, so that was throwing an error in the kube-apiserver pod.

```
BundlesRef:(*v1alpha1.BundlesRef)(0xc000fce960), EksaVersion:(*v1alpha1.EksaVersion)(0xc000fc7a30)}: cannot pass both bundlesRef and eksaVersion. New clusters should use eksaVersion instead of bundlesRef“
```

Though the Cluster object that was force applied was valid with only the eksaVersion specified and no  bundlesRef set, it was trying to do that 3 way strategic merge and added the old bundlesRef to the new spec as well. 

We had decided that a solution addressing the root cause at this point would be risky for and would require more discussion. Therefore, a temporary patch was made with [this PR](https://github.com/aws/eks-anywhere/pull/6335), which utilized an alternate ClusterSpec struct called ClusterSpecGenerate, where the bundlesRef is not omitted when empty. This addresses the issue at the time of force apply by forcing the inclusion of a nil bundlesRef field in the kube-apiserver, avoiding the 3 way strategic merge behavior that was happening here.

**Case 2**

A user report an issue with a cluster in a similar state to the aforementioned issue. They were trying to upgrade their EKS-A cluster managed through GitOps from Kubernetes version 1.26 to 1.27. However, they encountered a validation error:

```
W0809 17:39:26.913668       1 dispatcher.go:216] rejected by webhook "validation.cluster.anywhere.amazonaws.com": &errors.StatusError{ErrStatus:v1.Status{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ListMeta:v1.ListMeta{SelfLink:"", ResourceVersion:"", Continue:"", RemainingItemCount:(*int64)(nil)}, Status:"Failure", Message:"admission webhook \"validation.cluster.anywhere.amazonaws.com\" denied the request: Cluster.anywhere.eks.amazonaws.com \"psv2-cdp-dev\" is invalid: spec.kubernetesVersion: Forbidden: field is immutable 1.27", Reason:"Invalid", Details:(*v1.StatusDetails)(0xc015c02360), Code:422}}
```

In the cluster web-hook, we skip the [immutable field validations](https://github.com/aws/eks-anywhere/blob/79c297c4d012ba29fea1770e69546fc563cf10af/pkg/api/v1alpha1/cluster_webhook.go#L251) when the Cluster resource has the paused annotation. In this case, after investigating, we saw that the user's `Cluster` object resource in etcd did not have the `paused` annotation when retrieved at the point of failure.

Upon further testing, the upgrade under the conditions described by the user succeeds, so we can conclude that the cause of the failure here was for some reason their cluster did not have the expected paused annotation. However, with the use of force apply operation was attempting to be delete the Cluster object which could have had unintended effects since  did not have reconciliation paused for some reason.

**Solution**

So, in the case management clusters the force apply mechanism is broken completely, and if encountered a validation error would never accomplish it's purpose, stalling and then timing out eventually with a vague error. For workload clusters, there may be a situation where we are unexpectedly bypassing a valid web-hook validation as described in case 2 above. Instead of force applying the `Cluster` spec resources, we should update the code to do a regular `kubectl apply`  instead of a `kubectl apply --force` of the Cluster spec resources and bubble up any errors that result. This would be better for simply debugging and identifying validations that should be skipped in the web-hooks when cluster reconciliation is paused earlier. Moreover, this is the approach we currently take when validating the `cluster`,  `machineconfig` and `datacenterconfig` objects against updates in their respective web-hooks across all providers. So, allowing the error to bubble up should not have no or little impact on the current state of things.

For workload clusters, the controller would [remove the finalizer](https://github.com/aws/eks-anywhere/blob/4c752b8ceb56e3489065435d82ea515b12bb5ede/controllers/cluster_controller.go#L477) when the cluster is managed by the CLI. If reconciliation is paused for the cluster after the deletion, the rest of the reconciliation process is [short circuited](https://github.com/aws/eks-anywhere/blob/4c752b8ceb56e3489065435d82ea515b12bb5ede/controllers/cluster_controller.go#L274). During the upgrade process, we pause the reconciliation on the cluster object, so at this point there should be no side-effects those things considered. However, this may still undesirable because it effectively ignores web-hook errors which may be valid instead of properly handling them.

In the event, that there is an immutable field validation that is currently not being skipped in the web-hook when cluster reconciliation is paused or handled properly otherwise, then we would have to address it or add fixes to the webhooks to skip the validations when the cluster object is paused for reconciliation if not already.

*Testing (if applicable):*
- Running a few e2e upgrade tests across the providers. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

