### PR TITLE
Extend vsphere provider api surface to use  management component

### DIFF
--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1200,6 +1200,40 @@ func (p *vsphereProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.
 	}
 }
 
+// ChangeDiffFromManagementComponents returns the component change diff for the provider.
+func (p *vsphereProvider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+	if currentComponents.VSphere.Version == newComponents.VSphere.Version {
+		return nil
+	}
+
+	return &types.ComponentChangeDiff{
+		ComponentName: constants.VSphereProviderName,
+		NewVersion:    newComponents.VSphere.Version,
+		OldVersion:    currentComponents.VSphere.Version,
+	}
+}
+
+// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle for the provider.
+func (p *vsphereProvider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+	folderName := fmt.Sprintf("infrastructure-vsphere/%s/", components.VSphere.Version)
+
+	infraBundle := types.InfrastructureBundle{
+		FolderName: folderName,
+		Manifests: []releasev1alpha1.Manifest{
+			components.VSphere.Components,
+			components.VSphere.Metadata,
+			components.VSphere.ClusterTemplate,
+		},
+	}
+
+	return &infraBundle
+}
+
+// VersionFromManagementComponents returns the version of the provider.
+func (p *vsphereProvider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+	return components.VSphere.Version
+}
+
 func (p *vsphereProvider) RunPostControlPlaneUpgrade(_ context.Context, _ *cluster.Spec, _ *cluster.Spec, _ *types.Cluster, _ *types.Cluster) error {
 	return nil
 }

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -230,6 +230,32 @@ func givenEmptyClusterSpec() *cluster.Spec {
 	})
 }
 
+func givenManagementComponents() *cluster.ManagementComponents {
+	return &cluster.ManagementComponents{
+		VSphere: releasev1alpha1.VSphereBundle{
+			Version: "v0.7.8",
+			ClusterAPIController: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v0.7.8-35f54b0a7ff0f4f3cb0b8e30a0650acd0e55496a",
+			},
+			Manager: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.18.1-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
+			},
+			KubeVip: releasev1alpha1.Image{
+				URI: "public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.3.2-2093eaeda5a4567f0e516d652e0b25b1d7abc774",
+			},
+			Metadata: releasev1alpha1.Manifest{
+				URI: "Metadata.yaml",
+			},
+			Components: releasev1alpha1.Manifest{
+				URI: "Components.yaml",
+			},
+			ClusterTemplate: releasev1alpha1.Manifest{
+				URI: "ClusterTemplate.yaml",
+			},
+		},
+	}
+}
+
 func givenDatacenterConfig(t *testing.T, fileName string) *v1alpha1.VSphereDatacenterConfig {
 	datacenterConfig, err := v1alpha1.GetVSphereDatacenterConfig(path.Join(testDataDir, fileName))
 	if err != nil {
@@ -1813,6 +1839,19 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestVersionFromManagementComponents(t *testing.T) {
+	vSphereProviderVersion := "v0.7.10"
+	provider := givenProvider(t)
+	managementComponents := givenManagementComponents()
+	managementComponents.VSphere.Version = vSphereProviderVersion
+	setupContext(t)
+
+	result := provider.VersionFromManagementComponents(managementComponents)
+	if result != vSphereProviderVersion {
+		t.Fatalf("Unexpected version expected <%s> actual=<%s>", vSphereProviderVersion, result)
+	}
+}
+
 func TestProviderBootstrapSetup(t *testing.T) {
 	ctx := context.Background()
 	datacenterConfig := givenDatacenterConfig(t, testClusterConfigMainFilename)
@@ -2843,6 +2882,37 @@ func TestGetInfrastructureBundleSuccess(t *testing.T) {
 	}
 }
 
+func TestGetInfrastructureBundleFromManagementComponentsSuccess(t *testing.T) {
+	tests := []struct {
+		testName             string
+		managementComponents *cluster.ManagementComponents
+	}{
+		{
+			testName:             "correct Overrides layer",
+			managementComponents: givenManagementComponents(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			p := givenProvider(t)
+
+			infraBundle := p.GetInfrastructureBundleFromManagementComponents(tt.managementComponents)
+			if infraBundle == nil {
+				t.Fatalf("provider.GetInfrastructureBundle() should have an infrastructure bundle")
+			}
+			assert.Equal(t, "infrastructure-vsphere/v0.7.8/", infraBundle.FolderName, "Incorrect folder name")
+			assert.Equal(t, len(infraBundle.Manifests), 3, "Wrong number of files in the infrastructure bundle")
+			wantManifests := []releasev1alpha1.Manifest{
+				tt.managementComponents.VSphere.Components,
+				tt.managementComponents.VSphere.Metadata,
+				tt.managementComponents.VSphere.ClusterTemplate,
+			}
+			assert.ElementsMatch(t, infraBundle.Manifests, wantManifests, "Incorrect manifests")
+		})
+	}
+}
+
 func TestGetDatacenterConfig(t *testing.T) {
 	tt := newProviderTest(t)
 
@@ -3068,6 +3138,12 @@ func TestChangeDiffNoChange(t *testing.T) {
 	assert.Nil(t, provider.ChangeDiff(clusterSpec, clusterSpec))
 }
 
+func TestChangeDiffFromManagementComponentsNoChange(t *testing.T) {
+	provider := givenProvider(t)
+	managementComponents := givenManagementComponents()
+	assert.Nil(t, provider.ChangeDiffFromManagementComponents(managementComponents, managementComponents))
+}
+
 func TestChangeDiffWithChange(t *testing.T) {
 	provider := givenProvider(t)
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
@@ -3084,6 +3160,23 @@ func TestChangeDiffWithChange(t *testing.T) {
 	}
 
 	assert.Equal(t, wantDiff, provider.ChangeDiff(clusterSpec, newClusterSpec))
+}
+
+func TestChangeDiffFromManagementComponentsWithChange(t *testing.T) {
+	provider := givenProvider(t)
+	managementComponents := givenManagementComponents()
+	managementComponents.VSphere.Version = "v0.3.18"
+
+	newManagementComponents := givenManagementComponents()
+	newManagementComponents.VSphere.Version = "v0.3.19"
+
+	wantDiff := &types.ComponentChangeDiff{
+		ComponentName: "vsphere",
+		NewVersion:    "v0.3.19",
+		OldVersion:    "v0.3.18",
+	}
+
+	assert.Equal(t, wantDiff, provider.ChangeDiffFromManagementComponents(managementComponents, newManagementComponents))
 }
 
 func TestVsphereProviderRunPostControlPlaneUpgrade(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR extends the vsphere provider api surface to use management component to gradually introduce the changes outlined in https://github.com/aws/eks-anywhere/pull/7353, split out into multiple.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

