### PR TITLE
Remove supfluous context in `ForSpec()` func

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -176,7 +176,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		}
 	}
 
-	factory := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
+	factory := dependencies.ForSpec(clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -108,7 +108,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		return err
 	}
 
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
+	deps, err := dependencies.ForSpec(clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, nil).

--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -75,7 +75,7 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 		return nil, fmt.Errorf("unable to get cluster config from file: %v", err)
 	}
 
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+	deps, err := dependencies.ForSpec(clusterSpec).
 		WithProvider(clusterConfigPath, clusterSpec.Cluster, cc.skipIpCheck, gsbo.hardwareFileName, false, gsbo.tinkerbellBootstrapIP, map[string]bool{}, nil).
 		WithDiagnosticBundleFactory().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/supportbundle.go
+++ b/cmd/eksctl-anywhere/cmd/supportbundle.go
@@ -76,7 +76,7 @@ func (csbo *createSupportBundleOptions) createBundle(ctx context.Context, since,
 		return fmt.Errorf("unable to get cluster config from file: %v", err)
 	}
 
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+	deps, err := dependencies.ForSpec(clusterSpec).
 		WithProvider(csbo.fileName, clusterSpec.Cluster, cc.skipIpCheck, csbo.hardwareFileName, false, csbo.tinkerbellBootstrapIP, map[string]bool{}, nil).
 		WithDiagnosticBundleFactory().
 		Build(ctx)

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -141,7 +141,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command, args []strin
 		}
 	}
 
-	factory := dependencies.ForSpec(ctx, clusterSpec).WithExecutableMountDirs(dirs...).
+	factory := dependencies.ForSpec(clusterSpec).WithExecutableMountDirs(dirs...).
 		WithBootstrapper().
 		WithCliConfig(cliConfig).
 		WithClusterManager(clusterSpec.Cluster, clusterManagerTimeoutOpts).

--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -64,7 +64,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 		return err
 	}
 
-	deps, err := dependencies.ForSpec(ctx, newClusterSpec).
+	deps, err := dependencies.ForSpec(newClusterSpec).
 		WithClusterManager(newClusterSpec.Cluster, nil).
 		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP, map[string]bool{}, uc.providerOptions).
 		WithGitOpsFlux(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).

--- a/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
+++ b/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
@@ -79,7 +79,7 @@ func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []str
 	if err != nil {
 		return err
 	}
-	deps, err := dependencies.ForSpec(ctx, clusterSpec).
+	deps, err := dependencies.ForSpec(clusterSpec).
 		WithExecutableMountDirs(dirs...).
 		WithWriterFolder(tmpPath).
 		WithDocker().

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -128,7 +128,8 @@ func (d *Dependencies) Close(ctx context.Context) error {
 	return nil
 }
 
-func ForSpec(ctx context.Context, clusterSpec *cluster.Spec) *Factory {
+// ForSpec constructs a Factory using the bundle referenced by clusterSpec.
+func ForSpec(clusterSpec *cluster.Spec) *Factory {
 	versionsBundle := clusterSpec.RootVersionsBundle()
 	eksaToolsImage := versionsBundle.Eksa.CliTools
 	return NewFactory().


### PR DESCRIPTION
Removes a superfluous use of `context.Context` when constructing the global factory data structure.