### PR TITLE
Strip comments from ssh key from the controller using mutating webhook

### DIFF
--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -45,6 +45,8 @@ var _ webhook.Defaulter = &TinkerbellMachineConfig{}
 func (r *TinkerbellMachineConfig) Default() {
 	tinkerbellmachineconfiglog.Info("Setting up Tinkerbell Machine Config defaults", klog.KObj(r))
 	r.SetDefaults()
+	tinkerbellmachineconfiglog.Info("Normalize SSHKeys by removing comments from the keys", klog.KObj(r))
+	normalizeSSHKeys(r)
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
@@ -1,6 +1,7 @@
 package v1alpha1_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -147,6 +148,38 @@ func TestTinkerbellMachineConfigDefaultOSFamily(t *testing.T) {
 	mOld.Default()
 	g := NewWithT(t)
 	g.Expect(mOld.Spec.OSFamily).To(Equal(v1alpha1.Bottlerocket))
+}
+
+func TestTinkerbellMachineConfigMutateSSHKey(t *testing.T) {
+	sshKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGuWn+GtgUe/g85l4SqSsGCV56CXZzqktKX/hYAl7MwO"
+	mOld := v1alpha1.CreateTinkerbellMachineConfig(func(mc *v1alpha1.TinkerbellMachineConfig) {
+		mc.Spec.Users = []v1alpha1.UserConfiguration{
+			{
+				Name:              "user",
+				SshAuthorizedKeys: []string{fmt.Sprintf("%s abc@xyz.com", sshKey)},
+			},
+		}
+	})
+
+	mOld.Default()
+	g := NewWithT(t)
+	g.Expect(mOld.Spec.Users[0].SshAuthorizedKeys[0]).To(Equal(sshKey))
+}
+
+func TestTinkerbellMachineConfigMutateSSHKeyNotMutated(t *testing.T) {
+	sshKey := "ssh incorrect Key abc@xyz.com"
+	mOld := v1alpha1.CreateTinkerbellMachineConfig(func(mc *v1alpha1.TinkerbellMachineConfig) {
+		mc.Spec.Users = []v1alpha1.UserConfiguration{
+			{
+				Name:              "user",
+				SshAuthorizedKeys: []string{sshKey},
+			},
+		}
+	})
+
+	mOld.Default()
+	g := NewWithT(t)
+	g.Expect(mOld.Spec.Users[0].SshAuthorizedKeys[0]).To(Equal(sshKey))
 }
 
 func TestTinkerbellMachineConfigValidateUpdateFailUsers(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
We srtip the comments for tinkerbell cluster create and upgrade operations using CLI. If the `sshAuthorizedKey` is something like `ssh AAAAC3NzaC1lZD abc@xyz.com` we strip the comment portion and make it `ssh AAAAC3NzaC1lZD`. We did not implement this feature for eksa controller. This PR adds the same feature for controller using mutating webhook. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

