### PR TITLE
Add permission used by helm to update its secret

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6920,6 +6920,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - addons.cluster.x-k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - addons.cluster.x-k8s.io

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -172,7 +172,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="",namespace=eksa-system,resources=secrets,verbs=patch;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=create;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list


### PR DESCRIPTION
*Issue #, if available:* helm silently ignored the error of updating its secret.

*Description of changes:* "helm upgrade" invoked by the eksa reconciler  returns nil error, but in fact the release's status stuck at "pending-installation" as it fails to update the release status stored in secret.

Error is shown when "--debug" option is turned on for 'helm upgrade' command
```
sh.helm.release.v1.eks-anywhere-packages-workload-0.v1" is forbidden: User "system:serviceaccount:eksa-system:eksa-controller-manager" cannot update resource "secrets" in API group "" in the namespace "eksa-packages"
```

*Testing (if applicable):* 1. Manually reproduced the error with `kubectl exec eksa-controller helm ...." 2. Verified the issue is fixed when the missing permission is added manually.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

