### PR TITLE
Remove patch for bundlesRef and ClusterSpecGenerate struct

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -49,7 +49,7 @@ func NewClusterGenerate(clusterName string, opts ...ClusterGenerateOpt) *Cluster
 		ObjectMeta: ObjectMeta{
 			Name: clusterName,
 		},
-		Spec: ClusterSpecGenerate{
+		Spec: ClusterSpec{
 			KubernetesVersion: GetClusterDefaultKubernetesVersion(),
 			ClusterNetwork: ClusterNetwork{
 				Pods: Pods{

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -74,36 +74,6 @@ type ClusterSpec struct {
 	EtcdEncryption     *[]EtcdEncryption   `json:"etcdEncryption,omitempty"`
 }
 
-// ClusterSpecGenerate is the same as ClusterSpec except for removing the omitempty tag from BundlesRef.
-// TODO: We needed this specifically such that we could generate a yaml with bundlesRef null so that it would
-// not be omitted from the kubeapi-server. There was an issue where the apply ekas yaml resources step when
-// upgrading from the latest minor release with gitps v0.16.2 to v0.17, where the newly added eksaVersion field
-// and the bundlesRef should were both populated in submission to the kubeapi server, though bundlesRef was nil
-// in the initially applied Cluster spec. After addressing that issue, we should clean this up
-// https://github.com/aws/eks-anywhere-internal/issues/1611
-// +kubebuilder:object:generate=false
-type ClusterSpecGenerate struct {
-	KubernetesVersion             KubernetesVersion              `json:"kubernetesVersion,omitempty"`
-	ControlPlaneConfiguration     ControlPlaneConfiguration      `json:"controlPlaneConfiguration,omitempty"`
-	WorkerNodeGroupConfigurations []WorkerNodeGroupConfiguration `json:"workerNodeGroupConfigurations,omitempty"`
-	DatacenterRef                 Ref                            `json:"datacenterRef,omitempty"`
-	IdentityProviderRefs          []Ref                          `json:"identityProviderRefs,omitempty"`
-	GitOpsRef                     *Ref                           `json:"gitOpsRef,omitempty"`
-	ClusterNetwork                ClusterNetwork                 `json:"clusterNetwork,omitempty"`
-	// +kubebuilder:validation:Optional
-	ExternalEtcdConfiguration   *ExternalEtcdConfiguration   `json:"externalEtcdConfiguration,omitempty"`
-	ProxyConfiguration          *ProxyConfiguration          `json:"proxyConfiguration,omitempty"`
-	RegistryMirrorConfiguration *RegistryMirrorConfiguration `json:"registryMirrorConfiguration,omitempty"`
-	ManagementCluster           ManagementCluster            `json:"managementCluster,omitempty"`
-	PodIAMConfig                *PodIAMConfig                `json:"podIamConfig,omitempty"`
-	Packages                    *PackageConfiguration        `json:"packages,omitempty"`
-	// BundlesRef contains a reference to the Bundles containing the desired dependencies for the cluster.
-	// DEPRECATED: Use EksaVersion instead.
-	BundlesRef         *BundlesRef         `json:"bundlesRef"`
-	EksaVersion        *EksaVersion        `json:"eksaVersion,omitempty"`
-	MachineHealthCheck *MachineHealthCheck `json:"machineHealthCheck,omitempty"`
-}
-
 // EksaVersion is the semver identifying the release of eks-a used to populate the cluster components.
 type EksaVersion string
 
@@ -1258,7 +1228,7 @@ type ClusterGenerate struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      `json:"metadata,omitempty"`
 
-	Spec ClusterSpecGenerate `json:"spec,omitempty"`
+	Spec ClusterSpec `json:"spec,omitempty"`
 }
 
 func (c *Cluster) Kind() string {
@@ -1419,7 +1389,7 @@ func (c *Cluster) ConvertConfigToConfigGenerateStruct() *ClusterGenerate {
 			Annotations: c.Annotations,
 			Namespace:   namespace,
 		},
-		Spec: ClusterSpecGenerate{
+		Spec: ClusterSpec{
 			KubernetesVersion:             c.Spec.KubernetesVersion,
 			ControlPlaneConfiguration:     c.Spec.ControlPlaneConfiguration,
 			WorkerNodeGroupConfigurations: c.Spec.WorkerNodeGroupConfigurations,

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -3104,7 +3104,7 @@ func TestCluster_ConvertConfigToConfigGenerateStruct(t *testing.T) {
 			Annotations: testCluster.Annotations,
 			Namespace:   testCluster.Namespace,
 		},
-		Spec: v1alpha1.ClusterSpecGenerate{
+		Spec: v1alpha1.ClusterSpec{
 			KubernetesVersion:             testCluster.Spec.KubernetesVersion,
 			ControlPlaneConfiguration:     testCluster.Spec.ControlPlaneConfiguration,
 			WorkerNodeGroupConfigurations: testCluster.Spec.WorkerNodeGroupConfigurations,

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mycluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mycluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mycluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_snow.yaml
@@ -4,7 +4,6 @@ metadata:
   name: testcluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     pods: {}
     services: {}

--- a/pkg/gitops/flux/files_test.go
+++ b/pkg/gitops/flux/files_test.go
@@ -23,7 +23,6 @@ metadata:
   name: test-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-default-path-management.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-default-path-management.yaml
@@ -4,7 +4,6 @@ metadata:
   name: management-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-default-path-workload.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-default-path-workload.yaml
@@ -6,7 +6,6 @@ metadata:
   name: workload-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}

--- a/pkg/gitops/flux/testdata/cluster-config-user-provided-path.yaml
+++ b/pkg/gitops/flux/testdata/cluster-config-user-provided-path.yaml
@@ -4,7 +4,6 @@ metadata:
   name: management-cluster
   namespace: default
 spec:
-  bundlesRef: null
   clusterNetwork:
     cniConfig: {}
     pods: {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR removes a patch that substitutes the ClusterSpec with a ClusterSpecGenerate so that the bundlesRef field on the would not use `omitempty` on it's JSON tag. This patch is no longer needed, the following was why it was added before.

There was an issue when upgrading from the latest minor release with gitops to v0.17 during the "Applying eksa yaml resources to cluster" step stalled indefinitely. This seems to happen when there is a web-hook validation error, triggering the `k --force apply` to delete the Cluster resource.

In this case, ghough the Cluster object that was force applied was valid with the `eksaVersion` specified and no  `bundlesRef` set, it was trying to do that 3 way strategic merge and added the old `bundlesRef` to the new spec as well. However, there is a web-hook validation that does not allow both to be set at the same time, so that was throwing an error in the `kube-apiserver` pod. Normally, the `k --force apply` would delete the resource and just recreate it, but instead it the CLI gets stuck. We patched this issue by creating `ClusterSpecGenerate` so that we could generate a yaml where `bundlesRef` null so that it would not be omitted when submitted to the `kube-apiserver`.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

