### PR TITLE
Setting the right permission for ssh config

### DIFF
--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -349,6 +349,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="RHEL" lang="bash" >}}
@@ -358,6 +359,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="Amazon Linux 2" lang="bash" >}}
@@ -367,6 +369,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< /tabpane >}}
@@ -493,6 +496,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="RHEL" lang="bash" >}}
@@ -505,6 +509,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="Amazon Linux" lang="bash" >}}
@@ -517,6 +522,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< /tabpane >}}
@@ -634,6 +640,7 @@ These steps use `image-builder` to create a RHEL-based image for CloudStack. Bef
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="RHEL" lang="bash" >}}
@@ -646,6 +653,7 @@ These steps use `image-builder` to create a RHEL-based image for CloudStack. Bef
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="Amazon Linux" lang="bash" >}}
@@ -658,6 +666,7 @@ These steps use `image-builder` to create a RHEL-based image for CloudStack. Bef
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< /tabpane >}}
@@ -741,6 +750,7 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="RHEL" lang="bash" >}}
@@ -750,6 +760,7 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="Amazon Linux 2" lang="bash" >}}
@@ -759,6 +770,7 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< /tabpane >}}
@@ -897,6 +909,7 @@ These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV a
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="RHEL" lang="bash" >}}
@@ -906,6 +919,7 @@ These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV a
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< tab header="Amazon Linux 2" lang="bash" >}}
@@ -915,6 +929,7 @@ These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV a
    mkdir -p /home/$USER/.ssh
    echo "HostKeyAlgorithms +ssh-rsa" >> /home/$USER/.ssh/config
    echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /home/$USER/.ssh/config
+   sudo chmod 600 /home/$USER/.ssh/config
    {{< /tab >}}
 
    {{< /tabpane >}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
By creating the ssh config file, we should set the correct permission for this file, otherwise, the below error would come up with:

```code
*********************************************************
    qemu: fatal: [default]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Bad owner or permissions on /home/image-builder/.ssh/config", "unreachable": true}
    qemu:
    qemu: PLAY RECAP 
```


*Testing (if applicable):*
Yes
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

