### PR TITLE
Increase timeout to wait for cluster generations to be same

### DIFF
--- a/pkg/clustermanager/applier.go
+++ b/pkg/clustermanager/applier.go
@@ -20,7 +20,7 @@ const (
 	applyClusterSpecTimeout           = 2 * time.Minute
 	waitForClusterReconcileTimeout    = time.Hour
 	retryBackOff                      = time.Second
-	waitForFailureMessageErrorTimeout = time.Minute
+	waitForFailureMessageErrorTimeout = 10 * time.Minute
 	defaultFieldManager               = "eks-a-cli"
 	defaultConditionCheckTotalCount   = 20
 )


### PR DESCRIPTION
*Description of changes:*
For nutanix e2e tests, cluster controller takes some more time to reconcile generation and observered generation value and also takes some more time to reconcile cluster and machineconfig objects. Increased wait time to 10 minutes.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

