### PR TITLE
Issue 6985: Bare metal upgrade should honor the TinkerbellDatacenterC…

### DIFF
--- a/pkg/providers/tinkerbell/stack/mocks/stack.go
+++ b/pkg/providers/tinkerbell/stack/mocks/stack.go
@@ -252,15 +252,20 @@ func (mr *MockStackInstallerMockRecorder) UninstallLocal(ctx interface{}) *gomoc
 }
 
 // Upgrade mocks base method.
-func (m *MockStackInstaller) Upgrade(arg0 context.Context, arg1 v1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string) error {
+func (m *MockStackInstaller) Upgrade(arg0 context.Context, arg1 v1alpha1.TinkerbellBundle, tinkerbellIP, kubeconfig, hookOverride string, opts ...stack.InstallOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, tinkerbellIP, kubeconfig, hookOverride)
+	varargs := []interface{}{arg0, arg1, tinkerbellIP, kubeconfig, hookOverride}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Upgrade", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockStackInstallerMockRecorder) Upgrade(arg0, arg1, tinkerbellIP, kubeconfig, hookOverride interface{}) *gomock.Call {
+func (mr *MockStackInstallerMockRecorder) Upgrade(arg0, arg1, tinkerbellIP, kubeconfig, hookOverride interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockStackInstaller)(nil).Upgrade), arg0, arg1, tinkerbellIP, kubeconfig, hookOverride)
+	varargs := append([]interface{}{arg0, arg1, tinkerbellIP, kubeconfig, hookOverride}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockStackInstaller)(nil).Upgrade), varargs...)
 }

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -21,6 +21,7 @@ hegel:
     value: 192.168.0.0/16
   image: public.ecr.aws/eks-anywhere/hegel:latest
 kubevip:
+  deploy: false
   image: public.ecr.aws/eks-anywhere/kube-vip:latest
 namespace: eksa-system
 rufio:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -22,6 +22,7 @@ hegel:
     value: 192.168.0.0/16
   image: public.ecr.aws/eks-anywhere/hegel:latest
 kubevip:
+  deploy: false
   image: public.ecr.aws/eks-anywhere/kube-vip:latest
 namespace: eksa-system
 rufio:

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/rufiounreleased"
+	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/stack"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/utils/yaml"
 )
@@ -456,6 +457,9 @@ func (p *Provider) PreCoreComponentsUpgrade(
 		p.datacenterConfig.Spec.TinkerbellIP,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
+		stack.WithLoadBalancerEnabled(
+			len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations) != 0 && // load balancer is handled by kube-vip in control plane nodes
+				!p.datacenterConfig.Spec.SkipLoadBalancerDeployment), // configure load balancer based on datacenterConfig.Spec.SkipLoadBalancerDeployment
 	)
 	if err != nil {
 		return fmt.Errorf("upgrading stack: %v", err)

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -82,6 +82,7 @@ func TestProviderPreCoreComponentsUpgrade_StackUpgradeError(t *testing.T) {
 			tconfig.DatacenterConfig.Spec.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
 			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
+			gomock.Any(),
 		).
 		Return(errors.New(expect))
 
@@ -108,6 +109,7 @@ func TestProviderPreCoreComponentsUpgrade_HasBaseboardManagementCRDError(t *test
 			tconfig.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
 			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
+			gomock.Any(),
 		).
 		Return(nil)
 
@@ -143,6 +145,7 @@ func TestProviderPreCoreComponentsUpgrade_NoBaseboardManagementCRD(t *testing.T)
 			tconfig.TinkerbellIP,
 			tconfig.Management.KubeconfigFile,
 			tconfig.DatacenterConfig.Spec.HookImagesURLPath,
+			gomock.Any(),
 		).
 		Return(nil)
 
@@ -454,6 +457,7 @@ func TestProviderPreCoreComponentsUpgrade_RufioConversions(t *testing.T) {
 					tconfig.DatacenterConfig.Spec.TinkerbellIP,
 					tconfig.Management.KubeconfigFile,
 					tconfig.DatacenterConfig.Spec.HookImagesURLPath,
+					gomock.Any(),
 				).
 				Return(nil)
 			tconfig.KubeClient.EXPECT().
@@ -624,6 +628,7 @@ func (t *PreCoreComponentsUpgradeTestConfig) WithStackUpgrade() *PreCoreComponen
 			t.TinkerbellIP,
 			t.Management.KubeconfigFile,
 			t.DatacenterConfig.Spec.HookImagesURLPath,
+			gomock.Any(),
 		).
 		Return(nil)
 	t.KubeClient.EXPECT().


### PR DESCRIPTION
…onfig.skipLoadBalancerDeployment config value

*Issue 6985:*
https://github.com/aws/eks-anywhere/issues/6985

*Description of changes:*
Ensures the value of `TinkerbellDatacenterConfig.skipLoadBalancerDeployment` is honored when upgrading a bare metal cluster.  If set to `true` then `kube-vip` should not be installed.

*Testing (if applicable):*
Covered by existing and built the local binary and ran for our clusters and worked as expected

*Documentation added/planned (if applicable):*
Already documented in the bare metal configuration options

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

