### PR TITLE
adding snow and cluster api upgrade rollout strategy

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -199,6 +199,8 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 		setStackedEtcdConfigInKubeadmControlPlane(kcp, bundle.KubeDistro.Etcd)
 	}
 
+	SetUpgradeRolloutStrategyInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy)
+
 	return kcp, nil
 }
 
@@ -290,6 +292,8 @@ func MachineDeployment(clusterSpec *cluster.Spec, workerNodeGroupConfig anywhere
 			Replicas: &replicas,
 		},
 	}
+
+	SetUpgradeRolloutStrategyInMachineDeployment(md, workerNodeGroupConfig.UpgradeRolloutStrategy)
 
 	ConfigureAutoscalingInMachineDeployment(md, workerNodeGroupConfig.AutoScalingConfiguration)
 

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -268,9 +268,11 @@ func TestCluster(t *testing.T) {
 	tt.Expect(got).To(Equal(want))
 }
 
-func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
+type kubeadmControlPlaneOpt func(k *controlplanev1.KubeadmControlPlane)
+
+func wantKubeadmControlPlane(opts ...kubeadmControlPlaneOpt) *controlplanev1.KubeadmControlPlane {
 	replicas := int32(3)
-	return &controlplanev1.KubeadmControlPlane{
+	kcp := &controlplanev1.KubeadmControlPlane{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
 			Kind:       "KubeadmControlPlane",
@@ -363,6 +365,12 @@ func wantKubeadmControlPlane() *controlplanev1.KubeadmControlPlane {
 			Version:  "v1.21.5-eks-1-21-9",
 		},
 	}
+
+	for _, opt := range opts {
+		opt(kcp)
+	}
+
+	return kcp
 }
 
 func TestKubeadmControlPlane(t *testing.T) {
@@ -429,10 +437,12 @@ func TestKubeadmConfigTemplate(t *testing.T) {
 	tt.Expect(got).To(Equal(want))
 }
 
-func wantMachineDeployment() *clusterv1.MachineDeployment {
+type machineDeploymentOpt func(m *clusterv1.MachineDeployment)
+
+func wantMachineDeployment(opts ...machineDeploymentOpt) *clusterv1.MachineDeployment {
 	replicas := int32(3)
 	version := "v1.21.5-eks-1-21-9"
-	return &clusterv1.MachineDeployment{
+	md := &clusterv1.MachineDeployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cluster.x-k8s.io/v1beta1",
 			Kind:       "MachineDeployment",
@@ -478,6 +488,12 @@ func wantMachineDeployment() *clusterv1.MachineDeployment {
 			Replicas: &replicas,
 		},
 	}
+
+	for _, opt := range opts {
+		opt(md)
+	}
+
+	return md
 }
 
 func TestMachineDeployment(t *testing.T) {

--- a/pkg/clusterapi/rollout_strategy.go
+++ b/pkg/clusterapi/rollout_strategy.go
@@ -1,0 +1,37 @@
+package clusterapi
+
+import (
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+)
+
+// SetUpgradeRolloutStrategyInKubeadmControlPlane updates the kubeadm control plane with the upgrade rollout strategy defined in an eksa cluster.
+func SetUpgradeRolloutStrategyInKubeadmControlPlane(kcp *controlplanev1.KubeadmControlPlane, rolloutStrategy *anywherev1.ControlPlaneUpgradeRolloutStrategy) {
+	if rolloutStrategy != nil {
+		maxSurge := intstr.FromInt(rolloutStrategy.RollingUpdate.MaxSurge)
+		kcp.Spec.RolloutStrategy = &controlplanev1.RolloutStrategy{
+			Type: controlplanev1.RollingUpdateStrategyType,
+			RollingUpdate: &controlplanev1.RollingUpdate{
+				MaxSurge: &maxSurge,
+			},
+		}
+	}
+}
+
+// SetUpgradeRolloutStrategyInMachineDeployment updates the machine deployment with the upgrade rollout strategy defined in an eksa cluster.
+func SetUpgradeRolloutStrategyInMachineDeployment(md *clusterv1.MachineDeployment, rolloutStrategy *anywherev1.WorkerNodesUpgradeRolloutStrategy) {
+	if rolloutStrategy != nil {
+		maxSurge := intstr.FromInt(rolloutStrategy.RollingUpdate.MaxSurge)
+		maxUnavailable := intstr.FromInt(rolloutStrategy.RollingUpdate.MaxUnavailable)
+		md.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{
+			Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+			RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+			},
+		}
+	}
+}

--- a/pkg/clusterapi/rollout_strategy_test.go
+++ b/pkg/clusterapi/rollout_strategy_test.go
@@ -1,0 +1,92 @@
+package clusterapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clusterapi"
+)
+
+func TestSetUpgradeRolloutStrategyInKubeadmControlPlane(t *testing.T) {
+	tests := []struct {
+		name            string
+		rolloutStrategy *anywherev1.ControlPlaneUpgradeRolloutStrategy
+		want            *controlplanev1.KubeadmControlPlane
+	}{
+		{
+			name:            "no upgrade rollout strategy",
+			rolloutStrategy: nil,
+			want:            wantKubeadmControlPlane(),
+		},
+		{
+			name: "with maxSurge",
+			rolloutStrategy: &anywherev1.ControlPlaneUpgradeRolloutStrategy{
+				RollingUpdate: anywherev1.ControlPlaneRollingUpdateParams{
+					MaxSurge: 1,
+				},
+			},
+			want: wantKubeadmControlPlane(func(k *controlplanev1.KubeadmControlPlane) {
+				maxSurge := intstr.FromInt(1)
+				k.Spec.RolloutStrategy = &controlplanev1.RolloutStrategy{
+					Type: controlplanev1.RollingUpdateStrategyType,
+					RollingUpdate: &controlplanev1.RollingUpdate{
+						MaxSurge: &maxSurge,
+					},
+				}
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kcp := wantKubeadmControlPlane()
+			clusterapi.SetUpgradeRolloutStrategyInKubeadmControlPlane(kcp, tt.rolloutStrategy)
+			assert.Equal(t, tt.want, kcp)
+		})
+	}
+}
+
+func TestSetUpgradeRolloutStrategyInMachineDeployment(t *testing.T) {
+	tests := []struct {
+		name            string
+		rolloutStrategy *anywherev1.WorkerNodesUpgradeRolloutStrategy
+		want            *clusterv1.MachineDeployment
+	}{
+		{
+			name:            "no upgrade rollout strategy",
+			rolloutStrategy: nil,
+			want:            wantMachineDeployment(),
+		},
+		{
+			name: "with maxSurge and maxUnavailable",
+			rolloutStrategy: &anywherev1.WorkerNodesUpgradeRolloutStrategy{
+				RollingUpdate: anywherev1.WorkerNodesRollingUpdateParams{
+					MaxSurge:       1,
+					MaxUnavailable: 0,
+				},
+			},
+			want: wantMachineDeployment(func(m *clusterv1.MachineDeployment) {
+				maxSurge := intstr.FromInt(1)
+				maxUnavailable := intstr.FromInt(0)
+				m.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{
+					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+						MaxSurge:       &maxSurge,
+						MaxUnavailable: &maxUnavailable,
+					},
+				}
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := wantMachineDeployment()
+			clusterapi.SetUpgradeRolloutStrategyInMachineDeployment(md, tt.rolloutStrategy)
+			assert.Equal(t, tt.want, md)
+		})
+	}
+}

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -70,9 +70,6 @@ func (p *SnowProvider) Name() string {
 }
 
 func (p *SnowProvider) SetupAndValidateCreateCluster(ctx context.Context, clusterSpec *cluster.Spec) error {
-	if err := p.validateUpgradeRolloutStrategy(clusterSpec); err != nil {
-		return fmt.Errorf("failed setup and validations: %v", err)
-	}
 	if err := p.configManager.SetDefaultsAndValidate(ctx, clusterSpec.Config); err != nil {
 		return fmt.Errorf("setting defaults and validate snow config: %v", err)
 	}
@@ -87,9 +84,6 @@ func (p *SnowProvider) SetupAndValidateCreateCluster(ctx context.Context, cluste
 }
 
 func (p *SnowProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, _ *cluster.Spec) error {
-	if err := p.validateUpgradeRolloutStrategy(clusterSpec); err != nil {
-		return fmt.Errorf("failed setup and validations: %v", err)
-	}
 	if err := p.configManager.SetDefaultsAndValidate(ctx, clusterSpec.Config); err != nil {
 		return fmt.Errorf("setting defaults and validate snow config: %v", err)
 	}
@@ -97,9 +91,6 @@ func (p *SnowProvider) SetupAndValidateUpgradeCluster(ctx context.Context, clust
 }
 
 func (p *SnowProvider) SetupAndValidateDeleteCluster(ctx context.Context, _ *types.Cluster, clusterSpec *cluster.Spec) error {
-	if err := p.validateUpgradeRolloutStrategy(clusterSpec); err != nil {
-		return fmt.Errorf("failed setup and validations: %v", err)
-	}
 	if err := SetupEksaCredentialsSecret(clusterSpec.Config); err != nil {
 		return fmt.Errorf("setting up credentials: %v", err)
 	}
@@ -316,18 +307,6 @@ func namespaceOrDefault(obj client.Object) string {
 	}
 
 	return ns
-}
-
-func (p *SnowProvider) validateUpgradeRolloutStrategy(clusterSpec *cluster.Spec) error {
-	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy != nil {
-		return fmt.Errorf("Upgrade rollout strategy customization is not supported for snow provider")
-	}
-	for _, workerNodeGroupConfiguration := range clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
-		if workerNodeGroupConfiguration.UpgradeRolloutStrategy != nil {
-			return fmt.Errorf("Upgrade rollout strategy customization is not supported for snow provider")
-		}
-	}
-	return nil
 }
 
 // UpgradeNeeded compares the new snow version bundle and objects with the existing ones in the cluster and decides whether

--- a/pkg/providers/snow/testdata/expected_results_main_cp_bottlerocket.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp_bottlerocket.yaml
@@ -189,6 +189,10 @@ spec:
       name: snow-test-control-plane-1
     metadata: {}
   replicas: 3
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   version: v1.21.5-eks-1-21-9
 status:
   initialized: false

--- a/pkg/providers/snow/testdata/expected_results_main_cp_ubuntu.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_cp_ubuntu.yaml
@@ -151,6 +151,10 @@ spec:
       name: snow-test-control-plane-1
     metadata: {}
   replicas: 3
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   version: v1.21.5-eks-1-21-9
 status:
   initialized: false

--- a/pkg/providers/snow/testdata/expected_results_main_md_bottlerocket.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md_bottlerocket.yaml
@@ -63,6 +63,11 @@ spec:
   clusterName: snow-test
   replicas: 3
   selector: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/pkg/providers/snow/testdata/expected_results_main_md_ubuntu.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md_ubuntu.yaml
@@ -50,6 +50,11 @@ spec:
   clusterName: snow-test
   replicas: 3
   selector: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/pkg/providers/snow/testdata/expected_results_main_md_ubuntu_worker_version.yaml
+++ b/pkg/providers/snow/testdata/expected_results_main_md_ubuntu_worker_version.yaml
@@ -50,6 +50,11 @@ spec:
   clusterName: snow-test
   replicas: 3
   selector: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -154,6 +159,11 @@ spec:
   clusterName: snow-test
   replicas: 3
   selector: {}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/eks-anywhere/issues/6719

Description of changes:
Adding UpgradeRolloutStrategy knobs for workers and control plane to snow provider.

Updated cluster api apibuilder as well since this should be available for all providers. Other providers use templater, while snow uses apibuilder.

Testing (if applicable):
Updated unit tests.

Documentation added/planned (if applicable):
Planning on adding docs on knobs for other providers following the [Tinkerbell upgrade strategy format](https://anywhere.eks.amazonaws.com/docs/clustermgmt/cluster-upgrades/baremetal-upgrades/#upgraderolloutstrategy).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.