### PR TITLE
Fix controller generating cilium manifests with registry mirror

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -1,0 +1,44 @@
+package controllers
+
+import (
+	"context"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/registrymirror"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HelmFactory is responsible for creating and owning instances of Helm client,
+// configured using information from the current state of the cluster using a k8s client.
+type HelmFactory struct {
+	client                client.Client
+	dependencyHelmFactory dependencies.HelmFactory
+}
+
+// NewHelmFactory returns a new HelmFactory.
+func NewHelmFactory(client client.Client, dependencyHelmFactory *dependencies.HelmFactory) *HelmFactory {
+	return &HelmFactory{
+		client: client,
+	}
+}
+
+// GetClientForCluster returns a new Helm client configured using information from the provided cluster.
+func (f *HelmFactory) GetClientForCluster(ctx context.Context, clusterName string) (*executables.Helm, error) {
+	cluster := &anywherev1.Cluster{}
+	namespacedNamed := types.NamespacedName{
+		Name:      clusterName,
+		Namespace: constants.EksaSystemNamespace,
+	}
+
+	if err := f.client.Get(ctx, namespacedNamed, cluster); err != nil {
+		return nil, err
+	}
+
+	r := registrymirror.FromCluster(cluster)
+	return f.dependencyHelmFactory.GetClient(executables.WithRegistryMirror(r)), nil
+
+}

--- a/controllers/helm_test.go
+++ b/controllers/helm_test.go
@@ -1,0 +1,31 @@
+package controllers_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/eks-anywhere/controllers"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNewHelmFactory(t *testing.T) {
+	type args struct {
+		client                client.Client
+		dependencyHelmFactory *dependencies.HelmFactory
+	}
+	tests := []struct {
+		name string
+		args args
+		want *controllers.HelmFactory
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := controllers.NewHelmFactory(tt.args.client, tt.args.dependencyHelmFactory); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewHelmFactory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -771,7 +771,7 @@ func (f *Factory) WithHelm(opts ...executables.HelmOpt) *Factory {
 	return f
 }
 
-func (f *Factory) WithHelmFactory(opts ...executables.HelmOpt) *Factory {
+func (f *Factory) WithHelmFactory() *Factory {
 	f.WithExecutableBuilder()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {

--- a/pkg/dependencies/helm.go
+++ b/pkg/dependencies/helm.go
@@ -1,0 +1,68 @@
+package dependencies
+
+import (
+	"sync"
+
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/registrymirror"
+)
+
+type ExecutableBuilder interface {
+	BuildHelmExecutable(...executables.HelmOpt) *executables.Helm
+}
+
+type HelmFactory struct {
+	mu                 sync.Mutex
+	builder            ExecutableBuilder
+	helm               *executables.Helm
+	registryMirror     *registrymirror.RegistryMirror
+	proxyConfiguration map[string]string
+	insecure           bool
+}
+
+// WithRegistryMirror configures the factory to use registry mirror wherever applicable.
+func (f *HelmFactory) WithRegistryMirror(registryMirror *registrymirror.RegistryMirror) *HelmFactory {
+	f.registryMirror = registryMirror
+
+	return f
+}
+
+// WithProxyConfigurations configures the factory to use proxy configurations wherever applicable.
+func (f *HelmFactory) WithProxyConfigurations(proxyConfiguration map[string]string) *HelmFactory {
+	f.proxyConfiguration = proxyConfiguration
+
+	return f
+}
+
+// WithInsecure configures the factory to configure helm to use to allow connections to TLS registry without certs or with self-signed certs
+func (f *HelmFactory) WithInsecure() *HelmFactory {
+	f.insecure = true
+
+	return f
+}
+
+func NewHelmFactory(builder ExecutableBuilder) *HelmFactory {
+	return &HelmFactory{
+		builder: builder,
+	}
+}
+
+func (f *HelmFactory) GetInstance(opts ...executables.HelmOpt) *executables.Helm {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.registryMirror != nil {
+		opts = append(opts, executables.WithRegistryMirror(f.registryMirror))
+	}
+
+	if f.proxyConfiguration != nil {
+		opts = append(opts, executables.WithEnv(f.proxyConfiguration))
+	}
+
+	if f.insecure {
+		opts = append(opts, executables.WithInsecure())
+	}
+
+	f.helm = f.builder.BuildHelmExecutable(opts...)
+	return f.helm
+}

--- a/pkg/dependencies/helm_test.go
+++ b/pkg/dependencies/helm_test.go
@@ -1,0 +1,41 @@
+package dependencies_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/dependencies"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelmFactory_GetClient(t *testing.T) {
+	tests := map[string]struct {
+		wantErr error
+	}{
+		"Success": {
+			wantErr: nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			g := NewWithT(t)
+			deps, err := dependencies.NewFactory().
+				WithLocalExecutables().
+				WithHelmFactory().
+				Build(context.Background())
+
+			g.Expect(err).To(BeNil())
+
+			helm, err := deps.HelmFactory.GetClientForCluster(ctx, "")
+
+			if tt.wantErr != nil {
+				g.Expect(err).To(Equal(tt.wantErr))
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(deps.HelmFactory).NotTo(BeNil())
+				g.Expect(helm).NotTo(BeNil())
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The CNI reconciler fails to generate cilium manifests in an airgapped environment because it tries to fetch the image from public.ecr.aws instead of the registry mirror. This is because the registry mirror for the [helm](https://github.com/aws/eks-anywhere/blob/c4d01fed9ae8030a948a939315f8747d7d53e429/pkg/executables/helm.go#L20) executable reference in the [cilium templater](https://github.com/aws/eks-anywhere/blob/6f5168b9121b1e8fbb3527119f0ffae83a4ef8bb/pkg/networking/cilium/templater.go#L33) is never set when managing a cluster using FLC, so when generating the manifests helm , [the logic that replaces the host](https://github.com/aws/eks-anywhere/blob/6f5168b9121b1e8fbb3527119f0ffae83a4ef8bb/pkg/registrymirror/registrymirror.go#L85) in the image uri is skipped

This PR addresses the issue by enabling the controller to handle helm charts when reconciling the CNI is to construct the `Helm` instance in the controller. Instead of depending directly on the Helm, we can inject a HelmFactory to the [cilium templater](https://github.com/aws/eks-anywhere/blob/6f5168b9121b1e8fbb3527119f0ffae83a4ef8bb/pkg/networking/cilium/templater.go#L33).  We can then use the `HelmFactory` to create an instance of `Helm` with a registry mirror configuration if one is defined on the `Cluster` object.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

