### PR TITLE
Fix latest minor version issue in docker skip cilium upgrade E2E

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -1166,16 +1165,7 @@ func TestDockerCiliumSkipUpgrade_CLICreate(t *testing.T) {
 }
 
 func TestDockerCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
-	release, err := framework.GetLatestMinorReleaseFromTestBranch()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ver, _ := semver.New(release.Version)
-	previousRelease, err := framework.GetPreviousMinorReleaseFromVersion(ver)
-	if err != nil {
-		t.Fatal(err)
-	}
+	previousRelease := prevLatestMinorRelease(t)
 
 	provider := framework.NewDocker(t)
 	test := framework.NewClusterE2ETest(t, provider,


### PR DESCRIPTION
Cilium Skip Upgrade tests fail when run against the release branch when the release isn't out already as it picks up the wrong latest minor version. Make the test to derive at the latest minor based on the test branch it is run against to rightly calculate the previous latest minor release.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

