### PR TITLE
Enable kindless upgrade management feature for baremetal

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -120,7 +120,7 @@ func NewClusterE2ETest(t T, provider Provider, opts ...ClusterE2ETestOpt) *Clust
 
 	// For kindless management upgrade task
 	// Remove this once we remove feature flag for ExpSelfManagedAPIUpgrade.
-	if provider.Name() == constants.VSphereProviderName || provider.Name() == constants.CloudStackProviderName {
+	if provider.Name() == constants.VSphereProviderName || provider.Name() == constants.CloudStackProviderName || provider.Name() == constants.TinkerbellProviderName {
 		opts = append(opts, WithEnvVar(features.ExperimentalSelfManagedClusterUpgradeGate, "true"))
 		opts = append(opts, WithEnvVar(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true"))
 	}


### PR DESCRIPTION
*Description of changes:*
Enable kindless upgrade management test for baremetal provider.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

