### PR TITLE
Update troubleshooting docs indicating taints validation only applies to management clusters 

### DIFF
--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -155,9 +155,9 @@ Either use a different cluster name or move the directory.
 ```
 Error: the cluster config file provided is invalid: at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints
 ```
-At least one schedulable worker node group is required to run cluster administration components. Both `NoExecute` and `NoSchedule` taints must be absent from the workerNodeGroup for it to be considered schedulable.
+An EKS Anywhere management cluster requires at least one schedulable worker node group to run cluster administration components. Both `NoExecute` and `NoSchedule` taints must be absent from the workerNodeGroup for it to be considered schedulable. This validation was removed for workload clusters from v0.19.0 onwards, so now it only applies to management clusters.
 
-To remedy, remove `NoExecute` and `NoSchedule` taints from at least one WorkerNodeGroupConfiguration.
+To remedy, remove `NoExecute` and `NoSchedule` taints from at least one WorkerNodeGroupConfiguration on your management cluster.
 
 Invalid configuration example:
 ```


### PR DESCRIPTION
*Issue #, if available:*
[#1527](https://github.com/aws/eks-anywhere-internal/issues/1527)

*Description of changes:*
This PR modifies documentation was added to indicate that at least one workergroup must be schedulable for now. These conditions now now applies only to management clusters, after merging this [PR](https://github.com/aws/eks-anywhere/pull/6294) to remove this validation for workload clusters.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

