### PR TITLE
Add docs for routing mode

### DIFF
--- a/docs/content/en/docs/getting-started/_configuration/cluster_clusterNetwork.html
+++ b/docs/content/en/docs/getting-started/_configuration/cluster_clusterNetwork.html
@@ -1,0 +1,45 @@
+### clusterNetwork (required)
+Network configuration.
+
+### clusterNetwork.cniConfig (required)
+CNI plugin configuration. Supports `cilium`.
+
+### clusterNetwork.cniConfig.cilium.policyEnforcementMode
+Optionally specify a policyEnforcementMode of `default`, `always` or `never`.
+
+### clusterNetwork.cniConfig.cilium.egressMasqueradeInterfaces
+Optionally specify a network interface name or interface prefix used for
+masquerading. See <a href="/docs/getting-started/optional/cni/#egressmasqueradeinterfaces-option-for-cilium-plugin">EgressMasqueradeInterfaces</a>
+option.
+
+### clusterNetwork.cniConfig.cilium.skipUpgrade
+When true, skip Cilium maintenance during upgrades. Also see <a href="/docs/getting-started/optional/cni/#use-a-custom-cni">Use a custom
+CNI</a>.
+
+### clusterNetwork.cniConfig.cilium.routingMode
+Optionally specify the routing mode. Accepts `default` and `direct`. Also see <a href="/docs/getting-started/optional/cni/#routingmode-option-for-cilium-plugin">RoutingMode</a>
+option.
+
+### clusterNetwork.cniConfig.cilium.ipv4NativeRoutingCIDR
+Optionally specify the CIDR to use when RoutingMode is set to direct.
+When specified, Cilium assumes networking for this CIDR is preconfigured and
+hands traffic destined for that range to the Linux network stack without
+applying any SNAT.
+
+### clusterNetwork.cniConfig.cilium.ipv6NativeRoutingCIDR
+Optionally specify the IPv6 CIDR to use when RoutingMode is set to direct.
+When specified, Cilium assumes networking for this CIDR is preconfigured and
+hands traffic destined for that range to the Linux network stack without
+applying any SNAT.
+
+### clusterNetwork.pods.cidrBlocks[0] (required)
+The pod subnet specified in CIDR notation. Only 1 pod CIDR block is permitted.
+The CIDR block should not conflict with the host or service network ranges.
+
+### clusterNetwork.services.cidrBlocks[0] (required)
+The service subnet specified in CIDR notation. Only 1 service CIDR block is
+permitted.
+This CIDR block should not conflict with the host or pod network ranges.
+
+### clusterNetwork.dns.resolvConf.path (optional)
+File path to a file containing a custom DNS resolver configuration.

--- a/docs/content/en/docs/getting-started/baremetal/bare-spec.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-spec.md
@@ -38,7 +38,7 @@ spec:
     services:
       cidrBlocks:
       - 10.96.0.0/12
-  controlPlaneConfiguration:              
+  controlPlaneConfiguration:
     count: 1
     endpoint:
       host: "<Control Plane Endpoint IP>"
@@ -102,22 +102,7 @@ spec:
 ### name (required)
 Name of your cluster (`my-cluster-name` in this example).
 
-### clusterNetwork (required)
-Specific network configuration for your Kubernetes cluster.
-
-### clusterNetwork.cniConfig (required)
-CNI plugin to be installed in the cluster. The only supported value at the moment is `cilium`.
-
-### clusterNetwork.pods.cidrBlocks[0] (required)
-Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted.
-This CIDR block should not conflict with the `clusterNetwork.services.cidrBlocks` and network subnet range selected for the machines.
-
-### clusterNetwork.services.cidrBlocks[0] (required)
-Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted.
-This CIDR block should not conflict with the `clusterNetwork.pods.cidrBlocks` and network subnet range selected for the machines.
-
-### clusterNetwork.dns.resolvConf.path (optional)
-Path to the file with a custom DNS resolver configuration.
+{{% include "../_configuration/cluster_clusterNetwork.html" %}}
 
 ### controlPlaneConfiguration (required)
 Specific control plane configuration for your Kubernetes cluster.
@@ -131,7 +116,7 @@ A unique IP you want to use for the control plane in your EKS Anywhere cluster. 
 range that does not conflict with other machines.
 
 >**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
-the control plane nodes for kube-apiserver loadbalancing. 
+the control plane nodes for kube-apiserver loadbalancing.
 
 ### controlPlaneConfiguration.machineGroupRef (required)
 Refers to the Kubernetes object with Tinkerbell-specific configuration for your nodes. See `TinkerbellMachineConfig Fields` below.
@@ -145,7 +130,7 @@ Modifying the taints associated with the control plane configuration will cause 
 
 >**_NOTE:_** The taints provided will be used instead of the default control plane taint.
 Any pods that you run on the control plane nodes must tolerate the taints you provide in the control plane configuration.
-> 
+>
 
 ### controlPlaneConfiguration.labels
 A list of labels to apply to the control plane nodes of the cluster. This is in addition to the labels that
@@ -232,7 +217,7 @@ See [Artifacts]({{< relref "../../osmgmt/artifacts/#hookos-kernel-and-initial-ra
 spec:
   tinkerbellIP: "192.168.0.10"                                          # Available, routable IP
   osImageURL: "http://my-web-server/ubuntu-v1.23.7-eks-a-12-amd64.gz"   # Full URL to the OS Image hosted locally
-  hookImagesURLPath: "http://my-web-server/hook"                        # Path to the hook images. This path must contain vmlinuz-x86_64 and initramfs-x86_64 
+  hookImagesURLPath: "http://my-web-server/hook"                        # Path to the hook images. This path must contain vmlinuz-x86_64 and initramfs-x86_64
 ```
 This is the folder structure for `my-web-server`:
 ```
@@ -248,7 +233,7 @@ Optional field to skip deploying the default load balancer for Tinkerbell stack.
 
 EKS Anywhere for Bare Metal uses `kube-vip` load balancer by default to expose the Tinkerbell stack externally.
 You can disable this feature by setting this field to `true`.
->**_NOTE:_** If you skip load balancer deployment, you will have to ensure that the Tinkerbell stack is available at [tinkerbellIP]({{< relref "#tinkerbellip" >}}) once the cluster creation is finished. One way to achieve this is by using the [MetalLB]({{< relref "../../packages/metallb" >}}) package. 
+>**_NOTE:_** If you skip load balancer deployment, you will have to ensure that the Tinkerbell stack is available at [tinkerbellIP]({{< relref "#tinkerbellip" >}}) once the cluster creation is finished. One way to achieve this is by using the [MetalLB]({{< relref "../../packages/metallb" >}}) package.
 
 ## TinkerbellMachineConfig Fields
 In the example, there are `TinkerbellMachineConfig` sections for control plane (`my-cluster-name-cp`) and worker (`my-cluster-name`) machine groups.
@@ -318,7 +303,7 @@ They can also add their own [Tinkerbell actions](https://docs.tinkerbell.org/act
 The following shows two `TinkerbellTemplateConfig` examples that you can add to your cluster configuration file to override the values that EKS Anywhere sets: one for Ubuntu and one for Bottlerocket.
 Most actions used differ for different operating systems.
 
->**_NOTE:_** For the `stream-image` action, `DEST_DISK` points to the device representing the entire hard disk (for example, `/dev/sda`). 
+>**_NOTE:_** For the `stream-image` action, `DEST_DISK` points to the device representing the entire hard disk (for example, `/dev/sda`).
 For UEFI-enabled images, such as Ubuntu, write actions use `DEST_DISK` to point to the second partition (for example, `/dev/sda2`), with the first being the EFI partition.
 For the Bottlerocket image, which has 12 partitions, `DEST_DISK` is partition 12 (for example, `/dev/sda12`).
 Device names will be different for different disk types.
@@ -392,7 +377,7 @@ spec:
         name: disable-cloud-init-network-capabilities
         timeout: 90
       - environment:
-          CONTENTS: | 
+          CONTENTS: |
             datasource: Ec2
           DEST_DISK: /dev/sda2
           DEST_PATH: /etc/cloud/ds-identify.cfg
@@ -565,7 +550,7 @@ The `write-netplan` action writes Ubuntu network configuration information to th
 * environment.CONTENTS.network.version: Identifies the network version.
 * environment.CONTENTS.network.renderer: Defines the service to manage networking. By default, the `networkd` systemd service is used.
 * environment.CONTENTS.network.ethernets: Network interface to external network (eno1, by default) and whether or not to use dhcp4 (true, by default).
-* environment.DEST_DISK: Destination block storage device partition where the operating system is copied. By default, /dev/sda2 is used (sda1 is the EFI partition). 
+* environment.DEST_DISK: Destination block storage device partition where the operating system is copied. By default, /dev/sda2 is used (sda1 is the EFI partition).
 * environment.DEST_PATH: File where the networking configuration is written (/etc/netplan/config.yaml, by default).
 * environment.DIRMODE: Linux directory permissions bits to use when creating directories (0755, by default)
 * environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
@@ -597,7 +582,7 @@ The `add-tink-cloud-init-ds-config` action configures cloud-init data store feat
 
 * environment.CONTENTS.datasource: Sets the datasource. Uses Ec2, by default.
 * environment.DEST_DISK: Destination block storage device partition where the operating system is located (/dev/sda2, by default).
-* environment.DEST_PATH: Location of the data store identity configuration file on disk (/etc/cloud/ds-identify.cfg, by default) 
+* environment.DEST_PATH: Location of the data store identity configuration file on disk (/etc/cloud/ds-identify.cfg, by default)
 * environment.DIRMODE: Linux directory permissions bits to use when creating directories (0700, by default)
 * environment.FS_TYPE: Type of filesystem on the partition (ext4, by default).
 * environment.GID: The Linux group ID to set on file. Set to 0 (root group) by default.

--- a/docs/content/en/docs/getting-started/cloudstack/cloud-spec.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloud-spec.md
@@ -149,7 +149,7 @@ spec:
     name: "m4-large"
   users:
   - name: "capc"
-    sshAuthorizedKeys: 
+    sshAuthorizedKeys:
     - "ssh-rsa AAAAB3N...
   template:
     name: "rhel8-k8s-118"
@@ -170,22 +170,7 @@ spec:
 ### name (required)
 Name of your cluster `my-cluster-name` in this example
 
-### clusterNetwork (required)
-Specific network configuration for your Kubernetes cluster.
-
-### clusterNetwork.cniConfig (required)
-CNI plugin configuration to be used in the cluster. The only supported configuration at the moment is `cilium`.
-
-### clusterNetwork.cniConfig.cilium.policyEnforcementMode
-Optionally, you may specify a policyEnforcementMode of default, always, never.
-
-### clusterNetwork.pods.cidrBlocks[0] (required)
-Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the VMs.
-
-### clusterNetwork.services.cidrBlocks[0] (required)
-Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the VMs.
+{{% include "../_configuration/cluster_clusterNetwork.html" %}}
 
 ### controlPlaneConfiguration (required)
 Specific control plane configuration for your Kubernetes cluster.
@@ -368,7 +353,7 @@ These can be used for things like identifying sets of nodes that you want to add
 
 ### affinityGroupIDs (optional)
 Group ID to attach to the set of host systems to indicate how affinity is done for services on those systems.
- 
+
 ### affinity (optional)
 Allows you to set `pro` and `anti` affinity for the `CloudStackMachineConfig`.
 This can be used in a mutually exclusive fashion with the affinityGroupIDs field.

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
@@ -97,7 +97,7 @@ spec:
  vcpusPerSocket: 1
  additionalCategories:
    - key: my-category
-     value: my-category-value 
+     value: my-category-value
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: NutanixMachineConfig
@@ -134,23 +134,7 @@ spec:
 ### name (required)
 Name of your cluster `mgmt` in this example.
 
-### clusterNetwork (required)
-Specific network configuration for your Kubernetes cluster.
-
-### clusterNetwork.cniConfig (required)
-CNI plugin configuration to be used in the cluster. The only supported configuration at the moment is `cilium`.
-
-### clusterNetwork.cniConfig.cilium.policyEnforcementMode
-Optionally, you may specify a `policyEnforcementMode` of `default`, `always`, `never`.
-
-### clusterNetwork.pods.cidrBlocks[0] (required)
-Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted. This CIDR block should not conflict with the network subnet range selected for the VMs.
-
-### clusterNetwork.services.cidrBlocks[0] (required)
-Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted. This CIDR block should not conflict with the network subnet range selected for the VMs.
-
-### clusterNetwork.dns.resolvConf.path (optional)
-Path to the file with a custom DNS resolver configuration.
+{{% include "../_configuration/cluster_clusterNetwork.html" %}}
 
 ### controlPlaneConfiguration (required)
 Specific control plane configuration for your Kubernetes cluster.
@@ -165,7 +149,7 @@ Refers to the Kubernetes object with Nutanix specific configuration for your nod
 A unique IP you want to use for the control plane VM in your EKS Anywhere cluster. Choose an IP in your network range that does not conflict with other VMs.
 
 >**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
-the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster 
+the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster
 creation process are [here]({{< relref "./nutanix-prereq/#prepare-a-nutanix-environment" >}}).
 
 ### workerNodeGroupConfigurations (required)
@@ -202,8 +186,8 @@ The Kubernetes version you want to use for your cluster. Supported values: `1.28
 ### endpoint (required)
 The Prism Central server fully qualified domain name or IP address. If the server IP is used, the PC SSL certificate must have an IP SAN configured.
 
-### port (required) 
-The Prism Central server port. (Default: `9440`) 
+### port (required)
+The Prism Central server port. (Default: `9440`)
 
 ### credentialRef (required)
 Reference to the Kubernetes secret that contains the Prism Central credentials.
@@ -232,74 +216,74 @@ __Example__:</br>
 ### cluster
 Reference to the Prism Element cluster.
 
-### cluster.type	
+### cluster.type
 Type to identify the Prism Element cluster. (Permitted values: `name` or `uuid`)
- 
-### cluster.name	
+
+### cluster.name
 Name of the Prism Element cluster.
 
 ### cluster.uuid
 UUID of the Prism Element cluster.
- 
-### image	
+
+### image
 Reference to the OS image used for the system disk.
- 
+
 ### image.type
 Type to identify the OS image. (Permitted values: `name` or `uuid`)
- 
+
 ### image.name (`name` or `UUID` required)
 Name of the image
 The `image.name` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, `image.name` must include 1.24, 1_24, 1-24 or 124.
- 
+
 ### image.uuid (`name` or `UUID` required)
 UUID of the image
 The name of the image associated with the `uuid` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, the name associated with `image.uuid` field must include 1.24, 1_24, 1-24 or 124.
- 
+
 ### memorySize
 Size of RAM on virtual machines (Default: `4Gi`)
 
 ### osFamily (optional)
 Operating System on virtual machines. Permitted values: `ubuntu` and `redhat`. (Default: `ubuntu`)
- 
+
 ### subnet
 Reference to the subnet to be assigned to the VMs.
- 
+
 ### subnet.name (`name` or `UUID` required)
 Name of the subnet.
- 
+
 ### subnet.type
 Type to identify the subnet. (Permitted values: `name` or `uuid`)
- 
+
 ### subnet.uuid (`name` or `UUID` required)
 UUID of the subnet.
- 
+
 ### systemDiskSize
 Amount of storage assigned to the system disk. (Default: `40Gi`)
- 
+
 ### vcpuSockets
 Amount of vCPU sockets. (Default: `2`)
- 
+
 ### vcpusPerSocket
 Amount of vCPUs per socket. (Default: `1`)
- 
+
 ### project	(optional)
 Reference to an existing project used for the virtual machines.
- 
+
 ### project.type
 Type to identify the project. (Permitted values: `name` or `uuid`)
- 
+
 ### project.name (`name` or `UUID` required)
 Name of the project
- 
+
 ### project.uuid (`name` or `UUID` required)
 UUID of the project
 
 ### additionalCategories (optional)
-Reference to a list of existing [Nutanix Categories](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide:ssp-ssp-categories-manage-pc-c.html) to be assigned to virtual machines. 
- 
+Reference to a list of existing [Nutanix Categories](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide:ssp-ssp-categories-manage-pc-c.html) to be assigned to virtual machines.
+
 ### additionalCategories[0].key
-Nutanix Category to add to the virtual machine. 
- 
+Nutanix Category to add to the virtual machine.
+
 ### additionalCategories[0].value
 Value of the Nutanix Category to add to the virtual machine
 

--- a/docs/content/en/docs/getting-started/optional/cni.md
+++ b/docs/content/en/docs/getting-started/optional/cni.md
@@ -84,7 +84,7 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
     cniConfig:
-      cilium: 
+      cilium:
         policyEnforcementMode: "always"
 ```
 
@@ -137,7 +137,7 @@ through the cli upgrade command.
 EKS Anywhere will create the required NetworkPolicy objects for its core components (listed above).
    This will ensure that the cluster gets upgraded successfully. But it is up to the user to create
    the NetworkPolicy objects required for the user workloads.
-   
+
 2. Switching from `always` mode: When switching from `always` to `default` mode, EKS Anywhere
 will not delete any of the existing NetworkPolicy objects, including the ones required
    for EKS Anywhere components (listed above). The user must delete NetworkPolicy objects as needed.
@@ -165,13 +165,13 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
     cniConfig:
-      cilium: 
+      cilium:
         egressMasqueradeInterfaces: "eth0"
 ```
 
 ### RoutingMode option for Cilium plugin
 
-By default all traffic is sent by Cilium over Geneve tunneling on the network. The `routingMode` option allows users to switch to [native routing](https://docs.cilium.io/en/v1.12/concepts/networking/routing/#native-routing) instead. 
+By default all traffic is sent by Cilium over Geneve tunneling on the network. The `routingMode` option allows users to switch to [native routing](https://docs.cilium.io/en/v1.12/concepts/networking/routing/#native-routing) instead.
 
 This field can be set as follows:
 ```yaml
@@ -188,18 +188,18 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
     cniConfig:
-      cilium: 
+      cilium:
         routingMode: "direct"
 ```
 
 ### Use a custom CNI
 
-EKS Anywhere can be configured to skip EKS Anywhere's default Cilium CNI upgrades via the `skipUpgrade` field. 
+EKS Anywhere can be configured to skip EKS Anywhere's default Cilium CNI upgrades via the `skipUpgrade` field.
 `skipUpgrade` can be `true` or `false`. When not set, it defaults to `false`.
 
-When creating a new cluster with `skipUpgrade` enabled, EKS Anywhere Cilium will be installed as it 
-is required to successfully provision an EKS Anywhere cluster. 
-When the cluster successfully provisions, EKS Anywhere Cilium may be uninstalled and replaced with 
+When creating a new cluster with `skipUpgrade` enabled, EKS Anywhere Cilium will be installed as it
+is required to successfully provision an EKS Anywhere cluster.
+When the cluster successfully provisions, EKS Anywhere Cilium may be uninstalled and replaced with
 a different CNI.
 Subsequent upgrades to the cluster will not attempt to upgrade or re-install EKS Anywhere Cilium.
 
@@ -219,17 +219,17 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
     cniConfig:
-      cilium: 
+      cilium:
         skipUpgrade: true
 ```
 
-The [Cilium CLI](https://github.com/cilium/cilium-cli) can be used to uninstall EKS Anywhere Cilium 
+The [Cilium CLI](https://github.com/cilium/cilium-cli) can be used to uninstall EKS Anywhere Cilium
 via `cilium uninstall`.
 See the [replacing Cilium task]({{< ref "../../clustermgmt/networking/cluster-replace-cilium" >}}) for a walkthrough on how to successfully replace EKS Anywhere Cilium.
 
 {{% alert title="Warning" color="warning" %}}
-When uninstalling EKS Anywhere Cilium, nodes will become unhealthy. If nodes are left without a CNI 
-for longer than 5m the nodes will begin rolling. To maintain a healthy cluster, operators should 
+When uninstalling EKS Anywhere Cilium, nodes will become unhealthy. If nodes are left without a CNI
+for longer than 5m the nodes will begin rolling. To maintain a healthy cluster, operators should
 immediately install a CNI after uninstalling EKS Anywhere Cilium.
 {{% /alert %}}
 
@@ -243,9 +243,9 @@ anywhere.eks.amazonaws.com/eksa-cilium: ""
 
 ### Node IPs configuration option
 
-Starting with release v0.10, the `node-cidr-mask-size` [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options) 
-for Kubernetes controller manager (kube-controller-manager) is configurable via the EKS anywhere cluster spec. The `clusterNetwork.nodes` being an optional field, 
-is not generated in the EKS Anywhere spec using `generate clusterconfig` command. This block for `nodes` will need to be manually added to the cluster spec under the 
+Starting with release v0.10, the `node-cidr-mask-size` [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options)
+for Kubernetes controller manager (kube-controller-manager) is configurable via the EKS anywhere cluster spec. The `clusterNetwork.nodes` being an optional field,
+is not generated in the EKS Anywhere spec using `generate clusterconfig` command. This block for `nodes` will need to be manually added to the cluster spec under the
 `clusterNetwork` section:
 
 ```yaml
@@ -262,17 +262,17 @@ is not generated in the EKS Anywhere spec using `generate clusterconfig` command
       cidrMaskSize: 24
 ```
 
-If the user does not specify the `clusterNetwork.nodes` field in the cluster yaml spec, the value for this flag defaults to 24 for IPv4. 
+If the user does not specify the `clusterNetwork.nodes` field in the cluster yaml spec, the value for this flag defaults to 24 for IPv4.
 Please note that this mask size needs to be greater than the pods CIDR mask size. In the above spec, the pod CIDR mask size is `16`
-and the node CIDR mask size is `24`. This ensures the cluster 256 blocks of /24 networks. For example, node1 will get 
-192.168.0.0/24, node2 will get 192.168.1.0/24, node3 will get 192.168.2.0/24 and so on. 
+and the node CIDR mask size is `24`. This ensures the cluster 256 blocks of /24 networks. For example, node1 will get
+192.168.0.0/24, node2 will get 192.168.1.0/24, node3 will get 192.168.2.0/24 and so on.
 
-To support more than 256 nodes, the cluster CIDR block needs to be large, and the node CIDR mask size needs to be 
-small, to support that many IPs. 
+To support more than 256 nodes, the cluster CIDR block needs to be large, and the node CIDR mask size needs to be
+small, to support that many IPs.
 For instance, to support 1024 nodes, a user can do any of the following things
 - Set the pods cidr blocks to `192.168.0.0/16` and node cidr mask size to 26
 - Set the pods cidr blocks to `192.168.0.0/15` and node cidr mask size to 25
 
-Please note that the `node-cidr-mask-size` needs to be large enough to accommodate the number of pods you want to run on each node. 
+Please note that the `node-cidr-mask-size` needs to be large enough to accommodate the number of pods you want to run on each node.
 A size of 24 will give enough IP addresses for about 250 pods per node, however a size of 26 will only give you about 60 IPs.
 This is an immutable field, and the value can't be updated once the cluster has been created.

--- a/docs/content/en/docs/getting-started/snow/snow-spec.md
+++ b/docs/content/en/docs/getting-started/snow/snow-spec.md
@@ -106,25 +106,7 @@ spec:
 ### name (required)
 Name of your cluster `my-cluster-name` in this example
 
-### clusterNetwork (required)
-Specific network configuration for your Kubernetes cluster.
-
-### clusterNetwork.cniConfig (required)
-CNI plugin configuration to be used in the cluster. The only supported configuration at the moment is `cilium`.
-
-### clusterNetwork.cniConfig.cilium.policyEnforcementMode
-Optionally, you may specify a policyEnforcementMode of default, always, never.
-
-### clusterNetwork.pods.cidrBlocks[0] (required)
-Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the devices.
-
-### clusterNetwork.services.cidrBlocks[0] (required)
-Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the devices.
-
-### clusterNetwork.dns.resolvConf.path (optional)
-Path to the file with a custom DNS resolver configuration.
+{{% include "../_configuration/cluster_clusterNetwork.html" %}}
 
 ### controlPlaneConfiguration (required)
 Specific control plane configuration for your Kubernetes cluster.
@@ -151,7 +133,7 @@ Modifying the taints associated with the control plane configuration will cause 
 
 >**_NOTE:_** The taints provided will be used instead of the default control plane taint.
 Any pods that you run on the control plane nodes must tolerate the taints you provide in the control plane configuration.
-> 
+>
 
 ### controlPlaneConfiguration.labels
 A list of labels to apply to the control plane nodes of the cluster. This is in addition to the labels that
@@ -267,7 +249,7 @@ The field is optional for Ubuntu and if specified, the size must be no smaller t
 Containers volume device name.
 
 ### containersVolume.type (optional)
-Type of the containers volume. Permitted values: `sbp1`, `sbg1`. (Default: `sbp1`) 
+Type of the containers volume. Permitted values: `sbp1`, `sbg1`. (Default: `sbp1`)
 
 `sbp1` stands for capacity-optimized HDD. `sbg1` is performance-optimized SSD.
 
@@ -281,7 +263,7 @@ Non root volume device name. Must be specified and cannot have prefix "/dev/sda"
 Size of the storage device for the non root volume. Must be no smaller than 8 Gi.
 
 ### nonRootVolumes[0].type (optional)
-Type of the non root volume. Permitted values: `sbp1`, `sbg1`. (Default: `sbp1`) 
+Type of the non root volume. Permitted values: `sbp1`, `sbg1`. (Default: `sbp1`)
 
 `sbp1` stands for capacity-optimized HDD. `sbg1` is performance-optimized SSD.
 

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-spec.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-spec.md
@@ -40,9 +40,9 @@ spec:
         effect: <span>"NoSchedule"</span>
       labels:                        <a href="#controlplaneconfigurationlabels"># Labels applied to control plane nodes </a>
         <span>"key1"</span>: <span>"value1"</span>
-        <span>"key2"</span>: <span>"value2"</span> 
+        <span>"key2"</span>: <span>"value2"</span>
    datacenterRef:                    <a href="#datacenterref"># Kubernetes object with vSphere-specific config </a>
-      kind: VSphereDatacenterConfig  
+      kind: VSphereDatacenterConfig
       name: my-cluster-datacenter
    externalEtcdConfiguration:
      count: <span style="color:green">3</span>                        <a href="#externaletcdconfigurationcount"># Number of etcd members </a>
@@ -57,12 +57,12 @@ spec:
        name: my-cluster-machines
      name: md-0                      <a href="#workernodegroupconfigurationsname-required"># Name of the worker nodegroup (required) </a>
      taints:                         <a href="#workernodegroupconfigurationstaints"># Taints to apply to worker node group nodes </a>
-     - key: <span>"key1"</span>                       
+     - key: <span>"key1"</span>
        value: <span>"value1"</span>
        effect: <span>"NoSchedule"</span>
      labels:                         <a href="#workernodegroupconfigurationslabels"># Labels to apply to worker node group nodes </a>
        <span>"key1"</span>: <span>"value1"</span>
-       <span">"key2"</span>: <span>"value2"</span> 
+       <span">"key2"</span>: <span>"value2"</span>
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: VSphereDatacenterConfig
@@ -117,25 +117,7 @@ The following additional optional configuration can also be included:
 ### name (required)
 Name of your cluster `my-cluster-name` in this example
 
-### clusterNetwork (required)
-Specific network configuration for your Kubernetes cluster.
-
-### clusterNetwork.cniConfig (required)
-CNI plugin configuration to be used in the cluster. The only supported configuration at the moment is `cilium`.
-
-### clusterNetwork.cniConfig.cilium.policyEnforcementMode
-Optionally, you may specify a policyEnforcementMode of `default`, `always`, `never`.
-
-### clusterNetwork.pods.cidrBlocks[0] (required)
-Subnet used by pods in CIDR notation. Please note that only 1 custom pods CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the VMs.
-
-### clusterNetwork.services.cidrBlocks[0] (required)
-Subnet used by services in CIDR notation. Please note that only 1 custom services CIDR block specification is permitted.
-This CIDR block should not conflict with the network subnet range selected for the VMs.
-
-### clusterNetwork.dns.resolvConf.path (optional)
-Path to the file with a custom DNS resolver configuration.
+{{% include "../_configuration/cluster_clusterNetwork.html" %}}
 
 ### controlPlaneConfiguration (required)
 Specific control plane configuration for your Kubernetes cluster.
@@ -151,7 +133,7 @@ A unique IP you want to use for the control plane VM in your EKS Anywhere cluste
 range that does not conflict with other VMs.
 
 >**_NOTE:_** This IP should be outside the network DHCP range as it is a floating IP that gets assigned to one of
-the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster 
+the control plane nodes for kube-apiserver loadbalancing. Suggestions on how to ensure this IP does not cause issues during cluster
 creation process are [here]({{< relref "../vsphere/vsphere-prereq/#prepare-a-vmware-vsphere-environment" >}})
 
 ### controlPlaneConfiguration.taints
@@ -163,7 +145,7 @@ Modifying the taints associated with the control plane configuration will cause 
 
 >**_NOTE:_** The taints provided will be used instead of the default control plane taint.
 Any pods that you run on the control plane nodes must tolerate the taints you provide in the control plane configuration.
-> 
+>
 
 ### controlPlaneConfiguration.labels
 A list of labels to apply to the control plane nodes of the cluster. This is in addition to the labels that
@@ -306,7 +288,7 @@ The `template` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spe
 
 ### cloneMode (optional)
 `cloneMode` defines the clone mode to use when creating the cluster VMs from the template. Allowed values are:
-- `fullClone`: With full clone, the cloned VM is a separate independent copy of the template. This makes provisioning the VMs a bit slower at the cost of better customization and performance. 
+- `fullClone`: With full clone, the cloned VM is a separate independent copy of the template. This makes provisioning the VMs a bit slower at the cost of better customization and performance.
 - `linkedClone`: With linked clone, the cloned VM shares the parent template's virtual disk. This makes provisioning the VMs faster while also saving the disk space. Linked clone does **not** allow customizing the disk size.
 The template should meet the following properties to use `linkedClone`:
   - The template needs to have a snapshot
@@ -355,7 +337,7 @@ Example:
 Optional host OS configurations for the EKS Anywhere Kubernetes nodes.
 More information in the [Host OS Configuration]({{< relref "../optional/hostOSConfig.md" >}}) section.
 
-## Optional VSphere Credentials 
+## Optional VSphere Credentials
 Use the following environment variables to configure the Cloud Provider with different credentials.
 
 ### EKSA_VSPHERE_CP_USERNAME

--- a/docs/layouts/shortcodes/include.html
+++ b/docs/layouts/shortcodes/include.html
@@ -1,0 +1,2 @@
+{{ $file := .Get 0 }}
+{{ (printf "%s%s" .Page.File.Dir $file) | readFile | replaceRE "^---[\\s\\S]+?---" "" | safeHTML }}


### PR DESCRIPTION
Direct routing was added as part of #3182. This adds the API documentation to providers as well as other missing documentation.