### PR TITLE
Update e2e constants kubeVersion to remove 1.23 and add 1.28

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -48,5 +48,5 @@ const (
 
 var (
 	EksaPackageControllerHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
-	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube123, v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127}
+	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127, v1alpha1.Kube128}
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the e2e `kubeVersions` constant to remove 1.23 and add 1.28 to match current supported k8s versions.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

