### PR TITLE
Added an additional check to make sure etcdadm and capi clusters are available

### DIFF
--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -48,6 +48,9 @@ const (
 	// RollingUpgradeInProgress reports the Cluster is executing a rolling upgrading to align the nodes to
 	// a new desired machine spec.
 	RollingUpgradeInProgress = "RollingUpgradeInProgress"
+
+	// ExternalEtcdNotAvailable reports the Cluster status is waiting for Etcd to be available.
+	ExternalEtcdNotAvailable = "ExternalEtcdNotAvailable"
 )
 
 const (


### PR DESCRIPTION
*Description of changes:*
We are having an issue in creating workload cluster using the controller if external Etcd is configured on the workload cluster. It used to fail with `failed calling webhook "mutation.vspheremachineconfig.anywhere.amazonaws.com` error. This issue happens because reconciler tries to get the CAPI cluster before the CAPI cluster becomes available for the workload cluster.
Added additional checks to make sure CAPI cluster are Etcdadm cluster are available before moving to check if the etcd machines are available or not.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

