### PR TITLE
Add image repo prefix field for AWS upgrader project

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -843,6 +843,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				},
 			},
 		},
+		ImageRepoPrefix: "aws",
 		ImageTagOptions: []string{
 			"eksDReleaseChannel",
 			"eksDReleaseNumber",

--- a/release/cli/pkg/test/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/test/testdata/main-bundle-release.yaml
@@ -289,7 +289,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -759,7 +759,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-24-30-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-24-30-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -769,11 +769,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -802,8 +802,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.4-eks-d-1-24-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.3/bootstrap-components.yaml
@@ -1076,7 +1076,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -1528,7 +1528,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-25-26-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-25-26-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -1538,11 +1538,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1571,8 +1571,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.1-eks-d-1-25-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.3/bootstrap-components.yaml
@@ -1845,7 +1845,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -2297,7 +2297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-26-22-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-26-22-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -2307,11 +2307,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2340,8 +2340,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.26.0-eks-d-1-26-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.3/bootstrap-components.yaml
@@ -2614,7 +2614,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -3066,7 +3066,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-27-16-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-27-16-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -3076,11 +3076,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3109,8 +3109,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.27.0-eks-d-1-27-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.3/bootstrap-components.yaml
@@ -3383,7 +3383,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.1/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/image-builder/v0.3.2/image-builder-v0.0.0-dev-build.0-linux-amd64.tar.gz
       kindNode:
         arch:
         - amd64
@@ -3835,7 +3835,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-28-9-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-28-9-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -3845,11 +3845,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3878,6 +3878,6 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.28.0-eks-d-1-28-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
 status: {}

--- a/release/cli/pkg/test/testdata/release-0.18-bundle-release.yaml
+++ b/release/cli/pkg/test/testdata/release-0.18-bundle-release.yaml
@@ -759,7 +759,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-24-29-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-24-29-eks-a-v0.0.0-dev-release-0.18-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -769,11 +769,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-release-0.18-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -802,8 +802,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.24.4-eks-d-1-24-eks-a-v0.0.0-dev-release-0.18-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.2/bootstrap-components.yaml
@@ -1528,7 +1528,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-25-25-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-25-25-eks-a-v0.0.0-dev-release-0.18-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -1538,11 +1538,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-release-0.18-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1571,8 +1571,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.25.1-eks-d-1-25-eks-a-v0.0.0-dev-release-0.18-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.2/bootstrap-components.yaml
@@ -2297,7 +2297,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-26-21-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-26-21-eks-a-v0.0.0-dev-release-0.18-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -2307,11 +2307,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-release-0.18-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2340,8 +2340,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.26.0-eks-d-1-26-eks-a-v0.0.0-dev-release-0.18-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.2/bootstrap-components.yaml
@@ -3066,7 +3066,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-27-15-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-27-15-eks-a-v0.0.0-dev-release-0.18-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -3076,11 +3076,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-release-0.18-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3109,8 +3109,8 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.27.0-eks-d-1-27-eks-a-v0.0.0-dev-release-0.18-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
   - bootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.5.2/bootstrap-components.yaml
@@ -3835,7 +3835,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/upgrader:v1-28-8-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-28-8-eks-a-v0.0.0-dev-release-0.18-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -3845,11 +3845,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-vsphere
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.0-eks-a-v0.0.0-dev-release-0.18-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.7.4-eks-a-v0.0.0-dev-release-0.18-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/infrastructure-components.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3878,6 +3878,6 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/kubernetes/cloud-provider-vsphere/cpi/manager:v1.28.0-eks-d-1-28-eks-a-v0.0.0-dev-release-0.18-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.0/metadata.yaml
-      version: v1.7.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-release-0.18-build.0/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.7.4/metadata.yaml
+      version: v1.7.4+abcdef1
 status: {}


### PR DESCRIPTION
Add image repo prefix field for AWS upgrader project to fix the constructed URI for images in the `aws/upgrader` repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

