### PR TITLE
Add feature flag for Kubernetes v1.29 support

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -791,6 +791,7 @@ const (
 	Kube126 KubernetesVersion = "1.26"
 	Kube127 KubernetesVersion = "1.27"
 	Kube128 KubernetesVersion = "1.28"
+	Kube129 KubernetesVersion = "1.29"
 )
 
 // KubeVersionToSemver converts kube version to semver for comparisons.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -6,6 +6,7 @@ const (
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
+	K8s129SupportEnvVar             = "K8S_1_29_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -52,5 +53,13 @@ func UseControllerViaCLIWorkflow() Feature {
 	return Feature{
 		Name:     "Use new workflow logic for cluster operations leveraging controller via CLI",
 		IsActive: globalFeatures.isActiveForEnvVar(UseControllerForCli),
+	}
+}
+
+// K8s129Support is the feature flag for Kubernetes 1.29 support.
+func K8s129Support() Feature {
+	return Feature{
+		Name:     "Kubernetes version 1.29 support",
+		IsActive: globalFeatures.isActiveForEnvVar(K8s129SupportEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -85,3 +85,11 @@ func TestUseControllerForCliTrue(t *testing.T) {
 	t.Setenv(UseControllerForCli, "true")
 	g.Expect(UseControllerViaCLIWorkflow().IsActive()).To(BeTrue())
 }
+
+func TestWithK8s129FeatureFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(K8s129SupportEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(K8s129Support())).To(BeTrue())
+}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -203,4 +204,14 @@ func parseClusterEksaVersion(mgmtCluster, cluster *v1alpha1.Cluster) (*semver.Ve
 	}
 
 	return mVersion, wVersion, nil
+}
+
+// ValidateK8s129Support checks if the 1.29 feature flag is set when using k8s 1.29.
+func ValidateK8s129Support(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.K8s129Support()) {
+		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube129 {
+			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube129, features.K8s129SupportEnvVar)
+		}
+	}
+	return nil
 }

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -507,4 +508,19 @@ func TestValidateManagementClusterEksaVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateK8s129Support(t *testing.T) {
+	tt := newTest(t)
+	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube129
+	tt.Expect(validations.ValidateK8s129Support(tt.clusterSpec)).To(
+		MatchError(ContainSubstring("kubernetes version 1.29 is not enabled. Please set the env variable K8S_1_29_SUPPORT")))
+}
+
+func TestValidateK8s129SupportActive(t *testing.T) {
+	tt := newTest(t)
+	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube129
+	features.ClearCache()
+	os.Setenv(features.K8s129SupportEnvVar, "true")
+	tt.Expect(validations.ValidateK8s129Support(tt.clusterSpec)).To(Succeed())
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -6,6 +6,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -46,6 +47,14 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate cluster's eksaVersion matches EKS-A version",
 				Remediation: "ensure EksaVersion matches the EKS-A release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, v.Opts.CliVersion, v.Opts.Spec),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.29 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s129SupportEnvVar),
+				Err:         validations.ValidateK8s129Support(v.Opts.Spec),
+				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -8,6 +8,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -111,6 +112,14 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate cluster's eksaVersion matches EKS-A Version",
 				Remediation: "ensure EksaVersion matches the EKS-A release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, u.Opts.CliVersion, u.Opts.Spec),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.29 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s129SupportEnvVar),
+				Err:         validations.ValidateK8s129Support(u.Opts.Spec),
+				Silent:      true,
 			}
 		},
 	}


### PR DESCRIPTION
Add feature flag for Kubernetes v1.29 support in EKS-A.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

