### PR TITLE
Improve Binary Installation Process for K8s Tools

### DIFF
--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -55,7 +55,7 @@ Install `eksctl`
 curl "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
     --silent --location \
     | tar xz -C /tmp
-sudo mv /tmp/eksctl /usr/local/bin/
+sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
 ```
 
 Install the `eksctl-anywhere` plugin
@@ -66,7 +66,7 @@ EKS_ANYWHERE_TARBALL_URL=$(curl https://anywhere-assets.eks.amazonaws.com/releas
 curl $EKS_ANYWHERE_TARBALL_URL \
     --silent --location \
     | tar xz ./eksctl-anywhere
-sudo mv ./eksctl-anywhere /usr/local/bin/
+sudo install -m 0755 ./eksctl-anywhere /usr/local/bin/eksctl-anywhere
 ```
 
 Install `kubectl`. See the Kubernetes [documentation](https://kubernetes.io/docs/tasks/tools/) for more information.
@@ -74,8 +74,7 @@ Install `kubectl`. See the Kubernetes [documentation](https://kubernetes.io/docs
 ```bash
 export OS="$(uname -s | tr A-Z a-z)" ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${OS}/${ARCH}/kubectl"
-sudo mv ./kubectl /usr/local/bin
-sudo chmod +x /usr/local/bin/kubectl
+sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
 ```
 
 ### Create a local Docker cluster


### PR DESCRIPTION
*Issue #, if available:*
The method for installing the eksctl and associated commands is not secure as it creates a file in a system-wide directory owned by a user (user = whoever the person is logged in as).

*Description of changes:*
Cleanup aligned with previous PR
https://github.com/aws/eks-anywhere/pull/5680

Instead of using mv (and chmod in some of the examples), use the "install" command with appropriate flags
ex - replace first line (mv) with the second (install)

sudo mv /tmp/eksctl /usr/local/bin/
sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl

*Testing (if applicable):*

*Documentation added/planned (if applicable):*
N/A - this is an upd ate, not an add.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

