### PR TITLE
Update package controller docs overview section

### DIFF
--- a/docs/content/en/docs/getting-started/optional/packages.md
+++ b/docs/content/en/docs/getting-started/optional/packages.md
@@ -9,7 +9,7 @@ description: >
 ---
 
 ## Package Controller Configuration (optional)
-You can configure EKS Anywhere controller configuration.
+You can specify EKS Anywhere package controller configurations. For more on the curated packages and the package controller, visit the [package management]({{< relref "../../packages" >}}) documentation.
 
 The following cluster spec shows an example of how to configure package controller:
 ```yaml

--- a/docs/content/en/docs/packages/overview.md
+++ b/docs/content/en/docs/packages/overview.md
@@ -12,13 +12,13 @@ weight: 1
 Components of EKS Anywhere curated packages consist of a controller, a CLI, and artifacts.
 
 ### Package controller
-The package controller is responsible for installing, upgrading, configuring, and removing packages from the cluster. It performs these actions by watching the package and packagebundle custom resources. Morever, it uses the packagebundle to determine which packages to run and by setting their appropriate configuration values.
+The package controller is responsible for installing, upgrading, configuring, and removing packages from the cluster. It performs these actions by watching the package and packagebundle custom resources. Moreover, it uses the packagebundle to determine which packages to run and sets appropriate configuration values.
 
 Packages custom resources map to helm charts that the package controller uses to install packages workloads (such as cluster-autoscaler or metrics-server) on your clusters. The packagebundle object is the mapping between the package name and the specific helm chart and images that will be installed.
 
-The package controller only runs on the management cluster, including single-node clusters, to perform the above outlined responsibilities. However, packages may be installed on both management and workload clusters. For more, see the guide on [installing packages on workload clusters.]({{< relref "./overview/#installing-packages-on-workload-clusters" >}})
+The package controller only runs on the management cluster, including single-node clusters, to perform the above outlined responsibilities. However, packages may be installed on both management and workload clusters. For more information, see the guide on [installing packages on workload clusters.]({{< relref "./overview/#installing-packages-on-workload-clusters" >}})
 
-Package release information is stored in a package bundle manifest. The package controller will continually monitor and download new package bundles. When a new package bundle is downloaded, it will show up as "available" in the PackageBundleController resource's `status.detail` field. A package bundle upgrade always requires manual intervention as outlined in the [package bundles docs.]({{< relref "./packagebundles/" >}})
+Package release information is stored in a package bundle manifest. The package controller will continually monitor and download new package bundles. When a new package bundle is downloaded, it will show up as "available" in the PackageBundleController resource's `status.detail` field. A package bundle upgrade always requires manual intervention as outlined in the [package bundles]({{< relref "./packagebundles/" >}}) docs.
 
 Any changes to a package custom resource will trigger an install, upgrade, configuration or removal of that package. The package controller will use ECR or private registry to get all resources including bundle, helm charts, and container images.
 
@@ -38,7 +38,7 @@ An upgrade through the CLI (`eksctl anywhere upgrade packages`) upgrades all pac
 
 Please check out [Install EKS Anywhere]({{< relref "../getting-started/install" >}}) to install the `eksctl anywhere` CLI on your machine.
 
-The create cluster page for each [EKS Anywhere providers]({{< relref "../getting-started/chooseprovider/" >}}) describes how to configure and install curated packages at cluster creation time.
+The create cluster page for each [EKS Anywhere provider]({{< relref "../getting-started/chooseprovider/" >}}) describes how to configure and install curated packages at cluster creation time.
 
 ### Curated packages artifacts
 There are three types of build artifacts for packages: the container images, the helm charts and the package bundle manifests. The container images, helm charts and bundle manifests for all of the packages will be built and stored in EKS Anywhere ECR repository. Each package may have multiple versions specified in the packages bundle. The bundle will reference the helm chart tag in the ECR repository. The helm chart will reference the container images for the package.

--- a/docs/content/en/docs/packages/overview.md
+++ b/docs/content/en/docs/packages/overview.md
@@ -12,23 +12,17 @@ weight: 1
 Components of EKS Anywhere curated packages consist of a controller, a CLI, and artifacts.
 
 ### Package controller
-The package controller is responsible for installing, upgrading, configuring, and removing packages from the cluster.
-
-The package controller performs these actions by watching the package and packagebundle custom resources. It uses the packagebundle to determine which packages to run and by setting their appropriate configuration values.
+The package controller is responsible for installing, upgrading, configuring, and removing packages from the cluster. It performs these actions by watching the package and packagebundle custom resources. Morever, it uses the packagebundle to determine which packages to run and by setting their appropriate configuration values.
 
 Packages custom resources map to helm charts that the package controller uses to install packages workloads (such as cluster-autoscaler or metrics-server) on your clusters. The packagebundle object is the mapping between the package name and the specific helm chart and images that will be installed.
 
-The package controller only runs on the management cluster and manages packages on the management cluster and on the workload clusters.
-The package controller also runs on single-node clusters.
-To learn more about how to install packages on both management and workload clusters, see below.
+The package controller only runs on the management cluster, including single-node clusters, to perform the above outlined responsibilities. However, packages may be installed on both management and workload clusters. For more, see the guide on [installing packages on workload clusters.]({{< relref "./overview/#installing-packages-on-workload-clusters" >}})
 
-Package release information is stored in a package bundle manifest. The package controller will continually monitor and download new package bundles. When a new package bundle is downloaded, it will show up as "available" in the PackageBundleController resource's `status.detail` field. A package bundle upgrade always requires manual intervention as outlined in the [package bundles docs]({{< relref "./packagebundles/" >}}).
+Package release information is stored in a package bundle manifest. The package controller will continually monitor and download new package bundles. When a new package bundle is downloaded, it will show up as "available" in the PackageBundleController resource's `status.detail` field. A package bundle upgrade always requires manual intervention as outlined in the [package bundles docs.]({{< relref "./packagebundles/" >}})
 
 Any changes to a package custom resource will trigger an install, upgrade, configuration or removal of that package. The package controller will use ECR or private registry to get all resources including bundle, helm charts, and container images.
 
-The Getting started page for each EKS Anywhere provider describes how to install the package controller at the cluster creation time. See the [EKS Anywhere providers]({{< relref "../getting-started/chooseprovider/" >}}) page the list of providers.
-
-Please check out [package management]({{< relref "../packages/packages" >}}) for how to install package controller after cluster creation and manage curated packages.
+You may [install the package controller]({{< relref "../packages/packagecontroller" >}}) after cluster creation to take advantage of curated package features.
 
 ### Packages CLI
 The Curated Packages CLI provides the user experience required to manage curated packages.
@@ -44,9 +38,7 @@ An upgrade through the CLI (`eksctl anywhere upgrade packages`) upgrades all pac
 
 Please check out [Install EKS Anywhere]({{< relref "../getting-started/install" >}}) to install the `eksctl anywhere` CLI on your machine.
 
-The Getting started page for each EKS Anywhere provider describes how to install the package controller at the cluster creation time. See the [EKS Anywhere providers]({{< relref "../getting-started/chooseprovider/" >}}) page the list of providers.
-
-Please check out [package management]({{< relref "../packages/packages" >}}) for how to install package controller after cluster creation and manage curated packages.
+The create cluster page for each [EKS Anywhere providers]({{< relref "../getting-started/chooseprovider/" >}}) describes how to configure and install curated packages at cluster creation time.
 
 ### Curated packages artifacts
 There are three types of build artifacts for packages: the container images, the helm charts and the package bundle manifests. The container images, helm charts and bundle manifests for all of the packages will be built and stored in EKS Anywhere ECR repository. Each package may have multiple versions specified in the packages bundle. The bundle will reference the helm chart tag in the ECR repository. The helm chart will reference the container images for the package.

--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -1,6 +1,6 @@
 ---
 title: "Managing package bundles"
-linkTitle: "Package bundles"
+linkTitle: "Manage package bundles"
 weight: 5
 aliases:
     /docs/tasks/packages/packagebundles/

--- a/docs/content/en/docs/packages/packagecontroller.md
+++ b/docs/content/en/docs/packages/packagecontroller.md
@@ -1,6 +1,6 @@
 ---
 title: "Managing the package controller"
-linkTitle: "Package controller"
+linkTitle: "Manage package controller"
 weight: 4
 aliases:
     /docs/tasks/packages/packagecontroller/
@@ -79,7 +79,7 @@ You may need to create or update your credentials which you can do with a comman
 
 ### Upgrade the packages controller
 
-EKS Anywhere v0.15.0 (packages controller v0.3.9+) and onwards includes support for eks-anywhere-packages controller as a self-managed package feature. The package controller now  upgrades automatically according to the version specified within the management cluster's selected package bundle.
+EKS Anywhere v0.15.0 (packages controller v0.3.9+) and onwards includes support for eks-anywhere-packages controller as a self-managed package feature. The package controller now upgrades automatically according to the version specified within the management cluster's selected package bundle.
 
 For any version prior to v0.3.X, manual steps must be executed to upgrade.
 

--- a/docs/content/en/docs/packages/packagecontroller.md
+++ b/docs/content/en/docs/packages/packagecontroller.md
@@ -79,7 +79,7 @@ You may need to create or update your credentials which you can do with a comman
 
 ### Upgrade the packages controller
 
-EKS Anywhere v0.15.0 (packages controller v0.3.9+) and onwards includes support for eks-anywhere-packages controller as a self-managed package feature. The package controller now upgrades automatically according to the version specified within the management cluster's selected package bundle.
+EKS Anywhere v0.15.0 (packages controller v0.3.9+) and onwards includes support for the eks-anywhere-packages controller as a self-managed package feature. The package controller now upgrades automatically according to the version specified within the management cluster's selected package bundle.
 
 For any version prior to v0.3.X, manual steps must be executed to upgrade.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR:
- Refines some of the packages overview section.
- Removes unsuitable reference to install package controller in Package CLI in package overview.
- Adds link to package management section in Optional Configuration section for packages controller.
- Update managing package controller and package bundles menu item titles.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

