### PR TITLE
Set etcd url in cloud-config when external etcd is enabled

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -86,9 +86,9 @@ const (
 	// DevBuildVersion is the version string for the dev build of EKS-A.
 	DevBuildVersion = "v0.0.0-dev"
 
-	// EtcdUrlEksAVersion is the version from which the etcd url will be set
-	// for etcdadm to pull the etcd tarball if that binary isnt cached
-	EtcdUrlEksAVersion = "v0.19.0"
+	// MinEksAVersionWithEtcdURL is the version from which the etcd url will be set
+	// for etcdadm to pull the etcd tarball if that binary isnt cached.
+	MinEksAVersionWithEtcdURL = "v0.19.0"
 )
 
 // Equal checks if two EksaVersions are equal.

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -82,8 +82,14 @@ type ClusterSpec struct {
 // EksaVersion is the semver identifying the release of eks-a used to populate the cluster components.
 type EksaVersion string
 
-// DevBuildVersion is the version string for the dev build of EKS-A.
-const DevBuildVersion = "v0.0.0-dev"
+const (
+	// DevBuildVersion is the version string for the dev build of EKS-A.
+	DevBuildVersion = "v0.0.0-dev"
+
+	// EtcdUrlEksAVersion is the version from which the etcd url will be set
+	// for etcdadm to pull the etcd tarball if that binary isnt cached
+	EtcdUrlEksAVersion = "v0.19.0"
+)
 
 // Equal checks if two EksaVersions are equal.
 func (n *EksaVersion) Equal(o *EksaVersion) bool {

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -294,6 +294,14 @@ func wantKubeDistroForEksdRelease() (*eksdv1.Release, *cluster.KubeDistro) {
 				{
 					Name:   "etcd",
 					GitTag: "v3.4.14",
+					Assets: []eksdv1.Asset{
+						{
+							Arch: []string{"amd64"},
+							Archive: &eksdv1.AssetArchive{
+								URI: "https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz",
+							},
+						},
+					},
 				},
 				{
 					Name: "comp-1",
@@ -405,6 +413,7 @@ func wantKubeDistroForEksdRelease() (*eksdv1.Release, *cluster.KubeDistro) {
 			URI: "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.19.8",
 		},
 		EtcdVersion: "3.4.14",
+		EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz",
 	}
 
 	return eksdRelease, kubeDistro

--- a/pkg/cluster/spec.go
+++ b/pkg/cluster/spec.go
@@ -80,6 +80,7 @@ type KubeDistro struct {
 	Pause               v1alpha1.Image
 	EtcdImage           v1alpha1.Image
 	EtcdVersion         string
+	EtcdURL             string
 	AwsIamAuthImage     v1alpha1.Image
 	KubeProxy           v1alpha1.Image
 }
@@ -200,9 +201,17 @@ func buildKubeDistro(eksd *eksdv1alpha1.Release) (*KubeDistro, error) {
 			if asset.Image != nil {
 				assets[asset.Name] = asset.Image
 			}
-		}
-		if component.Name == "etcd" {
-			kubeDistro.EtcdVersion = strings.TrimPrefix(component.GitTag, "v")
+
+			if component.Name == "etcd" {
+				kubeDistro.EtcdVersion = strings.TrimPrefix(component.GitTag, "v")
+
+				// Get archive uri for amd64
+				if asset.Archive != nil && len(asset.Arch) > 0 {
+					if asset.Arch[0] == "amd64" {
+						kubeDistro.EtcdURL = asset.Archive.URI
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -120,6 +120,8 @@ func newApiBuilerTest(t *testing.T) apiBuilerTest {
 					EtcdImage: v1alpha1.Image{
 						URI: "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
 					},
+					EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz",
+					EtcdVersion: "3.4.14",
 					Pause: v1alpha1.Image{
 						URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
 					},

--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -11,14 +11,19 @@ import (
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/providers/common"
 )
 
 // SetUbuntuConfigInEtcdCluster sets up the etcd config in EtcdadmCluster.
-func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, version string) {
+func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle, clusterSpec *cluster.Spec) {
 	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
-		Version:    version,
+		Version:    versionsBundle.KubeDistro.EtcdVersion,
 		InstallDir: "/usr/bin",
+	}
+	etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+	if etcdUrl != "" {
+		etcd.Spec.EtcdadmConfigSpec.CloudInitConfig.EtcdReleaseURL = etcdUrl
 	}
 }
 

--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -15,15 +15,15 @@ import (
 )
 
 // SetUbuntuConfigInEtcdCluster sets up the etcd config in EtcdadmCluster.
-func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle, clusterSpec *cluster.Spec) {
+func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle, eksaVersion string) {
 	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
 		Version:    versionsBundle.KubeDistro.EtcdVersion,
 		InstallDir: "/usr/bin",
 	}
-	etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
-	if etcdUrl != "" {
-		etcd.Spec.EtcdadmConfigSpec.CloudInitConfig.EtcdReleaseURL = etcdUrl
+	etcdURL, _ := common.GetExternalEtcdReleaseURL(eksaVersion, versionsBundle)
+	if etcdURL != "" {
+		etcd.Spec.EtcdadmConfigSpec.CloudInitConfig.EtcdReleaseURL = etcdURL
 	}
 }
 

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -26,7 +26,7 @@ func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 		InstallDir:     "/usr/bin",
 		EtcdReleaseURL: versionBundle.KubeDistro.EtcdURL,
 	}
-	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, g.clusterSpec)
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, string(eksaVersion))
 	g.Expect(got).To(Equal(want))
 }
 
@@ -43,7 +43,7 @@ func TestSetUbuntuConfigInEtcdClusterNoEtcdUrl(t *testing.T) {
 		Version:    versionBundle.KubeDistro.EtcdVersion,
 		InstallDir: "/usr/bin",
 	}
-	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, g.clusterSpec)
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, string(eksaVersion))
 	g.Expect(got).To(Equal(want))
 }
 

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -14,15 +14,36 @@ import (
 
 func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 	g := newApiBuilerTest(t)
+	eksaVersion := anywherev1.EksaVersion("v0.19.2")
+	g.clusterSpec.Cluster.Spec.EksaVersion = &eksaVersion
 	got := wantEtcdCluster()
-	v := "0.0.1"
+	versionBundle := g.clusterSpec.VersionsBundles["1.21"]
+
 	want := got.DeepCopy()
 	want.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	want.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
-		Version:    v,
+		Version:        versionBundle.KubeDistro.EtcdVersion,
+		InstallDir:     "/usr/bin",
+		EtcdReleaseURL: versionBundle.KubeDistro.EtcdURL,
+	}
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, g.clusterSpec)
+	g.Expect(got).To(Equal(want))
+}
+
+func TestSetUbuntuConfigInEtcdClusterNoEtcdUrl(t *testing.T) {
+	g := newApiBuilerTest(t)
+	eksaVersion := anywherev1.EksaVersion("v0.18.2")
+	g.clusterSpec.Cluster.Spec.EksaVersion = &eksaVersion
+	got := wantEtcdCluster()
+	versionBundle := g.clusterSpec.VersionsBundles["1.21"]
+
+	want := got.DeepCopy()
+	want.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
+	want.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
+		Version:    versionBundle.KubeDistro.EtcdVersion,
 		InstallDir: "/usr/bin",
 	}
-	clusterapi.SetUbuntuConfigInEtcdCluster(got, v)
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, g.clusterSpec)
 	g.Expect(got).To(Equal(want))
 }
 

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -400,6 +400,9 @@ spec:
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
       installDir: "/usr/bin"
+{{- if .externalEtcdReleaseUrl }}
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
+{{- end }}
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -231,9 +231,9 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
-		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
-		if etcdUrl != "" {
-			values["externalEtcdReleaseUrl"] = etcdUrl
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdURL != "" {
+			values["externalEtcdReleaseUrl"] = etcdURL
 		}
 	}
 

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -195,6 +195,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"schedulerExtraArgs":                         sharedExtraArgs.ToPartialYaml(),
 		"format":                                     format,
 		"externalEtcdVersion":                        versionsBundle.KubeDistro.EtcdVersion,
+		"externalEtcdReleaseUrl":                     versionsBundle.KubeDistro.EtcdURL,
 		"etcdImage":                                  versionsBundle.KubeDistro.EtcdImage.VersionedImage(),
 		"eksaSystemNamespace":                        constants.EksaSystemNamespace,
 	}
@@ -230,6 +231,10 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
+		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdUrl != "" {
+			values["externalEtcdReleaseUrl"] = etcdUrl
+		}
 	}
 
 	if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -364,6 +364,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
@@ -385,6 +385,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp_kubernetes_version.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp_kubernetes_version.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -383,6 +383,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -384,6 +384,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -373,6 +373,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -395,6 +395,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
@@ -387,6 +387,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
@@ -375,6 +375,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -388,6 +388,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     etcdadmInstallCommands:
       - echo this line exists so that etcdadmInstallCommands is not empty
       - echo etcdadmInstallCommands can be removed once etcdadm bootstrap and controller fix the bug

--- a/pkg/providers/common/common_test.go
+++ b/pkg/providers/common/common_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 
+	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
 )
@@ -133,6 +134,44 @@ func TestGetCAPIBottlerocketSettingsConfig(t *testing.T) {
 			}
 
 			g.Expect(got).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestGetExternalEtcdReleaseUrl(t *testing.T) {
+	g := NewWithT(t)
+	testcases := []struct {
+		name           string
+		clusterVersion string
+		etcdUrl        string
+		err            error
+	}{
+		{
+			name:           "Pre-etcd url enabled version < 0.19.0",
+			clusterVersion: "v0.15.2",
+			etcdUrl:        "",
+			err:            fmt.Errorf("external etcd not enabled for eks-a version: v0.15.2"),
+		},
+		{
+			name:           "Etcd url enabled version = 0.19.0",
+			clusterVersion: "v0.19.0",
+			etcdUrl:        test.VersionBundle().KubeDistro.EtcdURL,
+		},
+		{
+			name:           "Post etcd url enabled version > 0.19.0",
+			clusterVersion: "v0.21.0",
+			etcdUrl:        test.VersionBundle().KubeDistro.EtcdURL,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := common.GetExternalEtcdReleaseUrl(tt.clusterVersion, test.VersionBundle())
+			if tt.err == nil {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err.Error()).To(Equal(tt.err.Error()))
+			}
+			g.Expect(got).To(Equal(tt.etcdUrl))
 		})
 	}
 }

--- a/pkg/providers/common/common_test.go
+++ b/pkg/providers/common/common_test.go
@@ -138,40 +138,45 @@ func TestGetCAPIBottlerocketSettingsConfig(t *testing.T) {
 	}
 }
 
-func TestGetExternalEtcdReleaseUrl(t *testing.T) {
+func TestGetExternalEtcdReleaseURL(t *testing.T) {
 	g := NewWithT(t)
 	testcases := []struct {
 		name           string
 		clusterVersion string
-		etcdUrl        string
+		etcdURL        string
 		err            error
 	}{
 		{
 			name:           "Pre-etcd url enabled version < 0.19.0",
 			clusterVersion: "v0.15.2",
-			etcdUrl:        "",
-			err:            fmt.Errorf("external etcd not enabled for eks-a version: v0.15.2"),
+			etcdURL:        "",
+			err:            nil,
 		},
 		{
 			name:           "Etcd url enabled version = 0.19.0",
 			clusterVersion: "v0.19.0",
-			etcdUrl:        test.VersionBundle().KubeDistro.EtcdURL,
+			etcdURL:        test.VersionBundle().KubeDistro.EtcdURL,
 		},
 		{
 			name:           "Post etcd url enabled version > 0.19.0",
 			clusterVersion: "v0.21.0",
-			etcdUrl:        test.VersionBundle().KubeDistro.EtcdURL,
+			etcdURL:        test.VersionBundle().KubeDistro.EtcdURL,
+		},
+		{
+			name:           "Invalid semver for eks-a cluster version",
+			clusterVersion: "a.12.4.3.78",
+			err:            fmt.Errorf("invalid semver for clusterVersion: invalid major version in semver a.12.4.3.78: strconv.ParseInt: parsing \"\": invalid syntax"),
 		},
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := common.GetExternalEtcdReleaseUrl(tt.clusterVersion, test.VersionBundle())
+			got, err := common.GetExternalEtcdReleaseURL(tt.clusterVersion, test.VersionBundle())
 			if tt.err == nil {
 				g.Expect(err).ToNot(HaveOccurred())
 			} else {
 				g.Expect(err.Error()).To(Equal(tt.err.Error()))
 			}
-			g.Expect(got).To(Equal(tt.etcdUrl))
+			g.Expect(got).To(Equal(tt.etcdURL))
 		})
 	}
 }

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -276,6 +276,9 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
+{{- if .externalEtcdReleaseUrl }}
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
+{{- end }}
 {{- if .etcdCipherSuites }}
     cipherSuites: {{.etcdCipherSuites}}
 {{- end }}

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -301,6 +301,7 @@ func TestControlPlaneUpgradeRolloutStrategy(t *testing.T) {
 func testClusterSpec(opts ...test.ClusterSpecOpt) *cluster.Spec {
 	name := "test"
 	namespace := "test-namespace"
+	devVersion := test.DevEksaVersion()
 
 	clusterOpts := make([]test.ClusterSpecOpt, 0)
 	clusterOpts = append(clusterOpts, func(s *cluster.Spec) {
@@ -322,6 +323,7 @@ func testClusterSpec(opts ...test.ClusterSpecOpt) *cluster.Spec {
 					Count: 3,
 				},
 				KubernetesVersion: "1.23",
+				EksaVersion:       &devVersion,
 				WorkerNodeGroupConfigurations: []anywherev1.WorkerNodeGroupConfiguration{
 					{
 						Count:           ptr.Int(3),

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -323,6 +323,10 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
+		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdUrl != "" {
+			values["externalEtcdReleaseUrl"] = etcdUrl
+		}
 	}
 	if clusterSpec.AWSIamConfig != nil {
 		values["awsIamAuth"] = true

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -323,9 +323,9 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
-		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
-		if etcdUrl != "" {
-			values["externalEtcdReleaseUrl"] = etcdUrl
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdURL != "" {
+			values["externalEtcdReleaseUrl"] = etcdURL
 		}
 	}
 	if clusterSpec.AWSIamConfig != nil {

--- a/pkg/providers/docker/docker_test.go
+++ b/pkg/providers/docker/docker_test.go
@@ -603,6 +603,7 @@ var versionsBundle = &cluster.VersionsBundle{
 			Tag:        "v3.4.14-eks-1-19-2",
 		},
 		EtcdVersion: "3.4.14",
+		EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
 	},
 	VersionsBundle: &releasev1alpha1.VersionsBundle{
 		EksD: releasev1alpha1.EksDRelease{

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -299,6 +299,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -294,6 +294,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
@@ -302,6 +302,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.16
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -328,6 +328,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.16
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
@@ -325,6 +325,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.16
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -292,6 +292,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
@@ -320,6 +320,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -293,6 +293,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -312,6 +312,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -294,6 +294,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -294,6 +294,7 @@ spec:
     etcdadmBuiltin: true
     cloudInitConfig:
       version: 3.4.14
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -161,7 +161,7 @@ func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTempl
 		clusterapi.SetBottlerocketHostConfigInEtcdCluster(etcd, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
-		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle.KubeDistro.EtcdVersion)
+		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle, clusterSpec)
 		etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = append(etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands,
 			"/etc/eks/bootstrap.sh",
 		)

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -161,7 +161,7 @@ func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTempl
 		clusterapi.SetBottlerocketHostConfigInEtcdCluster(etcd, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
-		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle, clusterSpec)
+		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle, string(*clusterSpec.Cluster.Spec.EksaVersion))
 		etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = append(etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands,
 			"/etc/eks/bootstrap.sh",
 		)

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -1074,8 +1074,9 @@ func wantEtcdClusterUbuntu() *etcdv1.EtcdadmCluster {
 	etcd := wantEtcdCluster()
 	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
-		Version:    "3.4.16",
-		InstallDir: "/usr/bin",
+		Version:        "3.4.16",
+		InstallDir:     "/usr/bin",
+		EtcdReleaseURL: "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
 	}
 	etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = []string{
 		"/etc/eks/bootstrap.sh",
@@ -1119,6 +1120,8 @@ func wantEtcdClusterBottlerocket() *etcdv1.EtcdadmCluster {
 
 func TestEtcdadmClusterUbuntu(t *testing.T) {
 	tt := newApiBuilerTest(t)
+	eksaVersion := v1alpha1.EksaVersion("v0.19.0")
+	tt.clusterSpec.Cluster.Spec.EksaVersion = &eksaVersion
 	tt.clusterSpec.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 		Count: 3,
 		MachineGroupRef: &v1alpha1.Ref{

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,6 +167,7 @@ func givenManagementCluster() *types.Cluster {
 }
 
 func givenClusterConfig() *v1alpha1.Cluster {
+	devVersion := test.DevEksaVersion()
 	return &v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "snow-test",
@@ -202,6 +204,7 @@ func givenClusterConfig() *v1alpha1.Cluster {
 				},
 			},
 			KubernetesVersion: "1.21",
+			EksaVersion:       &devVersion,
 			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
 				{
 					Name:  "md-0",
@@ -216,57 +219,6 @@ func givenClusterConfig() *v1alpha1.Cluster {
 							MaxSurge:       1,
 							MaxUnavailable: 0,
 						},
-					},
-				},
-			},
-			DatacenterRef: v1alpha1.Ref{
-				Kind: "SnowDatacenterConfig",
-				Name: "test",
-			},
-		},
-	}
-}
-
-func givenClusterConfig() *v1alpha1.Cluster {
-	devVersion := test.DevEksaVersion()
-	return &v1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "snow-test",
-			Namespace: "test-namespace",
-		},
-		Spec: v1alpha1.ClusterSpec{
-			ClusterNetwork: v1alpha1.ClusterNetwork{
-				CNI: v1alpha1.Cilium,
-				Pods: v1alpha1.Pods{
-					CidrBlocks: []string{
-						"10.1.0.0/16",
-					},
-				},
-				Services: v1alpha1.Services{
-					CidrBlocks: []string{
-						"10.96.0.0/12",
-					},
-				},
-			},
-			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
-				Count: 3,
-				Endpoint: &v1alpha1.Endpoint{
-					Host: "1.2.3.4",
-				},
-				MachineGroupRef: &v1alpha1.Ref{
-					Kind: "SnowMachineConfig",
-					Name: "test-cp",
-				},
-			},
-			KubernetesVersion: "1.21",
-			EksaVersion:       &devVersion,
-			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
-				{
-					Name:  "md-0",
-					Count: ptr.Int(3),
-					MachineGroupRef: &v1alpha1.Ref{
-						Kind: "SnowMachineConfig",
-						Name: "test-wn",
 					},
 				},
 			},

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,6 +112,7 @@ func givenVersionsBundle() *cluster.VersionsBundle {
 				URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
 			},
 			EtcdVersion: "3.4.16",
+			EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
 		},
 		VersionsBundle: &releasev1alpha1.VersionsBundle{
 			KubeVersion: "1.21",
@@ -216,6 +216,57 @@ func givenClusterConfig() *v1alpha1.Cluster {
 							MaxSurge:       1,
 							MaxUnavailable: 0,
 						},
+					},
+				},
+			},
+			DatacenterRef: v1alpha1.Ref{
+				Kind: "SnowDatacenterConfig",
+				Name: "test",
+			},
+		},
+	}
+}
+
+func givenClusterConfig() *v1alpha1.Cluster {
+	devVersion := test.DevEksaVersion()
+	return &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snow-test",
+			Namespace: "test-namespace",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetwork{
+				CNI: v1alpha1.Cilium,
+				Pods: v1alpha1.Pods{
+					CidrBlocks: []string{
+						"10.1.0.0/16",
+					},
+				},
+				Services: v1alpha1.Services{
+					CidrBlocks: []string{
+						"10.96.0.0/12",
+					},
+				},
+			},
+			ControlPlaneConfiguration: v1alpha1.ControlPlaneConfiguration{
+				Count: 3,
+				Endpoint: &v1alpha1.Endpoint{
+					Host: "1.2.3.4",
+				},
+				MachineGroupRef: &v1alpha1.Ref{
+					Kind: "SnowMachineConfig",
+					Name: "test-cp",
+				},
+			},
+			KubernetesVersion: "1.21",
+			EksaVersion:       &devVersion,
+			WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
+				{
+					Name:  "md-0",
+					Count: ptr.Int(3),
+					MachineGroupRef: &v1alpha1.Ref{
+						Kind: "SnowMachineConfig",
+						Name: "test-wn",
 					},
 				},
 			},

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -446,6 +446,9 @@ spec:
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
       installDir: "/usr/bin"
+{{- if .externalEtcdReleaseUrl }}
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
+{{- end }}
     preEtcdadmCommands:
       - hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -472,6 +472,10 @@ func buildTemplateMapCP(
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 		values["etcdTemplateOverride"] = etcdTemplateOverride
 		values["etcdHardwareSelector"] = etcdMachineSpec.HardwareSelector
+		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdUrl != "" {
+			values["externalEtcdReleaseUrl"] = etcdUrl
+		}
 	}
 
 	if controlPlaneMachineSpec.OSFamily == v1alpha1.Bottlerocket {

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -472,9 +472,9 @@ func buildTemplateMapCP(
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 		values["etcdTemplateOverride"] = etcdTemplateOverride
 		values["etcdHardwareSelector"] = etcdMachineSpec.HardwareSelector
-		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
-		if etcdUrl != "" {
-			values["externalEtcdReleaseUrl"] = etcdUrl
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdURL != "" {
+			values["externalEtcdReleaseUrl"] = etcdURL
 		}
 	}
 

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -551,6 +551,9 @@ spec:
     cloudInitConfig:
       version: {{.externalEtcdVersion}}
       installDir: "/usr/bin"
+{{- if .externalEtcdReleaseUrl }}
+      etcdReleaseURL: {{.externalEtcdReleaseUrl}}
+{{- end }}
     preEtcdadmCommands:
       - hostname "{{`{{ ds.meta_data.hostname }}`}}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -783,6 +783,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -297,6 +297,10 @@ func buildTemplateMapCP(
 				}
 			}
 		}
+		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdUrl != "" {
+			values["externalEtcdReleaseUrl"] = etcdUrl
+		}
 	}
 
 	if controlPlaneMachineSpec.OSFamily == anywherev1.Bottlerocket {

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -297,9 +297,9 @@ func buildTemplateMapCP(
 				}
 			}
 		}
-		etcdUrl, _ := common.GetExternalEtcdReleaseUrl(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
-		if etcdUrl != "" {
-			values["externalEtcdReleaseUrl"] = etcdUrl
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		if etcdURL != "" {
+			values["externalEtcdReleaseUrl"] = etcdURL
 		}
 	}
 

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -400,6 +400,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -398,6 +398,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -400,6 +400,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -418,6 +418,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -407,6 +407,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -431,6 +431,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -432,6 +432,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -399,6 +399,7 @@ spec:
     cloudInitConfig:
       version: 3.4.14
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-19/releases/4/artifacts/etcd/v3.4.14/etcd-linux-amd64-v3.4.14.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp.yaml
@@ -448,6 +448,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -410,6 +410,7 @@ spec:
     cloudInitConfig:
       version: 3.4.16
       installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     preEtcdadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2116

*Description of changes:*
These changes will set a release-url for etcdadm to download the etcd tarball if the right version is not cached already in the OS during build time. This is especially useful, when user is creating a cluster with a really old OS template but with a new EKS-A version. This change will also only be in effect for clusters created/upgraded with 0.19.0 or above, to avoid node rollouts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

