### PR TITLE
cli validate cluster name in cmd and config

### DIFF
--- a/pkg/validations/input.go
+++ b/pkg/validations/input.go
@@ -2,6 +2,7 @@ package validations
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -30,4 +31,18 @@ func FileExists(filename string) bool {
 func FileExistsAndIsNotEmpty(filename string) bool {
 	info, err := os.Stat(filename)
 	return err == nil && info.Size() > 0
+}
+
+// ValidateClusterNameFromCommandAndConfig validates if cluster name provided in command matches with cluster name in config file.
+func ValidateClusterNameFromCommandAndConfig(args []string, clusterNameConfig string) error {
+	if len(args) != 0 {
+		clusterNameCli, err := ValidateClusterNameArg(args)
+		if err != nil {
+			return fmt.Errorf("please provide a valid <cluster-name>")
+		}
+		if clusterNameCli != clusterNameConfig {
+			return fmt.Errorf("please make sure cluster name provided in command matches with cluster name in config file")
+		}
+	}
+	return nil
 }

--- a/pkg/validations/input_test.go
+++ b/pkg/validations/input_test.go
@@ -111,3 +111,46 @@ func TestValidateClusterNameArg(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateClusterNameFromCommandAndConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		clusterNameConfig string
+		expectedError     error
+	}{
+		{
+			name:              "Success cluster name match",
+			args:              []string{"test-cluster"},
+			clusterNameConfig: "test-cluster",
+			expectedError:     nil,
+		},
+		{
+			name:              "Success empty Arguments",
+			args:              []string{},
+			clusterNameConfig: "test-cluster",
+			expectedError:     nil,
+		},
+		{
+			name:              "Failure invalid cluster name",
+			args:              []string{"123test-Cluster"},
+			clusterNameConfig: "test-cluster",
+			expectedError:     errors.New("please provide a valid <cluster-name>"),
+		},
+		{
+			name:              "Failure cluster name not match",
+			args:              []string{"test-cluster-1"},
+			clusterNameConfig: "test-cluster",
+			expectedError:     errors.New("please make sure cluster name provided in command matches with cluster name in config file"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			gotError := validations.ValidateClusterNameFromCommandAndConfig(tc.args, tc.clusterNameConfig)
+			if !reflect.DeepEqual(tc.expectedError, gotError) {
+				t.Errorf("\n%v got Error = %v, want Error %v", tc.name, gotError, tc.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/6716

*Description of changes:*
add validation checking cluster name provided in command matches with config

*Testing (if applicable):*
unit test

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

