### PR TITLE
Docs: make prereq titles consistent

### DIFF
--- a/docs/content/en/docs/getting-started/cloudstack/cloudstack-prereq.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloudstack-prereq.md
@@ -10,10 +10,10 @@ description: >
 
 To run EKS Anywhere, you will need:
 
-### Prepare Administrative machine
+## Prepare Administrative machine
 Set up an Administrative machine as described in [Install EKS Anywhere ]({{< relref "../../getting-started/install/" >}}).
 
-### Prepare a CloudStack environment
+## Prepare a CloudStack environment
 
 To prepare a CloudStack environment to run EKS Anywhere, you need the following:
 
@@ -46,7 +46,7 @@ The administrative machine and the target workload environment will need network
 * d5l0dvt14r5h8.cloudfront.net (http://d5l0dvt14r5h8.cloudfront.net/) (for EKS Anywhere package ECR container images)
 * api.github.com (http://api.github.com/) (only if GitOps is enabled)
 
-### CloudStack information needed before creating the cluster
+## CloudStack information needed before creating the cluster
 
 You need at least the following information before creating the cluster.
 See [CloudStack configuration]({{< relref "./cloud-spec/" >}}) for a complete list of options and [Preparing CloudStack]({{< relref "./cloudstack-preparation/" >}}) for instructions on creating the assets.
@@ -62,9 +62,9 @@ An IP address will be the value of the property controlPlaneConfiguration.endpoi
     * Account (account): Account with permission to create a cluster (optional, admin by default).
     * Credentials (credentialsRef): Credentials provided in an ini file used to access the CloudStack API endpoint. See [CloudStack Getting started]({{< relref "../../getting-started/cloudstack/" >}}) for details.
     * Domain (domain):  The CloudStack domain in which to deploy the cluster (optional, ROOT by default)
-    * Management endpoint (managementApiEndpoint): Endpoint for a cloudstack client to make API calls to client. 
-    * Zone network (zone.network): Either name or ID of the network. 
+    * Management endpoint (managementApiEndpoint): Endpoint for a cloudstack client to make API calls to client.
+    * Zone network (zone.network): Either name or ID of the network.
 * CloudStack machine configuration: For each set of machines (for example, you could configure separate set of machines for control plane, worker, and etcd nodes), obtain the following information. This must be predefined in the cloudStack instance and identified by name or ID:
     * Compute offering (computeOffering): Choose an existing compute offering (such as `large-instance`), reflecting the amount of resources to apply to each VM.
     * Operating system (template): Identifies the operating system image to use (such as rhel8-k8s-118).
-    * Users (users.name): Identifies users and SSH keys needed to access the VMs. 
+    * Users (users.name): Identifies users and SSH keys needed to access the VMs.

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-prereq.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-prereq.md
@@ -10,10 +10,10 @@ description: >
 
 To run EKS Anywhere, you will need:
 
-### Prepare Administrative machine
+## Prepare Administrative machine
 Set up an Administrative machine as described in [Install EKS Anywhere ]({{< relref "../../getting-started/install/" >}}).
 
-### Prepare a Nutanix environment
+## Prepare a Nutanix environment
 To prepare a Nutanix environment to run EKS Anywhere, you need the following:
 * A Nutanix environment running AOS 5.20.4+ with AHV and Prism Central 2022.1+
 * Capacity to deploy 6-10 VMs
@@ -21,16 +21,16 @@ To prepare a Nutanix environment to run EKS Anywhere, you need the following:
 * [Prepare DHCP IP addresses pool]({{< relref "../../clustermgmt/cluster-upgrades/vsphere-and-cloudstack-upgrades.md/#prepare-dhcp-ip-addresses-pool" >}})
 * A VM image imported into the Prism Image Service for the workload VMs
 * User credentials to create VMs and attach networks, etc
-* One IP address routable from cluster but excluded from DHCP/IPAM offering. 
+* One IP address routable from cluster but excluded from DHCP/IPAM offering.
   This IP address is to be used as the [Control Plane Endpoint IP]({{< relref "./nutanix-spec/#controlplaneconfigurationendpointhost-required" >}})
 
-  Below are some suggestions to ensure that this IP address is never handed out by your DHCP server. 
- 
+  Below are some suggestions to ensure that this IP address is never handed out by your DHCP server.
+
   You may need to contact your network engineer.
-      
+
    *  Pick an IP address reachable from cluster subnet which is excluded from DHCP range OR
    *  Alter DHCP ranges to leave out an IP address(s) at the top and/or the bottom of the range OR
-   *  Create an IP reservation for this IP on your DHCP server. This is usually accomplished by adding 
+   *  Create an IP reservation for this IP on your DHCP server. This is usually accomplished by adding
 a dummy mapping of this IP address to a non-existent mac address.
    *  Block an IP address from the Nutanix IPAM managed network using aCLI
 
@@ -46,11 +46,11 @@ The administrative machine and the target workload environment will need network
 {{% content "./domains.md" %}}
 
 
-### Nutanix information needed before creating the cluster
+## Nutanix information needed before creating the cluster
 You need to get the following information before creating the cluster:
 
-* **Static IP Addresses**: 
-You will need one IP address for the management cluster control plane endpoint, and a separate one for the controlplane of each workload cluster you add. 
+* **Static IP Addresses**:
+You will need one IP address for the management cluster control plane endpoint, and a separate one for the controlplane of each workload cluster you add.
 
   Let’s say you are going to have the management cluster and two workload clusters.
 For those, you would need three IP addresses, one for each.
@@ -62,7 +62,7 @@ Choose IP addresses in your network range that do not conflict with other VMs an
   An IP address will be the value of the property `controlPlaneConfiguration.endpoint.host` in the config file of the management cluster.
 A separate IP address must be assigned for each workload cluster.
 
-  ![Import ova wizard](/images/ip.png) 
+  ![Import ova wizard](/images/ip.png)
 
 * **Prism Central FQDN or IP Address**: The Prism Central fully qualified domain name or IP address.
 

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-prereq.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-prereq.md
@@ -10,10 +10,10 @@ description: >
 
 To run EKS Anywhere, you will need:
 
-### Prepare Administrative machine
+## Prepare Administrative machine
 Set up an Administrative machine as described in [Install EKS Anywhere ]({{< relref "../../getting-started/install/" >}}).
 
-### Prepare a VMware vSphere environment
+## Prepare a VMware vSphere environment
 To prepare a VMware vSphere environment to run EKS Anywhere, you need the following:
 * A vSphere 7+ environment running vCenter.
 * Capacity to deploy 6-10 VMs.
@@ -22,16 +22,16 @@ To prepare a VMware vSphere environment to run EKS Anywhere, you need the follow
 * One network in vSphere to use for the cluster. EKS Anywhere clusters need access to vCenter through the network to enable self-managing and storage capabilities.
 * An [OVA]({{< relref "customize/vsphere-ovas/" >}}) imported into vSphere and converted into a template for the workload VMs
 * It's critical that you set up your [vSphere user credentials properly.]({{< relref "./vsphere-preparation#configuring-vsphere-user-group-and-roles" >}})
-* One IP address routable from cluster but excluded from DHCP offering. 
+* One IP address routable from cluster but excluded from DHCP offering.
   This IP address is to be used as the [Control Plane Endpoint IP.]({{< relref "./vsphere-spec/#controlplaneconfigurationendpointhost-required" >}})
 
-  Below are some suggestions to ensure that this IP address is never handed out by your DHCP server. 
- 
+  Below are some suggestions to ensure that this IP address is never handed out by your DHCP server.
+
   You may need to contact your network engineer.
-      
+
    *  Pick an IP address reachable from cluster subnet which is excluded from DHCP range OR
    *  Alter DHCP ranges to leave out an IP address(s) at the top and/or the bottom of the range OR
-   *  Create an IP reservation for this IP on your DHCP server. This is usually accomplished by adding 
+   *  Create an IP reservation for this IP on your DHCP server. This is usually accomplished by adding
 a dummy mapping of this IP address to a non-existent mac address.
 
 
@@ -46,11 +46,11 @@ The administrative machine and the target workload environment will need network
 {{% content "./domains.md" %}}
 
 
-### vSphere information needed before creating the cluster
+## vSphere information needed before creating the cluster
 You need to get the following information before creating the cluster:
 
-* **Static IP Addresses**: 
-You will need one IP address for the management cluster control plane endpoint, and a separate IP address for the control plane of each workload cluster you add. 
+* **Static IP Addresses**:
+You will need one IP address for the management cluster control plane endpoint, and a separate IP address for the control plane of each workload cluster you add.
 
   Let’s say you are going to have the management cluster and two workload clusters.
 For those, you would need three IP addresses, one for each cluster.
@@ -62,19 +62,19 @@ Choose IP addresses in your network range that do not conflict with other VMs an
   An IP address will be the value of the property `controlPlaneConfiguration.endpoint.host` in the config file of the management cluster.
 A separate IP address must be assigned for each workload cluster.
 
-  ![Import ova wizard](/images/ip.png) 
+  ![Import ova wizard](/images/ip.png)
 
 * **vSphere Datacenter Name**: The vSphere datacenter to deploy the EKS Anywhere cluster on.
 
-  ![Import ova wizard](/images/datacenter.png) 
+  ![Import ova wizard](/images/datacenter.png)
 
 * **VM Network Name**: The VM network to deploy your EKS Anywhere cluster on.
 
-  ![Import ova wizard](/images/networkname.png) 
+  ![Import ova wizard](/images/networkname.png)
 
 * **vCenter Server Domain Name**: The vCenter server fully qualified domain name or IP address. If the server IP is used, the thumbprint must be set or insecure must be set to true.
 
-  ![Import ova wizard](/images/domainname.png) 
+  ![Import ova wizard](/images/domainname.png)
 
 * **thumbprint** (required if insecure=false): The SHA1 thumbprint of the vCenter server certificate which is only required if you have a self-signed certificate for your vSphere endpoint.
 
@@ -86,24 +86,24 @@ If you have [govc installed,](https://github.com/vmware/govmomi/blob/master/govc
   ```
 
 * **template**: The VM template to use for your EKS Anywhere cluster.
-This template was created when you imported the [OVA file]({{< relref "./vsphere-preparation#deploy-an-ova-template" >}}) into vSphere. 
+This template was created when you imported the [OVA file]({{< relref "./vsphere-preparation#deploy-an-ova-template" >}}) into vSphere.
 
-  ![Import ova wizard](/images/ovatemplate.png) 
+  ![Import ova wizard](/images/ovatemplate.png)
 
 * **datastore**: The vSphere [datastore](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.storage.doc/GUID-3CC7078E-9C30-402C-B2E1-2542BEE67E8F.html) to deploy your EKS Anywhere cluster on.
 
-  ![Import ova wizard](/images/storage.png) 
+  ![Import ova wizard](/images/storage.png)
 
 
 * **folder**:
 The [folder]({{< relref "./vsphere-preparation#configuring-folder-resources" >}}) parameter in VSphereMachineConfig allows you to organize the VMs of an EKS Anywhere cluster.
 With this, each cluster can be organized as a folder in vSphere.
-You will have a separate folder for the management cluster and each cluster you are adding. 
+You will have a separate folder for the management cluster and each cluster you are adding.
 
-  ![Import ova wizard](/images/folder.png) 
+  ![Import ova wizard](/images/folder.png)
 
 
 * **resourcePool**:
 The vSphere resource pools for your VMs in the EKS Anywhere cluster. If there is a resource pool: `/<datacenter>/host/<resource-pool-name>/Resources`
 
-  ![Import ova wizard](/images/resourcepool.png) 
+  ![Import ova wizard](/images/resourcepool.png)


### PR DESCRIPTION
The titles for most requirements pages had an additional `#` making them inconsistent with other pages under the same sections.