### PR TITLE
Skip signing images for now

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -194,11 +194,12 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			err = operations.SignImagesNotation(releaseConfig, imageDigests)
-			if err != nil {
-				fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
-				os.Exit(1)
-			}
+			// WIP[Pankti Shah]: skip image signing until we fix maximum number of artifacts issue from Public ECR
+			// err = operations.SignImagesNotation(releaseConfig, imageDigests)
+			// if err != nil {
+			// 	fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
+			// 	os.Exit(1)
+			// }
 
 			err = operations.GenerateBundleSpec(releaseConfig, bundle, imageDigests)
 			if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Skip signing images and enable it after we resolve maximum artifacts limit issue on Public ECR

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

