### PR TITLE
Add controlplane spec field in CPUpgrade

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_controlplaneupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_controlplaneupgrades.yaml
@@ -74,6 +74,14 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              controlPlaneSpecData:
+                description: ControlPlaneSpecData contains base64 encoded KCP spec
+                  that's used to update the statuses of CAPI objects once the control
+                  plane upgrade is done. This field is needed so that we have a static
+                  copy of the control plane spec in case it gets modified after the
+                  ControlPlaneUpgrade was created, as ControlPlane is a reference
+                  to the object in real time.
+                type: string
               etcdVersion:
                 description: EtcdVersion refers to the version of ETCD to upgrade
                   to.
@@ -148,6 +156,7 @@ spec:
                 type: array
             required:
             - controlPlane
+            - controlPlaneSpecData
             - etcdVersion
             - kubernetesVersion
             - machinesRequireUpgrade

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4452,6 +4452,14 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              controlPlaneSpecData:
+                description: ControlPlaneSpecData contains base64 encoded KCP spec
+                  that's used to update the statuses of CAPI objects once the control
+                  plane upgrade is done. This field is needed so that we have a static
+                  copy of the control plane spec in case it gets modified after the
+                  ControlPlaneUpgrade was created, as ControlPlane is a reference
+                  to the object in real time.
+                type: string
               etcdVersion:
                 description: EtcdVersion refers to the version of ETCD to upgrade
                   to.
@@ -4526,6 +4534,7 @@ spec:
                 type: array
             required:
             - controlPlane
+            - controlPlaneSpecData
             - etcdVersion
             - kubernetesVersion
             - machinesRequireUpgrade

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -2,6 +2,8 @@ package controllers_test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -108,6 +110,9 @@ func TestKCPReconcileCreateControlPlaneUpgrade(t *testing.T) {
 	g.Expect(len(cpu.Spec.MachinesRequireUpgrade)).To(BeEquivalentTo(len(kcpObjs.cpUpgrade.Spec.MachinesRequireUpgrade)))
 	g.Expect(cpu.Spec.EtcdVersion).To(BeEquivalentTo(kcpObjs.cpUpgrade.Spec.EtcdVersion))
 	g.Expect(cpu.Spec.KubernetesVersion).To(BeEquivalentTo(kcpObjs.cpUpgrade.Spec.KubernetesVersion))
+	kcpSpec, err := json.Marshal(kcpObjs.kcp.Spec)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cpu.Spec.ControlPlaneSpecData).To(BeEquivalentTo(base64.StdEncoding.EncodeToString(kcpSpec)))
 }
 
 func TestKCPReconcileControlPlaneUpgradeReady(t *testing.T) {

--- a/pkg/api/v1alpha1/controlplaneupgrade_types.go
+++ b/pkg/api/v1alpha1/controlplaneupgrade_types.go
@@ -21,6 +21,13 @@ type ControlPlaneUpgradeSpec struct {
 
 	// EtcdVersion refers to the version of ETCD to upgrade to.
 	EtcdVersion string `json:"etcdVersion"`
+
+	// ControlPlaneSpecData contains base64 encoded KCP spec that's used to update
+	// the statuses of CAPI objects once the control plane upgrade is done.
+	// This field is needed so that we have a static copy of the control plane spec
+	// in case it gets modified after the ControlPlaneUpgrade was created,
+	// as ControlPlane is a reference to the object in real time.
+	ControlPlaneSpecData string `json:"controlPlaneSpecData"`
 }
 
 // ControlPlaneUpgradeStatus defines the observed state of ControlPlaneUpgrade.


### PR DESCRIPTION
*Description of changes:*
Add `ControlPlaneSpec` field in CPUpgrade which will store the base64 encoded KCP.Spec
This field is needed to update the CAPI objects to the desired state so CAPI and KCP controllers can determine that the in-place upgrade is complete.
This PR also uses this field to update the control plane machine annotation `controlplane.cluster.x-k8s.io/kubeadm-cluster-configuration` with the updated kubeadmClusterConfig.

This new field is needed because if we try to fetch the kcp.spec from the controlPlane ref, we get a dynamic copy of the the spec. It's possible that the KCP object was modified after the `ControlPlaneUpgrade` object was created. In cases like this, we need a static copy of KCP.Spec so we can update the relevant objects with the KCP.Spec values that were there when the `ControlPlaneUpgrade` object was created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

