### PR TITLE
Add template name and k8s version check for all cloudstack machines

### DIFF
--- a/pkg/providers/cloudstack/validator.go
+++ b/pkg/providers/cloudstack/validator.go
@@ -118,7 +118,7 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, clusterSp
 		return fmt.Errorf("cannot find CloudStackMachineConfig %v for control plane", clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
 	}
 
-	// validate template field of each CloudStackMachineConfigs with the cluster spec kubernetes version.
+	// validate template field name contains cluster kubernetes version for the control plane machine.
 	if err := v.validateTemplateMatchesKubernetesVersion(ctx, controlPlaneMachineConfig.Spec.Template.Name, string(clusterSpec.Cluster.Spec.KubernetesVersion)); err != nil {
 		return fmt.Errorf("machine config %s validation failed: %v", controlPlaneMachineConfig.Name, err)
 	}
@@ -127,6 +127,10 @@ func (v *Validator) ValidateClusterMachineConfigs(ctx context.Context, clusterSp
 		etcdMachineConfig := etcdMachineConfig(clusterSpec)
 		if etcdMachineConfig == nil {
 			return fmt.Errorf("cannot find CloudStackMachineConfig %v for etcd machines", clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.MachineGroupRef.Name)
+		}
+		// validate template field name contains cluster kubernetes version for the external etcd machine.
+		if err := v.validateTemplateMatchesKubernetesVersion(ctx, etcdMachineConfig.Spec.Template.Name, string(clusterSpec.Cluster.Spec.KubernetesVersion)); err != nil {
+			return fmt.Errorf("machine config %s validation failed: %v", etcdMachineConfig.Name, err)
 		}
 	}
 

--- a/pkg/providers/cloudstack/validator_test.go
+++ b/pkg/providers/cloudstack/validator_test.go
@@ -320,6 +320,34 @@ func TestValidateClusterMachineConfigsError(t *testing.T) {
 	}
 }
 
+func TestValidateClusterMachineConfigsCPError(t *testing.T) {
+	ctx := context.Background()
+	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
+	clusterSpec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
+	clusterSpec.CloudStackMachineConfigs["test-cp"].Spec.Template.Name = "kubernetes_1_22"
+
+	validator := NewValidator(cmk, &DummyNetClient{}, true)
+
+	err := validator.ValidateClusterMachineConfigs(ctx, clusterSpec)
+	if err == nil {
+		t.Fatalf("validation should not pass: %v", err)
+	}
+}
+
+func TestValidateClusterMachineConfigsEtcdError(t *testing.T) {
+	ctx := context.Background()
+	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))
+	clusterSpec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
+	clusterSpec.CloudStackMachineConfigs["test-etcd"].Spec.Template.Name = "kubernetes_1_22"
+
+	validator := NewValidator(cmk, &DummyNetClient{}, true)
+
+	err := validator.ValidateClusterMachineConfigs(ctx, clusterSpec)
+	if err == nil {
+		t.Fatalf("validation should not pass: %v", err)
+	}
+}
+
 func TestValidateClusterMachineConfigsModularUpgradeError(t *testing.T) {
 	ctx := context.Background()
 	cmk := mocks.NewMockProviderCmkClient(gomock.NewController(t))


### PR DESCRIPTION
*Description of changes:*
Template name field in each cloudstack machine object should contain Cluster object's kubernetes version and/or worker machine's kubernetes version.

Simple Upgrade:
- [x] Control plane machine's template name should contain cluster object's kubernetes version
- [x] External Etcd (if present) machine's template name should contain cluster object's kubernetes version
- [x] Worker machine's template name should contain cluster object's kubernetes version

Modular Upgrade: 
- [x] Control plane machine's template name should contain cluster object's kubernetes version
- [x] External Etcd (if present) machine's template name should contain cluster object's kubernetes version
- [x] Worker machine's template name should contain cluster object's kubernetes version _**or**_ Worker machine's template name should contain workerNodeGroupConfigurations's kubernetes version

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

