### PR TITLE
Advocate using `etcdutl` instead of `etcdctl` for backup and restore

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,7 +50,7 @@ deploy: zip ## Deploy docs to Amplify
 	bash ./deploy-docs.sh public.zip
 
 serve: submodule build ## Boot the development server.
-	hugo server --buildFuture --baseUrl http://127.0.0.1
+	hugo server --buildFuture --baseURL http://127.0.0.1
 
 server: serve
 
@@ -70,7 +70,7 @@ container-serve: ## Boot the development server using container. Run `make conta
 		--bind 0.0.0.0 \
 		--destination /tmp/hugo \
 		--cleanDestinationDir \
-		--baseUrl http://0.0.0.0
+		--baseURL http://0.0.0.0
 
 container-server: container-serve
 


### PR DESCRIPTION
The v3.5.0 release of etcd saw the introduction of a new command-line tool called `etcdutl` that took over the snapshot/restore/backup functionalities of `etcdctl`. Hence, from etcd version v3.5.0, using `etcdctl` for creating and restoring snapshots is deprecated and using this command displays a deprecation warning which suggests to use `etcdutl` tool instead. This PR updates the docs to do the same based on etcd version. The `etcdutl` snapshot and restore commands are essentially drop-in replacements for their `etcdctl` counterparts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

