### PR TITLE
Update Github organization for eksctl repository

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -67,7 +67,7 @@ Install the latest release of `eksctl`.
 The EKS Anywhere plugin requires `eksctl` version 0.66.0 or newer.
 
 ```bash
-curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
+curl "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
     --silent --location \
     | tar xz -C /tmp
 sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl


### PR DESCRIPTION
`eksctl` has now moved to a new GitHub Organisation so updating docs to reflect that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

