### PR TITLE
Allow E2E tests for individual providers to be kicked off from CodeBuild

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -72,7 +72,11 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
       - export CLUSTER_NAME_PREFIX="${BRANCH_NAME//./-}"
-      - >
+      - |
+        if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
+          make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e cloudstack" E2E_OUTPUT_FILE=bin/cloudstack/e2e.test
+        fi
+        - >
         ./bin/test e2e cleanup cloudstack
         -n ${CLUSTER_NAME_PREFIX}
         -v 4

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -31,6 +31,10 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
+      - |
+        if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
+          make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e docker" E2E_OUTPUT_FILE=bin/docker/e2e.test
+        fi
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -57,6 +57,10 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
+      - |
+        if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
+          make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e nutanix" E2E_OUTPUT_FILE=bin/nutanix/e2e.test
+        fi
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
@@ -31,6 +31,10 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
+      - |
+        if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
+          make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e snow" E2E_OUTPUT_FILE=bin/snow/e2e.test
+        fi
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -72,6 +72,10 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/setup_profile.sh
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
+      - |
+        if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
+          make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e tinkerbell" E2E_OUTPUT_FILE=bin/tinkerbell/e2e.test
+        fi
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -91,6 +91,10 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
       - export CLUSTER_NAME_PREFIX="${BRANCH_NAME//./-}"
+      - |
+        if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
+          make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e vsphere" E2E_OUTPUT_FILE=bin/vsphere/e2e.test
+        fi
       - >
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}


### PR DESCRIPTION
In the E2E pipelines, the build stage builds all the binaries required for the tests and then passes them through to the test stage, so they're available in test stage only when run through the pipeline. This also means you can't trigger E2E tests for individual providers since triggering the pipeline will make it run all the provider E2E tests. This PR allows them to be run standalone as a CodeBuild job by building the binaries _in situ_ in the test stage if the initiator is not CodePipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

