### PR TITLE
Verify image signature and skip signing if already signed

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -194,12 +194,11 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			// WIP[Pankti Shah]: skip image signing until we fix maximum number of artifacts issue from Public ECR
-			// err = operations.SignImagesNotation(releaseConfig, imageDigests)
-			// if err != nil {
-			// 	fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
-			// 	os.Exit(1)
-			// }
+			err = operations.SignImagesNotation(releaseConfig, imageDigests)
+			if err != nil {
+				fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
+				os.Exit(1)
+			}
 
 			err = operations.GenerateBundleSpec(releaseConfig, bundle, imageDigests)
 			if err != nil {


### PR DESCRIPTION
*Description of changes:*
We have added a feature to sign all the container images using AWS Signer and Notation CLI. Notation signs the images again even if the image is already signed which causes an issue in the particular public ECR repository and ran into maximum number of artifacts issue. 
With this PR, we have added a check to see if the image with particular digest is not signed then only sign the image.
 
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

