### PR TITLE
Remove ExistingManagement field from Cluster type

### DIFF
--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -134,13 +134,11 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		cluster = &types.Cluster{
 			Name:               clusterSpec.Cluster.Name,
 			KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
-			ExistingManagement: false,
 		}
 	} else {
 		cluster = &types.Cluster{
 			Name:               clusterSpec.Cluster.Name,
 			KubeconfigFile:     clusterSpec.ManagementCluster.KubeconfigFile,
-			ExistingManagement: true,
 		}
 	}
 

--- a/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
@@ -81,9 +81,8 @@ var upgradeManagementComponentsCmd = &cobra.Command{
 		)
 
 		managementCluster := &types.Cluster{
-			Name:               clusterSpec.Cluster.Name,
-			KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
-			ExistingManagement: clusterSpec.Cluster.IsSelfManaged(),
+			Name:           clusterSpec.Cluster.Name,
+			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		}
 
 		validator := management.NewUMCValidator(managementCluster, deps.Kubectl)

--- a/pkg/cluster/load.go
+++ b/pkg/cluster/load.go
@@ -39,6 +39,5 @@ func LoadManagement(kubeconfig string) (*types.Cluster, error) {
 	return &types.Cluster{
 		Name:               kc.Clusters[0].Name,
 		KubeconfigFile:     kubeconfig,
-		ExistingManagement: true,
 	}, nil
 }

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -407,8 +407,7 @@ func (c *ClusterManager) CreateWorkloadCluster(ctx context.Context, managementCl
 	clusterName := clusterSpec.Cluster.Name
 
 	workloadCluster := &types.Cluster{
-		Name:               clusterName,
-		ExistingManagement: managementCluster.ExistingManagement,
+		Name: clusterName,
 	}
 
 	if err := c.applyProviderManifests(ctx, clusterSpec, managementCluster, provider); err != nil {
@@ -590,7 +589,7 @@ func (c *ClusterManager) deleteEKSAObjects(ctx context.Context, managementCluste
 
 func (c *ClusterManager) UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, newClusterSpec *cluster.Spec, provider providers.Provider) error {
 	eksaMgmtCluster := workloadCluster
-	if managementCluster != nil && managementCluster.ExistingManagement {
+	if managementCluster != nil {
 		eksaMgmtCluster = managementCluster
 	}
 

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -842,8 +842,7 @@ func TestClusterManagerUpgradeWorkloadClusterSuccess(t *testing.T) {
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,
@@ -888,8 +887,7 @@ func TestClusterManagerUpgradeWorkloadClusterAWSIamConfigSuccess(t *testing.T) {
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,
@@ -969,8 +967,7 @@ func TestClusterManagerUpgradeCloudStackWorkloadClusterSuccess(t *testing.T) {
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,
@@ -1015,8 +1012,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForMDReadyErrorOnce(t *testing.
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,
@@ -1064,8 +1060,7 @@ func TestClusterManagerUpgradeWorkloadClusterWaitForMDReadyUnreadyOnce(t *testin
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,
@@ -1152,8 +1147,7 @@ func TestClusterManagerUpgradeWorkloadClusterGetMachineDeploymentError(t *testin
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,
@@ -1188,8 +1182,7 @@ func TestClusterManagerUpgradeWorkloadClusterRemoveOldWorkerNodeGroupsError(t *t
 	workClusterName := "cluster-name-w"
 
 	mCluster := &types.Cluster{
-		Name:               mgmtClusterName,
-		ExistingManagement: true,
+		Name: mgmtClusterName,
 	}
 	wCluster := &types.Cluster{
 		Name: workClusterName,

--- a/pkg/gitops/flux/flux.go
+++ b/pkg/gitops/flux/flux.go
@@ -126,7 +126,7 @@ func (f *Flux) Bootstrap(ctx context.Context, cluster *types.Cluster, clusterSpe
 }
 
 func (f *Flux) BootstrapGithub(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
-	if cluster.ExistingManagement || clusterSpec.FluxConfig.Spec.Github == nil {
+	if clusterSpec.Cluster.IsManaged() || clusterSpec.FluxConfig.Spec.Github == nil {
 		return nil
 	}
 
@@ -134,7 +134,7 @@ func (f *Flux) BootstrapGithub(ctx context.Context, cluster *types.Cluster, clus
 }
 
 func (f *Flux) BootstrapGit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
-	if cluster.ExistingManagement || clusterSpec.FluxConfig.Spec.Git == nil {
+	if clusterSpec.Cluster.IsManaged() || clusterSpec.FluxConfig.Spec.Git == nil {
 		return nil
 	}
 

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -732,9 +732,8 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
 	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
-		Name:               "management-cluster",
-		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
+		Name:           "management-cluster",
+		KubeconfigFile: "kc.kubeconfig",
 	}
 
 	setupContext(t)
@@ -765,9 +764,8 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T)
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
 	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
-		Name:               "management-cluster",
-		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
+		Name:           "management-cluster",
+		KubeconfigFile: "kc.kubeconfig",
 	}
 
 	setupContext(t)
@@ -808,9 +806,8 @@ func TestSetupAndValidateSelfManagedClusterSkipMachineNameValidateSuccess(t *tes
 	provider.providerKubectlClient = kubectl
 
 	clusterSpec.ManagementCluster = &types.Cluster{
-		Name:               "management-cluster",
-		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
+		Name:           "management-cluster",
+		KubeconfigFile: "kc.kubeconfig",
 	}
 
 	kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -828,9 +825,8 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	clusterSpec := givenClusterSpec(t, testClusterConfigMainFilename)
 	clusterSpec.Cluster.SetManagedBy("management-cluster")
 	clusterSpec.ManagementCluster = &types.Cluster{
-		Name:               "management-cluster",
-		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
+		Name:           "management-cluster",
+		KubeconfigFile: "kc.kubeconfig",
 	}
 
 	setupContext(t)
@@ -864,9 +860,8 @@ func TestSetupAndValidateSelfManagedClusterSkipDatacenterNameValidateSuccess(t *
 	provider.providerKubectlClient = kubectl
 
 	clusterSpec.ManagementCluster = &types.Cluster{
-		Name:               "management-cluster",
-		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
+		Name:           "management-cluster",
+		KubeconfigFile: "kc.kubeconfig",
 	}
 
 	kubectl.EXPECT().SearchCloudStackMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -1134,7 +1134,6 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1183,7 +1182,6 @@ func TestSetupAndValidateCreateWorkloadClusterDifferentNamespaceSuccess(t *testi
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1230,7 +1228,6 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T)
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	idx := 0
@@ -1276,7 +1273,6 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	for _, config := range machineConfigs {
@@ -1315,7 +1311,6 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterConfigError(t *te
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	for _, config := range machineConfigs {
@@ -1353,7 +1348,6 @@ func TestSetupAndValidateCreateWorkloadClusterErrorUnprovisionedHardware(t *test
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1392,7 +1386,6 @@ func TestSetupAndValidateCreateWorkloadClusterErrorProvisionedHardware(t *testin
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1463,7 +1456,6 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorApplyHardware(t *testing.T) 
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	cluster.KubeconfigFile = "kc.kubeconfig"
 
@@ -1502,7 +1494,6 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorBMC(t *testing.T) {
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	cluster.KubeconfigFile = "kc.kubeconfig"
 
@@ -1544,7 +1535,6 @@ func TestSetupAndValidateCreateWorkloadClusterErrorManagementCluster(t *testing.
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1590,7 +1580,6 @@ func TestSetupAndValidateCreateWorkloadClusterErrorUnspecifiedTinkerbellIP(t *te
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1632,7 +1621,6 @@ func TestSetupAndValidateCreateWorkloadClusterErrorManagementClusterTinkerbellIP
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)
@@ -1677,7 +1665,6 @@ func TestSetupAndValidateCreateWorkloadClusterErrorDifferentTinkerbellIP(t *test
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range machineConfigs {
 		kubectl.EXPECT().SearchTinkerbellMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.TinkerbellMachineConfig{}, nil)

--- a/pkg/providers/vsphere/template_test.go
+++ b/pkg/providers/vsphere/template_test.go
@@ -1,12 +1,14 @@
 package vsphere_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
 )
 
@@ -50,6 +52,9 @@ func TestVsphereTemplateBuilderGenerateCAPISpecControlPlaneInvalidEtcdSSHKey(t *
 }
 
 func TestTemplateBuilder_CertSANs(t *testing.T) {
+	os.Unsetenv(config.EksavSphereUsernameKey)
+	os.Unsetenv(config.EksavSpherePasswordKey)
+
 	for _, tc := range []struct {
 		Input  string
 		Output string

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1572,7 +1572,6 @@ func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	for _, config := range clusterSpec.VSphereMachineConfigs {
 		kubectl.EXPECT().SearchVsphereMachineConfig(ctx, config.Name, clusterSpec.ManagementCluster.KubeconfigFile, config.Namespace).Return([]*v1alpha1.VSphereMachineConfig{}, nil)
@@ -1603,7 +1602,6 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfMachineExists(t *testing.T)
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	idx := 0
@@ -1638,7 +1636,6 @@ func TestSetupAndValidateSelfManagedClusterSkipMachineNameValidateSuccess(t *tes
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	kubectl.EXPECT().SearchVsphereMachineConfig(context.TODO(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -1669,7 +1666,6 @@ func TestSetupAndValidateCreateWorkloadClusterFailsIfDatacenterExists(t *testing
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	for _, config := range clusterSpec.VSphereMachineConfigs {
@@ -1697,7 +1693,6 @@ func TestSetupAndValidateSelfManagedClusterSkipDatacenterNameValidateSuccess(t *
 	clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 
 	kubectl.EXPECT().SearchVsphereMachineConfig(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -172,7 +172,6 @@ func TestUnmarshalTaskCheckpointSuccess(t *testing.T) {
 	testTaskCheckpoint := types.Cluster{
 		Name:               "test-cluster",
 		KubeconfigFile:     "test.kubeconfig",
-		ExistingManagement: false,
 	}
 
 	if err := task.UnmarshalTaskCheckpoint(testTaskCheckpoint, testConfigType); err != nil {

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -3,17 +3,15 @@ package types
 import "github.com/aws/eks-anywhere/release/api/v1alpha1"
 
 type Cluster struct {
-	Name               string
-	KubeconfigFile     string
-	ExistingManagement bool // true is the cluster has EKS Anywhere management components
+	Name           string
+	KubeconfigFile string
 }
 
 // DeepCopy creates a new in-memory copy of c.
 func (c *Cluster) DeepCopy() *Cluster {
 	return &Cluster{
-		Name:               c.Name,
-		KubeconfigFile:     c.KubeconfigFile,
-		ExistingManagement: c.ExistingManagement,
+		Name:           c.Name,
+		KubeconfigFile: c.KubeconfigFile,
 	}
 }
 

--- a/pkg/validations/upgradevalidations/versions.go
+++ b/pkg/validations/upgradevalidations/versions.go
@@ -10,12 +10,7 @@ import (
 )
 
 // ValidateServerVersionSkew validates Kubernetes version skew between upgrades for the CLI.
-func ValidateServerVersionSkew(ctx context.Context, newCluster *anywherev1.Cluster, cluster *types.Cluster, mgmtCluster *types.Cluster, kubectl validations.KubectlClient) error {
-	managementCluster := cluster
-	if !cluster.ExistingManagement {
-		managementCluster = mgmtCluster
-	}
-
+func ValidateServerVersionSkew(ctx context.Context, newCluster *anywherev1.Cluster, cluster *types.Cluster, managementCluster *types.Cluster, kubectl validations.KubectlClient) error {
 	eksaCluster, err := kubectl.GetEksaCluster(ctx, managementCluster, newCluster.Name)
 	if err != nil {
 		return fmt.Errorf("fetching old cluster: %v", err)
@@ -25,12 +20,7 @@ func ValidateServerVersionSkew(ctx context.Context, newCluster *anywherev1.Clust
 }
 
 // ValidateWorkerServerVersionSkew validates worker node group Kubernetes version skew between upgrades.
-func ValidateWorkerServerVersionSkew(ctx context.Context, newCluster *anywherev1.Cluster, cluster *types.Cluster, mgmtCluster *types.Cluster, kubectl validations.KubectlClient) error {
-	managementCluster := cluster
-	if !cluster.ExistingManagement {
-		managementCluster = mgmtCluster
-	}
-
+func ValidateWorkerServerVersionSkew(ctx context.Context, newCluster *anywherev1.Cluster, cluster *types.Cluster, managementCluster *types.Cluster, kubectl validations.KubectlClient) error {
 	eksaCluster, err := kubectl.GetEksaCluster(ctx, managementCluster, newCluster.Name)
 	if err != nil {
 		return fmt.Errorf("fetching old cluster: %v", err)

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -98,7 +98,7 @@ func (s *setupAndValidate) Checkpoint() *task.CompletedTask {
 }
 
 func (s *createManagementCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	if commandContext.BootstrapCluster != nil && commandContext.BootstrapCluster.ExistingManagement {
+	if commandContext.ClusterSpec.Cluster.IsManaged() {
 		return &deleteWorkloadCluster{}
 	}
 	logger.Info("Creating management cluster")
@@ -228,7 +228,7 @@ func (s *cleanupGitRepo) Checkpoint() *task.CompletedTask {
 }
 
 func (s *deletePackageResources) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	if !commandContext.BootstrapCluster.ExistingManagement {
+	if commandContext.ClusterSpec.Cluster.IsSelfManaged() {
 		return &deleteManagementCluster{}
 	}
 
@@ -263,7 +263,7 @@ func (s *deleteManagementCluster) Run(ctx context.Context, commandContext *task.
 		collector := &CollectMgmtClusterDiagnosticsTask{}
 		collector.Run(ctx, commandContext)
 	}
-	if commandContext.BootstrapCluster != nil && !commandContext.BootstrapCluster.ExistingManagement {
+	if commandContext.ClusterSpec.Cluster.IsSelfManaged() {
 		if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, constants.Delete, false); err != nil {
 			commandContext.SetError(err)
 		}

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -170,7 +170,6 @@ func TestDeleteWorkloadRunSuccess(t *testing.T) {
 	test.clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	test.clusterSpec.Cluster.SetManagedBy(test.clusterSpec.ManagementCluster.Name)
 	test.expectDeleteWorkload(test.clusterSpec.ManagementCluster)
@@ -192,7 +191,6 @@ func TestDeleteWorkloadDeletePackageResourceError(t *testing.T) {
 	test.clusterSpec.ManagementCluster = &types.Cluster{
 		Name:               "management-cluster",
 		KubeconfigFile:     "kc.kubeconfig",
-		ExistingManagement: true,
 	}
 	test.clusterSpec.Cluster.SetManagedBy(test.clusterSpec.ManagementCluster.Name)
 	test.expectDeleteWorkload(test.clusterSpec.ManagementCluster)

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -84,7 +84,6 @@ func TestRunnerHappyPath(t *testing.T) {
 	managementCluster := &types.Cluster{
 		Name:               clusterSpec.Cluster.Name,
 		KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
-		ExistingManagement: clusterSpec.Cluster.IsSelfManaged(),
 	}
 
 	ctx := context.Background()
@@ -135,7 +134,6 @@ func TestRunnerStopsWhenValidationFailed(t *testing.T) {
 	managementCluster := &types.Cluster{
 		Name:               clusterSpec.Cluster.Name,
 		KubeconfigFile:     kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
-		ExistingManagement: clusterSpec.Cluster.IsSelfManaged(),
 	}
 
 	ctx := context.Background()

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -105,9 +105,8 @@ func (c *upgradeTestSetup) WithForceCleanup() *upgradeTestSetup {
 func newUpgradeSelfManagedClusterTest(t *testing.T) *upgradeTestSetup {
 	tt := newUpgradeTest(t)
 	tt.bootstrapCluster = &types.Cluster{
-		Name:               "bootstrap",
-		ExistingManagement: false,
-		KubeconfigFile:     "kubeconfig.yaml",
+		Name:           "bootstrap",
+		KubeconfigFile: "kubeconfig.yaml",
 	}
 	tt.managementCluster = tt.workloadCluster
 	return tt
@@ -116,13 +115,12 @@ func newUpgradeSelfManagedClusterTest(t *testing.T) *upgradeTestSetup {
 func newUpgradeManagedClusterTest(t *testing.T) *upgradeTestSetup {
 	tt := newUpgradeTest(t)
 	tt.managementCluster = &types.Cluster{
-		Name:               "management-cluster",
-		ExistingManagement: true,
-		KubeconfigFile:     "kubeconfig.yaml",
+		Name:           "management-cluster",
+		KubeconfigFile: "kubeconfig.yaml",
 	}
 	tt.workloadCluster.KubeconfigFile = "wl-kubeconfig.yaml"
 
-	tt.newClusterSpec.Cluster.SetSelfManaged()
+	tt.newClusterSpec.Cluster.SetManagedBy(tt.managementCluster.Name)
 	tt.newClusterSpec.ManagementCluster = tt.managementCluster
 	return tt
 }
@@ -246,7 +244,7 @@ func (c *upgradeTestSetup) expectUpgradeWorkload(managementCluster *types.Cluste
 		c.expectUpgradeWorkloadToReturn(managementCluster, workloadCluster, nil),
 	}
 
-	if managementCluster != nil && managementCluster.ExistingManagement {
+	if c.newClusterSpec.Cluster.IsManaged() {
 		calls = append(calls,
 			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec, managementCluster),
 			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec, managementCluster),

--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -40,6 +40,5 @@ func withMgmtClusterSetup(cluster *framework.ClusterE2ETest) *types.Cluster {
 	return &types.Cluster{
 		Name:               cluster.ClusterName,
 		KubeconfigFile:     filepath.Join(cluster.ClusterName, fmt.Sprintf("%s-eks-a-cluster.kubeconfig", cluster.ClusterName)),
-		ExistingManagement: true,
 	}
 }

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -219,7 +219,6 @@ func withMgmtCluster(cluster *framework.ClusterE2ETest) *types.Cluster {
 	return &types.Cluster{
 		Name:               cluster.ClusterName,
 		KubeconfigFile:     filepath.Join(cluster.ClusterName, fmt.Sprintf("%s-eks-a-cluster.kubeconfig", cluster.ClusterName)),
-		ExistingManagement: true,
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*
The function of this field was unclear and its name was confusing to say
the least. It seems like we now have a better way to achieve the same
thing and the resulting code is simpler and more expressive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

