### PR TITLE
Allow mgmt create via controller if managed by cli

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -295,6 +295,21 @@ func (c *Cluster) ClearPauseAnnotation() {
 	}
 }
 
+// AddManagedByCLIAnnotation adds the managed-by-cli annotation to the cluster.
+func (c *Cluster) AddManagedByCLIAnnotation() {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
+	}
+	c.Annotations[ManagedByCLIAnnotation] = "true"
+}
+
+// ClearManagedByCLIAnnotation removes the managed-by-cli annotation from the cluster.
+func (c *Cluster) ClearManagedByCLIAnnotation() {
+	if c.Annotations != nil {
+		delete(c.Annotations, ManagedByCLIAnnotation)
+	}
+}
+
 // RegistryAuth returns whether registry requires authentication or not.
 func (c *Cluster) RegistryAuth() bool {
 	if c.Spec.RegistryMirrorConfiguration == nil {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -1521,6 +1521,24 @@ func TestCluster_IsReconcilePaused(t *testing.T) {
 	}
 }
 
+func TestCluster_AddRemoveManagedByCLIAnnotation(t *testing.T) {
+	g := NewWithT(t)
+	c := &Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster_test",
+		},
+	}
+	c.AddManagedByCLIAnnotation()
+	val, ok := c.Annotations[ManagedByCLIAnnotation]
+
+	g.Expect(ok).To(BeTrue())
+	g.Expect(val).To(ContainSubstring("true"))
+
+	c.ClearManagedByCLIAnnotation()
+	_, ok = c.Annotations[ManagedByCLIAnnotation]
+	g.Expect(ok).To(BeFalse())
+}
+
 func TestGitOpsEquals(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1426,6 +1426,15 @@ func (c *Cluster) ManagedBy() string {
 	return c.Spec.ManagementCluster.Name
 }
 
+// IsManagedByCLI returns true if the cluster has the managed-by-cli annotation.
+func (c *Cluster) IsManagedByCLI() bool {
+	if len(c.Annotations) == 0 {
+		return false
+	}
+	val, ok := c.Annotations[ManagedByCLIAnnotation]
+	return ok && val == "true"
+}
+
 // +kubebuilder:object:root=true
 // ClusterList contains a list of Cluster.
 type ClusterList struct {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -61,7 +61,7 @@ func (r *Cluster) ValidateCreate() error {
 
 	var allErrs field.ErrorList
 
-	if !r.IsReconcilePaused() && r.IsSelfManaged() {
+	if !r.IsReconcilePaused() && r.IsSelfManaged() && !r.IsManagedByCLI() {
 		return apierrors.NewBadRequest("creating new cluster on existing cluster is not supported for self managed clusters")
 	}
 

--- a/pkg/api/v1alpha1/nodeupgrade_types.go
+++ b/pkg/api/v1alpha1/nodeupgrade_types.go
@@ -38,6 +38,7 @@ type NodeUpgradeSpec struct {
 	Machine corev1.ObjectReference `json:"machine"`
 
 	// TODO(in-place): Determine if there's a way to get these dynamically instead of expecting it from the CRD.
+
 	KubernetesVersion string  `json:"kubernetesVersion"`
 	EtcdVersion       *string `json:"etcdVersion,omitempty"`
 	CoreDNSVersion    *string `json:"coreDNSVersion,omitempty"`

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -1358,6 +1358,15 @@ func (c *ClusterManager) resumeReconcileForCluster(ctx context.Context, clusterC
 	return nil
 }
 
+// RemoveManagedByCLIAnnotationForCluster removes the managed-by-cli annotation from the cluster.
+func (c *ClusterManager) RemoveManagedByCLIAnnotationForCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error {
+	err := c.clusterClient.RemoveAnnotationInNamespace(ctx, clusterSpec.Cluster.ResourceType(), cluster.Name, v1alpha1.ManagedByCLIAnnotation, cluster, clusterSpec.Cluster.Namespace)
+	if err != nil {
+		return fmt.Errorf("removing managed by CLI annotation after apply cluster spec: %v", err)
+	}
+	return nil
+}
+
 func (c *ClusterManager) applyResource(ctx context.Context, cluster *types.Cluster, resourcesSpec []byte) error {
 	err := c.clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, resourcesSpec)
 	if err != nil {

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -2878,3 +2878,29 @@ func TestClusterManagerDeleteClusterManagedCluster(t *testing.T) {
 		tt.clusterManager.DeleteCluster(tt.ctx, managementCluster, tt.cluster, tt.mocks.provider, tt.clusterSpec),
 	).To(Succeed())
 }
+
+func TestClusterManagerRemoveManagedByCLIAnnotationSuccess(t *testing.T) {
+	clusterName := "cluster-name"
+	cluster := &types.Cluster{
+		Name: clusterName,
+	}
+
+	tt := newTest(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
+
+	tt.mocks.client.EXPECT().RemoveAnnotationInNamespace(tt.ctx, gomock.Any(), gomock.Any(), gomock.Any(), cluster, gomock.Any()).Return(nil)
+
+	tt.Expect(tt.clusterManager.RemoveManagedByCLIAnnotationForCluster(tt.ctx, cluster, tt.clusterSpec, tt.mocks.provider)).To(BeNil())
+}
+
+func TestClusterManagerRemoveManagedByCLIAnnotationError(t *testing.T) {
+	clusterName := "cluster-name"
+	cluster := &types.Cluster{
+		Name: clusterName,
+	}
+
+	tt := newTest(t, clustermanager.WithRetrier(retrier.NewWithMaxRetries(1, 0)))
+
+	tt.mocks.client.EXPECT().RemoveAnnotationInNamespace(tt.ctx, gomock.Any(), gomock.Any(), gomock.Any(), cluster, gomock.Any()).Return(errors.New("removing annotation"))
+
+	tt.Expect(tt.clusterManager.RemoveManagedByCLIAnnotationForCluster(tt.ctx, cluster, tt.clusterSpec, tt.mocks.provider)).To(MatchError(ContainSubstring("removing annotation")))
+}

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -38,6 +38,7 @@ type ClusterManager interface {
 	ApplyReleases(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
 	PauseEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	ResumeEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
+	RemoveManagedByCLIAnnotationForCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	EKSAClusterSpecChanged(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (bool, error)
 	InstallMachineHealthChecks(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster) error
 	GetCurrentClusterSpec(ctx context.Context, cluster *types.Cluster, clusterName string) (*cluster.Spec, error)

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -385,6 +385,20 @@ func (mr *MockClusterManagerMockRecorder) PauseEKSAControllerReconcile(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseEKSAControllerReconcile", reflect.TypeOf((*MockClusterManager)(nil).PauseEKSAControllerReconcile), arg0, arg1, arg2, arg3)
 }
 
+// RemoveManagedByCLIAnnotationForCluster mocks base method.
+func (m *MockClusterManager) RemoveManagedByCLIAnnotationForCluster(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 providers.Provider) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveManagedByCLIAnnotationForCluster", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveManagedByCLIAnnotationForCluster indicates an expected call of RemoveManagedByCLIAnnotationForCluster.
+func (mr *MockClusterManagerMockRecorder) RemoveManagedByCLIAnnotationForCluster(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveManagedByCLIAnnotationForCluster", reflect.TypeOf((*MockClusterManager)(nil).RemoveManagedByCLIAnnotationForCluster), arg0, arg1, arg2, arg3)
+}
+
 // ResumeCAPIWorkloadClusters mocks base method.
 func (m *MockClusterManager) ResumeCAPIWorkloadClusters(arg0 context.Context, arg1 *types.Cluster) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
*Issue #, if available:*
The unification of the controller and CLI requires the ability to create mgmt clusters via the controller. However, we should only allow this creation when it's initiated by the CLI. 

*Description of changes:*
Modifies webhook create validations to return an error for self-managed clusters only if the managed-by-cli annotation is not present. 

*Testing (if applicable):*
Manually created mgmt clusters with CLI (both old and new workflows) and FLC. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

