### PR TITLE
Sign container images with notation CLI with image digest instead of image tag

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -194,6 +194,12 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
+			err = operations.SignImagesNotation(releaseConfig, imageDigests)
+			if err != nil {
+				fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
+				os.Exit(1)
+			}
+
 			err = operations.GenerateBundleSpec(releaseConfig, bundle, imageDigests)
 			if err != nil {
 				fmt.Printf("Error generating bundles manifest: %+v\n", err)

--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -65,7 +65,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 		}
 		if !PackageImage {
 			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
-			err := images.CopyToDestination(r.SourceClients.ECR.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.SourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag), r.AwsSignerProfileArn)
+			err := images.CopyToDestination(r.SourceClients.ECR.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.SourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
 			if err != nil {
 				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
 			}
@@ -80,7 +80,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests map[string]st
 		}
 		if !TokenImage {
 			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
-			err := images.CopyToDestination(r.SourceClients.ECR.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.SourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag), r.AwsSignerProfileArn)
+			err := images.CopyToDestination(r.SourceClients.ECR.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.SourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
 			if err != nil {
 				fmt.Printf("Error copying dev EKS Anywhere package token refresher image, to ECR Public: %v", err)
 			}

--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -94,7 +94,7 @@ func PollForExistence(devRelease bool, authConfig *docker.AuthConfiguration, ima
 	return nil
 }
 
-func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfiguration, sourceImageUri, releaseImageUri, awsSignerProfileArn string) error {
+func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfiguration, sourceImageUri, releaseImageUri string) error {
 	retrier := retrier.NewRetrier(60*time.Minute, retrier.WithRetryPolicy(func(totalRetries int, err error) (retry bool, wait time.Duration) {
 		if err != nil && totalRetries < 10 {
 			return true, 30 * time.Second
@@ -118,14 +118,6 @@ func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfigura
 	})
 	if err != nil {
 		return fmt.Errorf("retries exhausted performing image copy from source to destination: %v", err)
-	}
-	// Sign public ECR image using AWS signer and notation CLI
-	// notation sign <registry>/<repository>:<tag> --plugin com.amazonaws.signer.notation.plugin --id <signer_profile_arn>
-	cmd := exec.Command("notation", "sign", releaseImageUri, "--plugin", "com.amazonaws.signer.notation.plugin", "--id", awsSignerProfileArn, "-u", releaseRegistryUsername, "-p", releaseRegistryPassword)
-	out, err := commandutils.ExecCommand(cmd)
-	fmt.Println(out)
-	if err != nil {
-		return fmt.Errorf("executing sigining container image with Notation CLI: %v", err)
 	}
 
 	return nil

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -111,7 +111,7 @@ func UploadArtifacts(r *releasetypes.ReleaseConfig, eksArtifacts map[string][]re
 				releaseImageUri := artifact.Image.ReleaseImageURI
 				fmt.Printf("Source Image - %s\n", sourceImageUri)
 				fmt.Printf("Destination Image - %s\n", releaseImageUri)
-				err := images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri, r.AwsSignerProfileArn)
+				err := images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri)
 				if err != nil {
 					return fmt.Errorf("copying image from source to destination: %v", err)
 				}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sign container images using shasum256 image digest(@sha256:...) instead of using image tag(:latest).

notation sign registry/repository@<sha256:shasum> --plugin com.amazonaws.signer.notation.plugin --id <signer_profile_arn>

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

