### PR TITLE
Fixup Autoscaler Tinkerbell Tests

### DIFF
--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -7,12 +7,28 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
+const (
+		autoscalerName = "cluster-autoscaler"
+		metricServerName = "metrics-server"
+		targetNamespace = "eksa-packages"
+)
+
 func runAutoscalerWithMetricsServerSimpleFlow(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(e *framework.ClusterE2ETest) {
-		autoscalerName := "cluster-autoscaler"
-		metricServerName := "metrics-server"
-		targetNamespace := "eksa-packages"
 		test.InstallAutoScalerWithMetricServer(targetNamespace)
 		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
 	})
+}
+
+func runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test *framework.ClusterE2ETest) {
+	test.GenerateHardwareConfig()
+	test.PowerOffHardware()
+	test.GenerateClusterConfig()
+	test.PowerOnHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.InstallAutoScalerWithMetricServer(targetNamespace)
+	test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
+	test.DeleteCluster()
+	test.PowerOffHardware()
+	test.ValidateHardwareDecommissioned()
 }

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -441,7 +441,7 @@ func TestTinkerbellKubernetes127UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes126UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
@@ -953,7 +953,7 @@ func TestTinkerbellKubernetes128UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
 // Single node

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2016,7 +2016,7 @@ func (e *ClusterE2ETest) CombinedAutoScalerMetricServerTest(autoscalerName, metr
 		e.T.Fatalf("Failed waiting for test workload deployent %s", err)
 	}
 
-	params := []string{"autoscale", "deployment", name, "--cpu-percent=50", "--min=1", "--max=20", "--kubeconfig", e.KubeconfigFilePath()}
+	params := []string{"autoscale", "deployment", name, "--cpu-percent=50", "--min=1", "--max=150", "--kubeconfig", e.KubeconfigFilePath()}
 	_, err = e.KubectlClient.ExecuteCommand(ctx, params...)
 	if err != nil {
 		e.T.Fatalf("Failed to autoscale deployent: %s", err)

--- a/test/framework/testdata/hpa_busybox.yaml
+++ b/test/framework/testdata/hpa_busybox.yaml
@@ -20,7 +20,7 @@ spec:
               cpu: 50m
             requests:
               cpu: 10m
-              memory: 500Mi
+              memory: 1000Mi
           command: ["sh", "-c"]
           args:
             - while [ 1 ]; do


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Previous tests succeeded locally because a hand-generated hardware.csv was present.
This change aligns the cluster autoscaler tinkerbell test with other existing tinkerbell
packages tests.

*Testing (if applicable):*
Manually ran `TestTinkerbellKubernetes128UbuntuCuratedPackagesClusterAutoscalerSimpleFlow` successfully.

*Documentation added/planned (if applicable):*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->