### PR TITLE
OCI namespaces docs addition/clarification

### DIFF
--- a/docs/content/en/docs/getting-started/optional/registrymirror.md
+++ b/docs/content/en/docs/getting-started/optional/registrymirror.md
@@ -53,7 +53,7 @@ spec:
 * __Example__: ```port: 443```
 
 ### __ociNamespaces__ (optional)
-* __Description__: when you need to mirror multiple registries, you can map each upstream registry to the "namespace" of its mirror.
+* __Description__: when you need to mirror multiple registries, you can map each upstream registry to the "namespace" of its mirror. While using the `ociNamespaces`, at least one entry __must__ exist for the `public.ecr.aws` registry to pull EKS Anywhere images from. The registry for curated packages is an optional entry. 
 * __Type__: array
 * __Example__: <br/>
   ```yaml


### PR DESCRIPTION
*Issue #, if available:*
#6418 
*Description of changes:*
OCI namespaces docs addition/clarification on having at least one entry for public.ecr.aws
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

