### PR TITLE
Add e2e test new env variables to required env variables

### DIFF
--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -21,12 +21,12 @@ import (
 
 const (
 	cloudstackDomainVar                         = "T_CLOUDSTACK_DOMAIN"
-	cloudstackMultiLevelDomainVar               = "T_CLOUDSTACK_MULTILEVEL_DOMAIN" // Not a required env var
+	cloudstackMultiLevelDomainVar               = "T_CLOUDSTACK_MULTILEVEL_DOMAIN"
 	cloudstackZoneVar                           = "T_CLOUDSTACK_ZONE"
 	cloudstackZone2Var                          = "T_CLOUDSTACK_ZONE_2"
 	cloudstackZone3Var                          = "T_CLOUDSTACK_ZONE_3"
 	cloudstackAccountVar                        = "T_CLOUDSTACK_ACCOUNT"
-	cloudstackAccountForMultiLevelDomainVar     = "T_CLOUDSTACK_ACCOUNT_FOR_MULTILEVEL_DOMAIN" // Not a required env var
+	cloudstackAccountForMultiLevelDomainVar     = "T_CLOUDSTACK_ACCOUNT_FOR_MULTILEVEL_DOMAIN"
 	cloudstackNetworkVar                        = "T_CLOUDSTACK_NETWORK"
 	cloudstackNetwork2Var                       = "T_CLOUDSTACK_NETWORK_2"
 	cloudstackNetwork3Var                       = "T_CLOUDSTACK_NETWORK_3"
@@ -50,13 +50,16 @@ const (
 
 var requiredCloudStackEnvVars = []string{
 	cloudstackAccountVar,
+	cloudstackAccountForMultiLevelDomainVar,
 	cloudstackDomainVar,
+	cloudstackMultiLevelDomainVar,
 	cloudstackZoneVar,
 	cloudstackZone2Var,
 	cloudstackZone3Var,
 	cloudstackCredentialsVar,
 	cloudstackCredentials2Var,
 	cloudstackCredentials3Var,
+	cloudstackCredentialsForMultiLevelDomainVar,
 	cloudstackAccountVar,
 	cloudstackNetworkVar,
 	cloudstackNetwork2Var,


### PR DESCRIPTION
*Issue #, if available:*
[#2001](https://github.com/aws/eks-anywhere-internal/issues/2001)

*Description of changes:*
- Fix e2e test failure by adding the newly defined test env variables to the required env variables to export them in the ec2 instances launched for running tests

*Testing (if applicable):*
- Tested locally in dev and CI env

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

