### PR TITLE
Install CAPI task for controller via CLI

### DIFF
--- a/pkg/workflows/management/create_bootstrap.go
+++ b/pkg/workflows/management/create_bootstrap.go
@@ -25,7 +25,7 @@ func (s *createBootStrapClusterTask) Run(ctx context.Context, commandContext *ta
 	}
 	commandContext.BootstrapCluster = bootstrapCluster
 
-	return nil
+	return &installCAPIComponentsTask{}
 }
 
 func (s *createBootStrapClusterTask) Name() string {

--- a/pkg/workflows/management/create_install_capi.go
+++ b/pkg/workflows/management/create_install_capi.go
@@ -1,0 +1,45 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+)
+
+type installCAPIComponentsTask struct{}
+
+func (s *installCAPIComponentsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Provider specific pre-capi-install-setup on bootstrap cluster")
+	if err := commandContext.Provider.PreCAPIInstallOnBootstrap(ctx, commandContext.BootstrapCluster, commandContext.ClusterSpec); err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	logger.Info("Installing cluster-api providers on bootstrap cluster")
+	if err := commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider); err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	logger.Info("Provider specific post-setup")
+	if err := commandContext.Provider.PostBootstrapSetup(ctx, commandContext.ClusterSpec.Cluster, commandContext.BootstrapCluster); err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	return nil
+}
+
+func (s *installCAPIComponentsTask) Name() string {
+	return "install-capi-components-bootstrap"
+}
+
+func (s *installCAPIComponentsTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *installCAPIComponentsTask) Checkpoint() *task.CompletedTask {
+	return nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The original https://github.com/aws/eks-anywhere/pull/7110 is being split into smaller PRs. This PR is to install CAPI on bootstrap cluster.

*Testing (if applicable):*
- unit tests

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

