### PR TITLE
Update CLI tools image to latest dev version

### DIFF
--- a/pkg/executables/builder.go
+++ b/pkg/executables/builder.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
 )
 
-const defaultEksaImage = "public.ecr.aws/eks-anywhere/cli-tools:v0.17.0-eks-a-45"
+const defaultEksaImage = "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.4-eks-a-v0.0.0-dev-build.8100"
 
 type ExecutableBuilder interface {
 	Init(ctx context.Context) (Closer, error)


### PR DESCRIPTION
Update CLI tools image to latest dev version for E2E tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

