### PR TITLE
Fix WNGC field name in docs

### DIFF
--- a/docs/content/en/docs/clustermgmt/cluster-flux.md
+++ b/docs/content/en/docs/clustermgmt/cluster-flux.md
@@ -197,7 +197,7 @@ After your cluster has been created, you can test the GitOps controller by modif
     clusters/$CLUSTER_NAME/eksa-system/eksa-cluster.yaml
     ```
 
-1. Modify the `workerNodeGroupsConfigurations[0].count` field with your desired changes.
+1. Modify the `workerNodeGroupConfigurations[0].count` field with your desired changes.
 
 1. Commit the file to your git repository
 

--- a/docs/content/en/docs/clustermgmt/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/clustermgmt/cluster-scale/baremetal-scale.md
@@ -27,7 +27,7 @@ spec:
   controlPlaneConfiguration:
     count: 1     # increase this number to horizontally scale your control plane
 ...    
-  workerNodeGroupsConfiguration:
+  workerNodeGroupConfigurations:
   - count: 1     # increase this number to horizontally scale your data plane
 ```
 

--- a/docs/content/en/docs/clustermgmt/cluster-scale/cloudstack-scale.md
+++ b/docs/content/en/docs/clustermgmt/cluster-scale/cloudstack-scale.md
@@ -27,7 +27,7 @@ spec:
   controlPlaneConfiguration:
     count: 1     # increase this number to horizontally scale your control plane
 ...    
-  workerNodeGroupsConfiguration:
+  workerNodeGroupConfigurations:
   - count: 1     # increase this number to horizontally scale your data plane
 ```
 

--- a/docs/content/en/docs/clustermgmt/cluster-scale/nutanix-scale.md
+++ b/docs/content/en/docs/clustermgmt/cluster-scale/nutanix-scale.md
@@ -30,7 +30,7 @@ spec:
   controlPlaneConfiguration:
     count: 1     # increase this number to horizontally scale your control plane
 ...    
-  workerNodeGroupsConfiguration:
+  workerNodeGroupConfigurations:
   - count: 1     # increase this number to horizontally scale your data plane
 ```
 

--- a/docs/content/en/docs/clustermgmt/cluster-scale/vsphere-scale.md
+++ b/docs/content/en/docs/clustermgmt/cluster-scale/vsphere-scale.md
@@ -30,7 +30,7 @@ spec:
   controlPlaneConfiguration:
     count: 1     # increase this number to horizontally scale your control plane
 ...    
-  workerNodeGroupsConfiguration:
+  workerNodeGroupConfigurations:
   - count: 1     # increase this number to horizontally scale your data plane
 ```
 


### PR DESCRIPTION
Fix WNGC field name in docs: `workerNodeGroupsConfiguration` -> `workerNodeGroupConfigurations`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

