### PR TITLE
Use beta packages account public ECR as source registry for regional packages

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -249,7 +249,7 @@ func (pc *PackageControllerClient) GetCuratedPackagesRegistries(ctx context.Cont
 	if strings.Contains(pc.chart.Image(), stagingAccount) {
 		accountName = stagingAccount
 		defaultImageRegistry = packageProdDomain
-		sourceRegistry = stagingDevECR
+		sourceRegistry = publicStagingECR
 	}
 	defaultRegistry = sourceRegistry
 
@@ -270,6 +270,12 @@ func (pc *PackageControllerClient) GetCuratedPackagesRegistries(ctx context.Cont
 		if err := pc.registryAccessTester.Test(ctx, pc.eksaAccessKeyID, pc.eksaSecretAccessKey, pc.eksaRegion, pc.eksaAwsConfig, regionalRegistry); err == nil {
 			// use regional registry when the above credential is good
 			logger.V(6).Info("Using regional registry")
+			// In the dev case, we use a separate public ECR registry in the
+			// beta packages account to source the packages controller and
+			// credential provider package
+			if regionalRegistry == devRegionalECR {
+				sourceRegistry = devRegionalPublicECR
+			}
 			defaultRegistry = regionalRegistry
 			defaultImageRegistry = regionalRegistry
 		} else {

--- a/pkg/curatedpackages/reader.go
+++ b/pkg/curatedpackages/reader.go
@@ -22,7 +22,7 @@ const (
 	stagingAccount    = "w9m0f3l5"
 	publicProdECR     = "public.ecr.aws/" + prodAccount
 	publicDevECR      = "public.ecr.aws/" + devAccount
-	stagingDevECR     = "public.ecr.aws/" + stagingAccount
+	publicStagingECR  = "public.ecr.aws/" + stagingAccount
 	packageProdDomain = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
 	packageDevDomain  = "857151390494.dkr.ecr.us-west-2.amazonaws.com"
 )

--- a/pkg/curatedpackages/regional_registry.go
+++ b/pkg/curatedpackages/regional_registry.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	devRegionalECR     string = "067575901363.dkr.ecr.us-west-2.amazonaws.com"
-	stagingRegionalECR string = "TODO.dkr.ecr.us-west-2.amazonaws.com"
+	devRegionalECR       string = "067575901363.dkr.ecr.us-west-2.amazonaws.com"
+	devRegionalPublicECR string = "public.ecr.aws/x3k6m8v0"
+	stagingRegionalECR   string = "TODO.dkr.ecr.us-west-2.amazonaws.com"
 )
 
 var prodRegionalECRMap = map[string]string{


### PR DESCRIPTION
In the regional packages flow, we are using the eks-anywhere-packages, ecr-token-refresher and credential-provider-package from packages-beta public ECR account. So if access to regional registry is detected, then we need to set this public ECR as the sourceRegistry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

