### PR TITLE
Add template name and uuid name check for Nutanix kindless feature

### DIFF
--- a/pkg/providers/nutanix/testdata/cluster_nutanix_with_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/cluster_nutanix_with_trust_bundle.yaml
@@ -82,7 +82,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"

--- a/pkg/providers/nutanix/testdata/cluster_nutanix_with_upgrade_strategy_cp.yaml
+++ b/pkg/providers/nutanix/testdata/cluster_nutanix_with_upgrade_strategy_cp.yaml
@@ -79,7 +79,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"

--- a/pkg/providers/nutanix/testdata/cluster_nutanix_with_upgrade_strategy_md.yaml
+++ b/pkg/providers/nutanix/testdata/cluster_nutanix_with_upgrade_strategy_md.yaml
@@ -79,7 +79,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"

--- a/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-pc.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-pc.yaml
@@ -60,7 +60,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-central"

--- a/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-random-name.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-invalid-pe-cluster-random-name.yaml
@@ -60,7 +60,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "non-existent-cluster"

--- a/pkg/providers/nutanix/testdata/eksa-cluster-multiple-machineconfigs.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-multiple-machineconfigs.yaml
@@ -65,7 +65,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"
@@ -90,7 +90,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"
@@ -115,7 +115,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"
@@ -128,3 +128,29 @@ spec:
     - name: "mySshUsername"
       sshAuthorizedKeys:
         - "mySshAuthorizedKey"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: eksa-unit-test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image-1-19"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"
+---

--- a/pkg/providers/nutanix/testdata/eksa-cluster.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster.yaml
@@ -60,7 +60,7 @@ spec:
   memorySize: 8Gi
   image:
     type: "name"
-    name: "prism-image"
+    name: "prism-image-1-19"
   cluster:
     type: "name"
     name: "prism-cluster"


### PR DESCRIPTION
*Description of changes:*
Add template name and uuid name check for Nutanix kindless management cluster upgrade feature. This is needed for kubernetes version upgrade where the controller waits until the template name matches the kubernetes version before reconciling the objects. 

We rely on the eksa-controller from now onwards to upgrade the management cluster using CLI. Sometimes it happens that during the kubernetes version upgrade, when we apply the cluster spec changes to the cluster, the cluster object gets upgraded and starts reconciling immediately before machineconfig gets upgraded and it might upgrade the cluster with previous machine config's image UUID or name. To avoid this issue, we have made it mandatory for the image name and image we get from the UUID to have the cluster kubernetes version and/or worker node kubernetes version(modular upgrade) kubernetes version in the name. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

