### PR TITLE
Update binary installation procedure

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -53,7 +53,7 @@ The EKS Anywhere plugin requires `eksctl` version 0.66.0 or newer.
 curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
     --silent --location \
     | tar xz -C /tmp
-sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
+sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
 ```
 
 Install the `eksctl-anywhere` plugin.

--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -53,7 +53,7 @@ The EKS Anywhere plugin requires `eksctl` version 0.66.0 or newer.
 curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
     --silent --location \
     | tar xz -C /tmp
-sudo mv /tmp/eksctl /usr/local/bin/
+sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
 ```
 
 Install the `eksctl-anywhere` plugin.
@@ -64,7 +64,7 @@ EKS_ANYWHERE_TARBALL_URL=$(curl https://anywhere-assets.eks.amazonaws.com/releas
 curl $EKS_ANYWHERE_TARBALL_URL \
     --silent --location \
     | tar xz ./eksctl-anywhere
-sudo mv ./eksctl-anywhere /usr/local/bin/
+sudo install -m 0755 ./eksctl-anywhere /usr/local/bin/eksctl-anywhere
 ```
 
 Install the `kubectl` Kubernetes command line tool.
@@ -75,8 +75,7 @@ Or you can install the latest kubectl directly with the following.
 ```bash
 export OS="$(uname -s | tr A-Z a-z)" ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS}/${ARCH}/kubectl"
-sudo mv ./kubectl /usr/local/bin
-sudo chmod +x /usr/local/bin/kubectl
+sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
 ```
 
 ### Upgrade eksctl-anywhere


### PR DESCRIPTION
*Issue #, if available:*
The methods demonstrating who to install eksctl, eksctl-anywhere, and kubectl were not following best-practice.

*Description of changes:*
I am mirroring the process called out in another page:
https://anywhere.eks.amazonaws.com/docs/getting-started/install/

*Testing (if applicable):*
N/A - following other examples.

*Documentation added/planned (if applicable):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

