### PR TITLE
Allow empty commits with GoGit update

### DIFF
--- a/pkg/git/gitclient/gitclient.go
+++ b/pkg/git/gitclient/gitclient.go
@@ -360,7 +360,8 @@ func (gg *goGit) AddGlob(f string, w *gogit.Worktree) error {
 
 func (gg *goGit) Commit(m string, sig *object.Signature, w *gogit.Worktree) (plumbing.Hash, error) {
 	return w.Commit(m, &gogit.CommitOptions{
-		Author: sig,
+		Author:            sig,
+		AllowEmptyCommits: true,
 	})
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We updated the go-git version which now returns an error on commits with no changes. Adding this new commit option to keep our same behavior. See more here:
https://github.com/go-git/go-git/pull/623

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

