### PR TITLE
Remove kindless upgrade feature flag for all the providers

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/aflag"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
@@ -195,8 +194,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command, args []strin
 
 	upgradeValidations := upgradevalidations.New(validationOpts)
 
-	if features.ExperimentalSelfManagedClusterUpgrade().IsActive() && clusterConfig.IsSelfManaged() {
-		logger.Info("Management kindless upgrade")
+	if clusterConfig.IsSelfManaged() {
 		upgrade := management.NewUpgrade(
 			deps.Provider,
 			deps.CAPIManager,

--- a/manager/main.go
+++ b/manager/main.go
@@ -168,14 +168,9 @@ func setupReconcilers(ctx context.Context, setupLog logr.Logger, mgr ctrl.Manage
 		os.Exit(1)
 	}
 
-	expUpgrades := features.IsActive(features.ExperimentalSelfManagedClusterUpgrade())
-	if expUpgrades {
-		setupLog.Info("[EXPERIMENTAL] Self-managed cluster upgrades enabled. Proceed with caution, this is not intended for production scenarios.")
-	}
-
 	factory := controllers.NewFactory(ctrl.Log, mgr).
 		WithClusterReconciler(
-			providers, controllers.WithExperimentalSelfManagedClusterUpgrades(expUpgrades),
+			providers,
 		).
 		WithVSphereDatacenterReconciler().
 		WithSnowMachineConfigReconciler().

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -10,8 +9,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	"github.com/aws/eks-anywhere/pkg/features"
 )
 
 // log is for logging in this package.
@@ -129,68 +126,6 @@ func validateImmutableFieldsVSphereMachineConfig(new, old *VSphereMachineConfig)
 	if !old.IsEtcd() && !old.IsControlPlane() {
 		vspheremachineconfiglog.Info("Machine config is associated with management cluster's worker nodes", "name", old.Name)
 		return allErrs
-	}
-
-	if features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
-		return allErrs
-	}
-
-	vspheremachineconfiglog.Info("Machine config is associated with management cluster's control plane or etcd", "name", old.Name)
-
-	if !reflect.DeepEqual(old.Spec.Users, new.Spec.Users) {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("users"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.Template != new.Spec.Template {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("template"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.Datastore != new.Spec.Datastore {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("datastore"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.Folder != new.Spec.Folder {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("folder"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.ResourcePool != new.Spec.ResourcePool {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("resourcePool"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.MemoryMiB != new.Spec.MemoryMiB {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("memoryMiB"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.NumCPUs != new.Spec.NumCPUs {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("numCPUs"), "field is immutable"),
-		)
-	}
-
-	if old.Spec.DiskGiB != new.Spec.DiskGiB {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(specPath.Child("diskGiB"), "field is immutable"),
-		)
 	}
 
 	return allErrs

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
-func TestManagementCPVSphereMachineValidateUpdateTemplateImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateTemplateMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.Template = "oldTemplate"
@@ -17,7 +17,7 @@ func TestManagementCPVSphereMachineValidateUpdateTemplateImmutable(t *testing.T)
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.template: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
@@ -53,7 +53,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing.T
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateTemplateImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateEtcdUpdateTemplateMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.Template = "oldTemplate"
@@ -61,7 +61,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateTemplateImmutable(t *testing.
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.template: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
@@ -87,7 +87,7 @@ func TestVSphereMachineValidateUpdateOSFamilyImmutable(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.osFamily: Forbidden: field is immutable")))
 }
 
-func TestManagementCPVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateMemoryMiBMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.MemoryMiB = 2
@@ -95,7 +95,7 @@ func TestManagementCPVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing.T
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.memoryMiB: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
@@ -140,7 +140,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.memoryMiB: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
@@ -155,7 +155,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) 
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementCPVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateNumCPUsMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.NumCPUs = 1
@@ -163,7 +163,7 @@ func TestManagementCPVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T) 
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.numCPUs: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
@@ -199,7 +199,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T)
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateUpdateNumCPUsMmutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.NumCPUs = 1
@@ -207,7 +207,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateNumCPUsImmutable(t *testing.T
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.numCPUs: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
@@ -222,7 +222,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementCPVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateDiskGiBMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.DiskGiB = 1
@@ -230,7 +230,7 @@ func TestManagementCPVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T) 
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.diskGiB: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
@@ -266,7 +266,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T)
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateUpdateDiskGiBMmutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.DiskGiB = 1
@@ -275,7 +275,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateDiskGiBImmutable(t *testing.T
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.diskGiB: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
@@ -290,7 +290,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementControlPlaneSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestManagementControlPlaneSphereMachineValidateUpdateSshAuthorizedKeyMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
@@ -299,10 +299,10 @@ func TestManagementControlPlaneSphereMachineValidateUpdateSshAuthorizedKeyImmuta
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.users: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.SetManagedBy("test-cluster")
@@ -323,10 +323,10 @@ func TestManagementControlPlaneVSphereMachineValidateUpdateSshUsernameImmutable(
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.users: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.SetManagedBy("test-cluster")
@@ -354,7 +354,7 @@ func TestVSphereMachineValidateUpdateWithPausedAnnotation(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestManagementEtcdSphereMachineValidateUpdateSshAuthorizedKeyMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
@@ -363,7 +363,7 @@ func TestManagementEtcdSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *t
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.users: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
@@ -379,7 +379,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *te
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.Users[0].Name = "Jeff"
@@ -387,10 +387,10 @@ func TestManagementEtcdVSphereMachineValidateUpdateSshUsernameImmutable(t *testi
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.users: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestWorkloadEtcdVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestWorkloadEtcdVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.SetManagedBy("test-cluster")
@@ -402,7 +402,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateSshUsernameImmutable(t *testing
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementWorkerNodeSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestManagementWorkerNodeSphereMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
 	vOld.Spec.Users[0].SshAuthorizedKeys = []string{"rsa-blahdeblahbalh"}
@@ -413,7 +413,7 @@ func TestManagementWorkerNodeSphereMachineValidateUpdateSshAuthorizedKeyImmutabl
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
+func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetManagedBy("test-cluster")
 	vOld.Spec.Users = []v1alpha1.UserConfiguration{{Name: "Jeff"}}
@@ -425,7 +425,7 @@ func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshAuthorizedKeyImmutable
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementWorkerNodeVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestManagementWorkerNodeVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.Spec.Users[0].Name = "Jeff"
 	c := vOld.DeepCopy()
@@ -435,7 +435,7 @@ func TestManagementWorkerNodeVSphereMachineValidateUpdateSshUsernameImmutable(t 
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
+func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetManagedBy("test-cluster")
 	vOld.Spec.Users[0].Name = "Jeff"
@@ -480,7 +480,7 @@ func TestVSphereMachineValidateUpdateBottleRocketInvalidUserName(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).ToNot(Succeed())
 }
 
-func TestManagementCPVSphereMachineValidateUpdateDatastoreImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateDatastoreMutableSuccess(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.Datastore = "OldDataStore"
@@ -488,7 +488,7 @@ func TestManagementCPVSphereMachineValidateUpdateDatastoreImmutable(t *testing.T
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.datastore: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
@@ -503,7 +503,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateDatastoreImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateUpdateDatastoreMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.Datastore = "OldDataStore"
@@ -511,7 +511,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateDatastoreImmutable(t *testing
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.datastore: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
@@ -547,7 +547,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateDatastoreSuccess(t *testing.
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementCPVSphereMachineValidateUpdateFolderImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateFolderMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.Folder = "/dev/null"
@@ -555,7 +555,7 @@ func TestManagementCPVSphereMachineValidateUpdateFolderImmutable(t *testing.T) {
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.folder: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
@@ -570,7 +570,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateFolderImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateUpdateFolderMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.Folder = "/dev/null"
@@ -578,7 +578,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateFolderImmutable(t *testing.T)
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.folder: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
@@ -614,7 +614,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateFolderSuccess(t *testing.T) 
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementCPVSphereMachineValidateUpdateResourcePoolImmutable(t *testing.T) {
+func TestManagementCPVSphereMachineValidateUpdateResourcePoolMutableManagemenmt(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetControlPlane()
 	vOld.Spec.ResourcePool = "AbovegroundPool"
@@ -622,7 +622,7 @@ func TestManagementCPVSphereMachineValidateUpdateResourcePoolImmutable(t *testin
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.resourcePool: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {
@@ -637,7 +637,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T)
 	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
-func TestManagementEtcdVSphereMachineValidateUpdateResourcePoolImmutable(t *testing.T) {
+func TestManagementEtcdVSphereMachineValidateUpdateResourcePoolMutableManagement(t *testing.T) {
 	vOld := vsphereMachineConfig()
 	vOld.SetEtcd()
 	vOld.Spec.ResourcePool = "AbovegroundPool"
@@ -645,7 +645,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateResourcePoolImmutable(t *test
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(&vOld)).To(MatchError(ContainSubstring("spec.resourcePool: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(&vOld)).To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {

--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -18,7 +18,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -163,13 +162,7 @@ func setManagerEnvVars(d *appsv1.Deployment, spec *cluster.Spec) {
 }
 
 func managerEnabledGates(spec *cluster.Spec) []string {
-	g := []string{}
-	// TODO(pjshah): remove this feature flag after we implement kindless upgrade managaement feature for all the providers.
-	if features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
-		g = append(g, features.ExperimentalSelfManagedClusterUpgradeGate)
-	}
-
-	return g
+	return nil
 }
 
 func fullLifeCycleControllerForProvider(cluster *anywherev1.Cluster) bool {

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -2,7 +2,6 @@ package clustermanager_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -214,21 +213,9 @@ func TestSetManagerFlags(t *testing.T) {
 			spec:       test.NewClusterSpec(),
 			want:       deployment(),
 		},
-		{
-			name:           "kindless upgrades, feature flag enabled",
-			deployment:     deployment(),
-			spec:           test.NewClusterSpec(),
-			featureEnvVars: []string{features.ExperimentalSelfManagedClusterUpgradeEnvVar},
-			want: deployment(func(d *appsv1.Deployment) {
-				d.Spec.Template.Spec.Containers[0].Args = []string{
-					"--feature-gates=ExpSelfManagedAPIUpgrade=true",
-				}
-			}),
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Unsetenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar)
 			features.ClearCache()
 			for _, e := range tt.featureEnvVars {
 				t.Setenv(e, "true")

--- a/pkg/controller/clusters/clusterapi.go
+++ b/pkg/controller/clusters/clusterapi.go
@@ -11,7 +11,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
 	"github.com/aws/eks-anywhere/pkg/controller"
-	"github.com/aws/eks-anywhere/pkg/features"
 )
 
 // CheckControlPlaneReady is a controller helper to check whether KCP object for
@@ -19,48 +18,27 @@ import (
 // due its signature and that it returns controller results with appropriate wait times whenever
 // the cluster is not ready.
 func CheckControlPlaneReady(ctx context.Context, client client.Client, log logr.Logger, cluster *anywherev1.Cluster) (controller.Result, error) {
-	if features.IsActive(features.ExperimentalSelfManagedClusterUpgrade()) {
-		kcp, err := controller.GetKubeadmControlPlane(ctx, client, cluster)
-		if err != nil {
-			return controller.Result{}, err
-		}
-
-		if kcp == nil {
-			log.Info("KCP does not exist yet, requeuing")
-			return controller.ResultWithRequeue(5 * time.Second), nil
-		}
-
-		// We make sure to check that the status is up to date before using it
-		if kcp.Status.ObservedGeneration != kcp.ObjectMeta.Generation {
-			log.Info("KCP information is outdated, requeing")
-			return controller.ResultWithRequeue(5 * time.Second), nil
-		}
-
-		if !conditions.IsTrue(kcp, clusterapi.ReadyCondition) {
-			log.Info("KCP is not ready yet, requeing")
-			return controller.ResultWithRequeue(30 * time.Second), nil
-		}
-
-		log.Info("KCP is ready")
-		return controller.Result{}, nil
-	}
-
-	capiCluster, err := controller.GetCAPICluster(ctx, client, cluster)
+	kcp, err := controller.GetKubeadmControlPlane(ctx, client, cluster)
 	if err != nil {
 		return controller.Result{}, err
 	}
 
-	if capiCluster == nil {
-		log.Info("CAPI cluster does not exist yet, requeuing")
+	if kcp == nil {
+		log.Info("KCP does not exist yet, requeuing")
 		return controller.ResultWithRequeue(5 * time.Second), nil
 	}
 
-	if !conditions.IsTrue(capiCluster, clusterapi.ControlPlaneReadyCondition) {
-		log.Info("CAPI control plane is not ready yet, requeuing")
-		// TODO: eventually this can be implemented with controller watches
+	// We make sure to check that the status is up to date before using it
+	if kcp.Status.ObservedGeneration != kcp.ObjectMeta.Generation {
+		log.Info("KCP information is outdated, requeing")
+		return controller.ResultWithRequeue(5 * time.Second), nil
+	}
+
+	if !conditions.IsTrue(kcp, clusterapi.ReadyCondition) {
+		log.Info("KCP is not ready yet, requeing")
 		return controller.ResultWithRequeue(30 * time.Second), nil
 	}
 
-	log.Info("CAPI control plane is ready")
+	log.Info("KCP is ready")
 	return controller.Result{}, nil
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -5,9 +5,6 @@ const (
 	CloudStackKubeVipDisabledEnvVar = "CLOUDSTACK_KUBE_VIP_DISABLED"
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
-
-	ExperimentalSelfManagedClusterUpgradeEnvVar = "EXP_SELF_MANAGED_API_UPGRADE"
-	ExperimentalSelfManagedClusterUpgradeGate   = "ExpSelfManagedAPIUpgrade"
 )
 
 func FeedGates(featureGates []string) {
@@ -26,17 +23,6 @@ func IsActive(feature Feature) bool {
 // ClearCache is mainly used for unit tests as of now.
 func ClearCache() {
 	globalFeatures.clearCache()
-}
-
-// ExperimentalSelfManagedClusterUpgrade allows self managed cluster upgrades through the API.
-func ExperimentalSelfManagedClusterUpgrade() Feature {
-	return Feature{
-		Name: "[EXPERIMENTAL] Upgrade self-managed clusters through the API",
-		IsActive: globalFeatures.isActiveForEnvVarOrGate(
-			ExperimentalSelfManagedClusterUpgradeEnvVar,
-			ExperimentalSelfManagedClusterUpgradeGate,
-		),
-	}
 }
 
 func CloudStackKubeVipDisabled() Feature {

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,10 +50,27 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	// We want to check that the cluster status is cleaned up if validations are passed
 	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 
-	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
-		c.Name = tt.cluster.Name
+	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+		kcp.Name = tt.cluster.Name
+		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
+			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
+				},
+			},
+		}
+		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Conditions: clusterv1.Conditions{
+				{
+					Type:               clusterapi.ReadyCondition,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			ObservedGeneration: 2,
+		}
 	})
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, kcp)
 	tt.createAllObjs()
 
 	logger := test.NewNullLogger()
@@ -66,7 +84,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	tt.govcClient.EXPECT().ListTags(tt.ctx).Return([]executables.Tag{}, nil)
 
 	tt.remoteClientRegistry.EXPECT().GetClient(
-		tt.ctx, client.ObjectKey{Name: "workload-cluster", Namespace: "eksa-system"},
+		tt.ctx, client.ObjectKey{Name: tt.cluster.Name, Namespace: "eksa-system"},
 	).Return(remoteClient, nil).Times(1)
 	tt.cniReconciler.EXPECT().Reconcile(tt.ctx, logger, remoteClient, tt.buildSpec())
 
@@ -167,17 +185,28 @@ func TestSetupEnvVars(t *testing.T) {
 
 func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 	tt := newReconcilerTest(t)
-	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
-		c.Name = tt.cluster.Name
+	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+		kcp.Name = tt.cluster.Name
+		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
+			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
+				},
+			},
+		}
+		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Conditions: clusterv1.Conditions{
+				{
+					Type:               clusterapi.ReadyCondition,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			ObservedGeneration: 2,
+		}
 	})
-	capiCluster.Status.Conditions = clusterv1.Conditions{
-		{
-			Type:               clusterapi.ControlPlaneReadyCondition,
-			Status:             corev1.ConditionFalse,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		},
-	}
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)
+
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, kcp)
 	tt.createAllObjs()
 
 	logger := test.NewNullLogger()
@@ -199,10 +228,9 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 
 func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
-	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
-	})
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster)
+	}))
 	tt.createAllObjs()
 
 	result, err := tt.reconciler().ReconcileWorkers(tt.ctx, test.NewNullLogger(), tt.buildSpec())
@@ -252,7 +280,7 @@ func TestReconcileCNISuccess(t *testing.T) {
 	spec := tt.buildSpec()
 
 	tt.remoteClientRegistry.EXPECT().GetClient(
-		tt.ctx, client.ObjectKey{Name: "workload-cluster", Namespace: "eksa-system"},
+		tt.ctx, client.ObjectKey{Name: tt.cluster.Name, Namespace: "eksa-system"},
 	).Return(remoteClient, nil)
 	tt.cniReconciler.EXPECT().Reconcile(tt.ctx, logger, remoteClient, spec)
 
@@ -272,7 +300,7 @@ func TestReconcileCNIErrorClientRegistry(t *testing.T) {
 	spec := tt.buildSpec()
 
 	tt.remoteClientRegistry.EXPECT().GetClient(
-		tt.ctx, client.ObjectKey{Name: "workload-cluster", Namespace: "eksa-system"},
+		tt.ctx, client.ObjectKey{Name: tt.cluster.Name, Namespace: "eksa-system"},
 	).Return(nil, errors.New("building client"))
 
 	result, err := tt.reconciler().ReconcileCNI(tt.ctx, logger, spec)
@@ -297,7 +325,7 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	tt.ShouldEventuallyExist(tt.ctx,
 		&addonsv1.ClusterResourceSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "workload-cluster-cpi",
+				Name:      tt.cluster.Name + "-cpi",
 				Namespace: "eksa-system",
 			},
 		},
@@ -306,7 +334,7 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	tt.ShouldEventuallyExist(tt.ctx,
 		&controlplanev1.KubeadmControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "workload-cluster",
+				Name:      tt.cluster.Name,
 				Namespace: "eksa-system",
 			},
 		},
@@ -315,20 +343,20 @@ func TestReconcilerReconcileControlPlaneSuccess(t *testing.T) {
 	tt.ShouldEventuallyExist(tt.ctx,
 		&vspherev1.VSphereMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "workload-cluster-control-plane-1",
+				Name:      tt.cluster.Name + "-control-plane-1",
 				Namespace: "eksa-system",
 			},
 		},
 	)
 
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
-		c.Name = "workload-cluster"
+		c.Name = tt.cluster.Name
 	})
 	tt.ShouldEventuallyExist(tt.ctx, capiCluster)
 
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cloud-controller-manager", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cloud-provider-vsphere-credentials", Namespace: "eksa-system"}})
-	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "workload-cluster-cpi-manifests", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tt.cluster.Name + "-cloud-controller-manager", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tt.cluster.Name + "-cloud-provider-vsphere-credentials", Namespace: "eksa-system"}})
+	tt.ShouldEventuallyExist(tt.ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: tt.cluster.Name + "-cpi-manifests", Namespace: "eksa-system"}})
 }
 
 type reconcilerTest struct {
@@ -397,7 +425,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 	})
 
 	cluster := test.Cluster(func(c *anywherev1.Cluster) {
-		c.Name = "workload-cluster"
+		c.Name = strings.ToLower(t.Name())
 		c.Namespace = clusterNamespace
 		c.Spec.ManagementCluster = anywherev1.ManagementCluster{
 			Name: managementCluster.Name,

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -278,7 +278,6 @@ func (c *upgradeManagementTestSetup) expectPreflightValidationsToPass() {
 func TestUpgradeManagementRunUpdateSetupFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetupToFail()
 	test.expectWriteCheckpointFile()
@@ -292,7 +291,6 @@ func TestUpgradeManagementRunUpdateSetupFailed(t *testing.T) {
 func TestUpgradeManagementRunUpdateSecretFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -309,7 +307,6 @@ func TestUpgradeManagementRunUpdateSecretFailed(t *testing.T) {
 func TestUpgradeManagementRunEnsureETCDFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -327,7 +324,6 @@ func TestUpgradeManagementRunEnsureETCDFailed(t *testing.T) {
 func TestUpgradeManagementRunPauseGitOpsReconcileUpgradeFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -346,7 +342,6 @@ func TestUpgradeManagementRunPauseGitOpsReconcileUpgradeFailed(t *testing.T) {
 func TestUpgradeManagementRunFailedBackup(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -368,7 +363,6 @@ func TestUpgradeManagementRunFailedBackup(t *testing.T) {
 func TestUpgradeManagementRunPauseWorkloadCAPIFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -390,7 +384,6 @@ func TestUpgradeManagementRunPauseWorkloadCAPIFailed(t *testing.T) {
 func TestUpgradeManagementRunFailedUpgradeInstallEksd(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -417,7 +410,6 @@ func TestUpgradeManagementRunFailedUpgradeInstallEksd(t *testing.T) {
 func TestUpgradeManagementRunFailedUpgradeApplyBundles(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -442,7 +434,6 @@ func TestUpgradeManagementRunFailedUpgradeApplyBundles(t *testing.T) {
 func TestUpgradeManagementRunFailedUpgradeApplyReleases(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -468,7 +459,6 @@ func TestUpgradeManagementRunFailedUpgradeApplyReleases(t *testing.T) {
 func TestUpgradeManagementRunFailedUpgrade(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -496,7 +486,6 @@ func TestUpgradeManagementRunFailedUpgrade(t *testing.T) {
 func TestUpgradeManagementRunResumeCAPIWorkloadFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -529,7 +518,6 @@ func TestUpgradeManagementRunResumeCAPIWorkloadFailed(t *testing.T) {
 func TestUpgradeManagementRunUpdateGitEksaSpecFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -558,7 +546,6 @@ func TestUpgradeManagementRunUpdateGitEksaSpecFailed(t *testing.T) {
 func TestUpgradeManagementRunForceReconcileGitRepoFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -588,7 +575,6 @@ func TestUpgradeManagementRunForceReconcileGitRepoFailed(t *testing.T) {
 func TestUpgradeManagementRunResumeClusterResourcesReconcileFailed(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -620,7 +606,6 @@ func TestUpgradeManagementRunResumeClusterResourcesReconcileFailed(t *testing.T)
 func TestUpgradeManagementRunSuccess(t *testing.T) {
 	os.Unsetenv(features.CheckpointEnabledEnvVar)
 	features.ClearCache()
-	t.Setenv(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true")
 	test := newUpgradeManagementClusterTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -119,11 +118,6 @@ func NewClusterE2ETest(t T, provider Provider, opts ...ClusterE2ETestOpt) *Clust
 		KubectlClient:         buildKubectl(t),
 		eksaBinaryLocation:    defaultEksaBinaryLocation,
 	}
-
-	// For kindless management upgrade task
-	// Remove this once we remove feature flag for ExpSelfManagedAPIUpgrade.
-	opts = append(opts, WithEnvVar(features.ExperimentalSelfManagedClusterUpgradeGate, "true"))
-	opts = append(opts, WithEnvVar(features.ExperimentalSelfManagedClusterUpgradeEnvVar, "true"))
 
 	for _, opt := range opts {
 		opt(e)


### PR DESCRIPTION
*Description of changes:*
Do not create a kind cluster to upgrade the management cluster of all the providers. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

