### PR TITLE
Add in place rollout strategy option

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -825,19 +825,20 @@ func validatePodIAMConfig(clusterConfig *Cluster) error {
 }
 
 func validateCPUpgradeRolloutStrategy(clusterConfig *Cluster) error {
-	if clusterConfig.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy == nil {
+	cpUpgradeRolloutStrategy := clusterConfig.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy
+	if cpUpgradeRolloutStrategy == nil {
 		return nil
 	}
 
-	if clusterConfig.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type != "RollingUpdate" {
-		return fmt.Errorf("ControlPlaneConfiguration: only 'RollingUpdate' supported for upgrade rollout strategy type")
+	if cpUpgradeRolloutStrategy.Type != "RollingUpdate" && cpUpgradeRolloutStrategy.Type != "InPlace" {
+		return fmt.Errorf("ControlPlaneConfiguration: only 'RollingUpdate' and 'InPlace' are supported for upgrade rollout strategy type")
 	}
 
-	if clusterConfig.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge < 0 {
+	if cpUpgradeRolloutStrategy.RollingUpdate.MaxSurge < 0 {
 		return fmt.Errorf("ControlPlaneConfiguration: maxSurge for control plane cannot be a negative value")
 	}
 
-	if clusterConfig.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge > 1 {
+	if cpUpgradeRolloutStrategy.RollingUpdate.MaxSurge > 1 {
 		return fmt.Errorf("ControlPlaneConfiguration: maxSurge for control plane must be 0 or 1")
 	}
 
@@ -849,8 +850,8 @@ func validateMDUpgradeRolloutStrategy(w *WorkerNodeGroupConfiguration) error {
 		return nil
 	}
 
-	if w.UpgradeRolloutStrategy.Type != "RollingUpdate" {
-		return fmt.Errorf("WorkerNodeGroupConfiguration: only 'RollingUpdate' supported for upgrade rollout strategy type")
+	if w.UpgradeRolloutStrategy.Type != "RollingUpdate" && w.UpgradeRolloutStrategy.Type != "InPlace" {
+		return fmt.Errorf("WorkerNodeGroupConfiguration: only 'RollingUpdate' and 'InPlace' are supported for upgrade rollout strategy type")
 	}
 
 	if w.UpgradeRolloutStrategy.RollingUpdate.MaxSurge < 0 || w.UpgradeRolloutStrategy.RollingUpdate.MaxUnavailable < 0 {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3246,7 +3246,7 @@ func TestValidateCPUpgradeRolloutStrategy(t *testing.T) {
 	}{
 		{
 			name:    "rolling upgrade strategy invalid",
-			wantErr: "ControlPlaneConfiguration: only 'RollingUpdate' supported for upgrade rollout strategy type",
+			wantErr: "ControlPlaneConfiguration: only 'RollingUpdate' and 'InPlace' are supported for upgrade rollout strategy type",
 			cluster: &Cluster{
 				Spec: ClusterSpec{
 					ControlPlaneConfiguration: ControlPlaneConfiguration{
@@ -3332,7 +3332,7 @@ func TestValidateMDUpgradeRolloutStrategy(t *testing.T) {
 	}{
 		{
 			name:    "rolling upgrade strategy invalid",
-			wantErr: "WorkerNodeGroupConfiguration: only 'RollingUpdate' supported for upgrade rollout strategy type",
+			wantErr: "WorkerNodeGroupConfiguration: only 'RollingUpdate' and 'InPlace' are supported for upgrade rollout strategy type",
 			cluster: &Cluster{
 				Spec: ClusterSpec{
 					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -468,7 +468,8 @@ func ExtraHardwareAvailableAssertionForRollingUpgrade(catalogue *hardware.Catalo
 func ensureCPHardwareAvailability(spec *ClusterSpec, current ValidatableCluster, hwReq minimumHardwareRequirements) error {
 	maxSurge := 1
 
-	if spec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy != nil {
+	rolloutStrategy := spec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy
+	if rolloutStrategy != nil && rolloutStrategy.Type == "RollingUpdate" {
 		maxSurge = spec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
 	}
 	err := hwReq.Add(
@@ -489,7 +490,7 @@ func ensureWorkerHardwareAvailability(spec *ClusterSpec, current ValidatableClus
 		// As rolling upgrades and scale up/down is not permitted in a single operation, its safe to access directly using the md name.
 		mdName := fmt.Sprintf("%s-%s", spec.Cluster.Name, nodeGroup.Name)
 		if currentWngK8sversion[mdName] != desiredWngK8sVersion[mdName] || eksaVersionUpgrade {
-			if nodeGroup.UpgradeRolloutStrategy != nil {
+			if nodeGroup.UpgradeRolloutStrategy != nil && nodeGroup.UpgradeRolloutStrategy.Type == "RollingUpdate" {
 				maxSurge = nodeGroup.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
 			}
 			err := hwReq.Add(

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -27,10 +27,21 @@ func validateOsFamily(spec *ClusterSpec) error {
 		if spec.MachineConfigs[groupRef.Name].OSFamily() != controlPlaneOsFamily {
 			return fmt.Errorf("worker node group osFamily cannot be different from control plane osFamily")
 		}
+		if group.UpgradeRolloutStrategy != nil {
+			if spec.MachineConfigs[groupRef.Name].OSFamily() != v1alpha1.DefaultOSFamily && group.UpgradeRolloutStrategy.Type == "InPlace" {
+				return fmt.Errorf("InPlace upgrades are only supported on the Ubuntu OS family")
+			}
+		}
 	}
 
 	if controlPlaneOsFamily != v1alpha1.Bottlerocket && spec.DatacenterConfig.Spec.OSImageURL == "" && spec.ControlPlaneMachineConfig().Spec.OSImageURL == "" {
 		return fmt.Errorf("please use bottlerocket as osFamily for auto-importing or provide a valid osImageURL")
+	}
+
+	if spec.ControlPlaneConfiguration().UpgradeRolloutStrategy != nil {
+		if controlPlaneOsFamily != v1alpha1.DefaultOSFamily && spec.ControlPlaneConfiguration().UpgradeRolloutStrategy.Type == "InPlace" {
+			return fmt.Errorf("InPlace upgrades are only supported on the Ubuntu OS family")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds the option for InPlace upgrade rollout strategy type in EKS-A spec. We will update the KCP/MD objects in a separate PR

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

