### PR TITLE
Cleanup E2E Let's Encrypt TXT Records

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -29,6 +29,7 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		packageFile := e.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)
 		test.ManagementCluster.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ManagementCluster.ClusterName))
 		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withMgmtClusterSetup(test.ManagementCluster))
+		e.CleanupCerts(withMgmtClusterSetup(test.ManagementCluster))
 		e.DeleteCluster()
 	})
 	time.Sleep(5 * time.Minute)

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1810,7 +1810,23 @@ func (e *ClusterE2ETest) verifyLetsEncryptCert(mgmtCluster *types.Cluster) error
 	err = e.KubectlClient.WaitJSONPathLoop(ctx, e.Cluster().KubeconfigFile, "5m", "status.conditions[?(@.type=='Ready')].status", "True",
 		fmt.Sprintf("certificates.cert-manager.io/%s", letsEncryptCert), constants.EksaPackagesName)
 	if err != nil {
-		return fmt.Errorf("failed to issue a self signed certificate: %v", err)
+		return fmt.Errorf("failed to issue a let's encrypt certificate: %v", err)
+	}
+
+	return nil
+}
+
+// CleanupCerts cleans up letsencrypt certificates.
+func (e *ClusterE2ETest) CleanupCerts(mgmtCluster *types.Cluster) error {
+	ctx := context.Background()
+	letsEncryptCert := "test-cert"
+	opts := &kubernetes.KubectlDeleteOptions{
+		Name:      letsEncryptCert,
+		Namespace: constants.EksaPackagesName,
+	}
+	err := e.KubectlClient.Delete(ctx, "certificates.cert-manager.io", e.Cluster().KubeconfigFile, opts)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup let's encrypt certificate: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Prior to this PR, cert-manager package end to end tests were failing with the following error:

```
Exceeded limit on number of multi-record answer RRSets _acme-challenge.<domain>

```
This PR should permanently fix the issue they were running into.

For context, when cert-manager provisions a certificate signed by Let's Encrypt it needs a DNS provider
to create a TXT record to verify control of the domain.

We use Route53 for this purpose.

However, Route53 has a service limit of 100 records per-domain within a zone.

The cert-manager packages tests were not cleaning up their Route53 entries, and so it was filling up and hitting the service quota.

By deleting the let's encrypt cert and allowing the cert-manager controller to cleanup related resources, we should avoid this problem in future.

*Testing (if applicable):*

Invoked E2E test.

*Documentation added/planned (if applicable):*

None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->