### PR TITLE
Update KubeadmConfig for cp machines when upgrade is complete

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -7145,6 +7145,16 @@ rules:
 - apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
+  - kubeadmconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
   - kubeadmconfigtemplates
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -233,6 +233,16 @@ rules:
 - apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
+  - kubeadmconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
   - kubeadmconfigtemplates
   verbs:
   - create

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -187,11 +187,13 @@ func getObjectsForKCP() kcpObjects {
 	node1 := generateNode()
 	node2 := node1.DeepCopy()
 	node2.ObjectMeta.Name = "node02"
-	machine1 := generateMachine(cluster, node1)
+	kubeadmConfig1 := generateKubeadmConfig()
+	kubeadmConfig2 := generateKubeadmConfig()
+	machine1 := generateMachine(cluster, node1, kubeadmConfig1)
 	machine1.Labels = map[string]string{
 		"cluster.x-k8s.io/control-plane-name": kcp.Name,
 	}
-	machine2 := generateMachine(cluster, node2)
+	machine2 := generateMachine(cluster, node2, kubeadmConfig2)
 	machine2.ObjectMeta.Name = "machine02"
 	machine2.Labels = map[string]string{
 		"cluster.x-k8s.io/control-plane-name": kcp.Name,
@@ -238,13 +240,13 @@ func generateKCP(name string) *controlplanev1.KubeadmControlPlane {
 					Etcd: bootstrapv1.Etcd{
 						Local: &bootstrapv1.LocalEtcd{
 							ImageMeta: bootstrapv1.ImageMeta{
-								ImageTag: "v3.5.9-eks-1-28-9",
+								ImageTag: etcd129,
 							},
 						},
 					},
 				},
 			},
-			Version: "v1.28.3-eks-1-28-9",
+			Version: k8s129,
 		},
 	}
 }

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -155,7 +155,8 @@ func getObjectsForMD() mdObjects {
 		Kind:       "MachineDeployment",
 	}
 	node := generateNode()
-	machine := generateMachine(cluster, node)
+	kubeadmConfig := generateKubeadmConfig()
+	machine := generateMachine(cluster, node, kubeadmConfig)
 	machine.Labels = map[string]string{
 		"cluster.x-k8s.io/deployment-name": md.Name,
 	}

--- a/controllers/machinedeploymentupgrade_controller_test.go
+++ b/controllers/machinedeploymentupgrade_controller_test.go
@@ -144,7 +144,8 @@ func TestMDUpgradeObjectDoesNotExist(t *testing.T) {
 func getObjectsForMDUpgradeTest() (*clusterv1.Cluster, *clusterv1.Machine, *corev1.Node, *anywherev1.MachineDeploymentUpgrade, *anywherev1.NodeUpgrade) {
 	cluster := generateCluster()
 	node := generateNode()
-	machine := generateMachine(cluster, node)
+	kubeadmConfig := generateKubeadmConfig()
+	machine := generateMachine(cluster, node, kubeadmConfig)
 	nodeUpgrade := generateNodeUpgrade(machine)
 	mdUpgrade := generateMDUpgrade(machine)
 	return cluster, machine, node, mdUpgrade, nodeUpgrade


### PR DESCRIPTION
*Description of changes:*
KCP controller expects `KubeadmConfig` corresponding to each control plane machine to match `KCP.Spec.KubeadmConfig` for a machine to be considered "UpToDate".

This PR updates the `KubeadmConfig` for each control plane machine as the in-place upgrade is done for that machine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

