### PR TITLE
Check for k8s version in the Cloudstack template name

### DIFF
--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -607,7 +607,7 @@ func cloudstackMachineTemplate(name string) *cloudstackv1.CloudStackMachineTempl
 			Template: cloudstackv1.CloudStackMachineTemplateResource{
 				Spec: cloudstackv1.CloudStackMachineSpec{
 					Template: cloudstackv1.CloudStackResourceIdentifier{
-						Name: "centos7-k8s-118",
+						Name: "kubernetes_1_21",
 					},
 					Offering: cloudstackv1.CloudStackResourceIdentifier{
 						Name: "m4-large",

--- a/pkg/providers/cloudstack/testdata/cluster_main.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main.yaml
@@ -65,7 +65,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -90,7 +90,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -118,7 +118,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/pkg/providers/cloudstack/testdata/cluster_main_with_cp_node_labels.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main_with_cp_node_labels.yaml
@@ -64,7 +64,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -87,7 +87,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -115,7 +115,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/pkg/providers/cloudstack/testdata/cluster_main_with_node_labels.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main_with_node_labels.yaml
@@ -64,7 +64,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -89,7 +89,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"
@@ -114,7 +114,7 @@ spec:
     sshAuthorizedKeys: # The key below was manually generated and not used in any production systems
     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
   template:
-    name: "centos7-k8s-118"
+    name: "kubernetes_1_21"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_autoscaling_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_autoscaling_md.yaml
@@ -124,7 +124,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -453,7 +453,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -484,6 +484,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_md.yaml
@@ -121,7 +121,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -453,7 +453,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -484,6 +484,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_md.yaml
@@ -121,7 +121,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -439,7 +439,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -469,6 +469,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_md.yaml
@@ -107,7 +107,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -453,7 +453,7 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
@@ -484,6 +484,6 @@ spec:
         name: m4-large
       sshKey: ""
       template:
-        name: centos7-k8s-118
+        name: kubernetes_1_21
 
 ---


### PR DESCRIPTION
*Description of changes:*
Template name field in each cloudstack machine object should contain Cluster object's kubernetes version and/or worker machine's kubernetes version.

Simple Upgrade:

- [x]  Control plane machine's template name should contain cluster object's kubernetes version
- [x]  External Etcd (if present) machine's template name should contain cluster object's kubernetes version
- [x]  Worker machine's template name should contain cluster object's kubernetes version

Modular Upgrade:
- [x]  Control plane machine's template name should contain cluster object's kubernetes version
- [x]  External Etcd (if present) machine's template name should contain cluster object's kubernetes version
- [x]  Worker machine's template name should contain cluster object's kubernetes version or Worker machine's template name should contain workerNodeGroupConfigurations's kubernetes version

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

