### PR TITLE
Add logic to get management components for cluster

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1299,6 +1299,14 @@ func (c *Cluster) ControlPlaneAnnotation() string {
 	return controlPlaneAnnotation
 }
 
+// ManagementComponentsVersion returns `management-components version`annotation value on the Cluster object.
+func (c *Cluster) ManagementComponentsVersion() string {
+	if c.Annotations == nil {
+		return ""
+	}
+	return c.Annotations[managementComponentsVersionAnnotation]
+}
+
 // SetManagementComponentsVersion sets the `management-components version` annotation on the Cluster object.
 func (c *Cluster) SetManagementComponentsVersion(version string) {
 	if c.IsManaged() {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -3263,3 +3263,40 @@ func TestCluster_SetManagmentComponentsVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestCluster_ManagementComponentsVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         *v1alpha1.Cluster
+		expectedVersion string
+	}{
+		{
+			name: "nil annotation",
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.Annotations = nil
+			}),
+			expectedVersion: "",
+		},
+		{
+			name: "empty management component version",
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.SetManagementComponentsVersion("")
+			}),
+			expectedVersion: "",
+		},
+		{
+			name: "existing management component version",
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.SetManagementComponentsVersion("v0.0.0-dev")
+			}),
+			expectedVersion: "v0.0.0-dev",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := tt.cluster.ManagementComponentsVersion()
+			g.Expect(got).To(Equal(tt.expectedVersion))
+		})
+	}
+}

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -15,6 +15,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/cluster/mocks"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -432,4 +433,152 @@ func TestManagementComponentsFromBundles(t *testing.T) {
 	}
 
 	g.Expect(got).To(Equal(want))
+}
+
+func TestGetManagementComponents(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterSpec *cluster.Spec
+		want        *cluster.ManagementComponents
+		wantErr     string
+	}{
+		{
+			name: "no management components version annotation",
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Annotations = nil
+				s.Bundles = &releasev1.Bundles{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bundles-1",
+						Namespace: "my-namespace",
+					},
+					Spec: releasev1.BundlesSpec{
+						VersionsBundles: []releasev1.VersionsBundle{
+							{
+								Eksa: releasev1.EksaBundle{
+									Version: "v0.0.0-dev",
+								},
+							},
+						},
+					},
+				}
+				s.EKSARelease = &releasev1.EKSARelease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "eksa-v0-0-0-dev",
+						Namespace: constants.EksaSystemNamespace,
+					},
+					Spec: releasev1.EKSAReleaseSpec{
+						BundlesRef: releasev1.BundlesRef{
+							Name:      "bundles-1",
+							Namespace: "my-namespace",
+						},
+					},
+				}
+			}),
+			want: &cluster.ManagementComponents{
+				Eksa: releasev1.EksaBundle{
+					Version: "v0.0.0-dev",
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "no management components version annotation and eksa version",
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				s.Cluster.Annotations = nil
+				s.Cluster.Spec.EksaVersion = nil
+			}),
+			want:    nil,
+			wantErr: "either management components version or cluster's EksaVersion need to be set",
+		},
+		{
+			name: "with management components version annotation",
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				eksaVersion := test.DevEksaVersion()
+				s.Cluster.Spec.EksaVersion = &eksaVersion
+				s.Cluster.SetManagementComponentsVersion("v0.0.1-dev")
+				s.Bundles = &releasev1.Bundles{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bundles-2",
+						Namespace: "my-namespace",
+					},
+					Spec: releasev1.BundlesSpec{
+						VersionsBundles: []releasev1.VersionsBundle{
+							{
+								Eksa: releasev1.EksaBundle{
+									Version: "v0.0.1-dev",
+								},
+							},
+						},
+					},
+				}
+				s.EKSARelease = &releasev1.EKSARelease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "eksa-v0-0-1-dev",
+						Namespace: constants.EksaSystemNamespace,
+					},
+					Spec: releasev1.EKSAReleaseSpec{
+						BundlesRef: releasev1.BundlesRef{
+							Name:      "bundles-2",
+							Namespace: "my-namespace",
+						},
+					},
+				}
+			}),
+			want: &cluster.ManagementComponents{
+				Eksa: releasev1.EksaBundle{
+					Version: "v0.0.1-dev",
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "eksarelease not found",
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				eksaVersion := test.DevEksaVersion()
+				s.Cluster.Spec.EksaVersion = &eksaVersion
+				s.Cluster.SetManagementComponentsVersion("v0.0.1-dev")
+				s.EKSARelease = &releasev1.EKSARelease{}
+			}),
+			want:    nil,
+			wantErr: "\"eksa-v0-0-1-dev\" not found",
+		},
+		{
+			name: "bundles not found",
+			clusterSpec: test.NewClusterSpec(func(s *cluster.Spec) {
+				eksaVersion := test.DevEksaVersion()
+				s.Cluster.Spec.EksaVersion = &eksaVersion
+				s.Cluster.SetManagementComponentsVersion("v0.0.1-dev")
+				s.EKSARelease = &releasev1.EKSARelease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "eksa-v0-0-1-dev",
+						Namespace: constants.EksaSystemNamespace,
+					},
+					Spec: releasev1.EKSAReleaseSpec{
+						BundlesRef: releasev1.BundlesRef{
+							Name:      "bundles-2",
+							Namespace: "my-namespace",
+						},
+					},
+				}
+			}),
+			want:    nil,
+			wantErr: " \"bundles-2\" not found",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			client := test.NewFakeKubeClient(tt.clusterSpec.Cluster, tt.clusterSpec.Bundles, tt.clusterSpec.EKSARelease)
+
+			vb, err := cluster.GetManagementComponents(ctx, client, tt.clusterSpec.Cluster)
+			if tt.wantErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(vb).To(Equal(tt.want))
+			}
+		})
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This logic was split out from the following PR with some changes to use `ManagementComponents`: https://github.com/aws/eks-anywhere/pull/7353

The notable change since the PR above include the create of a new struct `ManagementComponents` struct to use instead of using the `VersionsBundle` directly, decoupling the rest the business logic that uses it from the API.

Adds logic to retrieve cluster.ManagementComponents from a cluster using a kubernetes client.
- Gets management components version or fallsback to cluster's `EksaVersion` for older clusters.
- Retrieves corresponding **EKSARelease** and **Bundles**
-  Builds **ManagementComponents** from **Bundles** and returns it.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

