### PR TITLE
Remove redundant alias' from CLI cmds

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -38,10 +38,10 @@ func init() {
 }
 
 var applyPackagesCommand = &cobra.Command{
-	Use:          "package(s) [flags]",
+	Use:          "package [flags]",
 	Short:        "Apply curated packages",
 	Long:         "Apply Curated Packages Custom Resources to the cluster",
-	Aliases:      []string{"package", "packages"},
+	Aliases:      []string{"packages"},
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -38,10 +38,10 @@ func init() {
 }
 
 var createPackagesCommand = &cobra.Command{
-	Use:          "package(s) [flags]",
+	Use:          "package [flags]",
 	Short:        "Create curated packages",
 	Long:         "Create Curated Packages Custom Resources to the cluster",
-	Aliases:      []string{"package", "packages"},
+	Aliases:      []string{"packages"},
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -36,8 +36,8 @@ func init() {
 }
 
 var deletePackageCommand = &cobra.Command{
-	Use:          "package(s) [flags]",
-	Aliases:      []string{"package", "packages"},
+	Use:          "package [flags]",
+	Aliases:      []string{"packages"},
 	Short:        "Delete package(s)",
 	Long:         "This command is used to delete the curated packages custom resources installed in the cluster",
 	PreRunE:      preRunPackages,

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -36,9 +36,9 @@ func init() {
 }
 
 var describePackagesCommand = &cobra.Command{
-	Use:          "package(s) [flags]",
+	Use:          "package [flags]",
 	Short:        "Describe curated packages in the cluster",
-	Aliases:      []string{"package", "packages"},
+	Aliases:      []string{"packages"},
 	PreRunE:      preRunPackages,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/generatehardware.go
+++ b/cmd/eksctl-anywhere/cmd/generatehardware.go
@@ -27,11 +27,9 @@ var hOpts = &hardwareOptions{
 }
 
 var generateHardwareCmd = &cobra.Command{
-	Use:   "hardware",
-	Short: "Generate hardware files",
-	Long: `
-Generate Kubernetes hardware YAML manifests for each Hardware entry in the source.
-`,
+	Use:     "hardware",
+	Short:   "Generate hardware files",
+	Long:    `Generate Kubernetes hardware YAML manifests for each Hardware entry in the source.`,
 	RunE:    hOpts.generateHardware,
 	PreRunE: bindFlagsToViper,
 }

--- a/cmd/eksctl-anywhere/cmd/generatepackage.go
+++ b/cmd/eksctl-anywhere/cmd/generatepackage.go
@@ -37,8 +37,8 @@ func init() {
 }
 
 var generatePackageCommand = &cobra.Command{
-	Use:          "packages [flags] package",
-	Aliases:      []string{"package", "packages"},
+	Use:          "package [flags] <package>",
+	Aliases:      []string{"packages"},
 	Short:        "Generate package(s) configuration",
 	Long:         "Generates Kubernetes configuration files for curated packages",
 	PreRunE:      preRunPackages,

--- a/cmd/eksctl-anywhere/cmd/getpackage.go
+++ b/cmd/eksctl-anywhere/cmd/getpackage.go
@@ -36,8 +36,8 @@ func init() {
 }
 
 var getPackageCommand = &cobra.Command{
-	Use:          "package(s) [flags]",
-	Aliases:      []string{"package", "packages"},
+	Use:          "package [flags]",
+	Aliases:      []string{"packages"},
 	Short:        "Get package(s)",
 	Long:         "This command is used to display the curated packages installed in the cluster",
 	PreRunE:      preRunPackages,

--- a/cmd/eksctl-anywhere/cmd/getpackagebundle.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundle.go
@@ -28,8 +28,8 @@ func init() {
 }
 
 var getPackageBundleCommand = &cobra.Command{
-	Use:          "packagebundle(s) [flags]",
-	Aliases:      []string{"packagebundle", "packagebundles"},
+	Use:          "packagebundle [flags]",
+	Aliases:      []string{"packagebundles"},
 	Short:        "Get packagebundle(s)",
 	Long:         "This command is used to display the currently supported packagebundles",
 	PreRunE:      preRunPackages,

--- a/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
@@ -28,8 +28,8 @@ func init() {
 }
 
 var getPackageBundleControllerCommand = &cobra.Command{
-	Use:          "packagebundlecontroller(s) [flags]",
-	Aliases:      []string{"packagebundlecontroller", "packagebundlecontrollers", "pbc"},
+	Use:          "packagebundlecontroller [flags]",
+	Aliases:      []string{"packagebundlecontrollers", "pbc"},
 	Short:        "Get packagebundlecontroller(s)",
 	Long:         "This command is used to display the current packagebundlecontrollers",
 	PreRunE:      preRunPackages,

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -53,7 +53,6 @@ func init() {
 
 var installPackageCommand = &cobra.Command{
 	Use:          "package [flags] package",
-	Aliases:      []string{"package"},
 	Short:        "Install package",
 	Long:         "This command is used to Install a curated package. Use list to discover curated packages",
 	PreRunE:      preRunPackages,


### PR DESCRIPTION
The `Alias` field in the Cobra cmd data structure should only include alias', not the actual command.