### PR TITLE
fix: docs to show apple and arm support

### DIFF
--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -26,7 +26,7 @@ This allows you to try EKS Anywhere on your local machine or laptop before deplo
 * 30GB free disk space
 * If you are using Ubuntu, use the Docker CE installation instructions to install Docker and not the Snap installation, as described here.
 * For EKS Anywhere v0.15 and earlier, if you are using Ubuntu 21.10 or 22.04, you will need to switch from cgroups v2 to cgroups v1. For details, see [Troubleshooting Guide.]({{< relref "../../troubleshooting/troubleshooting.md#for-eks-anywhere-v015-and-earlier-cgroups-v2-is-not-supported-in-ubuntu-2110-and-2204" >}})
-* EKS Anywhere works with x86 and amd64 architectures. It currently will not work on computers with Apple Silicon or Arm based processors.
+* EKS Anywhere works with x86 and amd64 architectures, From v0.18.1 it also works with Apple Silicon or Arm based processors.
 
 ### Install EKS Anywhere CLI tools
 To get started with EKS Anywhere, you must first install the `eksctl` CLI and the `eksctl anywhere` plugin.

--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -26,7 +26,7 @@ This allows you to try EKS Anywhere on your local machine or laptop before deplo
 * 30GB free disk space
 * If you are using Ubuntu, use the Docker CE installation instructions to install Docker and not the Snap installation, as described here.
 * For EKS Anywhere v0.15 and earlier, if you are using Ubuntu 21.10 or 22.04, you will need to switch from cgroups v2 to cgroups v1. For details, see [Troubleshooting Guide.]({{< relref "../../troubleshooting/troubleshooting.md#for-eks-anywhere-v015-and-earlier-cgroups-v2-is-not-supported-in-ubuntu-2110-and-2204" >}})
-* EKS Anywhere works with x86 and amd64 architectures, From v0.18.1 it also works with Apple Silicon or Arm based processors.
+* EKS Anywhere works with x86 and amd64 architectures. From v0.18.1, it also works with Apple Silicon or Arm based processors.
 
 ### Install EKS Anywhere CLI tools
 To get started with EKS Anywhere, you must first install the `eksctl` CLI and the `eksctl anywhere` plugin.

--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -26,7 +26,7 @@ This allows you to try EKS Anywhere on your local machine or laptop before deplo
 * 30GB free disk space
 * If you are using Ubuntu, use the Docker CE installation instructions to install Docker and not the Snap installation, as described here.
 * For EKS Anywhere v0.15 and earlier, if you are using Ubuntu 21.10 or 22.04, you will need to switch from cgroups v2 to cgroups v1. For details, see [Troubleshooting Guide.]({{< relref "../../troubleshooting/troubleshooting.md#for-eks-anywhere-v015-and-earlier-cgroups-v2-is-not-supported-in-ubuntu-2110-and-2204" >}})
-* EKS Anywhere works with x86 and amd64 architectures. From v0.18.1, it also works with Apple Silicon or Arm based processors.
+* EKS Anywhere works with x86 and amd64 architectures. From v0.18.1, it also works with Apple Silicon or ARM based processors.
 
 ### Install EKS Anywhere CLI tools
 To get started with EKS Anywhere, you must first install the `eksctl` CLI and the `eksctl anywhere` plugin.

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -50,8 +50,8 @@ Here are a few other things to keep in mind:
 #### Via Homebrew (macOS and Linux)
 
 {{% alert title="Warning" color="warning" %}}
-EKS Anywhere only works on computers with x86 and amd64 process architecture.
-It currently will not work on computers with Apple Silicon or Arm based processors.
+EKS Anywhere works on computers with x86 and amd64 process architecture.
+From v0.18.1 it also works with Apple Silicon or Arm based processors.
 {{% /alert %}}
 
 You can install `eksctl` and `eksctl-anywhere` with [homebrew](http://brew.sh/).

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -49,11 +49,6 @@ Here are a few other things to keep in mind:
 
 #### Via Homebrew (macOS and Linux)
 
-{{% alert title="Warning" color="warning" %}}
-EKS Anywhere works on computers with x86 and amd64 process architecture.
-From v0.18.1, it also works with Apple Silicon or Arm based processors.
-{{% /alert %}}
-
 You can install `eksctl` and `eksctl-anywhere` with [homebrew](http://brew.sh/).
 This package will also install `kubectl` and the `aws-iam-authenticator` which will be helpful to test EKS Anywhere clusters.
 

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -51,7 +51,7 @@ Here are a few other things to keep in mind:
 
 {{% alert title="Warning" color="warning" %}}
 EKS Anywhere works on computers with x86 and amd64 process architecture.
-From v0.18.1 it also works with Apple Silicon or Arm based processors.
+From v0.18.1, it also works with Apple Silicon or Arm based processors.
 {{% /alert %}}
 
 You can install `eksctl` and `eksctl-anywhere` with [homebrew](http://brew.sh/).


### PR DESCRIPTION
This fix the docs to show that eks now supports apple and arm processor. 

related issue https://github.com/aws/eks-anywhere/issues/182
