### PR TITLE
Automatically Fix Linting Issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,10 @@ envtest-setup: $(SETUP_ENVTEST)
 lint: $(GOLANGCI_LINT) ## Run golangci-lint
 	$(GOLANGCI_LINT) run --new-from-rev main
 
+.PHONY: lint-fix
+lint-fix: $(GOLANGCI_LINT) ## Run golangci-lint and automatically fix lint errors
+	$(GOLANGCI_LINT) run --fix --new-from-rev main
+
 $(GOLANGCI_LINT): $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_CONFIG)
 	$(eval GOLANGCI_LINT_VERSION?=$(shell cat .github/workflows/golangci-lint.yml | yq e '.jobs.golangci.steps[] | select(.name == "golangci-lint") .with.version' -))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fixing linting errors now requires every developer to find the correct golangci incantation to resolve an issue.

By adding the --fix flag to the lint make target we automatically resolve most errors for developers.

*Testing (if applicable):*

```
make lint-fix
```

*Documentation added/planned (if applicable):*

N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->