### PR TITLE
Add methods to fetch upgrader image from bundle

### DIFF
--- a/controllers/controlplaneupgrade_controller_test.go
+++ b/controllers/controlplaneupgrade_controller_test.go
@@ -205,7 +205,7 @@ func getObjectsForCPUpgradeTest() (*clusterv1.Cluster, []*clusterv1.Machine, []*
 	machines := []*clusterv1.Machine{machine1, machine2}
 	nodes := []*corev1.Node{node1, node2}
 	nodeUpgrades := []*anywherev1.NodeUpgrade{nodeUpgrade1, nodeUpgrade2}
-	cpUpgrade := generateCPUpgrade(machines, cluster)
+	cpUpgrade := generateCPUpgrade(machines)
 	return cluster, machines, nodes, cpUpgrade, nodeUpgrades
 }
 
@@ -218,7 +218,7 @@ func cpUpgradeRequest(cpUpgrade *anywherev1.ControlPlaneUpgrade) reconcile.Reque
 	}
 }
 
-func generateCPUpgrade(machine []*clusterv1.Machine, cluster *clusterv1.Cluster) *anywherev1.ControlPlaneUpgrade {
+func generateCPUpgrade(machine []*clusterv1.Machine) *anywherev1.ControlPlaneUpgrade {
 	etcdVersion := "v1.28.3-eks-1-28-9"
 	return &anywherev1.ControlPlaneUpgrade{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/machinedeploymentupgrade_controller_test.go
+++ b/controllers/machinedeploymentupgrade_controller_test.go
@@ -146,7 +146,7 @@ func getObjectsForMDUpgradeTest() (*clusterv1.Cluster, *clusterv1.Machine, *core
 	node := generateNode()
 	machine := generateMachine(cluster, node)
 	nodeUpgrade := generateNodeUpgrade(machine)
-	mdUpgrade := generateMDUpgrade(machine, cluster)
+	mdUpgrade := generateMDUpgrade(machine)
 	return cluster, machine, node, mdUpgrade, nodeUpgrade
 }
 
@@ -159,7 +159,7 @@ func mdUpgradeRequest(mdUpgrade *anywherev1.MachineDeploymentUpgrade) reconcile.
 	}
 }
 
-func generateMDUpgrade(machine *clusterv1.Machine, cluster *clusterv1.Cluster) *anywherev1.MachineDeploymentUpgrade {
+func generateMDUpgrade(machine *clusterv1.Machine) *anywherev1.MachineDeploymentUpgrade {
 	return &anywherev1.MachineDeploymentUpgrade{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "md-upgrade-request",

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -47,11 +47,29 @@ func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
 	}
 	s.VersionsBundles = map[v1alpha1.KubernetesVersion]*cluster.VersionsBundle{
 		v1alpha1.Kube119: {
-			VersionsBundle: &releasev1alpha1.VersionsBundle{},
-			KubeDistro:     &cluster.KubeDistro{},
+			VersionsBundle: &releasev1alpha1.VersionsBundle{
+				EksD: releasev1alpha1.EksDRelease{
+					Name:           "kubernetes-1-19-eks-7",
+					EksDReleaseUrl: "embed:///testdata/release.yaml",
+					KubeVersion:    "1.19",
+				},
+			},
+			KubeDistro: &cluster.KubeDistro{},
 		},
 	}
-	s.Bundles = &releasev1alpha1.Bundles{}
+	s.Bundles = &releasev1alpha1.Bundles{
+		Spec: releasev1alpha1.BundlesSpec{
+			VersionsBundles: []releasev1alpha1.VersionsBundle{
+				{
+					EksD: releasev1alpha1.EksDRelease{
+						Name:           "kubernetes-1-19-eks-7",
+						EksDReleaseUrl: "embed:///testdata/release.yaml",
+						KubeVersion:    "1.19",
+					},
+				},
+			},
+		},
+	}
 	s.EKSARelease = EKSARelease()
 
 	for _, opt := range opts {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -19,6 +19,7 @@ import (
 	v1alpha11 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1beta10 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -293,6 +294,21 @@ func (m *MockClusterClient) GetClusters(arg0 context.Context, arg1 *types.Cluste
 func (mr *MockClusterClientMockRecorder) GetClusters(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusters", reflect.TypeOf((*MockClusterClient)(nil).GetClusters), arg0, arg1)
+}
+
+// GetConfigMap mocks base method.
+func (m *MockClusterClient) GetConfigMap(arg0 context.Context, arg1, arg2, arg3 string) (*v1.ConfigMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigMap", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1.ConfigMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfigMap indicates an expected call of GetConfigMap.
+func (mr *MockClusterClientMockRecorder) GetConfigMap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClusterClient)(nil).GetConfigMap), arg0, arg1, arg2, arg3)
 }
 
 // GetEksaAWSIamConfig mocks base method.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,6 +46,8 @@ const (
 	NutanixCredentialsName = "nutanix-credentials"
 	EksaLicenseName        = "eksa-license"
 	EksaPackagesName       = "eksa-packages"
+	// UpgraderConfigMapName is the name of config map that stores the upgrader images.
+	UpgraderConfigMapName = "in-place-upgrade"
 
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
 

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -2179,7 +2179,8 @@ func isKubectlAlreadyExistsError(err error) bool {
 
 const notFoundErrorMessageSubString = "NotFound"
 
-func isKubectlNotFoundError(err error) bool {
+// IsKubectlNotFoundError returns true if the kubectl call returned the NotFound error.
+func IsKubectlNotFoundError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), notFoundErrorMessageSubString)
 }
 
@@ -2285,7 +2286,7 @@ func (k *Kubectl) Delete(ctx context.Context, resourceType, kubeconfig string, o
 
 	params := deleteParams(resourceType, kubeconfig, o)
 	_, err := k.Execute(ctx, params...)
-	if isKubectlNotFoundError(err) {
+	if IsKubectlNotFoundError(err) {
 		return newNotFoundErrorForTypeAndName(resourceType, o.Name)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The eks-a controller will be responsible for creating the custom CP/MD upgrade resources for in-place upgrades. We need a way to fetch the upgrader image from the bundle so this adds methods that will be used in the controller to pull the bundle and fetch the images. The images will be stored in a config map. This upgrader config map will then be fetched by the node upgrader when the image is needed.

ConfigMap:
```
apiVersion: v1
data:
  v1.25.16-eks-1-25-29: public.ecr.aws/l0g8r8j6/aws/upgrader:v1-25-29-eks-a-v0.0.0-dev-build.8103
  v1.26.11-eks-1-26-25: public.ecr.aws/l0g8r8j6/aws/upgrader:v1-26-25-eks-a-v0.0.0-dev-build.8103
  v1.27.8-eks-1-27-19: public.ecr.aws/l0g8r8j6/aws/upgrader:v1-27-19-eks-a-v0.0.0-dev-build.8103
  v1.28.4-eks-1-28-12: public.ecr.aws/l0g8r8j6/aws/upgrader:v1-28-12-eks-a-v0.0.0-dev-build.8103
  v1.29.0-eks-1-29-1: public.ecr.aws/l0g8r8j6/aws/upgrader:v1-29-1-eks-a-v0.0.0-dev-build.8103
kind: ConfigMap

```

*Testing (if applicable):*
performed in-place upgrade with image from bundle

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

