### PR TITLE
Add initial set of cloudstack redhat 9 tests

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -1867,6 +1867,42 @@ func TestCloudStackKubernetes128SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
+func TestCloudStackKubernetes125RedHat9SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes125()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+	)
+	runSimpleFlow(test)
+}
+
+func TestCloudStackKubernetes126RedHat9SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes126()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+	)
+	runSimpleFlow(test)
+}
+
+func TestCloudStackKubernetes127RedHat9SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes127()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
+	)
+	runSimpleFlow(test)
+}
+
+func TestCloudStackKubernetes128RedHat9SimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+	)
+	runSimpleFlow(test)
+}
+
 func TestCloudStackKubernetes125ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -2609,6 +2645,132 @@ func TestCloudStackKubernetes127RedhatTo128StackedEtcdUpgrade(t *testing.T) {
 		v1alpha1.Kube128,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
 		provider.WithProviderUpgrade(provider.Redhat128Template()),
+	)
+}
+
+func TestCloudStackKubernetes125Redhat9To126Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes125())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube126,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes126Template()),
+	)
+}
+
+func TestCloudStackKubernetes126Redhat9To127Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes126())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube127,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes127Template()),
+	)
+}
+
+func TestCloudStackKubernetes127Redhat9To128Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes127())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube128,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes128Template()),
+	)
+}
+
+func TestCloudStackKubernetes125Redhat8ToRedhat9Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat125())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube125,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes125Template()),
+	)
+}
+
+func TestCloudStackKubernetes126Redhat8ToRedhat9Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat126())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube126,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube126)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes126Template()),
+	)
+}
+
+func TestCloudStackKubernetes127Redhat8ToRedhat9Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat127())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube127,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes127Template()),
+	)
+}
+
+func TestCloudStackKubernetes128Redhat8ToRedhat9Upgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube128,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		provider.WithProviderUpgrade(provider.Redhat9Kubernetes128Template()),
 	)
 }
 

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -190,6 +190,26 @@ func WithCloudStackRedhat128() CloudStackOpt {
 	return withCloudStackKubeVersionAndOS(anywherev1.Kube128, RedHat8, nil)
 }
 
+// WithCloudStackRedhat9Kubernetes125 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.25.
+func WithCloudStackRedhat9Kubernetes125() CloudStackOpt {
+	return withCloudStackKubeVersionAndOS(anywherev1.Kube125, RedHat9, nil)
+}
+
+// WithCloudStackRedhat9Kubernetes126 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.26.
+func WithCloudStackRedhat9Kubernetes126() CloudStackOpt {
+	return withCloudStackKubeVersionAndOS(anywherev1.Kube126, RedHat9, nil)
+}
+
+// WithCloudStackRedhat9Kubernetes127 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.27.
+func WithCloudStackRedhat9Kubernetes127() CloudStackOpt {
+	return withCloudStackKubeVersionAndOS(anywherev1.Kube127, RedHat9, nil)
+}
+
+// WithCloudStackRedhat9Kubernetes128 returns a function which can be invoked to configure the Cloudstack object to be compatible with K8s 1.28.
+func WithCloudStackRedhat9Kubernetes128() CloudStackOpt {
+	return withCloudStackKubeVersionAndOS(anywherev1.Kube128, RedHat9, nil)
+}
+
 func WithCloudStackFillers(fillers ...api.CloudStackFiller) CloudStackOpt {
 	return func(c *CloudStack) {
 		c.fillers = append(c.fillers, fillers...)
@@ -330,6 +350,26 @@ func (c *CloudStack) Redhat128Template() api.CloudStackFiller {
 	return c.templateForKubeVersionAndOS(anywherev1.Kube128, RedHat8, nil)
 }
 
+// Redhat9Kubernetes125Template returns cloudstack filler for 1.25 RedHat.
+func (c *CloudStack) Redhat9Kubernetes125Template() api.CloudStackFiller {
+	return c.templateForKubeVersionAndOS(anywherev1.Kube125, RedHat9, nil)
+}
+
+// Redhat9Kubernetes126Template returns cloudstack filler for 1.26 RedHat.
+func (c *CloudStack) Redhat9Kubernetes126Template() api.CloudStackFiller {
+	return c.templateForKubeVersionAndOS(anywherev1.Kube126, RedHat9, nil)
+}
+
+// Redhat9Kubernetes127Template returns cloudstack filler for 1.27 RedHat.
+func (c *CloudStack) Redhat9Kubernetes127Template() api.CloudStackFiller {
+	return c.templateForKubeVersionAndOS(anywherev1.Kube127, RedHat9, nil)
+}
+
+// Redhat9Kubernetes128Template returns cloudstack filler for 1.28 RedHat.
+func (c *CloudStack) Redhat9Kubernetes128Template() api.CloudStackFiller {
+	return c.templateForKubeVersionAndOS(anywherev1.Kube128, RedHat9, nil)
+}
+
 func buildCloudStackWorkerNodeGroupClusterFiller(machineConfigName string, workerNodeGroup *WorkerNodeGroup) api.ClusterFiller {
 	// Set worker node group ref to cloudstack machine config
 	workerNodeGroup.MachineConfigKind = anywherev1.CloudStackMachineConfigKind
@@ -380,6 +420,30 @@ func (c *CloudStack) WithRedhat127() api.ClusterConfigFiller {
 // as well as the right redhat template for all CloudStackMachineConfigs.
 func (c *CloudStack) WithRedhat128() api.ClusterConfigFiller {
 	return c.WithKubeVersionAndOS(anywherev1.Kube128, RedHat8, nil)
+}
+
+// WithRedhat9Kubernetes125 returns a cluster config filler that sets the kubernetes version of the cluster to 1.25
+// as well as the right redhat template for all CloudStackMachineConfigs.
+func (c *CloudStack) WithRedhat9Kubernetes125() api.ClusterConfigFiller {
+	return c.WithKubeVersionAndOS(anywherev1.Kube125, RedHat9, nil)
+}
+
+// WithRedhat9Kubernetes126 returns a cluster config filler that sets the kubernetes version of the cluster to 1.26
+// as well as the right redhat template for all CloudStackMachineConfigs.
+func (c *CloudStack) WithRedhat9Kubernetes126() api.ClusterConfigFiller {
+	return c.WithKubeVersionAndOS(anywherev1.Kube126, RedHat9, nil)
+}
+
+// WithRedhat9Kubernetes127 returns a cluster config filler that sets the kubernetes version of the cluster to 1.27
+// as well as the right redhat template for all CloudStackMachineConfigs.
+func (c *CloudStack) WithRedhat9Kubernetes127() api.ClusterConfigFiller {
+	return c.WithKubeVersionAndOS(anywherev1.Kube127, RedHat9, nil)
+}
+
+// WithRedhat9Kubernetes128 returns a cluster config filler that sets the kubernetes version of the cluster to 1.28
+// as well as the right redhat template for all CloudStackMachineConfigs.
+func (c *CloudStack) WithRedhat9Kubernetes128() api.ClusterConfigFiller {
+	return c.WithKubeVersionAndOS(anywherev1.Kube128, RedHat9, nil)
 }
 
 // WithRedhatVersion returns a cluster config filler that sets the kubernetes version of the cluster to the k8s


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add rhel 9 simpleflow, upgrade and rhel8 to rhel9 upgrade tests for all kubernetes versions

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

