### PR TITLE
Revert "Fix ADOT flaky test (#7332)"

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1455,7 +1455,7 @@ func (e *ClusterE2ETest) VerifyAdotPackageInstalled(packageName, targetNamespace
 	}
 	podFullIPAddress := strings.Trim(podIPAddress, `'"`) + ":8888/metrics"
 	e.T.Log("Validate content at endpoint", podFullIPAddress)
-	expectedLogs = "HTTP/1.1 200 OK"
+	expectedLogs = "otelcol_exporter"
 	e.ValidateEndpointContent(podFullIPAddress, targetNamespace, expectedLogs)
 }
 
@@ -2098,7 +2098,7 @@ func (e *ClusterE2ETest) CurlEndpoint(endpoint, namespace string) string {
 	e.T.Log("Launching pod to curl endpoint", endpoint)
 	randomname := fmt.Sprintf("%s-%s", "curl-test", utilrand.String(7))
 	curlPodName, err := e.KubectlClient.RunCurlPod(context.TODO(),
-		namespace, randomname, e.KubeconfigFilePath(), []string{"curl", "-I", endpoint})
+		namespace, randomname, e.KubeconfigFilePath(), []string{"curl", endpoint})
 	if err != nil {
 		e.T.Fatalf("error launching pod: %s", err)
 	}


### PR DESCRIPTION
This reverts commit 4495d29ce273e2deab76e29ca93098b77ecc738f.

*Issue #, if available:*

*Description of changes:*
Revert "Fix ADOT flaky test (#7332)"

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

