### PR TITLE
Validate oci namespaces for BR registry mirror

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -776,13 +776,7 @@ func validateMirrorConfig(clusterConfig *Cluster) error {
 			}
 		}
 	}
-	if mirrorCount == 1 {
-		// BottleRocket accepts only one registry mirror and that is hardcoded for public.ecr.aws at this moment.
-		// Such a validation will be removed once CAPI is patched to support more than one endpoints for BottleRocket.
-		if ociNamespaces[0].Registry != constants.DefaultCoreEKSARegistry {
-			return errors.New("registry must be public.ecr.aws when only one mapping is specified")
-		}
-	}
+
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	//nolint: staticcheck
 	"io/ioutil"
 	"reflect"
 	"strings"
@@ -2931,24 +2930,6 @@ func TestValidateMirrorConfig(t *testing.T) {
 							{
 								Registry:  "783794618700.dkr.ecr.us-east-1.amazonaws.com",
 								Namespace: "",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:    "one registry in OCINamespace but not public.ecr.aws",
-			wantErr: "registry must be public.ecr.aws when only one mapping is specified",
-			cluster: &Cluster{
-				Spec: ClusterSpec{
-					RegistryMirrorConfiguration: &RegistryMirrorConfiguration{
-						Endpoint: "1.2.3.4",
-						Port:     "30003",
-						OCINamespaces: []OCINamespace{
-							{
-								Registry:  "783794618700.dkr.ecr.us-west-2.amazonaws.com",
-								Namespace: "curated-packages",
 							},
 						},
 					},

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -42,16 +42,12 @@ func ValidateOSForRegistryMirror(clusterSpec *cluster.Spec, provider providers.P
 		return nil
 	}
 
-	ociNamespaceRegistryMap := make(map[string]bool)
-	for _, ns := range cluster.Spec.RegistryMirrorConfiguration.OCINamespaces {
-		ociNamespaceRegistryMap[ns.Registry] = true
-	}
-
 	for _, mc := range machineConfigs {
 		// BottleRocket accepts only one registry mirror and that is hardcoded for public.ecr.aws at this moment.
 		// Such a validation will be removed once CAPI is patched to support more than one endpoints for BottleRocket.
-		if mc.OSFamily() == v1alpha1.Bottlerocket && !ociNamespaceRegistryMap[constants.DefaultCoreEKSARegistry] {
-			return fmt.Errorf("%s is the only registry supported for %s", constants.DefaultCoreEKSARegistry, v1alpha1.Bottlerocket)
+		if mc.OSFamily() == v1alpha1.Bottlerocket &&
+			(len(ociNamespaces) != 1 || ociNamespaces[0].Registry != constants.DefaultCoreEKSARegistry) {
+			return fmt.Errorf("%s is the only registry supported in ociNamespaces for %s", constants.DefaultCoreEKSARegistry, v1alpha1.Bottlerocket)
 		}
 	}
 


### PR DESCRIPTION
*Issue #6418*

*Description of changes:*
Currently when we configure ociNamespaces, we are free to setup any values for registry and namespace fields. But the main registry lookup we perform in our codebase expects an entry for `public.ecr.aws` when OS Family is bottlerocket.

Given a configuration like

```
 ociNamespaces:
  - registry: "docker.io"
    namespace: "library"
```

This would be accepted and proceed with cluster creation but cause the template CP and MD to get an empty string for registry mirror endpoint since we do a lookup for `public.ecr.aws`, Example [template.go#L217]( https://github.com/aws/eks-anywhere/blob/main/pkg/providers/vsphere/template.go#L217).

Hence we are adding a preflight to validate and error when osFamily is bottlerocket and the supported registry is not found.

*Testing:*
```
./eksctl-anywhere create cluster -f ./br-regauth.yaml --bundles-override ./eks-anywhere-downloads/bundle-release.yaml
```
Error message

`2024-01-05T01:40:00.232Z	V0	❌ Validation failed	{"validation": "validate OS is compatible with registry mirror configuration", "error": "public.ecr.aws is the only registry supported for bottlerocket", "remediation": "please use a valid OS for your registry mirror configuration"}`

*Documentation planned:*
Planning to update documentation to better describe OCINamespaces option.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

