### PR TITLE
 Add cleanup to reset security group on aigrapped registry mirror docker tests

### DIFF
--- a/test/e2e/airgap.go
+++ b/test/e2e/airgap.go
@@ -189,13 +189,14 @@ func runDockerAirgapConfigFlow(test *framework.ClusterE2ETest) {
 	test.ExtractDownloadedArtifacts()
 	test.DownloadImages()
 	test.ChangeInstanceSecurityGroup(os.Getenv(framework.RegistryMirrorAirgappedSecurityGroup))
+	test.SetRegistryMirrorDefaultInstanceSecurityGroupOnCleanup()
 	test.ImportImages()
 	test.CreateCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
 	test.DeleteCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
-	test.ChangeInstanceSecurityGroup(os.Getenv(framework.RegistryMirrorDefaultSecurityGroup))
 }
 
 func runDockerAirgapUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *releasev1.EksARelease, wantVersion anywherev1.KubernetesVersion) {
+	test.SetRegistryMirrorDefaultInstanceSecurityGroupOnCleanup()
 	test.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
 
 	// Downloading and importing the artifacts from the previous version
@@ -214,11 +215,11 @@ func runDockerAirgapUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, lates
 	test.ExtractDownloadedArtifacts()
 	test.DownloadImages()
 	test.ChangeInstanceSecurityGroup(os.Getenv(framework.RegistryMirrorAirgappedSecurityGroup))
+	test.SetRegistryMirrorDefaultInstanceSecurityGroupOnCleanup()
 	test.ImportImages()
 
 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{}, framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
 	test.ValidateCluster(wantVersion)
 	test.StopIfFailed()
 	test.DeleteCluster(framework.WithBundlesOverride(bundleReleasePathFromArtifacts))
-	test.ChangeInstanceSecurityGroup(os.Getenv(framework.RegistryMirrorDefaultSecurityGroup))
 }

--- a/test/framework/registry_mirror.go
+++ b/test/framework/registry_mirror.go
@@ -164,3 +164,10 @@ func setupRegistryMirrorEndpointAndCert(e *ClusterE2ETest, providerName string, 
 		e.T.Fatalf("unable to set REGISTRY_PASSWORD: %v", err)
 	}
 }
+
+// SetRegistryMirrorDefaultInstanceSecurityGroupOnCleanup sets the instance security group to the registry mirror default security group on cleanup.
+func (e *ClusterE2ETest) SetRegistryMirrorDefaultInstanceSecurityGroupOnCleanup(opts ...CommandOpt) {
+	e.T.Cleanup(func() {
+		e.ChangeInstanceSecurityGroup(os.Getenv(RegistryMirrorDefaultSecurityGroup))
+	})
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, when a docker air-gapped e2e test fails, it does not reset the security group to default so outgoing commands fail. We have a few SSM commands run during [post test processing](https://github.com/aws/eks-anywhere/blob/b84f94b08010b5469927593473b36b4223071bbe/internal/test/e2e/run.go#L279), that timeout because the airgapped security group does not allow the outgoing connection. This increases the duration of the resulting codebuild  by at least 30 minutes (10 minute timeout per ssm command for`uploadJUnitReportFromInstance`, `uploadGeneratedFilesFromInstance` and `uploadDiagnosticArchiveFromInstance`). This PR adds a cleanup to docker air-gapped registry mirror e2e test, that resets the security group back to the default. This instead of relying on a successful test run to do so, this also captures in case of panic or some other kind of failure.

*Testing (if applicable):*
- Ran `TestDockerKubernetes127AirgappedUpgradeFromLatestRegistryMirrorAndCert` locally, observed the security group reset post test run.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

