### PR TITLE
Fix short Kubernetes version in bundle manifest

### DIFF
--- a/release/cli/pkg/aws/s3/s3.go
+++ b/release/cli/pkg/aws/s3/s3.go
@@ -80,7 +80,7 @@ func UploadFile(filePath string, bucket, key *string, s3Uploader *s3manager.Uplo
 	return nil
 }
 
-func KeyExists(bucket string, key string) bool {
+func KeyExists(bucket, key string) bool {
 	objectUrl := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", bucket, key)
 
 	resp, err := http.Head(objectUrl)

--- a/release/cli/pkg/bundles/bundles.go
+++ b/release/cli/pkg/bundles/bundles.go
@@ -151,7 +151,7 @@ func GetVersionsBundles(r *releasetypes.ReleaseConfig, imageDigests map[string]s
 		number := strconv.Itoa(release.Number)
 		dev := release.Dev
 		kubeVersion := release.KubeVersion
-		shortKubeVersion := kubeVersion[1:strings.LastIndex(kubeVersion, ".")]
+		shortKubeVersion := strings.Join(strings.SplitN(kubeVersion[1:], ".", 3)[:2], ".")
 
 		if !sliceutils.SliceContains(supportedK8sVersions, channel) {
 			continue


### PR DESCRIPTION
The PR improves the logic to get the short Kubernetes version (`major.minor`) for the bundle manifest. The previous method strictly allowed the input full Kubernetes version to have only upto three fields, i.e., `major.minor.patch`, while the new logic doesn't have this restriction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

