### PR TITLE
Make kcp and object of reconciler struct for different provider unit test

### DIFF
--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -48,27 +48,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	// We want to check that the cluster status is cleaned up if validations are passed
 	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 
-	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-		kcp.Name = tt.cluster.Name
-		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
-			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
-				InfrastructureRef: corev1.ObjectReference{
-					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
-				},
-			},
-		}
-		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
-			Conditions: clusterv1.Conditions{
-				{
-					Type:               clusterapi.ReadyCondition,
-					Status:             corev1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(time.Now()),
-				},
-			},
-			ObservedGeneration: 2,
-		}
-	})
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.secret, kcp)
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.secret, tt.kcp)
 	tt.createAllObjs()
 
 	logger := test.NewNullLogger()
@@ -198,27 +178,17 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 
 	tt := newReconcilerTest(t)
 
-	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-		kcp.Name = tt.cluster.Name
-		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
-			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
-				InfrastructureRef: corev1.ObjectReference{
-					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
-				},
+	tt.kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+		Conditions: clusterv1.Conditions{
+			{
+				Type:               clusterapi.ReadyCondition,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(time.Now()),
 			},
-		}
-		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
-			Conditions: clusterv1.Conditions{
-				{
-					Type:               clusterapi.ReadyCondition,
-					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(time.Now()),
-				},
-			},
-			ObservedGeneration: 2,
-		}
-	})
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, kcp, tt.secret)
+		},
+		ObservedGeneration: 2,
+	}
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.kcp, tt.secret)
 	tt.createAllObjs()
 
 	logger := test.NewNullLogger()
@@ -572,6 +542,7 @@ type reconcilerTest struct {
 	validatorRegistry         *cloudstack.MockValidatorRegistry
 	execConfig                *decoder.CloudStackExecConfig
 	secret                    *corev1.Secret
+	kcp                       *controlplanev1.KubeadmControlPlane
 }
 
 func newReconcilerTest(t testing.TB) *reconcilerTest {
@@ -676,6 +647,28 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 
 		c.Spec.EksaVersion = &version
 	})
+
+	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+		kcp.Name = cluster.Name
+		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
+			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: fmt.Sprintf("%s-control-plane-1", cluster.Name),
+				},
+			},
+		}
+		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Conditions: clusterv1.Conditions{
+				{
+					Type:               clusterapi.ReadyCondition,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			ObservedGeneration: 2,
+		}
+	})
+
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -717,6 +710,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		validatorRegistry:         validatorRegistry,
 		execConfig:                execConfig,
 		secret:                    secret,
+		kcp:                       kcp,
 	}
 
 	t.Cleanup(tt.cleanup)

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -63,29 +63,8 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	capiCluster := test.CAPICluster(func(c *clusterv1.Cluster) {
 		c.Name = tt.cluster.Name
 	})
-	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-		kcp.Name = tt.cluster.Name
-		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
-			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
-				InfrastructureRef: corev1.ObjectReference{
-					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
-				},
-			},
-			Version:  "v1.19.8",
-			Replicas: ptr.Int32(1),
-		}
-		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
-			Conditions: clusterv1.Conditions{
-				{
-					Type:               clusterapi.ReadyCondition,
-					Status:             corev1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(time.Now()),
-				},
-			},
-			ObservedGeneration: 2,
-		}
-	})
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster, kcp)
+
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, capiCluster, tt.kcp)
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tinkHardware("hw1", "cp"))
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tinkHardware("hw2", "worker"))
 	tt.createAllObjs()
@@ -871,6 +850,7 @@ type reconcilerTest struct {
 	ipValidator               *tinkerbellreconcilermocks.MockIPValidator
 	cniReconciler             *tinkerbellreconcilermocks.MockCNIReconciler
 	remoteClientRegistry      *tinkerbellreconcilermocks.MockRemoteClientRegistry
+	kcp                       *controlplanev1.KubeadmControlPlane
 }
 
 func newReconcilerTest(t testing.TB) *reconcilerTest {
@@ -957,6 +937,29 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		c.Spec.EksaVersion = &version
 	})
 
+	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+		kcp.Name = cluster.Name
+		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
+			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: fmt.Sprintf("%s-control-plane-1", cluster.Name),
+				},
+			},
+			Version:  "v1.19.8",
+			Replicas: ptr.Int32(1),
+		}
+		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Conditions: clusterv1.Conditions{
+				{
+					Type:               clusterapi.ReadyCondition,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			ObservedGeneration: 2,
+		}
+	})
+
 	tt := &reconcilerTest{
 		t:                    t,
 		WithT:                NewWithT(t),
@@ -980,6 +983,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		datacenterConfig:          workloadClusterDatacenter,
 		machineConfigControlPlane: machineConfigCP,
 		machineConfigWorker:       machineConfigWN,
+		kcp:                       kcp,
 	}
 
 	t.Cleanup(tt.cleanup)

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -52,27 +52,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	// We want to check that the cluster status is cleaned up if validations are passed
 	tt.cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 
-	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-		kcp.Name = tt.cluster.Name
-		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
-			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
-				InfrastructureRef: corev1.ObjectReference{
-					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
-				},
-			},
-		}
-		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
-			Conditions: clusterv1.Conditions{
-				{
-					Type:               clusterapi.ReadyCondition,
-					Status:             corev1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(time.Now()),
-				},
-			},
-			ObservedGeneration: 2,
-		}
-	})
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, kcp)
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.kcp)
 	tt.createAllObjs()
 
 	logger := test.NewNullLogger()
@@ -189,28 +169,18 @@ func TestReconcilerControlPlaneIsNotReady(t *testing.T) {
 	t.Skip("Flaky (https://github.com/aws/eks-anywhere/issues/7000)")
 
 	tt := newReconcilerTest(t)
-	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
-		kcp.Name = tt.cluster.Name
-		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
-			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
-				InfrastructureRef: corev1.ObjectReference{
-					Name: fmt.Sprintf("%s-control-plane-1", tt.cluster.Name),
-				},
+	tt.kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+		Conditions: clusterv1.Conditions{
+			{
+				Type:               clusterapi.ReadyCondition,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(time.Now()),
 			},
-		}
-		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
-			Conditions: clusterv1.Conditions{
-				{
-					Type:               clusterapi.ReadyCondition,
-					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(time.Now()),
-				},
-			},
-			ObservedGeneration: 2,
-		}
-	})
+		},
+		ObservedGeneration: 2,
+	}
 
-	tt.eksaSupportObjs = append(tt.eksaSupportObjs, kcp)
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.kcp)
 	tt.createAllObjs()
 
 	logger := test.NewNullLogger()
@@ -382,6 +352,7 @@ type reconcilerTest struct {
 	machineConfigControlPlane *anywherev1.VSphereMachineConfig
 	machineConfigWorker       *anywherev1.VSphereMachineConfig
 	ipValidator               *vspherereconcilermocks.MockIPValidator
+	kcp                       *controlplanev1.KubeadmControlPlane
 }
 
 func newReconcilerTest(t testing.TB) *reconcilerTest {
@@ -469,6 +440,27 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		c.Spec.EksaVersion = &version
 	})
 
+	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
+		kcp.Name = cluster.Name
+		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
+			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: fmt.Sprintf("%s-control-plane-1", cluster.Name),
+				},
+			},
+		}
+		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Conditions: clusterv1.Conditions{
+				{
+					Type:               clusterapi.ReadyCondition,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				},
+			},
+			ObservedGeneration: 2,
+		}
+	})
+
 	tt := &reconcilerTest{
 		t:                    t,
 		WithT:                NewWithT(t),
@@ -497,6 +489,7 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		datacenterConfig:          workloadClusterDatacenter,
 		machineConfigControlPlane: machineConfigCP,
 		machineConfigWorker:       machineConfigWN,
+		kcp:                       kcp,
 	}
 
 	t.Cleanup(tt.cleanup)


### PR DESCRIPTION
*Description of changes:*
Code refactoring for unit tests. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

