### PR TITLE
Add reconcile logic for MD Upgrade controller

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_machinedeploymentupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_machinedeploymentupgrades.yaml
@@ -45,19 +45,19 @@ spec:
                   name:
                     type: string
                 type: object
-              controlPlane:
-                properties:
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                type: object
               kubeadmClusterConfig:
                 type: string
               kubeletVersion:
                 type: string
               kubernetesVersion:
                 type: string
+              machineDeployment:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                type: object
               machinesRequireUpgrade:
                 items:
                   properties:
@@ -69,10 +69,10 @@ spec:
                 type: array
             required:
             - cluster
-            - controlPlane
             - kubeadmClusterConfig
             - kubeletVersion
             - kubernetesVersion
+            - machineDeployment
             - machinesRequireUpgrade
             type: object
           status:
@@ -87,10 +87,6 @@ spec:
               upgraded:
                 format: int64
                 type: integer
-            required:
-            - ready
-            - requireUpgrade
-            - upgraded
             type: object
         type: object
     served: true

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4830,19 +4830,19 @@ spec:
                   name:
                     type: string
                 type: object
-              controlPlane:
-                properties:
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                type: object
               kubeadmClusterConfig:
                 type: string
               kubeletVersion:
                 type: string
               kubernetesVersion:
                 type: string
+              machineDeployment:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                type: object
               machinesRequireUpgrade:
                 items:
                   properties:
@@ -4854,10 +4854,10 @@ spec:
                 type: array
             required:
             - cluster
-            - controlPlane
             - kubeadmClusterConfig
             - kubeletVersion
             - kubernetesVersion
+            - machineDeployment
             - machinesRequireUpgrade
             type: object
           status:
@@ -4872,10 +4872,6 @@ spec:
               upgraded:
                 format: int64
                 type: integer
-            required:
-            - ready
-            - requireUpgrade
-            - upgraded
             type: object
         type: object
     served: true

--- a/controllers/controlplaneupgrade_controller.go
+++ b/controllers/controlplaneupgrade_controller.go
@@ -156,11 +156,6 @@ func (r *ControlPlaneUpgradeReconciler) reconcile(ctx context.Context, log logr.
 	return ctrl.Result{}, nil
 }
 
-// nodeUpgradeName returns the name of the node upgrade object based on the machine reference.
-func nodeUpgraderName(machineRefName string) string {
-	return fmt.Sprintf("%s-node-upgrader", machineRefName)
-}
-
 func nodeUpgrader(machineRef anywherev1.Ref, kubernetesVersion, etcdVersion string, firstControlPlane bool) *anywherev1.NodeUpgrade {
 	return &anywherev1.NodeUpgrade{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/machinedeploymentupgrade_controller.go
+++ b/controllers/machinedeploymentupgrade_controller.go
@@ -18,23 +18,40 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+const (
+	// mdUpgradeFinalizerName is the finalizer added to MachineDeploymentUpgrade objects to handle deletion.
+	mdUpgradeFinalizerName = "machinedeploymentupgrades.anywhere.eks.amazonaws.com/finalizer"
 )
 
 // MachineDeploymentUpgradeReconciler reconciles a MachineDeploymentUpgrade object.
 type MachineDeploymentUpgradeReconciler struct {
 	client client.Client
+	log    logr.Logger
 }
 
 // NewMachineDeploymentUpgradeReconciler returns a new instance of MachineDeploymentUpgradeReconciler.
 func NewMachineDeploymentUpgradeReconciler(client client.Client) *MachineDeploymentUpgradeReconciler {
 	return &MachineDeploymentUpgradeReconciler{
 		client: client,
+		log:    ctrl.Log.WithName("MachineDeploymentUpgradeController"),
 	}
 }
 
@@ -43,12 +60,64 @@ func NewMachineDeploymentUpgradeReconciler(client client.Client) *MachineDeploym
 //+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=machinedeploymentupgrades/finalizers,verbs=update
 
 // Reconcile reconciles a MachineDeploymentUpgrade object.
-func (r *MachineDeploymentUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+// nolint:gocyclo
+// TODO: Reduce high cyclomatic complexity: https://github.com/aws/eks-anywhere-internal/issues/2119
+func (r *MachineDeploymentUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
+	log := r.log.WithValues("MachineDeploymentUpgrade", req.NamespacedName)
 
-	// TODO(user): your logic here
+	log.Info("Reconciling machine deployment upgrade object")
+	mdUpgrade := &anywherev1.MachineDeploymentUpgrade{}
+	if err := r.client.Get(ctx, req.NamespacedName, mdUpgrade); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		return ctrl.Result{}, err
+	}
 
-	return ctrl.Result{}, nil
+	patchHelper, err := patch.NewHelper(mdUpgrade, r.client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	defer func() {
+		err := r.updateStatus(ctx, log, mdUpgrade)
+		if err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+
+		// Always attempt to patch the object and status after each reconciliation.
+		patchOpts := []patch.Option{}
+
+		// We want the observedGeneration to indicate, that the status shown is up-to-date given the desired spec of the same generation.
+		// However, if there is an error while updating the status, we may get a partial status update, In this case,
+		// a partially updated status is not considered up to date, so we should not update the observedGeneration
+
+		// Patch ObservedGeneration only if the reconciliation completed without error
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchMachineDeploymentUpgrade(ctx, patchHelper, mdUpgrade, patchOpts...); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+
+		// Only requeue if we are not already re-queueing and the Ready condition is false.
+		// We do this to be able to update the status continuously until it becomes ready,
+		// since there might be changes in state of the world that don't trigger reconciliation requests
+
+		if reterr == nil && !result.Requeue && result.RequeueAfter <= 0 && !mdUpgrade.Status.Ready {
+			result = ctrl.Result{RequeueAfter: 10 * time.Second}
+		}
+	}()
+
+	// Reconcile the MachineDeploymentUpgrade deletion if the DeletionTimestamp is set.
+	if !mdUpgrade.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, log, mdUpgrade)
+	}
+
+	// AddFinalizer	is idempotent
+	controllerutil.AddFinalizer(mdUpgrade, mdUpgradeFinalizerName)
+
+	return r.reconcile(ctx, log, mdUpgrade)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -56,4 +125,103 @@ func (r *MachineDeploymentUpgradeReconciler) SetupWithManager(mgr ctrl.Manager) 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&anywherev1.MachineDeploymentUpgrade{}).
 		Complete(r)
+}
+
+func (r *MachineDeploymentUpgradeReconciler) reconcile(ctx context.Context, log logr.Logger, mdUpgrade *anywherev1.MachineDeploymentUpgrade) (ctrl.Result, error) {
+	log.Info("Upgrading all worker nodes")
+	for _, machineRef := range mdUpgrade.Spec.MachinesRequireUpgrade {
+		nodeUpgrade, err := getNodeUpgrade(ctx, r.client, nodeUpgraderName(machineRef.Name))
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				nodeUpgrade = mdNodeUpgrader(machineRef, kubernetesVersion)
+				if err := r.client.Create(ctx, nodeUpgrade); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to create node upgrader for machine %s:  %v", machineRef.Name, err)
+				}
+				return ctrl.Result{}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("getting node upgrader for machine %s: %v", machineRef.Name, err)
+		}
+		if !nodeUpgrade.Status.Completed {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *MachineDeploymentUpgradeReconciler) reconcileDelete(ctx context.Context, log logr.Logger, mdUpgrade *anywherev1.MachineDeploymentUpgrade) (ctrl.Result, error) {
+	log.Info("Reconcile MachineDeploymentUpgrade deletion")
+
+	for _, machineRef := range mdUpgrade.Spec.MachinesRequireUpgrade {
+		nodeUpgrade, err := getNodeUpgrade(ctx, r.client, nodeUpgraderName(machineRef.Name))
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("Node Upgrader not found, skipping node upgrade deletion")
+			} else {
+				return ctrl.Result{}, fmt.Errorf("getting node upgrader for machine %s: %v", machineRef.Name, err)
+			}
+		} else {
+			log.Info("Deleting node upgrader", "Machine", machineRef.Name)
+			if err := r.client.Delete(ctx, nodeUpgrade); err != nil {
+				return ctrl.Result{}, fmt.Errorf("deleting node upgrader: %v", err)
+			}
+		}
+	}
+
+	// Remove the finalizer on MachineDeploymentUpgrade object
+	controllerutil.RemoveFinalizer(mdUpgrade, mdUpgradeFinalizerName)
+	return ctrl.Result{}, nil
+}
+
+func patchMachineDeploymentUpgrade(ctx context.Context, patchHelper *patch.Helper, mdUpgrade *anywherev1.MachineDeploymentUpgrade, patchOpts ...patch.Option) error {
+	// Always attempt to patch the object and status after each reconciliation.
+	return patchHelper.Patch(ctx, mdUpgrade, patchOpts...)
+}
+
+func (r *MachineDeploymentUpgradeReconciler) updateStatus(ctx context.Context, log logr.Logger, mdUpgrade *anywherev1.MachineDeploymentUpgrade) error {
+	// When MachineDeploymentUpgrade is fully deleted, we do not need to update the status. Without this check
+	// the subsequent patch operations would fail if the status is updated after it is fully deleted.
+	if !mdUpgrade.DeletionTimestamp.IsZero() && len(mdUpgrade.GetFinalizers()) == 0 {
+		log.Info("MachineDeploymentUpgrade is deleted, skipping status update")
+		return nil
+	}
+
+	log.Info("Updating MachineDeploymentUpgrade status")
+
+	nodesUpgradeCompleted := 0
+	nodesUpgradeRequired := len(mdUpgrade.Spec.MachinesRequireUpgrade)
+
+	for _, machine := range mdUpgrade.Spec.MachinesRequireUpgrade {
+		nodeUpgrade, err := getNodeUpgrade(ctx, r.client, nodeUpgraderName(machine.Name))
+		if err != nil {
+			return err
+		}
+		if nodeUpgrade.Status.Completed {
+			nodesUpgradeCompleted++
+			nodesUpgradeRequired--
+
+		}
+	}
+	log.Info("Worker nodes ready", "total", mdUpgrade.Status.Upgraded, "need-upgrade", mdUpgrade.Status.RequireUpgrade)
+	mdUpgrade.Status.Upgraded = int64(nodesUpgradeCompleted)
+	mdUpgrade.Status.RequireUpgrade = int64(nodesUpgradeRequired)
+	mdUpgrade.Status.Ready = nodesUpgradeRequired == 0
+	return nil
+}
+
+func mdNodeUpgrader(machineRef anywherev1.Ref, kubernetesVersion string) *anywherev1.NodeUpgrade {
+	return &anywherev1.NodeUpgrade{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      nodeUpgraderName(machineRef.Name),
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: anywherev1.NodeUpgradeSpec{
+			Machine: corev1.ObjectReference{
+				Kind:      machineRef.Kind,
+				Namespace: constants.EksaSystemNamespace,
+				Name:      machineRef.Name,
+			},
+			KubernetesVersion: kubernetesVersion,
+		},
+	}
 }

--- a/controllers/machinedeploymentupgrade_controller_test.go
+++ b/controllers/machinedeploymentupgrade_controller_test.go
@@ -1,0 +1,188 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/controllers"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+func TestMDUpgradeReconcile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cluster, machine, node, mdUpgrade, nodeUpgrade := getObjectsForMDUpgradeTest()
+	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
+	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
+		Completed: true,
+	}
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade).Build()
+
+	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
+	req := mdUpgradeRequest(mdUpgrade)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	mdu := &anywherev1.MachineDeploymentUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: mdUpgrade.Name, Namespace: "eksa-system"}, mdu)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(mdu.Status.Ready).To(BeTrue())
+}
+
+func TestMDUpgradeReconcileNodesNotReadyYet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cluster, machine, node, mdUpgrade, nodeUpgrade := getObjectsForMDUpgradeTest()
+	mdUpgrade.Status = anywherev1.MachineDeploymentUpgradeStatus{
+		Upgraded:       0,
+		RequireUpgrade: 1,
+	}
+	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade).Build()
+
+	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
+	req := mdUpgradeRequest(mdUpgrade)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(mdUpgrade.Status.Ready).To(BeFalse())
+}
+
+func TestMDUpgradeReconcileDelete(t *testing.T) {
+	g := NewWithT(t)
+	now := metav1.Now()
+	ctx := context.Background()
+
+	cluster, machine, node, mdUpgrade, nodeUpgrade := getObjectsForMDUpgradeTest()
+	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
+	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
+		Completed: true,
+	}
+	mdUpgrade.DeletionTimestamp = &now
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade).Build()
+
+	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
+	req := mdUpgradeRequest(mdUpgrade)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	n := &anywherev1.NodeUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrade.Name, Namespace: "eksa-system"}, n)
+	g.Expect(err).To(MatchError("nodeupgrades.anywhere.eks.amazonaws.com \"machine01-node-upgrader\" not found"))
+}
+
+func TestMDUpgradeReconcileDeleteNodeUgradeAlreadyDeleted(t *testing.T) {
+	g := NewWithT(t)
+	now := metav1.Now()
+	ctx := context.Background()
+
+	cluster, machine, node, mdUpgrade, nodeUpgrade := getObjectsForMDUpgradeTest()
+	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
+	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
+		Completed: true,
+	}
+	mdUpgrade.DeletionTimestamp = &now
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade).Build()
+
+	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
+	req := mdUpgradeRequest(mdUpgrade)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	n := &anywherev1.NodeUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrade.Name, Namespace: "eksa-system"}, n)
+	g.Expect(err).To(MatchError("nodeupgrades.anywhere.eks.amazonaws.com \"machine01-node-upgrader\" not found"))
+
+	_, err = r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestMDUpgradeReconcileNodeUpgraderCreate(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	cluster, machine, node, mdUpgrade, _ := getObjectsForMDUpgradeTest()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade).Build()
+
+	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
+	req := mdUpgradeRequest(mdUpgrade)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	n := &anywherev1.NodeUpgrade{}
+	nodeUpgradeName := fmt.Sprintf("%s-node-upgrader", machine.Name)
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgradeName, Namespace: "eksa-system"}, n)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestMDUpgradeObjectDoesNotExist(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	cluster, machine, node, mdUpgrade, nodeUpgrade := getObjectsForMDUpgradeTest()
+	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrade", machine.Name)
+	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
+		Completed: true,
+	}
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade).Build()
+
+	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
+	req := mdUpgradeRequest(mdUpgrade)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).To(MatchError("machinedeploymentupgrades.anywhere.eks.amazonaws.com \"md-upgrade-request\" not found"))
+}
+
+func getObjectsForMDUpgradeTest() (*clusterv1.Cluster, *clusterv1.Machine, *corev1.Node, *anywherev1.MachineDeploymentUpgrade, *anywherev1.NodeUpgrade) {
+	cluster := generateCluster()
+	node := generateNode()
+	machine := generateMachine(cluster, node)
+	nodeUpgrade := generateNodeUpgrade(machine)
+	mdUpgrade := generateMDUpgrade(machine, cluster)
+	return cluster, machine, node, mdUpgrade, nodeUpgrade
+}
+
+func mdUpgradeRequest(mdUpgrade *anywherev1.MachineDeploymentUpgrade) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      mdUpgrade.Name,
+			Namespace: mdUpgrade.Namespace,
+		},
+	}
+}
+
+func generateMDUpgrade(machine *clusterv1.Machine, cluster *clusterv1.Cluster) *anywherev1.MachineDeploymentUpgrade {
+	return &anywherev1.MachineDeploymentUpgrade{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "md-upgrade-request",
+			Namespace: "eksa-system",
+		},
+		Spec: anywherev1.MachineDeploymentUpgradeSpec{
+			Cluster: anywherev1.Ref{
+				Name: cluster.Name,
+				Kind: "Cluster",
+			},
+			MachineDeployment: anywherev1.Ref{
+				Name: "my-md",
+				Kind: "MachineDeployment",
+			},
+			MachinesRequireUpgrade: []anywherev1.Ref{
+				{
+					Name: machine.Name,
+					Kind: "Machine",
+				},
+			},
+			KubernetesVersion:    "v1.28.1",
+			KubeletVersion:       "v1.28.1",
+			KubeadmClusterConfig: "",
+		},
+	}
+}

--- a/controllers/nodeupgrade_controller.go
+++ b/controllers/nodeupgrade_controller.go
@@ -390,3 +390,16 @@ func getUpgraderPod(ctx context.Context, remoteClient client.Client, nodeName st
 	}
 	return pod, nil
 }
+
+func getNodeUpgrade(ctx context.Context, remoteClient client.Client, nodeUpgradeName string) (*anywherev1.NodeUpgrade, error) {
+	n := &anywherev1.NodeUpgrade{}
+	if err := remoteClient.Get(ctx, GetNamespacedNameType(nodeUpgradeName, constants.EksaSystemNamespace), n); err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+// nodeUpgradeName returns the name of the node upgrade object based on the machine reference.
+func nodeUpgraderName(machineRefName string) string {
+	return fmt.Sprintf("%s-node-upgrader", machineRefName)
+}

--- a/pkg/api/v1alpha1/machinedeploymentupgrade_types.go
+++ b/pkg/api/v1alpha1/machinedeploymentupgrade_types.go
@@ -10,7 +10,7 @@ const MachineDeploymentUpgradeKind = "MachineDeploymentUpgrade"
 // MachineDeploymentUpgradeSpec defines the desired state of MachineDeploymentUpgrade.
 type MachineDeploymentUpgradeSpec struct {
 	Cluster                Ref    `json:"cluster"`
-	MachineDeployment      Ref    `json:"controlPlane"`
+	MachineDeployment      Ref    `json:"machineDeployment"`
 	MachinesRequireUpgrade []Ref  `json:"machinesRequireUpgrade"`
 	KubernetesVersion      string `json:"kubernetesVersion"`
 	KubeletVersion         string `json:"kubeletVersion"`
@@ -19,9 +19,9 @@ type MachineDeploymentUpgradeSpec struct {
 
 // MachineDeploymentUpgradeStatus defines the observed state of MachineDeploymentUpgrade.
 type MachineDeploymentUpgradeStatus struct {
-	RequireUpgrade int64 `json:"requireUpgrade"`
-	Upgraded       int64 `json:"upgraded"`
-	Ready          bool  `json:"ready"`
+	RequireUpgrade int64 `json:"requireUpgrade,omitempty"`
+	Upgraded       int64 `json:"upgraded,omitempty"`
+	Ready          bool  `json:"ready,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
   labels:
-    ekd-d-upgrader: "true"
+    eks-d-upgrader: "true"
   name: my-node-node-upgrader
   namespace: eksa-system
 spec:

--- a/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
   labels:
-    ekd-d-upgrader: "true"
+    eks-d-upgrader: "true"
   name: my-node-node-upgrader
   namespace: eksa-system
 spec:

--- a/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
@@ -1,7 +1,7 @@
 metadata:
   creationTimestamp: null
   labels:
-    ekd-d-upgrader: "true"
+    eks-d-upgrader: "true"
   name: my-node-node-upgrader
   namespace: eksa-system
 spec:

--- a/pkg/nodeupgrader/upgrader.go
+++ b/pkg/nodeupgrader/upgrader.go
@@ -65,7 +65,7 @@ func upgraderPod(nodeName, image string) *corev1.Pod {
 			Name:      PodName(nodeName),
 			Namespace: constants.EksaSystemNamespace,
 			Labels: map[string]string{
-				"ekd-d-upgrader": "true",
+				"eks-d-upgrader": "true",
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding logic to reconcile MachineDeploymentUpgrade objects. This performs upgrades on the nodes in place but using the upgrade script provided in the node upgrader controller image.

*Testing (if applicable):*
Tilt with upgrader image. I observed the workers upgrade from 1.27 to 1.28

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

