### PR TITLE
Enable snow ubuntu upgrade e2e test

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -45,13 +45,10 @@ skipped_tests:
 - TestSnowKubernetes128UbuntuRemoveWorkerNodeGroups
 - TestSnowKubernetes128OIDC
 - TestSnowKubernetes128UbuntuProxyConfig
-# - TestSnowKubernetes124SimpleFlow
-# - TestSnowKubernetes125SimpleFlow
-# - TestSnowKubernetes126SimpleFlow
-- TestSnowKubernetes127UbuntuTo128Upgrade
-- TestSnowKubernetes124UbuntuTo125Upgrade
-- TestSnowKubernetes125UbuntuTo126Upgrade
-- TestSnowKubernetes126UbuntuTo127Upgrade
+# - TestSnowKubernetes127UbuntuTo128Upgrade
+# - TestSnowKubernetes124UbuntuTo125Upgrade
+# - TestSnowKubernetes125UbuntuTo126Upgrade
+# - TestSnowKubernetes126UbuntuTo127Upgrade
 - TestSnowKubernetes127BottlerocketTo128Upgrade
 - TestSnowKubernetes124BottlerocketTo125Upgrade
 - TestSnowKubernetes125BottlerocketTo126Upgrade


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently, only simpleflow snow e2e tests are enabled. We would like to gradually enable more snow e2e tests. Meanwile, we will fix any test failure caused by environment setup.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

