### PR TITLE
Clear Status on Docker Reconcile

### DIFF
--- a/pkg/providers/docker/reconciler/reconciler.go
+++ b/pkg/providers/docker/reconciler/reconciler.go
@@ -53,6 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, log logr.Logger, c *anywhere
 	}
 
 	return controller.NewPhaseRunner[*cluster.Spec]().Register(
+		clusters.CleanupStatusAfterValidate,
 		r.ReconcileControlPlane,
 		r.CheckControlPlaneReady,
 		r.ReconcileCNI,


### PR DESCRIPTION
*Issue #, if available:*
Installing flux on upgrade failed due to a transient error that never cleared for docker clusters. 

*Description of changes:*
Clears the status on docker clusters during reconcile. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

