### PR TITLE
[Docs] Add wget when using proxy-enabled env for image building

### DIFF
--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -1136,7 +1136,7 @@ You can now run the `image-builder` CLI with the `files-config` option, with thi
      "no_proxy": "<optional comma seperated list of domains that should be excluded from proxying>"
   }
   ```
-In a proxy-enabled environment, `image-builder` uses `wget` to download artifacts instead of `curl`, as `curl` doesnt support reading proxy environment variables. In order to add `wget` to the node OS, add the following to the above json configuration file
+In a proxy-enabled environment, `image-builder` uses `wget` to download artifacts instead of `curl`, as `curl` does not support reading proxy environment variables. In order to add `wget` to the node OS, add the following to the above json configuration file:
    ```json
   {
       "extra_rpms": "wget" #If the node OS being built is RedHat

--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -1136,6 +1136,13 @@ You can now run the `image-builder` CLI with the `files-config` option, with thi
      "no_proxy": "<optional comma seperated list of domains that should be excluded from proxying>"
   }
   ```
+In a proxy-enabled environment, `image-builder` uses `wget` to download artifacts instead of `curl`, as `curl` doesnt support reading proxy environment variables. In order to add `wget` to the node OS, add the following to the above json configuration file
+   ```json
+  {
+      "extra_rpms": "wget" #If the node OS being built is RedHat
+      "extra_debs": "wget" #If the node OS being built is Ubuntu
+  }
+  ```
 
 Run `image-builder` CLI with the hypervisor configuration file
   ```bash


### PR DESCRIPTION
*Description of changes:*
Adding instructions to add `wget` to extra_rpms/debs for packer plugin goss to succeed at pulling the goss binary using proxy. Goss plugin doesn support adding proxy env vars to curl arguments and tries with wget if curl fails. Since wget by default read proxy env vars, adding wget to the OS will enable goss pluging to downlod goss and progress with image building.

/approve
/cherrypick release-0.18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

