### PR TITLE
Add e2e tests for CP management cluster upgrade

### DIFF
--- a/test/e2e/TINKERBELL_HARDWARE_COUNT.yaml
+++ b/test/e2e/TINKERBELL_HARDWARE_COUNT.yaml
@@ -130,3 +130,4 @@ TestTinkerbellKubernetes128UbuntuOOB: 2
 TestTinkerbellK8sUpgrade127to128WithUbuntuOOB: 4
 TestTinkerbellKubernetes127UbuntuTo128UpgradeCPOnly: 3
 TestTinkerbellKubernetes127UbuntuTo128UpgradeWorkerOnly: 3
+TestTinkerbellSingleNode127To128UbuntuManagementCPUpgradeAPI: 4

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -4382,3 +4382,24 @@ func TestCloudStackKubernetes124EtcdEncryption(t *testing.T) {
 	test.ValidateEtcdEncryption()
 	test.DeleteCluster()
 }
+
+func TestCloudstackKubernetes127To128RedHatManagementCPUpgradeAPI(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat127())
+	test := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube127),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+	)
+	runUpgradeFlowWithAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(3),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.RedHat8, nil),
+	)
+}

--- a/test/e2e/nutanix_test.go
+++ b/test/e2e/nutanix_test.go
@@ -1244,3 +1244,22 @@ func TestNutanixKubernetes127AWSIamAuth(t *testing.T) {
 	)
 	runAWSIamAuthFlow(test)
 }
+
+func TestNutanixKubernetes128UbuntuManagementCPUpgradeAPI(t *testing.T) {
+	provider := framework.NewNutanix(t, framework.WithUbuntu127Nutanix())
+	test := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+	)
+	runUpgradeFlowWithAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithControlPlaneCount(3),
+		),
+	)
+}

--- a/test/e2e/snow_test.go
+++ b/test/e2e/snow_test.go
@@ -40,6 +40,27 @@ func TestSnowKubernetes127To128AWSIamAuthUpgrade(t *testing.T) {
 	)
 }
 
+func TestSnowKubernetes127To128UbuntuManagementCPUpgradeAPI(t *testing.T) {
+	provider := framework.NewSnow(t, framework.WithSnowUbuntu127())
+	test := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube127),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+	)
+	runUpgradeFlowWithAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(3),
+		),
+		provider.WithUbuntu128(),
+	)
+}
+
 // Labels
 func TestSnowKubernetes128UbuntuLabelsUpgradeFlow(t *testing.T) {
 	provider := framework.NewSnow(t,

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -2212,3 +2212,32 @@ func TestTinkerbellK8sUpgrade127to128WithUbuntuOOB(t *testing.T) {
 		provider.WithProviderUpgrade(framework.Ubuntu128Image()),
 	)
 }
+
+func TestTinkerbellSingleNode127To128UbuntuManagementCPUpgradeAPI(t *testing.T) {
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu127Tinkerbell())
+	managementCluster := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithControlPlaneHardware(2),
+		framework.WithWorkerHardware(2),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube127),
+			api.WithControlPlaneCount(1),
+			api.WithEtcdCountIfExternal(0),
+			api.RemoveAllWorkerNodeGroups(),
+		),
+	)
+	test := framework.NewMulticlusterE2ETest(
+		t,
+		managementCluster,
+	)
+	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(3),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+	)
+}

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3324,3 +3324,27 @@ func runVSphereCloneModeFlow(test *framework.ClusterE2ETest, vsphere *framework.
 	vsphere.ValidateNodesDiskGiB(test.GetCapiMachinesForCluster(test.ClusterName), diskSize)
 	test.DeleteCluster()
 }
+
+func TestVSphereKubernetes127To128UbuntuManagementCPUpgradeAPI(t *testing.T) {
+	provider := framework.NewVSphere(t)
+	test := framework.NewClusterE2ETest(
+		t, provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube127),
+			api.WithExternalEtcdTopology(1),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+		provider.WithUbuntu127(),
+	)
+
+	runUpgradeFlowWithAPI(
+		test,
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(3),
+		),
+		provider.WithUbuntu128(),
+	)
+}


### PR DESCRIPTION
*Description of changes:*
Add e2e tests related to control plane upgrade using full life cycle controller. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

