### PR TITLE
Use super-admin Kubeconfig for kube-vip from Kubernetes v1.29 onwards

### DIFF
--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -352,6 +352,10 @@ spec:
         else echo "{{$dir}} already symlnk";
       fi
 {{- end}}
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
+{{- if (ge (atoi $kube_minor_version) 29) }}
+    - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+{{- end }}
 {{- if .cloudstackControlPlaneDiskOfferingProvided }}
     diskSetup:
       filesystems:

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -325,6 +325,10 @@ spec:
       - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >> /etc/hosts
     postKubeadmCommands:
       - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
+{{- if (ge (atoi $kube_minor_version) 29) }}
+      - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+{{- end }}
     useExperimentalRetryJoin: true
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/snow/objects_test.go
+++ b/pkg/providers/snow/objects_test.go
@@ -53,7 +53,7 @@ func TestControlPlaneObjects(t *testing.T) {
 	wantMachineTemplateName := "test-cp-2"
 	mt.SetName(wantMachineTemplateName)
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
-	kcp := wantKubeadmControlPlane()
+	kcp := wantKubeadmControlPlane("1.21")
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
@@ -117,7 +117,7 @@ func TestControlPlaneObjectsWithIPPools(t *testing.T) {
 	wantMachineTemplateName := "test-cp-2"
 	mt.SetName(wantMachineTemplateName)
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
-	kcp := wantKubeadmControlPlane()
+	kcp := wantKubeadmControlPlane("1.21")
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = wantMachineTemplateName
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
@@ -273,7 +273,7 @@ func TestControlPlaneObjectsOldControlPlaneNotExists(t *testing.T) {
 
 	mt.SetName("snow-test-control-plane-1")
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
-	kcp := wantKubeadmControlPlane()
+	kcp := wantKubeadmControlPlane("1.21")
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)
@@ -306,7 +306,7 @@ func TestControlPlaneObjectsOldMachineTemplateNotExists(t *testing.T) {
 
 	mt.SetName("snow-test-control-plane-1")
 	mt.Spec.Template.Spec.InstanceType = "sbe-c.large"
-	kcp := wantKubeadmControlPlane()
+	kcp := wantKubeadmControlPlane("1.21")
 	kcp.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
 
 	got, err := snow.ControlPlaneObjects(g.ctx, g.logger, g.clusterSpec, g.kubeconfigClient)

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -86,77 +86,149 @@ func givenClusterSpec() *cluster.Spec {
 		s.SnowCredentialsSecret = wantEksaCredentialsSecret()
 		s.SnowMachineConfigs = givenMachineConfigs()
 		s.SnowIPPools = givenIPPools()
-		s.VersionsBundles["1.21"] = givenVersionsBundle()
+		s.VersionsBundles["1.21"] = givenVersionsBundle("1.21")
+		s.VersionsBundles["1.29"] = givenVersionsBundle("1.29")
 		s.ManagementCluster = givenManagementCluster()
 	})
 }
 
-func givenVersionsBundle() *cluster.VersionsBundle {
-	return &cluster.VersionsBundle{
-		KubeDistro: &cluster.KubeDistro{
-			Kubernetes: cluster.VersionedRepository{
-				Repository: "public.ecr.aws/eks-distro/kubernetes",
-				Tag:        "v1.21.5-eks-1-21-9",
-			},
-			CoreDNS: cluster.VersionedRepository{
-				Repository: "public.ecr.aws/eks-distro/coredns",
-				Tag:        "v1.8.4-eks-1-21-9",
-			},
-			Etcd: cluster.VersionedRepository{
-				Repository: "public.ecr.aws/eks-distro/etcd-io",
-				Tag:        "v3.4.16-eks-1-21-9",
-			},
-			EtcdImage: releasev1alpha1.Image{
-				URI: "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
-			},
-			Pause: releasev1alpha1.Image{
-				URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
-			},
-			EtcdVersion: "3.4.16",
-			EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
-		},
-		VersionsBundle: &releasev1alpha1.VersionsBundle{
-			KubeVersion: "1.21",
-			Snow: releasev1alpha1.SnowBundle{
-				Version: "v1.0.2",
-				KubeVip: releasev1alpha1.Image{
-					Name:        "kube-vip",
-					OS:          "linux",
-					URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
-					ImageDigest: "sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1",
-					Description: "Container image for kube-vip image",
-					Arch:        []string{"amd64"},
+func givenVersionsBundle(kubeVersion v1alpha1.KubernetesVersion) *cluster.VersionsBundle {
+	switch kubeVersion {
+	case "1.21":
+		return &cluster.VersionsBundle{
+			KubeDistro: &cluster.KubeDistro{
+				Kubernetes: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/kubernetes",
+					Tag:        "v1.21.5-eks-1-21-9",
 				},
-				Manager: releasev1alpha1.Image{
-					Name:        "cluster-api-snow-controller",
-					OS:          "linux",
-					URI:         "public.ecr.aws/l0g8r8j6/aws/cluster-api-provider-aws-snow/manager:v0.1.4-eks-a-v0.0.0-dev-build.2216",
-					ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
-					Description: "Container image for cluster-api-snow-controller image",
-					Arch:        []string{"amd64"},
+				CoreDNS: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/coredns",
+					Tag:        "v1.8.4-eks-1-21-9",
 				},
-				BottlerocketBootstrapSnow: releasev1alpha1.Image{
-					Name:        "bottlerocket-bootstrap-snow",
-					OS:          "linux",
-					URI:         "public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow:v1-20-22-eks-a-v0.0.0-dev-build.4984",
-					ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
-					Description: "Container image for bottlerocket-bootstrap-snow image",
-					Arch:        []string{"amd64"},
+				Etcd: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/etcd-io",
+					Tag:        "v3.4.16-eks-1-21-9",
+				},
+				EtcdImage: releasev1alpha1.Image{
+					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:0.0.1",
+				},
+				Pause: releasev1alpha1.Image{
+					URI: "public.ecr.aws/eks-distro/kubernetes/pause:0.0.1",
+				},
+				EtcdVersion: "3.4.16",
+				EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz",
+			},
+			VersionsBundle: &releasev1alpha1.VersionsBundle{
+				KubeVersion: "1.21",
+				Snow: releasev1alpha1.SnowBundle{
+					Version: "v1.0.2",
+					KubeVip: releasev1alpha1.Image{
+						Name:        "kube-vip",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
+						ImageDigest: "sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1",
+						Description: "Container image for kube-vip image",
+						Arch:        []string{"amd64"},
+					},
+					Manager: releasev1alpha1.Image{
+						Name:        "cluster-api-snow-controller",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/aws/cluster-api-provider-aws-snow/manager:v0.1.4-eks-a-v0.0.0-dev-build.2216",
+						ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
+						Description: "Container image for cluster-api-snow-controller image",
+						Arch:        []string{"amd64"},
+					},
+					BottlerocketBootstrapSnow: releasev1alpha1.Image{
+						Name:        "bottlerocket-bootstrap-snow",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow:v1-20-22-eks-a-v0.0.0-dev-build.4984",
+						ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
+						Description: "Container image for bottlerocket-bootstrap-snow image",
+						Arch:        []string{"amd64"},
+					},
+				},
+				BottleRocketHostContainers: releasev1alpha1.BottlerocketHostContainersBundle{
+					Admin: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+					},
+					Control: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+					},
+					KubeadmBootstrap: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+					},
 				},
 			},
-			BottleRocketHostContainers: releasev1alpha1.BottlerocketHostContainersBundle{
-				Admin: releasev1alpha1.Image{
-					URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+		}
+	case "1.29":
+		return &cluster.VersionsBundle{
+			KubeDistro: &cluster.KubeDistro{
+				Kubernetes: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/kubernetes",
+					Tag:        "v1.29.0-eks-1-29-3",
 				},
-				Control: releasev1alpha1.Image{
-					URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+				CoreDNS: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/coredns",
+					Tag:        "v1.11.1-eks-1-29-3",
 				},
-				KubeadmBootstrap: releasev1alpha1.Image{
-					URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+				Etcd: cluster.VersionedRepository{
+					Repository: "public.ecr.aws/eks-distro/etcd-io",
+					Tag:        "v3.5.10-eks-1-29-3",
+				},
+				EtcdImage: releasev1alpha1.Image{
+					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.10-eks-1-29-3",
+				},
+				EtcdURL:     "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/3/artifacts/etcd/v3.5.10/etcd-linux-amd64-v3.5.10.tar.gz",
+				EtcdVersion: "3.5.10",
+				Pause: releasev1alpha1.Image{
+					URI: "public.ecr.aws/eks-distro/kubernetes/pause:v1.29.0-eks-1-29-3",
 				},
 			},
-		},
+			VersionsBundle: &releasev1alpha1.VersionsBundle{
+				KubeVersion: "1.29",
+				Snow: releasev1alpha1.SnowBundle{
+					Version: "v1.0.2",
+					KubeVip: releasev1alpha1.Image{
+						Name:        "kube-vip",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.7-eks-a-v0.0.0-dev-build.1433",
+						ImageDigest: "sha256:cf324971db7696810effd5c6c95e34b2c115893e1fbcaeb8877355dc74768ef1",
+						Description: "Container image for kube-vip image",
+						Arch:        []string{"amd64"},
+					},
+					Manager: releasev1alpha1.Image{
+						Name:        "cluster-api-snow-controller",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/aws/cluster-api-provider-aws-snow/manager:v0.1.4-eks-a-v0.0.0-dev-build.2216",
+						ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
+						Description: "Container image for cluster-api-snow-controller image",
+						Arch:        []string{"amd64"},
+					},
+					BottlerocketBootstrapSnow: releasev1alpha1.Image{
+						Name:        "bottlerocket-bootstrap-snow",
+						OS:          "linux",
+						URI:         "public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow:v1-20-22-eks-a-v0.0.0-dev-build.4984",
+						ImageDigest: "sha256:59da9c726c4816c29d119e77956c6391e2dff451daf36aeb60e5d6425eb88018",
+						Description: "Container image for bottlerocket-bootstrap-snow image",
+						Arch:        []string{"amd64"},
+					},
+				},
+				BottleRocketHostContainers: releasev1alpha1.BottlerocketHostContainersBundle{
+					Admin: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-admin:0.0.1",
+					},
+					Control: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-control:0.0.1",
+					},
+					KubeadmBootstrap: releasev1alpha1.Image{
+						URI: "public.ecr.aws/eks-anywhere/bottlerocket-bootstrap:0.0.1",
+					},
+				},
+			},
+		}
 	}
+
+	return nil
 }
 
 func givenManagementComponents() *cluster.ManagementComponents {
@@ -738,7 +810,7 @@ func TestGenerateCAPISpecForUpgrade(t *testing.T) {
 
 func TestGenerateCAPISpecForUpgradeWorkerVersion(t *testing.T) {
 	tt := newSnowTest(t)
-	workerVersionsBundle := givenVersionsBundle()
+	workerVersionsBundle := givenVersionsBundle("1.21")
 	workerVersionsBundle.KubeDistro.Kubernetes.Tag = "v1.20.2-eks-1-20-7"
 	tt.clusterSpec.VersionsBundles["1.20"] = workerVersionsBundle
 	nodeGroups := tt.clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -395,13 +395,19 @@ spec:
       - {{ . }}
       {{- end }}
 {{- end }}
-{{- if and (or .proxyConfig .registryMirrorMap) (ne .format "bottlerocket") }}
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
+{{- if and (or .registryMirrorMap .proxyConfig (ge (atoi $kube_minor_version) 29)) (ne .format "bottlerocket") }}
     preKubeadmCommands:
 {{- if .registryMirrorMap }}
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
 {{- end}}
+{{- if (or .registryMirrorMap .proxyConfig) }}
     - sudo systemctl daemon-reload
     - sudo systemctl restart containerd
+{{- end}}
+{{- if (ge (atoi $kube_minor_version) 29) }}
+    - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+{{- end }}
 {{- end }}
     users:
     - name: {{.controlPlaneSshUsername}}

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -472,6 +472,10 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
     - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
+{{- if and (ge (atoi $kube_minor_version) 29) (ne .format "bottlerocket") }}
+    - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+{{- end }}
     useExperimentalRetryJoin: true
     users:
     - name: {{.controlPlaneSshUsername}}


### PR DESCRIPTION
Before Kubernetes v1.29, the default Kubeconfig file `admin.conf` generated by `kubeadm` was bound to `system:masters` Group. In Kubernetes v1.29, a [change](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#no-really-you-must-read-this-before-you-upgrade) was made to `kubeadm` to provision a separate Kubeconfig file called `super-admin.conf` which is a break-glass Group that can bypass RBAC, and in addition, scoping down the `admin.conf` User's access to the permissions provided by the `cluster-admin` `ClusterRole`. It is to be noted that in a multi-cluster setup, the `super-admin.conf` is only created on the primary control plane node, which runs `kubeadm init`. This causes a bootstrap issue with EKS-A's `kube-vip` deployment because the static pod manifest is hardcoded to use `admin.conf` but `kube-vip` requires elevated permissions to access the API server during cluster initialization, which are available only when using the `super-admin.conf`. 

This [issue](https://github.com/kube-vip/kube-vip/issues/684) was first reported by CAPV maintainers in Kubernetes Slack `kube-vip` channel ([Initial issue report](https://kubernetes.slack.com/archives/C01RXPHDATB/p1703061589086269), [Workarounds discussion](https://kubernetes.slack.com/archives/C01RXPHDATB/p1704643142829679)) when they were trying to add Kubernetes v1.29 support. Since then, the CAPV maintainers have found a [workaround](https://github.com/kube-vip/kube-vip/issues/684#issuecomment-1864855405) that involves using the `super-admin.conf` only for `kubeadm init` and then migrating to using the `admin.conf` after the cluster has been initialized. This PR basically ports the workaround to our cluster templates for EKS-A's `kube-vip` deployment to work with Kubernetes v1.29.

This is similar to the [logic](https://github.com/aws/eks-anywhere-build-tooling/pull/2863) we added to the Bottlerocket kubeadm-bootstrap host container to fix the same issue for clusters using Bottlerocket nodes.

```console
$ kubectl --kubeconfig vsphere-1-29-test-ubuntu/vsphere-1-29-test-ubuntu-eks-a-cluster.kubeconfig get nodes -o wide       
NAME                                        STATUS   ROLES           AGE   VERSION               INTERNAL-IP     EXTERNAL-IP     OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
vsphere-1-29-test-ubuntu-4nwtt              Ready    control-plane   19h   v1.29.0-eks-a5ec690   196.18.91.211   196.18.91.211   Ubuntu 20.04.6 LTS   5.4.0-170-generic   containerd://1.7.12-0-g71909c181
vsphere-1-29-test-ubuntu-fptnj              Ready    control-plane   19h   v1.29.0-eks-a5ec690   196.18.96.242   196.18.96.242   Ubuntu 20.04.6 LTS   5.4.0-170-generic   containerd://1.7.12-0-g71909c181
vsphere-1-29-test-ubuntu-md-0-vwxjf-rg6b7   Ready    <none>          19h   v1.29.0-eks-a5ec690   196.18.34.251   196.18.34.251   Ubuntu 20.04.6 LTS   5.4.0-170-generic   containerd://1.7.12-0-g71909c181
```

References:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

