### PR TITLE
Allow adding extra curl args while keeping default behavior

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1007,7 +1007,7 @@ func (k *Kubectl) ValidatePods(ctx context.Context, kubeconfig string) error {
 
 // RunCurlPod will run Kubectl with an image (with curl installed) and the command you pass in.
 func (k *Kubectl) RunCurlPod(ctx context.Context, namespace, name, kubeconfig string, command []string) (string, error) {
-	params := []string{"run", name, "--image=public.ecr.aws/eks-anywhere/diagnostic-collector:v0.16.2-eks-a-41", "-o", "json", "--kubeconfig", kubeconfig, "--namespace", namespace, "--restart=Never"}
+	params := []string{"run", name, "--image=public.ecr.aws/eks-anywhere/diagnostic-collector:v0.16.2-eks-a-41", "-o", "json", "--kubeconfig", kubeconfig, "--namespace", namespace, "--restart=Never", "--"}
 	params = append(params, command...)
 	_, err := k.Execute(ctx, params...)
 	if err != nil {

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -3704,7 +3704,7 @@ func TestRunCurlPod(t *testing.T) {
 	t.Parallel()
 	tt := newKubectlTest(t)
 	var b bytes.Buffer
-	expectedParam := []string{"run", "testpod-123", "--image=public.ecr.aws/eks-anywhere/diagnostic-collector:v0.16.2-eks-a-41", "-o", "json", "--kubeconfig", "c.kubeconfig", "--namespace", "eksa-packages", "--restart=Never", "pwd"}
+	expectedParam := []string{"run", "testpod-123", "--image=public.ecr.aws/eks-anywhere/diagnostic-collector:v0.16.2-eks-a-41", "-o", "json", "--kubeconfig", "c.kubeconfig", "--namespace", "eksa-packages", "--restart=Never", "--", "pwd"}
 	tt.e.EXPECT().Execute(gomock.Any(), gomock.Eq(expectedParam)).Return(b, nil).AnyTimes()
 	if _, err := tt.k.RunCurlPod(tt.ctx, "eksa-packages", "testpod-123", tt.cluster.KubeconfigFile, []string{"pwd"}); err != nil {
 		t.Errorf("Kubectl.RunCurlPod() error = %v, want nil", err)


### PR DESCRIPTION
We use `curl` commands to validate the curated packages installations in E2E tests. The default command used is just `curl <endpoint>`, but this was changed to `curl -I <endpoint>` (which gets only curl headers) in #7332 for fixing ADOT tests, which caused other packages to fail since they expect output present in the full `curl` output. This PR allows to pass in custom  `curl` options to the `ValidateCurlEndpoint` method so that each package can customize how the `curl` command is run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

