### PR TITLE
Run CAPI Backup on workload cluster during upgrade

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -27,29 +27,29 @@ type Task interface {
 
 // Command context maintains the mutable and shared entities.
 type CommandContext struct {
-	ClientFactory             interfaces.ClientFactory
-	Bootstrapper              interfaces.Bootstrapper
-	Provider                  providers.Provider
-	ClusterManager            interfaces.ClusterManager
-	GitOpsManager             interfaces.GitOpsManager
-	Validations               interfaces.Validator
-	Writer                    filewriter.FileWriter
-	EksdInstaller             interfaces.EksdInstaller
-	PackageInstaller          interfaces.PackageInstaller
-	EksdUpgrader              interfaces.EksdUpgrader
-	ClusterUpgrader           interfaces.ClusterUpgrader
-	ClusterCreator            interfaces.ClusterCreator
-	CAPIManager               interfaces.CAPIManager
-	ClusterSpec               *cluster.Spec
-	CurrentClusterSpec        *cluster.Spec
-	UpgradeChangeDiff         *types.ChangeDiff
-	BootstrapCluster          *types.Cluster
-	ManagementCluster         *types.Cluster
-	WorkloadCluster           *types.Cluster
-	Profiler                  *Profiler
-	OriginalError             error
-	ManagementClusterStateDir string
-	ForceCleanup              bool
+	ClientFactory         interfaces.ClientFactory
+	Bootstrapper          interfaces.Bootstrapper
+	Provider              providers.Provider
+	ClusterManager        interfaces.ClusterManager
+	GitOpsManager         interfaces.GitOpsManager
+	Validations           interfaces.Validator
+	Writer                filewriter.FileWriter
+	EksdInstaller         interfaces.EksdInstaller
+	PackageInstaller      interfaces.PackageInstaller
+	EksdUpgrader          interfaces.EksdUpgrader
+	ClusterUpgrader       interfaces.ClusterUpgrader
+	ClusterCreator        interfaces.ClusterCreator
+	CAPIManager           interfaces.CAPIManager
+	ClusterSpec           *cluster.Spec
+	CurrentClusterSpec    *cluster.Spec
+	UpgradeChangeDiff     *types.ChangeDiff
+	BootstrapCluster      *types.Cluster
+	ManagementCluster     *types.Cluster
+	WorkloadCluster       *types.Cluster
+	Profiler              *Profiler
+	OriginalError         error
+	BackupClusterStateDir string
+	ForceCleanup          bool
 }
 
 func (c *CommandContext) SetError(err error) {
@@ -132,7 +132,7 @@ func (tr *taskRunner) RunTask(ctx context.Context, commandContext *CommandContex
 	var checkpointInfo CheckpointInfo
 	var err error
 
-	commandContext.ManagementClusterStateDir = fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05"))
+	commandContext.BackupClusterStateDir = fmt.Sprintf("%s-backup-%s", commandContext.ClusterSpec.Cluster.Name, time.Now().Format("2006-01-02T15_04_05"))
 	commandContext.Profiler = &Profiler{
 		metrics: make(map[string]map[string]time.Duration),
 		starts:  make(map[string]map[string]time.Time),

--- a/pkg/workflows/management/post_cluster_upgrade.go
+++ b/pkg/workflows/management/post_cluster_upgrade.go
@@ -23,7 +23,7 @@ func (s *postClusterUpgrade) Run(ctx context.Context, commandContext *task.Comma
 	}
 
 	logger.Info("Cleaning up backup resources")
-	capiObjectFile := filepath.Join(commandContext.ManagementCluster.Name, commandContext.ManagementClusterStateDir)
+	capiObjectFile := filepath.Join(commandContext.ManagementCluster.Name, commandContext.BackupClusterStateDir)
 	if err := os.RemoveAll(capiObjectFile); err != nil {
 		logger.Info(fmt.Sprintf("management cluster CAPI backup file not found: %v", err))
 	}

--- a/pkg/workflows/management/pre_cluster_upgrade.go
+++ b/pkg/workflows/management/pre_cluster_upgrade.go
@@ -12,12 +12,12 @@ type preClusterUpgrade struct{}
 
 // Run preClusterUpgrade implements steps to be performed before management cluster's upgrade.
 func (s *preClusterUpgrade) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	// Take best effort CAPI backup of workload cluster without filter.
-	// If that errors, then take CAPI backup filtering on only workload cluster.
+	// Take best effort CAPI backup of management cluster without filter.
+	// If that errors, then take CAPI backup filtering on only management cluster.
 	logger.Info("Backing up management cluster's resources before upgrading")
-	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.ManagementCluster, commandContext.ManagementClusterStateDir, "")
+	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.ManagementCluster, commandContext.BackupClusterStateDir, "")
 	if err != nil {
-		err = commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.ManagementCluster, commandContext.ManagementClusterStateDir, commandContext.ManagementCluster.Name)
+		err = commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.ManagementCluster, commandContext.BackupClusterStateDir, commandContext.ManagementCluster.Name)
 		if err != nil {
 			commandContext.SetError(err)
 			return &workflows.CollectMgmtClusterDiagnosticsTask{}

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -106,7 +106,7 @@ func newUpgradeManagementTest(t *testing.T) *upgradeManagementTestSetup {
 			s.Cluster.Name = "management"
 			s.Cluster.Spec.DatacenterRef.Kind = v1alpha1.VSphereDatacenterKind
 		}),
-		managementStatePath: fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05")),
+		managementStatePath: fmt.Sprintf("%s-backup-%s", "management", time.Now().Format("2006-01-02T15_04_05")),
 	}
 }
 

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -459,9 +459,9 @@ func (s *moveManagementToBootstrapTask) Run(ctx context.Context, commandContext 
 	// Take best effort CAPI backup of workload cluster without filter.
 	// If that errors, then take CAPI backup filtering on only workload cluster.
 	logger.Info("Backing up workload cluster's management resources before moving to bootstrap cluster")
-	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, "")
+	err := commandContext.ClusterManager.BackupCAPI(ctx, commandContext.WorkloadCluster, commandContext.BackupClusterStateDir, "")
 	if err != nil {
-		err = commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.WorkloadCluster, commandContext.ManagementClusterStateDir, commandContext.WorkloadCluster.Name)
+		err = commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.WorkloadCluster, commandContext.BackupClusterStateDir, commandContext.WorkloadCluster.Name)
 		if err != nil {
 			commandContext.SetError(err)
 			return &CollectDiagnosticsTask{}
@@ -521,7 +521,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 		// Take backup of bootstrap cluster capi components
 		if commandContext.BootstrapCluster != nil {
 			logger.Info("Backing up management components from bootstrap cluster")
-			err := commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.BootstrapCluster, fmt.Sprintf("bootstrap-%s", commandContext.ManagementClusterStateDir), commandContext.WorkloadCluster.Name)
+			err := commandContext.ClusterManager.BackupCAPIWaitForInfrastructure(ctx, commandContext.BootstrapCluster, fmt.Sprintf("bootstrap-%s", commandContext.BackupClusterStateDir), commandContext.WorkloadCluster.Name)
 			if err != nil {
 				logger.Info("Bootstrap management component backup failed, use existing workload cluster backup", "error", err)
 			}
@@ -701,7 +701,7 @@ func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *ta
 			logger.Info(fmt.Sprintf("%v", err))
 		}
 
-		capiObjectFile := filepath.Join(commandContext.BootstrapCluster.Name, commandContext.ManagementClusterStateDir)
+		capiObjectFile := filepath.Join(commandContext.BootstrapCluster.Name, commandContext.BackupClusterStateDir)
 		if err := os.RemoveAll(capiObjectFile); err != nil {
 			logger.Info(fmt.Sprintf("management cluster CAPI backup file not found: %v", err))
 		}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -93,7 +93,7 @@ func newUpgradeTest(t *testing.T) *upgradeTestSetup {
 		ctx:                 context.Background(),
 		newClusterSpec:      test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "cluster-name" }),
 		workloadCluster:     &types.Cluster{Name: "workload"},
-		managementStatePath: fmt.Sprintf("cluster-state-backup-%s", time.Now().Format("2006-01-02T15_04_05")),
+		managementStatePath: fmt.Sprintf("%s-backup-%s", "cluster-name", time.Now().Format("2006-01-02T15_04_05")),
 	}
 }
 

--- a/pkg/workflows/workload/validate.go
+++ b/pkg/workflows/workload/validate.go
@@ -69,7 +69,7 @@ func (s *setAndValidateUpgradeWorkloadTask) Run(ctx context.Context, commandCont
 		commandContext.SetError(err)
 		return nil
 	}
-	return &upgradeCluster{}
+	return &preClusterUpgrade{}
 }
 
 func (s *setAndValidateUpgradeWorkloadTask) providerValidation(ctx context.Context, commandContext *task.CommandContext) []validations.Validation {

--- a/pkg/workflows/workload/writeclusterconfig.go
+++ b/pkg/workflows/workload/writeclusterconfig.go
@@ -28,6 +28,9 @@ func (s *writeClusterConfig) Run(ctx context.Context, commandContext *task.Comma
 	if commandContext.OriginalError == nil {
 		logger.MarkSuccess(successMsg)
 	}
+	if commandContext.CurrentClusterSpec != nil {
+		return &postClusterUpgrade{}
+	}
 	return nil
 }
 
@@ -42,5 +45,8 @@ func (s *writeClusterConfig) Checkpoint() *task.CompletedTask {
 }
 
 func (s *writeClusterConfig) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	if commandContext.CurrentClusterSpec == nil {
+		return &postClusterUpgrade{}, nil
+	}
 	return nil, nil
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/6797

*Description of changes:*
Run CAPI Backup on workload cluster during upgrade.
With this change, 
- Management cluster's backup would be under <management-cluster-name>/<management-cluster-name>-backup-<current-time> directory. 
- Workload cluster's backup would be under <management-cluster-name>/<workload-cluster-name>-backup-<current-time> directory. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

