### PR TITLE
Add IAM Roles for Service Accounts to nutanix-spec.md doc

### DIFF
--- a/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
@@ -13,6 +13,7 @@ This is a generic template with detailed descriptions below for reference.
 The following additional optional configuration can also be included:
 
 * [CNI]({{< relref "../optional/cni.md" >}})
+* [IAM Roles for Service Accounts]({{< relref "../optional/irsa.md" >}})
 * [IAM Authenticator]({{< relref "../optional/iamauth.md" >}})
 * [OIDC]({{< relref "../optional/oidc.md" >}})
 * [Registry Mirror]({{< relref "../optional/registrymirror.md" >}})


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Update of the nutanix-spec.md to include "IAM Roles for Service Accounts" configuration

*Testing (if applicable):*
N/A

*Documentation added/planned (if applicable):*
Update of the nutanix-spec.md to include "IAM Roles for Service Accounts" configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

