### PR TITLE
Fix multi templates e2e

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -1004,6 +1004,7 @@ func TestVSphereMultipleTemplatesUbuntu127(t *testing.T) {
 	)
 
 	test.WithClusterConfig(
+		provider.WithKubeVersionAndOS(v1alpha1.Kube127, framework.Ubuntu2204, nil),
 		provider.WithMachineTemplate(providers.GetControlPlaneNodeName(test.ClusterName), os.Getenv(framework.VSphereMultiTemplateUbuntu127)),
 		provider.WithMachineTemplate(providers.GetEtcdNodeName(test.ClusterName), os.Getenv(framework.VSphereMultiTemplateUbuntu127)),
 	)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This e2e previously didn't set the Kubernetes version of the cluster so it used the default of 1.28, but expected a 1.27 template.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

