### PR TITLE
Add tinkerbell specific framework flow for autoscaler e2e tests

### DIFF
--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -16,3 +16,14 @@ func runAutoscalerWithMetricsServerSimpleFlow(test *framework.ClusterE2ETest) {
 		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
 	})
 }
+
+func runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test *framework.ClusterE2ETest) {
+	test.GenerateClusterConfig()
+	test.GenerateHardwareConfig()
+	test.PowerOnHardware()
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	runAutoscalerWithMetricsServerSimpleFlow(test)
+	test.DeleteCluster()
+	test.PowerOffHardware()
+	test.ValidateHardwareDecommissioned()
+}

--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -22,7 +22,11 @@ func runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test *framework.ClusterE
 	test.GenerateHardwareConfig()
 	test.PowerOnHardware()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	autoscalerName := "cluster-autoscaler"
+	metricServerName := "metrics-server"
+	targetNamespace := "eksa-packages"
+	test.InstallAutoScalerWithMetricServer(targetNamespace)
+	test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
 	test.DeleteCluster()
 	test.PowerOffHardware()
 	test.ValidateHardwareDecommissioned()

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -489,7 +489,7 @@ func TestTinkerbellKubernetes127UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
 func TestTinkerbellKubernetes126UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
@@ -1001,7 +1001,7 @@ func TestTinkerbellKubernetes128UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
 	)
-	runAutoscalerWithMetricsServerSimpleFlow(test)
+	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
 // Single node


### PR DESCRIPTION
*Issue #, if available:*
Tinkerbell Autoscaler tests use the common framework function used by other providers that does not cater to tinkerbell specific pre-requisites like generating hardware config. Add tinkerbell specific framework flow for autoscale tests.

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

