### PR TITLE
Add upgrade management components cmd

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/cmd/eksctl-anywhere/cmd/aflag"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/workflows/management"
+)
+
+type upgradeManagementComponentsOptions struct {
+	clusterOptions
+}
+
+var umco = &upgradeManagementComponentsOptions{}
+
+func init() {
+	flagSet := upgradeManagementComponentsCmd.Flags()
+	aflag.String(aflag.ClusterConfig, &umco.fileName, flagSet)
+	aflag.String(aflag.BundleOverride, &umco.bundlesOverride, flagSet)
+}
+
+var upgradeManagementComponentsCmd = &cobra.Command{
+	Use:          "management-components",
+	Short:        "Upgrade management components in a management cluster",
+	Long:         "The term 'management components' encompasses all Kubernetes controllers and their CRDs present in the management cluster that are responsible for reconciling your EKS Anywhere (EKS-A) cluster. This command is specifically designed to facilitate the upgrade of these management components. Post this upgrade, the cluster itself can be upgraded by updating the 'eksaRelease' field in your eksa cluster object.",
+	PreRunE:      bindFlagsToViper,
+	SilenceUsage: true,
+	Args:         cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		clusterSpec, err := newClusterSpec(clusterOptions{
+			fileName: umco.fileName,
+		})
+		if err != nil {
+			return err
+		}
+		if !clusterSpec.Cluster.IsSelfManaged() {
+			return fmt.Errorf("cluster %s doesn't contain management components to be upgraded", clusterSpec.Cluster.Name)
+		}
+
+		cliConfig := buildCliConfig(clusterSpec)
+		dirs, err := uc.directoriesToMount(clusterSpec, cliConfig)
+		if err != nil {
+			return err
+		}
+
+		factory := dependencies.ForSpec(clusterSpec).WithExecutableMountDirs(dirs...).
+			WithBootstrapper().
+			WithCliConfig(cliConfig).
+			WithClusterManager(clusterSpec.Cluster, nil).
+			WithClusterApplier().
+			WithProvider(umco.fileName, clusterSpec.Cluster, false, "", false, "", nil, nil).
+			WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
+			WithWriter().
+			WithCAPIManager().
+			WithEksdUpgrader().
+			WithEksdInstaller().
+			WithKubectl().
+			WithValidatorClients()
+
+		deps, err := factory.Build(ctx)
+		if err != nil {
+			return err
+		}
+		defer close(cmd.Context(), deps)
+
+		runner := management.NewUpgradeManagementComponentsRunner(
+			deps.Provider,
+			deps.CAPIManager,
+			deps.ClusterManager,
+			deps.GitOpsFlux,
+			deps.Writer,
+			deps.EksdUpgrader,
+			deps.EksdInstaller,
+		)
+
+		managementCluster := &types.Cluster{
+			Name:               clusterSpec.Cluster.Name,
+			KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
+			ExistingManagement: clusterSpec.Cluster.IsSelfManaged(),
+		}
+
+		validator := management.NewUMCValidator(managementCluster, deps.Kubectl)
+		return runner.Run(ctx, clusterSpec, managementCluster, validator)
+	},
+}
+
+func init() {
+	upgradeCmd.AddCommand(upgradeManagementComponentsCmd)
+}

--- a/pkg/workflows/management/upgrade_management_components.go
+++ b/pkg/workflows/management/upgrade_management_components.go
@@ -1,0 +1,206 @@
+package management
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/validations"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
+)
+
+// UpgradeManagementComponentsWorkflow is a schema for upgrade management components.
+type UpgradeManagementComponentsWorkflow struct {
+	provider       providers.Provider
+	clusterManager interfaces.ClusterManager
+	gitOpsManager  interfaces.GitOpsManager
+	writer         filewriter.FileWriter
+	capiManager    interfaces.CAPIManager
+	eksdInstaller  interfaces.EksdInstaller
+	eksdUpgrader   interfaces.EksdUpgrader
+}
+
+// NewUpgradeManagementComponentsRunner builds a new UpgradeManagementCommponents construct.
+func NewUpgradeManagementComponentsRunner(
+	provider providers.Provider,
+	capiManager interfaces.CAPIManager,
+	clusterManager interfaces.ClusterManager,
+	gitOpsManager interfaces.GitOpsManager,
+	writer filewriter.FileWriter,
+	eksdUpgrader interfaces.EksdUpgrader,
+	eksdInstaller interfaces.EksdInstaller,
+) *UpgradeManagementComponentsWorkflow {
+	return &UpgradeManagementComponentsWorkflow{
+		provider:       provider,
+		clusterManager: clusterManager,
+		gitOpsManager:  gitOpsManager,
+		writer:         writer,
+		capiManager:    capiManager,
+		eksdUpgrader:   eksdUpgrader,
+		eksdInstaller:  eksdInstaller,
+	}
+}
+
+// UMCValidator is a struct that holds a cluster and a kubectl executable.
+// It is used to perform preflight validations on the cluster.
+type UMCValidator struct {
+	cluster *types.Cluster
+	kubectl *executables.Kubectl
+}
+
+// NewUMCValidator is a constructor function that creates a new instance of UMCValidator.
+func NewUMCValidator(cluster *types.Cluster, kubectl *executables.Kubectl) *UMCValidator {
+	return &UMCValidator{
+		cluster: cluster,
+		kubectl: kubectl,
+	}
+}
+
+// PreflightValidations is a method of the UMCValidator struct.
+// It performs preflight validations on the cluster and returns a slice of Validation objects.
+func (u *UMCValidator) PreflightValidations(ctx context.Context) []validations.Validation {
+	return []validations.Validation{
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "control plane ready",
+				Remediation: fmt.Sprintf("ensure control plane nodes and pods for cluster %s are Ready", u.cluster.Name),
+				Err:         u.kubectl.ValidateControlPlaneNodes(ctx, u.cluster, u.cluster.Name),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "cluster CRDs ready",
+				Remediation: "",
+				Err:         u.kubectl.ValidateClustersCRD(ctx, u.cluster),
+			}
+		},
+	}
+}
+
+// Run Upgrade implements upgrade functionality for management cluster's upgrade operation.
+func (umc *UpgradeManagementComponentsWorkflow) Run(ctx context.Context, clusterSpec *cluster.Spec, managementCluster *types.Cluster, validator interfaces.Validator) error {
+	commandContext := &task.CommandContext{
+		Provider:          umc.provider,
+		ClusterManager:    umc.clusterManager,
+		ManagementCluster: managementCluster,
+		ClusterSpec:       clusterSpec,
+		Validations:       validator,
+		Writer:            umc.writer,
+		CAPIManager:       umc.capiManager,
+		UpgradeChangeDiff: types.NewChangeDiff(),
+		GitOpsManager:     umc.gitOpsManager,
+		EksdUpgrader:      umc.eksdUpgrader,
+		EksdInstaller:     umc.eksdInstaller,
+	}
+
+	return task.NewTaskRunner(&setupAndValidateMC{}, umc.writer).RunTask(ctx, commandContext)
+}
+
+type setupAndValidateMC struct{}
+
+// Run setupAndValidate validates management cluster before upgrade process starts.
+func (s *setupAndValidateMC) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Performing setup and validations")
+	currentSpec, err := commandContext.ClusterManager.GetCurrentClusterSpec(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec.Cluster.Name)
+	if err != nil {
+		commandContext.SetError(err)
+		return nil
+	}
+	commandContext.CurrentClusterSpec = currentSpec
+	runner := validations.NewRunner()
+	runner.Register(
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name: fmt.Sprintf("%s provider validation", commandContext.Provider.Name()),
+				Err:  commandContext.Provider.SetupAndValidateUpgradeCluster(ctx, commandContext.ManagementCluster, commandContext.ClusterSpec, commandContext.CurrentClusterSpec),
+			}
+		},
+	)
+	runner.Register(commandContext.Validations.PreflightValidations(ctx)...)
+
+	err = runner.Run()
+	if err != nil {
+		commandContext.SetError(err)
+		return nil
+	}
+
+	return &upgradeCoreComponentsMC{
+		UpgradeChangeDiff: &types.ChangeDiff{},
+	}
+}
+
+func (s *setupAndValidateMC) Name() string {
+	return "validate"
+}
+
+func (s *setupAndValidateMC) Restore(_ context.Context, _ *task.CommandContext, _ *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *setupAndValidateMC) Checkpoint() *task.CompletedTask {
+	return &task.CompletedTask{
+		Checkpoint: nil,
+	}
+}
+
+// This struct is similar to upgradeCoreComponents, but its returned value is different in Run() function.
+type upgradeCoreComponentsMC struct {
+	UpgradeChangeDiff *types.ChangeDiff
+}
+
+func (s *upgradeCoreComponentsMC) Name() string {
+	return "upgrade-core-components-mc"
+}
+
+func (s *upgradeCoreComponentsMC) Checkpoint() *task.CompletedTask {
+	return &task.CompletedTask{
+		Checkpoint: s.UpgradeChangeDiff,
+	}
+}
+
+func (s *upgradeCoreComponentsMC) Restore(_ context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	s.UpgradeChangeDiff = &types.ChangeDiff{}
+	if err := task.UnmarshalTaskCheckpoint(completedTask.Checkpoint, s.UpgradeChangeDiff); err != nil {
+		return nil, err
+	}
+	commandContext.UpgradeChangeDiff = s.UpgradeChangeDiff
+	return &installNewComponentsMC{}, nil
+}
+
+func (s *upgradeCoreComponentsMC) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	if err := runUpgradeCoreComponents(ctx, commandContext); err != nil {
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+	return &installNewComponentsMC{}
+}
+
+// This struct is similar to installNewComponents, but its returned value is different in Run() function.
+type installNewComponentsMC struct{}
+
+func (s *installNewComponentsMC) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	if err := runInstallNewComponents(ctx, commandContext); err != nil {
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+	return nil
+}
+
+func (s *installNewComponentsMC) Name() string {
+	return "install-new-eksa-version-components-mc"
+}
+
+func (s *installNewComponentsMC) Checkpoint() *task.CompletedTask {
+	return &task.CompletedTask{
+		Checkpoint: nil,
+	}
+}
+
+func (s *installNewComponentsMC) Restore(_ context.Context, _ *task.CommandContext, _ *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -1,0 +1,162 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
+	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/validations"
+	"github.com/aws/eks-anywhere/pkg/workflows/interfaces/mocks"
+)
+
+var capiChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
+	ComponentName: "vsphere",
+	OldVersion:    "v0.0.1",
+	NewVersion:    "v0.0.2",
+})
+
+var fluxChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
+	ComponentName: "Flux",
+	OldVersion:    "v0.0.1",
+	NewVersion:    "v0.0.2",
+})
+
+var eksaChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
+	ComponentName: "eks-a",
+	OldVersion:    "v0.0.1",
+	NewVersion:    "v0.0.2",
+})
+
+var eksdChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
+	ComponentName: "eks-d",
+	OldVersion:    "v0.0.1",
+	NewVersion:    "v0.0.2",
+})
+
+type TestMocks struct {
+	mockCtrl       *gomock.Controller
+	clusterManager *mocks.MockClusterManager
+	gitOpsManager  *mocks.MockGitOpsManager
+	provider       *providermocks.MockProvider
+	writer         *writermocks.MockFileWriter
+	eksdInstaller  *mocks.MockEksdInstaller
+	eksdUpgrader   *mocks.MockEksdUpgrader
+	capiManager    *mocks.MockCAPIManager
+	validator      *mocks.MockValidator
+}
+
+func NewTestMocks(t *testing.T) *TestMocks {
+	mockCtrl := gomock.NewController(t)
+	return &TestMocks{
+		mockCtrl:       mockCtrl,
+		clusterManager: mocks.NewMockClusterManager(mockCtrl),
+		gitOpsManager:  mocks.NewMockGitOpsManager(mockCtrl),
+		provider:       providermocks.NewMockProvider(mockCtrl),
+		writer:         writermocks.NewMockFileWriter(mockCtrl),
+		eksdInstaller:  mocks.NewMockEksdInstaller(mockCtrl),
+		eksdUpgrader:   mocks.NewMockEksdUpgrader(mockCtrl),
+		capiManager:    mocks.NewMockCAPIManager(mockCtrl),
+		validator:      mocks.NewMockValidator(mockCtrl),
+	}
+}
+
+func TestRunnerHappyPath(t *testing.T) {
+	mocks := NewTestMocks(t)
+	runner := NewUpgradeManagementComponentsRunner(
+		mocks.provider,
+		mocks.capiManager,
+		mocks.clusterManager,
+		mocks.gitOpsManager,
+		mocks.writer,
+		mocks.eksdUpgrader,
+		mocks.eksdInstaller,
+	)
+
+	clusterSpec := test.NewClusterSpec()
+	managementCluster := &types.Cluster{
+		Name:               clusterSpec.Cluster.Name,
+		KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
+		ExistingManagement: clusterSpec.Cluster.IsSelfManaged(),
+	}
+
+	ctx := context.Background()
+	curSpec := test.NewClusterSpec()
+	newSpec := test.NewClusterSpec()
+
+	mocks.clusterManager.EXPECT().GetCurrentClusterSpec(ctx, gomock.Any(), managementCluster.Name).Return(curSpec, nil)
+	gomock.InOrder(
+		mocks.validator.EXPECT().PreflightValidations(ctx).Return(nil),
+		mocks.provider.EXPECT().Name(),
+		mocks.provider.EXPECT().SetupAndValidateUpgradeCluster(ctx, gomock.Any(), newSpec, curSpec),
+		mocks.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any()),
+		mocks.capiManager.EXPECT().Upgrade(ctx, managementCluster, mocks.provider, curSpec, newSpec).Return(capiChangeDiff, nil),
+		mocks.gitOpsManager.EXPECT().Install(ctx, managementCluster, curSpec, newSpec).Return(nil),
+		mocks.gitOpsManager.EXPECT().Upgrade(ctx, managementCluster, curSpec, newSpec).Return(fluxChangeDiff, nil),
+		mocks.clusterManager.EXPECT().Upgrade(ctx, managementCluster, curSpec, newSpec).Return(eksaChangeDiff, nil),
+		mocks.eksdUpgrader.EXPECT().Upgrade(ctx, managementCluster, curSpec, newSpec).Return(eksdChangeDiff, nil),
+		mocks.clusterManager.EXPECT().ApplyBundles(
+			ctx, newSpec, managementCluster,
+		).Return(nil),
+		mocks.clusterManager.EXPECT().ApplyReleases(
+			ctx, newSpec, managementCluster,
+		).Return(nil),
+		mocks.eksdInstaller.EXPECT().InstallEksdManifest(
+			ctx, newSpec, managementCluster,
+		).Return(nil),
+	)
+
+	err := runner.Run(ctx, newSpec, managementCluster, mocks.validator)
+	if err != nil {
+		t.Fatalf("UpgradeManagementComponents.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestRunnerStopsWhenValidationFailed(t *testing.T) {
+	mocks := NewTestMocks(t)
+	runner := NewUpgradeManagementComponentsRunner(
+		mocks.provider,
+		mocks.capiManager,
+		mocks.clusterManager,
+		mocks.gitOpsManager,
+		mocks.writer,
+		mocks.eksdUpgrader,
+		mocks.eksdInstaller,
+	)
+
+	clusterSpec := test.NewClusterSpec()
+	managementCluster := &types.Cluster{
+		Name:               clusterSpec.Cluster.Name,
+		KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
+		ExistingManagement: clusterSpec.Cluster.IsSelfManaged(),
+	}
+
+	ctx := context.Background()
+	curSpec := test.NewClusterSpec()
+	newSpec := test.NewClusterSpec()
+
+	mocks.provider.EXPECT().Name()
+	mocks.provider.EXPECT().SetupAndValidateUpgradeCluster(ctx, gomock.Any(), newSpec, curSpec)
+	mocks.clusterManager.EXPECT().GetCurrentClusterSpec(ctx, gomock.Any(), managementCluster.Name).Return(curSpec, nil)
+	mocks.validator.EXPECT().PreflightValidations(ctx).Return(
+		[]validations.Validation{
+			func() *validations.ValidationResult {
+				return &validations.ValidationResult{
+					Err: errors.New("validation failed"),
+				}
+			},
+		})
+
+	mocks.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", newSpec.Cluster.Name), gomock.Any())
+	err := runner.Run(ctx, newSpec, managementCluster, mocks.validator)
+	if err == nil {
+		t.Fatalf("UpgradeManagementComponents.Run() err == nil, want err != nil")
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add "upgrade management-components" subcommand to allow users to upgrade their management components in management cluster.
 
*Testing (if applicable):* Manual test against docker and cloudstack. 1) upgrade management-components 2) upgrade the field of eksaVersion of a cluster object and observed that the clusters have been upgraded correctly. Notes, there is an issue with cluster-api 1.6.0 upgrade that requires restarting cluster-api controller to make the upgrade successful.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

