### PR TITLE
Update docker airgap upgrade from latest minor releast test to use non-authenticated registry mirror

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -597,7 +597,7 @@ func TestDockerKubernetes127AirgappedUpgradeFromLatestRegistryMirrorAndCert(t *t
 		framework.NewDocker(t),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
-		framework.WithAuthenticatedRegistryMirror(constants.DockerProviderName),
+		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
 	)
 	runDockerAirgapUpgradeFromReleaseFlow(
 		test,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ran locally, the test passes, the test currently fails in CI with the following error:

```
=== RUN   TestDockerKubernetes127AirgappedUpgradeFromLatestRegistryMirrorAndCert

    envars.go:10: Required env var [T_PRIVATE_REGISTRY_MIRROR_ENDPOINT] not present
--- FAIL: TestDockerKubernetes127AirgappedUpgradeFromLatestRegistryMirrorAndCert (15.68s)
FAIL

DONE 1 tests, 1 failure in 15.975s
```

 Even after being updated to use the proper environment variables private registry mirror, and running it against the CI env, it fails with the following:
 
```
=== RUN   TestDockerKubernetes127AirgappedUpgradeFromLatestRegistryMirrorAndCert

    registry_mirror.go:101: error logging into docker registry 196.18.89.98:443: Error response from daemon: Get "https://196.18.89.98:443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
--- FAIL: TestDockerKubernetes127AirgappedUpgradeFromLatestRegistryMirrorAndCert (12.22s)
FAIL
```

So, changing to non-authenticated registry mirror for now. There are no docker tests using authenticated registry mirrors yet, so that perhaps needs more investigation. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

