### PR TITLE
Update etcd backup restore doc cmd when grabbing etcd container id

### DIFF
--- a/docs/content/en/docs/clustermgmt/etcd-backup-restore/bottlerocket-etcd-backup.md
+++ b/docs/content/en/docs/clustermgmt/etcd-backup-restore/bottlerocket-etcd-backup.md
@@ -60,7 +60,7 @@ Make sure to setup the [admin environment variables]({{< relref "#admin-machine-
 1. Set these environment variables
     ```bash
     # get the container ID corresponding to etcd pod
-    export ETCD_CONTAINER_ID=$(ctr -n k8s.io c ls | grep -w "etcd-io" | cut -d " " -f1)
+    export ETCD_CONTAINER_ID=$(ctr -n k8s.io c ls | grep -w "etcd-io" | head -1 | cut -d " " -f1)
 
     # get the etcd endpoint
     export ETCD_ENDPOINT=$(cat /etc/kubernetes/manifests/etcd | grep -wA1 ETCD_ADVERTISE_CLIENT_URLS | tail -1 | grep -oE '[^ ]+$')
@@ -172,7 +172,7 @@ Make sure to setup the [admin environment variables]({{< relref "#admin-machine-
     export INITIAL_CLUSTER_TOKEN="etcd-cluster-1"
 
     # get the container ID corresponding to etcd pod
-    export ETCD_CONTAINER_ID=$(ctr -n k8s.io c ls | grep -w "etcd-io" | cut -d " " -f1)
+    export ETCD_CONTAINER_ID=$(ctr -n k8s.io c ls | grep -w "etcd-io" | head -1 | cut -d " " -f1)
 
     # run the restore command
     ctr -n k8s.io t exec -t --exec-id etcd ${ETCD_CONTAINER_ID} etcdctl \


### PR DESCRIPTION
*Issue #, if available:*

Sometimes, there are multiple etcd container running in BR node. Because of this, the below command from [bottlerocket-etcd-backup](https://anywhere.eks.amazonaws.com/docs/clustermgmt/etcd-backup-restore/bottlerocket-etcd-backup/) doc stored 2 container IDs for `ETCD_CONTAINER_ID` variable and the following ctr command to execute etcdctl failed with a cryptic error because of 2 container IDs instead of 1.

```
export ETCD_CONTAINER_ID=$(ctr -n k8s.io c ls | grep -w "etcd-io" | cut -d " " -f1)

ctr -n k8s.io t exec -t --exec-id etcd ${ETCD_CONTAINER_ID} etcdctl \
    --endpoints=${ETCD_ENDPOINT} \
    --cacert=/var/lib/etcd/pki/ca.crt \
    --cert=/var/lib/etcd/pki/server.crt \
    --key=/var/lib/etcd/pki/server.key \
    snapshot save /var/lib/etcd/data/etcd-backup.db
```

*Description of changes:*

As it doesn't matter which container ID we select to run the above ctr command, we edit the command from `export ETCD_CONTAINER_ID=$(ctr -n [k8s.io](http://k8s.io/) c ls | grep -w "etcd-io" | cut -d " " -f1)` to `export ETCD_CONTAINER_ID=$(ctr -n [k8s.io](http://k8s.io/) c ls | grep -w "etcd-io" | head -1 | cut -d " " -f1)`
in the above document to select only first container ID if multiple are present.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

