### PR TITLE
Skip flaky TestReaderReadFileHTTPSProxySuccess

### DIFF
--- a/pkg/files/reader_test.go
+++ b/pkg/files/reader_test.go
@@ -96,6 +96,7 @@ func TestReaderReadFileHTTPSSuccess(t *testing.T) {
 }
 
 func TestReaderReadFileHTTPSProxySuccess(t *testing.T) {
+	t.Skip("Flaky test, needs work")
 	g := NewWithT(t)
 	filePath := "testdata/file.yaml"
 	// It's important to use example.com because the certificate created for


### PR DESCRIPTION
*Description of changes:*
If we don't get to fix this eventually (I already tried twice) we should probably just delete it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

