### PR TITLE
Move image signing to staging release and copy sinatures from staging to prod account

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -196,10 +196,20 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			err = operations.SignImagesNotation(releaseConfig, imageDigests)
-			if err != nil {
-				fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
-				os.Exit(1)
+			if bundleRelease && releaseEnvironment == "development" {
+				err = operations.SignImagesNotation(releaseConfig, imageDigests)
+				if err != nil {
+					fmt.Printf("Error signing container images using notation CLI and AWS Signer: %v\n", err)
+					os.Exit(1)
+				}
+			}
+
+			if bundleRelease && releaseEnvironment == "production" {
+				err = operations.CopyImageSignatureUsingOras(releaseConfig, imageDigests)
+				if err != nil {
+					fmt.Printf("Error copying image signature: %v\n", err)
+					os.Exit(1)
+				}
 			}
 
 			err = operations.GenerateBundleSpec(releaseConfig, bundle, imageDigests)


### PR DESCRIPTION
*Description of changes:*
Move image signing feature to staging release and copy signatures from staging to prod account during prod bundle release.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

