### PR TITLE
Add change security group to default at the end of docker airgapped upgrade from release test

### DIFF
--- a/test/e2e/airgap.go
+++ b/test/e2e/airgap.go
@@ -220,4 +220,5 @@ func runDockerAirgapUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, lates
 	test.ValidateCluster(wantVersion)
 	test.StopIfFailed()
 	test.DeleteCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
+	test.ChangeInstanceSecurityGroup(os.Getenv(framework.RegistryMirrorDefaultSecurityGroup))
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a step to the test changes the security group of the EC2 instance back to the default security group. Otherwise, despite a successful run, uploading the test report will fail and so will the code build at the end of the test

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

