### PR TITLE
Update K8s version on Capi machine for in-place upgrades

### DIFF
--- a/controllers/controlplaneupgrade_controller.go
+++ b/controllers/controlplaneupgrade_controller.go
@@ -226,7 +226,7 @@ func (r *ControlPlaneUpgradeReconciler) updateStatus(ctx context.Context, log lo
 			log.Info("Updating K8s version in  machine", "Machine", machine.Name)
 			machine.Spec.Version = &nodeUpgrade.Spec.KubernetesVersion
 			if err := machinePatchHelper.Patch(ctx, machine); err != nil {
-				return fmt.Errorf("updating status for machine %s: %v", machine.Name, err)
+				return fmt.Errorf("updating spec for machine %s: %v", machine.Name, err)
 			}
 			nodesUpgradeCompleted++
 			nodesUpgradeRequired--

--- a/controllers/controlplaneupgrade_controller.go
+++ b/controllers/controlplaneupgrade_controller.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -214,6 +215,19 @@ func (r *ControlPlaneUpgradeReconciler) updateStatus(ctx context.Context, log lo
 			return fmt.Errorf("getting node upgrader for machine %s: %v", machineRef.Name, err)
 		}
 		if nodeUpgrade.Status.Completed {
+			machine, err := getCapiMachine(ctx, r.client, nodeUpgrade)
+			if err != nil {
+				return err
+			}
+			machinePatchHelper, err := patch.NewHelper(machine, r.client)
+			if err != nil {
+				return err
+			}
+			log.Info("Updating K8s version in  machine", "Machine", machine.Name)
+			machine.Spec.Version = &nodeUpgrade.Spec.KubernetesVersion
+			if err := machinePatchHelper.Patch(ctx, machine); err != nil {
+				return fmt.Errorf("updating status for machine %s: %v", machine.Name, err)
+			}
 			nodesUpgradeCompleted++
 			nodesUpgradeRequired--
 		}
@@ -223,4 +237,12 @@ func (r *ControlPlaneUpgradeReconciler) updateStatus(ctx context.Context, log lo
 	cpUpgrade.Status.RequireUpgrade = int64(nodesUpgradeRequired)
 	cpUpgrade.Status.Ready = nodesUpgradeRequired == 0
 	return nil
+}
+
+func getCapiMachine(ctx context.Context, client client.Client, nodeUpgrade *anywherev1.NodeUpgrade) (*clusterv1.Machine, error) {
+	machine := &clusterv1.Machine{}
+	if err := client.Get(ctx, GetNamespacedNameType(nodeUpgrade.Spec.Machine.Name, nodeUpgrade.Spec.Machine.Namespace), machine); err != nil {
+		return nil, fmt.Errorf("getting machine %s: %v", nodeUpgrade.Spec.Machine.Name, err)
+	}
+	return machine, nil
 }

--- a/controllers/nodeupgrade_controller.go
+++ b/controllers/nodeupgrade_controller.go
@@ -265,6 +265,15 @@ func (r *NodeUpgradeReconciler) updateStatus(ctx context.Context, log logr.Logge
 	conditions.MarkTrue(nodeUpgrade, anywherev1.UpgraderPodCreated)
 	updateComponentsConditions(pod, nodeUpgrade)
 
+	if nodeUpgrade.Status.Completed {
+		capiMachine := &clusterv1.Machine{}
+		if err := r.client.Get(ctx, GetNamespacedNameType(nodeUpgrade.Spec.Machine.Name, nodeUpgrade.Spec.Machine.Namespace), capiMachine); err != nil {
+			return fmt.Errorf("getting capi Machine: %v", err)
+		}
+		log.Info("Updating machine status", "Machine", capiMachine.Name)
+		capiMachine.Spec.Version = &nodeUpgrade.Spec.KubernetesVersion
+
+	}
 	// Always update the readyCondition by summarizing the state of other conditions.
 	conditions.SetSummary(nodeUpgrade,
 		conditions.WithConditions(

--- a/controllers/nodeupgrade_controller_test.go
+++ b/controllers/nodeupgrade_controller_test.go
@@ -246,7 +246,7 @@ func generateNodeUpgrade(machine *clusterv1.Machine) *anywherev1.NodeUpgrade {
 				Name:      machine.Name,
 				Namespace: machine.Namespace,
 			},
-			KubernetesVersion: "v1.28.1",
+			KubernetesVersion: "v1.28.3-eks-1-28-9",
 		},
 	}
 }
@@ -258,7 +258,7 @@ func generateMachine(cluster *clusterv1.Cluster, node *corev1.Node) *clusterv1.M
 			Namespace: "eksa-system",
 		},
 		Spec: clusterv1.MachineSpec{
-			Version:     ptr.String("v1.28.0"),
+			Version:     ptr.String("v1.27.8-eks-1-27-18"),
 			ClusterName: cluster.Name,
 		},
 		Status: clusterv1.MachineStatus{

--- a/controllers/nodeupgrade_controller_test.go
+++ b/controllers/nodeupgrade_controller_test.go
@@ -27,13 +27,11 @@ func TestNodeUpgradeReconcilerReconcileFirstControlPlane(t *testing.T) {
 	clientRegistry := mocks.NewMockRemoteClientRegistry(ctrl)
 
 	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
-	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
 	nodeUpgrade.Spec.FirstNodeToBeUpgraded = true
 	nodeUpgrade.Spec.EtcdVersion = ptr.String("v3.5.9-eks-1-28-9")
 	node.Labels = map[string]string{
 		"node-role.kubernetes.io/control-plane": "true",
 	}
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 
 	clientRegistry.EXPECT().GetClient(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}).Return(client, nil)
@@ -55,11 +53,9 @@ func TestNodeUpgradeReconcilerReconcileNextControlPlane(t *testing.T) {
 	clientRegistry := mocks.NewMockRemoteClientRegistry(ctrl)
 
 	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
-	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
 	node.Labels = map[string]string{
 		"node-role.kubernetes.io/control-plane": "true",
 	}
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 
 	clientRegistry.EXPECT().GetClient(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}).Return(client, nil)
@@ -82,8 +78,6 @@ func TestNodeUpgradeReconcilerReconcileWorker(t *testing.T) {
 
 	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
 	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
-	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 
 	clientRegistry.EXPECT().GetClient(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}).Return(client, nil)
 
@@ -103,8 +97,6 @@ func TestNodeUpgradeReconcilerReconcileCreateUpgraderPodState(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	clientRegistry := mocks.NewMockRemoteClientRegistry(ctrl)
 
-	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
 	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 
@@ -168,8 +160,6 @@ func TestNodeUpgradeReconcilerReconcileDelete(t *testing.T) {
 
 	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
 	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
-	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 
 	clientRegistry.EXPECT().GetClient(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}).Return(client, nil).Times(2)
 
@@ -201,8 +191,6 @@ func TestNodeUpgradeReconcilerReconcileDeleteUpgraderPodAlreadyDeleted(t *testin
 
 	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
 	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
-	cluster, machine, node, nodeUpgrade, configMap := getObjectsForNodeUpgradeTest()
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, configMap).Build()
 
 	clientRegistry.EXPECT().GetClient(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}).Return(client, nil).Times(2)
 
@@ -230,13 +218,10 @@ func TestNodeUpgradeReconcilerReconcileDeleteUpgraderPodAlreadyDeleted(t *testin
 }
 
 func getObjectsForNodeUpgradeTest() (*clusterv1.Cluster, *clusterv1.Machine, *corev1.Node, *anywherev1.NodeUpgrade, *corev1.ConfigMap) {
-func getObjectsForNodeUpgradeTest() (*clusterv1.Cluster, *clusterv1.Machine, *corev1.Node, *anywherev1.NodeUpgrade, *corev1.ConfigMap) {
 	cluster := generateCluster()
 	node := generateNode()
 	machine := generateMachine(cluster, node)
 	nodeUpgrade := generateNodeUpgrade(machine)
-	configMap := generateConfigMap()
-	return cluster, machine, node, nodeUpgrade, configMap
 	configMap := generateConfigMap()
 	return cluster, machine, node, nodeUpgrade, configMap
 }


### PR DESCRIPTION
*Issue #, if available:*
In-place upgrades directly upgrades the K8s components outside of the capi upgrade flow. This requires updating the K8s version on the capi objects once the in-place upgrade has been done to reflect the updated k8s version on the node. This change updates the K8s version on the capi machine once the nodeupgrader object has completed the upgrade on the node associated with the corresponding capi machine for the controlplane nodes. 

*Description of changes:*

*Testing (if applicable):*
Manually tested with updating the KCP controller image with one that accommodates InPlace as upgrade strategy type.
 
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

