### PR TITLE
Add in-place upgrade controller for kcp

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -7170,6 +7170,22 @@ rules:
 - apiGroups:
   - controlplane.cluster.x-k8s.io
   resources:
+  - kubeadmcontrolplane
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplane/status
+  verbs:
+  - get
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
   - kubeadmcontrolplanes
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -296,6 +296,22 @@ rules:
 - apiGroups:
   - controlplane.cluster.x-k8s.io
   resources:
+  - kubeadmcontrolplane
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplane/status
+  verbs:
+  - get
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
   - kubeadmcontrolplanes
   verbs:
   - create

--- a/controllers/controlplaneupgrade_controller_test.go
+++ b/controllers/controlplaneupgrade_controller_test.go
@@ -247,7 +247,7 @@ func cpUpgradeRequest(cpUpgrade *anywherev1.ControlPlaneUpgrade) reconcile.Reque
 }
 
 func generateCPUpgrade(machine []*clusterv1.Machine) *anywherev1.ControlPlaneUpgrade {
-	etcdVersion := "v1.28.3-eks-1-28-9"
+	etcdVersion := "v3.5.9-eks-1-28-9"
 	return &anywherev1.ControlPlaneUpgrade{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cp-upgrade-request",
@@ -271,7 +271,7 @@ func generateCPUpgrade(machine []*clusterv1.Machine) *anywherev1.ControlPlaneUpg
 					Namespace: machine[1].Namespace,
 				},
 			},
-			KubernetesVersion: "v1.28.1-eks-1-28-1",
+			KubernetesVersion: "v1.28.3-eks-1-28-9",
 			EtcdVersion:       etcdVersion,
 		},
 	}

--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -70,6 +70,7 @@ type Reconcilers struct {
 	TinkerbellDatacenterReconciler     *TinkerbellDatacenterReconciler
 	CloudStackDatacenterReconciler     *CloudStackDatacenterReconciler
 	NutanixDatacenterReconciler        *NutanixDatacenterReconciler
+	KubeadmControlPlaneReconciler      *KubeadmControlPlaneReconciler
 	ControlPlaneUpgradeReconciler      *ControlPlaneUpgradeReconciler
 	MachineDeploymentUpgradeReconciler *MachineDeploymentUpgradeReconciler
 	NodeUpgradeReconciler              *NodeUpgradeReconciler
@@ -582,6 +583,23 @@ func (f *Factory) withMachineHealthCheckReconciler() *Factory {
 		f.machineHealthCheckReconciler = mhcreconciler.New(
 			f.manager.GetClient(),
 			machineHealthCheckDefaulter,
+		)
+
+		return nil
+	})
+
+	return f
+}
+
+// WithKubeadmControlPlaneReconciler builds the KubeadmControlPlane reconciler.
+func (f *Factory) WithKubeadmControlPlaneReconciler() *Factory {
+	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
+		if f.reconcilers.KubeadmControlPlaneReconciler != nil {
+			return nil
+		}
+
+		f.reconcilers.KubeadmControlPlaneReconciler = NewKubeadmControlPlaneReconciler(
+			f.manager.GetClient(),
 		)
 
 		return nil

--- a/controllers/factory_test.go
+++ b/controllers/factory_test.go
@@ -230,6 +230,26 @@ func TestFactoryWithNutanixDatacenterReconciler(t *testing.T) {
 	g.Expect(reconcilers.NutanixDatacenterReconciler).NotTo(BeNil())
 }
 
+func TestFactoryWithKubeadmControlPlaneInPlaceUpgradeReconciler(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	logger := nullLog()
+	ctrl := gomock.NewController(t)
+	manager := mocks.NewMockManager(ctrl)
+	manager.EXPECT().GetClient().AnyTimes()
+	manager.EXPECT().GetScheme().AnyTimes()
+
+	f := controllers.NewFactory(logger, manager).
+		WithKubeadmControlPlaneReconciler()
+
+	// testing idempotence
+	f.WithKubeadmControlPlaneReconciler()
+
+	reconcilers, err := f.Build(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(reconcilers.KubeadmControlPlaneReconciler).NotTo(BeNil())
+}
+
 func TestFactoryWithNodeUpgradeReconciler(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/controllers/kubeadmcontrolplane_controller.go
+++ b/controllers/kubeadmcontrolplane_controller.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+const (
+	kcpInPlaceUpgradeNeededAnnotation = "controlplane.clusters.x-k8s.io/in-place-upgrade-needed"
+	controlPlaneMachineLabel          = "cluster.x-k8s.io/control-plane-name"
+)
+
+// KubeadmControlPlaneReconciler reconciles a KubeadmControlPlaneReconciler object.
+type KubeadmControlPlaneReconciler struct {
+	client client.Client
+	log    logr.Logger
+}
+
+// NewKubeadmControlPlaneReconciler returns a new instance of KubeadmControlPlaneReconciler.
+func NewKubeadmControlPlaneReconciler(client client.Client) *KubeadmControlPlaneReconciler {
+	return &KubeadmControlPlaneReconciler{
+		client: client,
+		log:    ctrl.Log.WithName("KubeadmControlPlaneController"),
+	}
+}
+
+//+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplane,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplane/status,verbs=get
+
+// Reconcile reconciles a KubeadmControlPlane object for in place upgrades.
+func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
+	log := r.log.WithValues("KubeadmControlPlane", req.NamespacedName)
+
+	kcp := &controlplanev1.KubeadmControlPlane{}
+	if err := r.client.Get(ctx, req.NamespacedName, kcp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !r.inPlaceUpgradeNeeded(kcp) {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciling KubeadmControlPlane object")
+	patchHelper, err := patch.NewHelper(kcp, r.client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	defer func() {
+		// Always attempt to patch after each reconciliation in case annotation is removed.
+		if err := patchHelper.Patch(ctx, kcp); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+
+		// Only requeue if we are not already re-queueing and the "in-place-upgrade-needed" annotation is not set.
+		// We do this to be able to update the status continuously until it becomes ready,
+		// since there might be changes in state of the world that don't trigger reconciliation requests
+		if reterr == nil && !result.Requeue && result.RequeueAfter <= 0 && r.inPlaceUpgradeNeeded(kcp) {
+			result = ctrl.Result{RequeueAfter: 10 * time.Second}
+		}
+	}()
+
+	return r.reconcile(ctx, log, kcp)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *KubeadmControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&controlplanev1.KubeadmControlPlane{}).
+		Complete(r)
+}
+
+func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, log logr.Logger, kcp *controlplanev1.KubeadmControlPlane) (ctrl.Result, error) {
+	log.Info("Reconciling in place upgrade for control plane")
+	if err := r.validateStackedEtcd(kcp); err != nil {
+		log.Info("Stacked etcd validation failed, unable to reconcile for in place upgrade")
+		return ctrl.Result{}, err
+	}
+	if kcp.Spec.Replicas != nil && (*kcp.Spec.Replicas == kcp.Status.UpdatedReplicas) {
+		log.Info("KubeadmControlPlane is ready, nothing else to reconcile for in place upgrade")
+		// Remove in-place-upgrade-needed annotation
+		delete(kcp.Annotations, kcpInPlaceUpgradeNeededAnnotation)
+		return ctrl.Result{}, nil
+	}
+	cpUpgrade := &anywherev1.ControlPlaneUpgrade{}
+	if err := r.client.Get(ctx, GetNamespacedNameType(cpUpgradeName(kcp.Name), constants.EksaSystemNamespace), cpUpgrade); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Creating control plane upgrade object")
+			machines, err := r.machinesToUpgrade(ctx, kcp)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("retrieving list of control plane machines: %v", err)
+			}
+			if err := r.client.Create(ctx, controlPlaneUpgrade(kcp, machines)); client.IgnoreAlreadyExists(err) != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create control plane upgrade for KubeadmControlPlane %s:  %v", kcp.Name, err)
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("getting control plane upgrade for KubeadmControlPlane %s: %v", kcp.Name, err)
+	}
+	if !cpUpgrade.Status.Ready {
+		return ctrl.Result{}, nil
+	}
+	// TODO: update status for templates and other resources
+	log.Info("Control plane upgrade complete, deleting object")
+	if err := r.client.Delete(ctx, cpUpgrade); err != nil {
+		return ctrl.Result{}, fmt.Errorf("deleting control plane upgrade object: %v", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *KubeadmControlPlaneReconciler) inPlaceUpgradeNeeded(kcp *controlplanev1.KubeadmControlPlane) bool {
+	_, ok := kcp.Annotations[kcpInPlaceUpgradeNeededAnnotation]
+	return ok
+}
+
+func (r *KubeadmControlPlaneReconciler) machinesToUpgrade(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) ([]corev1.ObjectReference, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{controlPlaneMachineLabel: kcp.Name}})
+	if err != nil {
+		return nil, err
+	}
+	machineList := &clusterv1.MachineList{}
+	if err := r.client.List(ctx, machineList, &client.ListOptions{LabelSelector: selector, Namespace: kcp.Namespace}); err != nil {
+		return nil, err
+	}
+	machines := collections.FromMachineList(machineList).SortedByCreationTimestamp()
+	machineObjects := make([]corev1.ObjectReference, 0, len(machines))
+	for _, machine := range machines {
+		machineObjects = append(machineObjects,
+			corev1.ObjectReference{
+				Kind:      machine.Kind,
+				Namespace: machine.Namespace,
+				Name:      machine.Name,
+			},
+		)
+	}
+	return machineObjects, nil
+}
+
+func (r *KubeadmControlPlaneReconciler) validateStackedEtcd(kcp *controlplanev1.KubeadmControlPlane) error {
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
+		return fmt.Errorf("ClusterConfiguration not set for KubeadmControlPlane, unable to retrieve etcd information")
+	}
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local == nil {
+		return fmt.Errorf("local etcd configuration is missing")
+	}
+	return nil
+}
+
+func controlPlaneUpgrade(kcp *controlplanev1.KubeadmControlPlane, machines []corev1.ObjectReference) *anywherev1.ControlPlaneUpgrade {
+	return &anywherev1.ControlPlaneUpgrade{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpUpgradeName(kcp.Name),
+			Namespace: constants.EksaSystemNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kcp.APIVersion,
+				Kind:       kcp.Kind,
+				Name:       kcp.Name,
+				UID:        kcp.UID,
+			}},
+		},
+		Spec: anywherev1.ControlPlaneUpgradeSpec{
+			ControlPlane: corev1.ObjectReference{
+				Kind:      kcp.Kind,
+				Namespace: kcp.Namespace,
+				Name:      kcp.Name,
+			},
+			KubernetesVersion:      kcp.Spec.Version,
+			EtcdVersion:            kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageTag,
+			MachinesRequireUpgrade: machines,
+		},
+	}
+}
+
+func cpUpgradeName(kcpName string) string {
+	return kcpName + "-cp-upgrade"
+}

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -1,0 +1,245 @@
+package controllers_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/eks-anywhere/controllers"
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
+)
+
+type kcpObjects struct {
+	machines  []*clusterv1.Machine
+	cpUpgrade *anywherev1.ControlPlaneUpgrade
+	kcp       *controlplanev1.KubeadmControlPlane
+}
+
+func TestKCPSetupWithManager(t *testing.T) {
+	client := env.Client()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+
+	g := NewWithT(t)
+	g.Expect(r.SetupWithManager(env.Manager())).To(Succeed())
+}
+
+func TestKCPReconcile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.cpUpgrade, kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cpu := &anywherev1.ControlPlaneUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: kcpObjs.cpUpgrade.Name, Namespace: constants.EksaSystemNamespace}, cpu)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestKCPReconcileComplete(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	count := int32(len(kcpObjs.machines))
+	kcpObjs.kcp.Spec.Replicas = pointer.Int32(count)
+	kcpObjs.kcp.Status.UpdatedReplicas = count
+
+	runtimeObjs := []runtime.Object{kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	kcp := &controlplanev1.KubeadmControlPlane{}
+	err = client.Get(ctx, types.NamespacedName{Name: kcpObjs.kcp.Name, Namespace: constants.EksaSystemNamespace}, kcp)
+	g.Expect(err).ToNot(HaveOccurred())
+	_, ok := kcp.Annotations["controlplane.clusters.x-k8s.io/in-place-upgrade-needed"]
+	g.Expect(ok).To(BeFalse())
+}
+
+func TestKCPReconcileNotNeeded(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	delete(kcpObjs.kcp.Annotations, "controlplane.clusters.x-k8s.io/in-place-upgrade-needed")
+
+	runtimeObjs := []runtime.Object{kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestKCPReconcileCreateControlPlaneUpgrade(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cpu := &anywherev1.ControlPlaneUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: kcpObjs.cpUpgrade.Name, Namespace: constants.EksaSystemNamespace}, cpu)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cpu.OwnerReferences).To(BeEquivalentTo(kcpObjs.cpUpgrade.OwnerReferences))
+	g.Expect(len(cpu.Spec.MachinesRequireUpgrade)).To(BeEquivalentTo(len(kcpObjs.cpUpgrade.Spec.MachinesRequireUpgrade)))
+	g.Expect(cpu.Spec.EtcdVersion).To(BeEquivalentTo(kcpObjs.cpUpgrade.Spec.EtcdVersion))
+	g.Expect(cpu.Spec.KubernetesVersion).To(BeEquivalentTo(kcpObjs.cpUpgrade.Spec.KubernetesVersion))
+}
+
+func TestKCPReconcileControlPlaneUpgradeReady(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	kcpObjs.cpUpgrade.Status.Ready = true
+
+	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.cpUpgrade, kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cpu := &anywherev1.ControlPlaneUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: kcpObjs.cpUpgrade.Name, Namespace: constants.EksaSystemNamespace}, cpu)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestKCPReconcileNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	client := fake.NewClientBuilder().WithRuntimeObjects().Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).To(MatchError("kubeadmcontrolplanes.controlplane.cluster.x-k8s.io \"my-cluster\" not found"))
+}
+
+func TestKCPReconcileClusterConfigurationMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	kcpObjs.kcp.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
+
+	runtimeObjs := []runtime.Object{kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).To(MatchError("ClusterConfiguration not set for KubeadmControlPlane, unable to retrieve etcd information"))
+}
+
+func TestKCPReconcileStackedEtcdMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	kcpObjs := getObjectsForKCP()
+
+	kcpObjs.kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = nil
+
+	runtimeObjs := []runtime.Object{kcpObjs.kcp}
+	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
+	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	req := kcpRequest(kcpObjs.kcp)
+	_, err := r.Reconcile(ctx, req)
+	g.Expect(err).To(MatchError("local etcd configuration is missing"))
+}
+
+func getObjectsForKCP() kcpObjects {
+	cluster := generateCluster()
+	kcp := generateKCP(cluster)
+	kcp.Name = cluster.Name
+	kcp.TypeMeta = metav1.TypeMeta{
+		APIVersion: controlplanev1.GroupVersion.String(),
+		Kind:       "KubeadmControlPlane",
+	}
+	node1 := generateNode()
+	node2 := node1.DeepCopy()
+	node2.ObjectMeta.Name = "node02"
+	machine1 := generateMachine(cluster, node1)
+	machine1.Labels = map[string]string{
+		"cluster.x-k8s.io/control-plane-name": kcp.Name,
+	}
+	machine2 := generateMachine(cluster, node2)
+	machine2.ObjectMeta.Name = "machine02"
+	machine2.Labels = map[string]string{
+		"cluster.x-k8s.io/control-plane-name": kcp.Name,
+	}
+	machines := []*clusterv1.Machine{machine1, machine2}
+	cpUpgrade := generateCPUpgrade(machines)
+	cpUpgrade.Name = kcp.Name + "-cp-upgrade"
+	cpUpgrade.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: kcp.APIVersion,
+		Kind:       kcp.Kind,
+		Name:       kcp.Name,
+		UID:        kcp.UID,
+	}}
+
+	return kcpObjects{
+		machines:  machines,
+		cpUpgrade: cpUpgrade,
+		kcp:       kcp,
+	}
+}
+
+func kcpRequest(kcp *controlplanev1.KubeadmControlPlane) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      kcp.Name,
+			Namespace: kcp.Namespace,
+		},
+	}
+}
+
+func generateKCP(cluster *clusterv1.Cluster) *controlplanev1.KubeadmControlPlane {
+	return &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: constants.EksaSystemNamespace,
+			UID:       "test-uid",
+			Annotations: map[string]string{
+				"controlplane.clusters.x-k8s.io/in-place-upgrade-needed": "",
+			},
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+				ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+					Etcd: bootstrapv1.Etcd{
+						Local: &bootstrapv1.LocalEtcd{
+							ImageMeta: bootstrapv1.ImageMeta{
+								ImageTag: "v3.5.9-eks-1-28-9",
+							},
+						},
+					},
+				},
+			},
+			Version: "v1.28.3-eks-1-28-9",
+		},
+	}
+}

--- a/manager/main.go
+++ b/manager/main.go
@@ -176,6 +176,7 @@ func setupReconcilers(ctx context.Context, setupLog logr.Logger, mgr ctrl.Manage
 		WithSnowMachineConfigReconciler().
 		WithNutanixDatacenterReconciler().
 		WithCloudStackDatacenterReconciler().
+		WithKubeadmControlPlaneReconciler().
 		WithControlPlaneUpgradeReconciler().
 		WithMachineDeploymentUpgradeReconciler().
 		WithNodeUpgradeReconciler()
@@ -214,6 +215,12 @@ func setupReconcilers(ctx context.Context, setupLog logr.Logger, mgr ctrl.Manage
 	setupLog.Info("Setting up cloudstackdatacenter controller")
 	if err := (reconcilers.CloudStackDatacenterReconciler).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", anywherev1.CloudStackDatacenterKind)
+		failed = true
+	}
+
+	setupLog.Info("Setting up kubeadmcontrolplane controller")
+	if err := (reconcilers.KubeadmControlPlaneReconciler).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "KubeadmControlPlane")
 		failed = true
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,6 +53,8 @@ const (
 
 	FailureDomainLabelName = "cluster.x-k8s.io/failure-domain"
 
+	InPlaceUpgradeNeededAnnotation = "cluster.x-k8s.io/in-place-upgrade-needed"
+
 	// CloudstackFailureDomainPlaceholder Provider specific keywork placeholder.
 	CloudstackFailureDomainPlaceholder = "ds.meta_data.failuredomain"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a new controller for KCP to reconcile changes based on seeing the in place upgrade annotation. This would be a temporary controller until we implement runtime webhooks, removing the need for this annotation from cluster api. This will create a ControlPlaneUpgrade object when this annotation is detected and delete it after it sees that it has completed.

*Testing (if applicable):*
unit and functional testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

