### PR TITLE
Update versioning page to indicate CVE patches not back ported in 0.17

### DIFF
--- a/docs/content/en/docs/concepts/support-versions.md
+++ b/docs/content/en/docs/concepts/support-versions.md
@@ -38,7 +38,7 @@ The following table notes which EKS Anywhere and related Kubernetes versions are
 | EKS Anywhere version      | Kubernetes versions included | EKS Anywhere Release Date | CVE patches and bug fixes back-ported? |
 |------------|------------------------------|---------------------------------|-------------------------|
 | 0.18 | 1.28, 1.27, 1.26, 1.25, 1.24 | October 30, 2023 | Yes |
-| 0.17 | 1.27, 1.26, 1.25, 1.24, 1.23 | August 16, 2023 | Yes |
+| 0.17 | 1.27, 1.26, 1.25, 1.24, 1.23 | August 16, 2023 | No |
 | 0.16 | 1.27, 1.26, 1.25, 1.24, 1.23 | June 1, 2023 | No |
 | 0.15 | 1.26, 1.25, 1.24, 1.23, 1.22 | March 30, 2023 | No |
 | 0.14 | 1.25, 1.24, 1.23, 1.22, 1.21 | January 19, 2023 | No |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When a new EKS-A minor release n is out, make sure you always update the n-1 version to indicate it is no longer backported with CVE patches.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

