### PR TITLE
Remove unused 1.23 and 1.24 methods from testing code

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -48,5 +48,5 @@ const (
 
 var (
 	EksaPackageControllerHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
-	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube124, v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127, v1alpha1.Kube128}
+	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube125, v1alpha1.Kube126, v1alpha1.Kube127, v1alpha1.Kube128}
 )

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -167,16 +167,6 @@ func withCloudStackKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os
 	}
 }
 
-// WithCloudStackRedhat123 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.23.
-func WithCloudStackRedhat123() CloudStackOpt {
-	return withCloudStackKubeVersionAndOS(anywherev1.Kube123, RedHat8, nil)
-}
-
-// WithCloudStackRedhat124 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.24.
-func WithCloudStackRedhat124() CloudStackOpt {
-	return withCloudStackKubeVersionAndOS(anywherev1.Kube124, RedHat8, nil)
-}
-
 // WithCloudStackRedhat125 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.25.
 func WithCloudStackRedhat125() CloudStackOpt {
 	return withCloudStackKubeVersionAndOS(anywherev1.Kube125, RedHat8, nil)
@@ -317,16 +307,6 @@ func (c *CloudStack) templateForKubeVersionAndOS(kubeVersion anywherev1.Kubernet
 	return api.WithCloudStackTemplateForAllMachines(template)
 }
 
-// Redhat123Template returns cloudstack filler for 1.23 RedHat.
-func (c *CloudStack) Redhat123Template() api.CloudStackFiller {
-	return c.templateForKubeVersionAndOS(anywherev1.Kube123, RedHat8, nil)
-}
-
-// Redhat124Template returns cloudstack filler for 1.24 RedHat.
-func (c *CloudStack) Redhat124Template() api.CloudStackFiller {
-	return c.templateForKubeVersionAndOS(anywherev1.Kube124, RedHat8, nil)
-}
-
 // Redhat125Template returns cloudstack filler for 1.25 RedHat.
 func (c *CloudStack) Redhat125Template() api.CloudStackFiller {
 	return c.templateForKubeVersionAndOS(anywherev1.Kube125, RedHat8, nil)
@@ -375,18 +355,6 @@ func (c *CloudStack) WithKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersi
 	)
 }
 
-// WithRedhat123 returns a cluster config filler that sets the kubernetes version of the cluster to 1.23
-// as well as the right redhat template for all CloudStackMachineConfigs.
-func (c *CloudStack) WithRedhat123() api.ClusterConfigFiller {
-	return c.WithKubeVersionAndOS(anywherev1.Kube123, RedHat8, nil)
-}
-
-// WithRedhat124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
-// as well as the right redhat template for all CloudStackMachineConfigs.
-func (c *CloudStack) WithRedhat124() api.ClusterConfigFiller {
-	return c.WithKubeVersionAndOS(anywherev1.Kube124, RedHat8, nil)
-}
-
 // WithRedhat125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
 // as well as the right redhat template for all CloudStackMachineConfigs.
 func (c *CloudStack) WithRedhat125() api.ClusterConfigFiller {
@@ -415,10 +383,6 @@ func (c *CloudStack) WithRedhat128() api.ClusterConfigFiller {
 // version provider, as well as the right redhat template for all CloudStackMachineConfigs.
 func (c *CloudStack) WithRedhatVersion(version anywherev1.KubernetesVersion) api.ClusterConfigFiller {
 	switch version {
-	case anywherev1.Kube123:
-		return c.WithRedhat123()
-	case anywherev1.Kube124:
-		return c.WithRedhat124()
 	case anywherev1.Kube125:
 		return c.WithRedhat125()
 	case anywherev1.Kube126:

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -221,18 +221,6 @@ func withNutanixKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS
 	}
 }
 
-// WithUbuntu123Nutanix returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template for k8s 1.23
-// and the "ubuntu" osFamily in all machine configs.
-func WithUbuntu123Nutanix() NutanixOpt {
-	return withNutanixKubeVersionAndOS(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-// WithUbuntu124Nutanix returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template for k8s 1.24
-// and the "ubuntu" osFamily in all machine configs.
-func WithUbuntu124Nutanix() NutanixOpt {
-	return withNutanixKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, nil)
-}
-
 // WithUbuntu125Nutanix returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template for k8s 1.25
 // and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu125Nutanix() NutanixOpt {
@@ -257,18 +245,6 @@ func WithUbuntu128Nutanix() NutanixOpt {
 	return withNutanixKubeVersionAndOS(anywherev1.Kube128, Ubuntu2004, nil)
 }
 
-// WithRedHat123Nutanix returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template for k8s 1.23
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat123Nutanix() NutanixOpt {
-	return withNutanixKubeVersionAndOS(anywherev1.Kube123, RedHat8, nil)
-}
-
-// WithRedHat124Nutanix returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template for k8s 1.24
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat124Nutanix() NutanixOpt {
-	return withNutanixKubeVersionAndOS(anywherev1.Kube124, RedHat8, nil)
-}
-
 // WithRedHat125Nutanix returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template for k8s 1.25
 // and the "redhat" osFamily in all machine configs.
 func WithRedHat125Nutanix() NutanixOpt {
@@ -291,18 +267,6 @@ func WithRedHat127Nutanix() NutanixOpt {
 // and the "redhat" osFamily in all machine configs.
 func WithRedHat128Nutanix() NutanixOpt {
 	return withNutanixKubeVersionAndOS(anywherev1.Kube128, RedHat8, nil)
-}
-
-// WithRedHat9Kubernetes123Nutanix returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template for k8s 1.23
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat9Kubernetes123Nutanix() NutanixOpt {
-	return withNutanixKubeVersionAndOS(anywherev1.Kube123, RedHat9, nil)
-}
-
-// WithRedHat9Kubernetes124Nutanix returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template for k8s 1.24
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat9Kubernetes124Nutanix() NutanixOpt {
-	return withNutanixKubeVersionAndOS(anywherev1.Kube124, RedHat9, nil)
 }
 
 // WithRedHat9Kubernetes125Nutanix returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template for k8s 1.25
@@ -339,18 +303,6 @@ func withNutanixKubeVersionAndOSForUUID(kubeVersion anywherev1.KubernetesVersion
 	}
 }
 
-// WithUbuntu123NutanixUUID returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template UUID for k8s 1.23
-// and the "ubuntu" osFamily in all machine configs.
-func WithUbuntu123NutanixUUID() NutanixOpt {
-	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-// WithUbuntu124NutanixUUID returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template UUID for k8s 1.24
-// and the "ubuntu" osFamily in all machine configs.
-func WithUbuntu124NutanixUUID() NutanixOpt {
-	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube124, Ubuntu2004, nil)
-}
-
 // WithUbuntu125NutanixUUID returns a NutanixOpt that adds API fillers to use a Ubuntu Nutanix template UUID for k8s 1.25
 // and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu125NutanixUUID() NutanixOpt {
@@ -375,18 +327,6 @@ func WithUbuntu128NutanixUUID() NutanixOpt {
 	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube128, Ubuntu2004, nil)
 }
 
-// WithRedHat123NutanixUUID returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template UUID for k8s 1.23
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat123NutanixUUID() NutanixOpt {
-	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube123, RedHat8, nil)
-}
-
-// WithRedHat124NutanixUUID returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template UUID for k8s 1.24
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat124NutanixUUID() NutanixOpt {
-	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube124, RedHat8, nil)
-}
-
 // WithRedHat125NutanixUUID returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template UUID for k8s 1.25
 // and the "redhat" osFamily in all machine configs.
 func WithRedHat125NutanixUUID() NutanixOpt {
@@ -409,18 +349,6 @@ func WithRedHat127NutanixUUID() NutanixOpt {
 // and the "redhat" osFamily in all machine configs.
 func WithRedHat128NutanixUUID() NutanixOpt {
 	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube128, RedHat8, nil)
-}
-
-// WithRedHat9Kubernetes123NutanixUUID returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template UUID for k8s 1.23
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat9Kubernetes123NutanixUUID() NutanixOpt {
-	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube123, RedHat9, nil)
-}
-
-// WithRedHat9Kubernetes124NutanixUUID returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template UUID for k8s 1.24
-// and the "redhat" osFamily in all machine configs.
-func WithRedHat9Kubernetes124NutanixUUID() NutanixOpt {
-	return withNutanixKubeVersionAndOSForUUID(anywherev1.Kube124, RedHat9, nil)
 }
 
 // WithRedHat9Kubernetes125NutanixUUID returns a NutanixOpt that adds API fillers to use a RedHat Nutanix template UUID for k8s 1.25
@@ -493,17 +421,6 @@ func (n *Nutanix) templateForKubeVersionAndOS(kubeVersion anywherev1.KubernetesV
 	return api.WithNutanixMachineTemplateImageName(template)
 }
 
-// Ubuntu123Template returns a Nutanix filler for 1.23 Ubuntu.
-func (n *Nutanix) Ubuntu123Template() api.NutanixFiller {
-	return n.templateForKubeVersionAndOS(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-// Ubuntu124Template returns NutanixFiller by reading the env var and setting machine config's
-// image name parameter in the spec.
-func (n *Nutanix) Ubuntu124Template() api.NutanixFiller {
-	return n.templateForKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, nil)
-}
-
 // Ubuntu125Template returns NutanixFiller by reading the env var and setting machine config's
 // image name parameter in the spec.
 func (n *Nutanix) Ubuntu125Template() api.NutanixFiller {
@@ -528,12 +445,6 @@ func (n *Nutanix) Ubuntu128Template() api.NutanixFiller {
 	return n.templateForKubeVersionAndOS(anywherev1.Kube128, Ubuntu2004, nil)
 }
 
-// RedHat124Template returns NutanixFiller by reading the env var and setting machine config's
-// image name parameter in the spec.
-func (n *Nutanix) RedHat124Template() api.NutanixFiller {
-	return n.templateForKubeVersionAndOS(anywherev1.Kube124, RedHat8, nil)
-}
-
 // RedHat125Template returns NutanixFiller by reading the env var and setting machine config's
 // image name parameter in the spec.
 func (n *Nutanix) RedHat125Template() api.NutanixFiller {
@@ -556,12 +467,6 @@ func (n *Nutanix) RedHat127Template() api.NutanixFiller {
 // image name parameter in the spec.
 func (n *Nutanix) RedHat128Template() api.NutanixFiller {
 	return n.templateForKubeVersionAndOS(anywherev1.Kube128, RedHat8, nil)
-}
-
-// RedHat9Kubernetes124Template returns NutanixFiller by reading the env var and setting machine config's
-// image name parameter in the spec.
-func (n *Nutanix) RedHat9Kubernetes124Template() api.NutanixFiller {
-	return n.templateForKubeVersionAndOS(anywherev1.Kube124, RedHat9, nil)
 }
 
 // RedHat9Kubernetes125Template returns NutanixFiller by reading the env var and setting machine config's

--- a/test/framework/snow.go
+++ b/test/framework/snow.go
@@ -211,24 +211,6 @@ func (s *Snow) WithProviderUpgrade(fillers ...api.SnowFiller) ClusterE2ETestOpt 
 	}
 }
 
-// WithBottlerocket123 returns a cluster config filler that sets the kubernetes version of the cluster to 1.23
-// as well as the right devices and osFamily for all SnowMachineConfigs. It also sets any
-// necessary machine config default required for BR, like the container volume size. If the env var is set, this will
-// also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
-func (s *Snow) WithBottlerocket123() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.withBottlerocketForKubeVersion(anywherev1.Kube123)
-}
-
-// WithBottlerocket124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
-// as well as the right devices and osFamily for all SnowMachineConfigs. It also sets any
-// necessary machine config default required for BR, like the container volume size. If the env var is set, this will
-// also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
-func (s *Snow) WithBottlerocket124() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.withBottlerocketForKubeVersion(anywherev1.Kube124)
-}
-
 // WithBottlerocket125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
 // as well as the right devices and osFamily for all SnowMachineConfigs. It also sets any
 // necessary machine config default required for BR, like the container volume size. If the env var is set, this will
@@ -265,22 +247,6 @@ func (s *Snow) WithBottlerocket128() api.ClusterConfigFiller {
 	return s.withBottlerocketForKubeVersion(anywherev1.Kube128)
 }
 
-// WithBottlerocketStaticIP123 returns a cluster config filler that sets the kubernetes version of the cluster to 1.23
-// as well as the right devices, osFamily and static ip config for all SnowMachineConfigs. Comparing to WithBottlerocket123,
-// this method also adds a snow ip pool to support static ip configuration.
-func (s *Snow) WithBottlerocketStaticIP123() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.withBottlerocketStaticIPForKubeVersion(anywherev1.Kube123)
-}
-
-// WithBottlerocketStaticIP124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
-// as well as the right devices, osFamily and static ip config for all SnowMachineConfigs. Comparing to WithBottlerocket124,
-// this method also adds a snow ip pool to support static ip configuration.
-func (s *Snow) WithBottlerocketStaticIP124() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.withBottlerocketStaticIPForKubeVersion(anywherev1.Kube124)
-}
-
 // WithBottlerocketStaticIP125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
 // as well as the right devices, osFamily and static ip config for all SnowMachineConfigs. Comparing to WithBottlerocket125,
 // this method also adds a snow ip pool to support static ip configuration.
@@ -311,22 +277,6 @@ func (s *Snow) WithBottlerocketStaticIP127() api.ClusterConfigFiller {
 func (s *Snow) WithBottlerocketStaticIP128() api.ClusterConfigFiller {
 	s.t.Helper()
 	return s.withBottlerocketStaticIPForKubeVersion(anywherev1.Kube128)
-}
-
-// WithUbuntu123 returns a cluster config filler that sets the kubernetes version of the cluster to 1.23
-// as well as the right devices and osFamily for all SnowMachineConfigs. If the env var is set, this will
-// also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
-func (s *Snow) WithUbuntu123() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-// WithUbuntu124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
-// as well as the right devices and osFamily for all SnowMachineConfigs. If the env var is set, this will
-// also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
-func (s *Snow) WithUbuntu124() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, nil)
 }
 
 // WithUbuntu125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -206,11 +206,6 @@ func withKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS, machi
 	}
 }
 
-// WithUbuntu124Tinkerbell tink test with ubuntu 1.24.
-func WithUbuntu124Tinkerbell() TinkerbellOpt {
-	return withKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, "", nil)
-}
-
 // WithUbuntu125Tinkerbell tink test with ubuntu 1.25.
 func WithUbuntu125Tinkerbell() TinkerbellOpt {
 	return withKubeVersionAndOS(anywherev1.Kube125, Ubuntu2004, "", nil)
@@ -229,11 +224,6 @@ func WithUbuntu127Tinkerbell() TinkerbellOpt {
 // WithUbuntu128Tinkerbell tink test with ubuntu 1.28.
 func WithUbuntu128Tinkerbell() TinkerbellOpt {
 	return withKubeVersionAndOS(anywherev1.Kube128, Ubuntu2004, "", nil)
-}
-
-// WithRedHat124Tinkerbell tink test with redhat 1.24.
-func WithRedHat124Tinkerbell() TinkerbellOpt {
-	return withKubeVersionAndOS(anywherev1.Kube124, RedHat8, "", nil)
 }
 
 // WithRedHat125Tinkerbell tink test with redhat 1.25.
@@ -311,11 +301,6 @@ func imageForKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, operatin
 		tinkerbellFiller = api.WithTinkerbellOSImageURL(os.Getenv(envVarForImage(operatingSystem, kubeVersion)))
 	}
 	return tinkerbellFiller
-}
-
-// Ubuntu124Image represents an Ubuntu raw image corresponding to Kubernetes 1.24.
-func Ubuntu124Image() api.TinkerbellFiller {
-	return imageForKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, "")
 }
 
 // Ubuntu125Image represents an Ubuntu raw image corresponding to Kubernetes 1.25.

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -140,16 +140,6 @@ func withVSphereKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS
 	}
 }
 
-// WithRedHat123VSphere vsphere test with redhat 8 for Kubernetes 1.23.
-func WithRedHat123VSphere() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube123, RedHat8, nil)
-}
-
-// WithRedHat124VSphere vsphere test with redhat 8 for Kubernetes 1.24.
-func WithRedHat124VSphere() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube124, RedHat8, nil)
-}
-
 // WithRedHat125VSphere vsphere test with redhat 8 for Kubernetes 1.25.
 func WithRedHat125VSphere() VSphereOpt {
 	return withVSphereKubeVersionAndOS(anywherev1.Kube125, RedHat8, nil)
@@ -192,27 +182,6 @@ func WithUbuntu126() VSphereOpt {
 // and the "ubuntu" osFamily in all machine configs.
 func WithUbuntu125() VSphereOpt {
 	return withVSphereKubeVersionAndOS(anywherev1.Kube125, Ubuntu2004, nil)
-}
-
-// WithUbuntu124 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.24
-// and the "ubuntu" osFamily in all machine configs.
-func WithUbuntu124() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, nil)
-}
-
-// WithUbuntu123 returns a VSphereOpt that adds API fillers to use a Ubuntu vSphere template for k8s 1.23
-// and the "ubuntu" osFamily in all machine configs.
-func WithUbuntu123() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-func WithBottleRocket123() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube123, Bottlerocket1, nil)
-}
-
-// WithBottleRocket124 returns br 124 var.
-func WithBottleRocket124() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube124, Bottlerocket1, nil)
 }
 
 // WithBottleRocket125 returns br 1.25 var.
@@ -400,18 +369,6 @@ func (v *VSphere) WithKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion,
 	)
 }
 
-// WithUbuntu123 returns a cluster config filler that sets the kubernetes version of the cluster to 1.23
-// as well as the right ubuntu template and osFamily for all VSphereMachineConfigs.
-func (v *VSphere) WithUbuntu123() api.ClusterConfigFiller {
-	return v.WithKubeVersionAndOS(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-// WithUbuntu124 returns a cluster config filler that sets the kubernetes version of the cluster to 1.24
-// as well as the right ubuntu template and osFamily for all VSphereMachineConfigs.
-func (v *VSphere) WithUbuntu124() api.ClusterConfigFiller {
-	return v.WithKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, nil)
-}
-
 // WithUbuntu125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
 // as well as the right ubuntu template and osFamily for all VSphereMachineConfigs.
 func (v *VSphere) WithUbuntu125() api.ClusterConfigFiller {
@@ -479,16 +436,6 @@ func (v *VSphere) templateForKubeVersionAndOS(kubeVersion anywherev1.KubernetesV
 	return api.WithTemplateForAllMachines(template)
 }
 
-// Ubuntu123Template returns vsphere filler for 1.23 Ubuntu.
-func (v *VSphere) Ubuntu123Template() api.VSphereFiller {
-	return v.templateForKubeVersionAndOS(anywherev1.Kube123, Ubuntu2004, nil)
-}
-
-// Ubuntu124Template returns vsphere filler for 1.24 Ubuntu.
-func (v *VSphere) Ubuntu124Template() api.VSphereFiller {
-	return v.templateForKubeVersionAndOS(anywherev1.Kube124, Ubuntu2004, nil)
-}
-
 // Ubuntu125Template returns vsphere filler for 1.25 Ubuntu.
 func (v *VSphere) Ubuntu125Template() api.VSphereFiller {
 	return v.templateForKubeVersionAndOS(anywherev1.Kube125, Ubuntu2004, nil)
@@ -522,16 +469,6 @@ func (v *VSphere) Ubuntu2204Kubernetes127Template() api.VSphereFiller {
 // Ubuntu2204Kubernetes128Template returns vsphere filler for 1.28 Ubuntu 22.04.
 func (v *VSphere) Ubuntu2204Kubernetes128Template() api.VSphereFiller {
 	return v.templateForKubeVersionAndOS(anywherev1.Kube128, Ubuntu2204, nil)
-}
-
-// Bottlerocket123Template returns vsphere filler for 1.23 BR.
-func (v *VSphere) Bottlerocket123Template() api.VSphereFiller {
-	return v.templateForKubeVersionAndOS(anywherev1.Kube123, Bottlerocket1, nil)
-}
-
-// Bottlerocket124Template returns vsphere filler for 1.24 BR.
-func (v *VSphere) Bottlerocket124Template() api.VSphereFiller {
-	return v.templateForKubeVersionAndOS(anywherev1.Kube124, Bottlerocket1, nil)
 }
 
 // Bottlerocket125Template returns vsphere filler for 1.25 BR.


### PR DESCRIPTION
Remove unused 1.23 and 1.24 methods from testing code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

