### PR TITLE
Fix incorrect regex for matching curated package registry URL

### DIFF
--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -118,8 +118,8 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 		WithRegistryMirror(&registrymirror.RegistryMirror{
 			BaseRegistry: c.RegistryEndpoint,
 			NamespacedRegistryMap: map[string]string{
-				constants.DefaultCoreEKSARegistry:             c.RegistryEndpoint,
-				constants.DefaultCuratedPackagesRegistryRegex: c.RegistryEndpoint,
+				constants.DefaultCoreEKSARegistry:        c.RegistryEndpoint,
+				constants.DefaultCuratedPackagesRegistry: c.RegistryEndpoint,
 			},
 			Auth: false,
 		}).

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,8 +56,12 @@ const (
 
 	// DefaultCoreEKSARegistry is the default registry for eks-a core artifacts.
 	DefaultCoreEKSARegistry = "public.ecr.aws"
-	// DefaultCuratedPackagesRegistryRegex matches the default registry for curated packages in all regions.
-	DefaultCuratedPackagesRegistryRegex = "783794618700.dkr.ecr.*.amazonaws.com"
+
+	// DefaultCuratedPackagesRegistry matches the default registry for curated packages in all regions.
+	DefaultCuratedPackagesRegistryRegex = `783794618700\.dkr\.ecr\..*\.amazonaws\.com`
+
+	// DefaultcuratedPackagesRegistry is a containerd compatible registry format that matches all AWS regions.
+	DefaultCuratedPackagesRegistry = "783794618700.dkr.ecr.*.amazonaws.com"
 
 	// Provider specific env vars.
 	VSphereUsernameKey     = "VSPHERE_USERNAME"

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -85,8 +85,8 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 	registryMirror := &registrymirror.RegistryMirror{
 		BaseRegistry: "1.2.3.4:443",
 		NamespacedRegistryMap: map[string]string{
-			constants.DefaultCoreEKSARegistry:             "1.2.3.4:443/public",
-			constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/private",
+			constants.DefaultCoreEKSARegistry:        "1.2.3.4:443/public",
+			constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/private",
 		},
 		Auth:               true,
 		CACertContent:      "-----BEGIN CERTIFICATE-----\nabc\nefg\n-----END CERTIFICATE-----\n",
@@ -95,8 +95,8 @@ func newPackageControllerTests(t *testing.T) []*packageControllerTest {
 	registryMirrorInsecure := &registrymirror.RegistryMirror{
 		BaseRegistry: "1.2.3.4:8443",
 		NamespacedRegistryMap: map[string]string{
-			constants.DefaultCoreEKSARegistry:             "1.2.3.4:443/public",
-			constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/private",
+			constants.DefaultCoreEKSARegistry:        "1.2.3.4:443/public",
+			constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/private",
 		},
 		Auth:               true,
 		CACertContent:      "-----BEGIN CERTIFICATE-----\nabc\nefg\n-----END CERTIFICATE-----\n",

--- a/pkg/registrymirror/containerd/utils_test.go
+++ b/pkg/registrymirror/containerd/utils_test.go
@@ -53,12 +53,12 @@ func TestToAPIEndpoints(t *testing.T) {
 		{
 			name: "mix",
 			URLs: map[string]string{
-				constants.DefaultCoreEKSARegistry:             "1.2.3.4:443",
-				constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/curated-packages",
+				constants.DefaultCoreEKSARegistry:        "1.2.3.4:443",
+				constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/curated-packages",
 			},
 			want: map[string]string{
-				constants.DefaultCoreEKSARegistry:             "1.2.3.4:443",
-				constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/v2/curated-packages",
+				constants.DefaultCoreEKSARegistry:        "1.2.3.4:443",
+				constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/v2/curated-packages",
 			},
 		},
 	}

--- a/pkg/registrymirror/registrymirror.go
+++ b/pkg/registrymirror/registrymirror.go
@@ -47,7 +47,7 @@ func FromClusterRegistryMirrorConfiguration(config *v1alpha1.RegistryMirrorConfi
 		if re.MatchString(ociNamespace.Registry) {
 			// handle curated packages in all regions
 			// static key makes it easier for mirror lookup
-			registryMap[constants.DefaultCuratedPackagesRegistryRegex] = mirror
+			registryMap[constants.DefaultCuratedPackagesRegistry] = mirror
 		} else {
 			registryMap[ociNamespace.Registry] = mirror
 		}
@@ -73,7 +73,7 @@ func (r *RegistryMirror) CoreEKSAMirror() string {
 
 // CuratedPackagesMirror returns the mirror for curated packages.
 func (r *RegistryMirror) CuratedPackagesMirror() string {
-	return r.NamespacedRegistryMap[constants.DefaultCuratedPackagesRegistryRegex]
+	return r.NamespacedRegistryMap[constants.DefaultCuratedPackagesRegistry]
 }
 
 // ReplaceRegistry replaces the host in a url with corresponding registry mirror
@@ -93,7 +93,7 @@ func (r *RegistryMirror) ReplaceRegistry(url string) string {
 	}
 	key := u.Host
 	if re.MatchString(key) {
-		key = constants.DefaultCuratedPackagesRegistryRegex
+		key = constants.DefaultCuratedPackagesRegistry
 	}
 	if v, ok := r.NamespacedRegistryMap[key]; ok {
 		return strings.Replace(url, u.Host, v, 1)

--- a/pkg/registrymirror/registrymirror_test.go
+++ b/pkg/registrymirror/registrymirror_test.go
@@ -46,7 +46,7 @@ func TestFromCluster(t *testing.T) {
 								Namespace: "eks-anywhere",
 							},
 							{
-								Registry:  "783794618700.dkr,ecr.us-west-2.amazonaws.com",
+								Registry:  "783794618700.dkr.ecr.us-west-2.amazonaws.com",
 								Namespace: "curated-packages",
 							},
 						},
@@ -56,8 +56,8 @@ func TestFromCluster(t *testing.T) {
 			want: &registrymirror.RegistryMirror{
 				BaseRegistry: "1.2.3.4:443",
 				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCoreEKSARegistry:             "1.2.3.4:443/eks-anywhere",
-					constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/curated-packages",
+					constants.DefaultCoreEKSARegistry:        "1.2.3.4:443/eks-anywhere",
+					constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/curated-packages",
 				},
 			},
 		},
@@ -174,8 +174,8 @@ func TestFromClusterRegistryMirrorConfiguration(t *testing.T) {
 			want: &registrymirror.RegistryMirror{
 				BaseRegistry: "harbor.eksa.demo:30003",
 				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCoreEKSARegistry:             "harbor.eksa.demo:30003/eks-anywhere",
-					constants.DefaultCuratedPackagesRegistryRegex: "harbor.eksa.demo:30003/curated-packages",
+					constants.DefaultCoreEKSARegistry:        "harbor.eksa.demo:30003/eks-anywhere",
+					constants.DefaultCuratedPackagesRegistry: "harbor.eksa.demo:30003/curated-packages",
 				},
 				Auth: false,
 			},
@@ -265,7 +265,7 @@ func TestCuratedPackagesMirror(t *testing.T) {
 			registryMirror: &registrymirror.RegistryMirror{
 				BaseRegistry: "1.2.3.4:443",
 				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCuratedPackagesRegistryRegex: "1.2.3.4:443/curated-packages",
+					constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/curated-packages",
 				},
 			},
 			want: "1.2.3.4:443/curated-packages",
@@ -307,7 +307,7 @@ func TestReplaceRegistry(t *testing.T) {
 			registryMirror: &registrymirror.RegistryMirror{
 				BaseRegistry: "harbor.eksa.demo:30003",
 				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCuratedPackagesRegistryRegex: "harbor.eksa.demo:30003/curated-packages",
+					constants.DefaultCuratedPackagesRegistry: "harbor.eksa.demo:30003/curated-packages",
 				},
 			},
 			URL:  "oci://public.ecr.aws/product/chart",
@@ -343,10 +343,10 @@ func TestReplaceRegistry(t *testing.T) {
 			registryMirror: &registrymirror.RegistryMirror{
 				BaseRegistry: "harbor.eksa.demo:30003",
 				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCuratedPackagesRegistryRegex: "harbor.eksa.demo:30003/curated-packages",
+					constants.DefaultCuratedPackagesRegistry: "harbor.eksa.demo:30003/curated-packages",
 				},
 			},
-			URL:  "https://783794618700.dkr,ecr.us-west-2.amazonaws.com/product/site",
+			URL:  "https://783794618700.dkr.ecr.us-west-2.amazonaws.com/product/site",
 			want: "https://harbor.eksa.demo:30003/curated-packages/product/site",
 		},
 		{
@@ -360,7 +360,7 @@ func TestReplaceRegistry(t *testing.T) {
 			registryMirror: &registrymirror.RegistryMirror{
 				BaseRegistry: "harbor.eksa.demo:30003",
 				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCuratedPackagesRegistryRegex: "harbor.eksa.demo:30003/curated-packages",
+					constants.DefaultCuratedPackagesRegistry: "harbor.eksa.demo:30003/curated-packages",
 				},
 			},
 			URL:  "public.ecr.aws/product/image:tag",


### PR DESCRIPTION
Related to https://github.com/aws/eks-anywhere/security/code-scanning/4.


Registry mirror configuration using namespaced registries [requires users to specify the curated packages registry](https://anywhere.eks.amazonaws.com/docs/getting-started/optional/registrymirror/#__ocinamespaces__-optional).

We have special handling for the curated packages URL and identify URLs of any region using regex. However, the regex was incorrect and matched invalid URLs such as `783794618700&dkr&ecr&amazonaws&com`. This is because the string is also used in containerd config that supports wildcard matching (as used in the string).

This change separates regex uses from containerd uses ensuring we correctly match curated packages URLs.