### PR TITLE
Change EKSA upgrader to use management components

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -125,8 +125,8 @@ type AwsIamAuth interface {
 
 // EKSAComponents allows to manage the eks-a components installation in a cluster.
 type EKSAComponents interface {
-	Install(ctx context.Context, log logr.Logger, cluster *types.Cluster, spec *cluster.Spec) error
-	Upgrade(ctx context.Context, log logr.Logger, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	Install(ctx context.Context, log logr.Logger, cluster *types.Cluster, managementComponents *cluster.ManagementComponents, spec *cluster.Spec) error
+	Upgrade(ctx context.Context, log logr.Logger, cluster *types.Cluster, currentManagementComponents, newManagementComponents *cluster.ManagementComponents, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 }
 
 type ClusterManagerOpt func(*ClusterManager)
@@ -1087,8 +1087,9 @@ func (c *ClusterManager) removeOldWorkerNodeGroups(ctx context.Context, workload
 	return nil
 }
 
-func (c *ClusterManager) InstallCustomComponents(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
-	if err := c.eksaComponents.Install(ctx, logger.Get(), cluster, clusterSpec); err != nil {
+// InstallCustomComponents installs the eks-a components in a cluster.
+func (c *ClusterManager) InstallCustomComponents(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
+	if err := c.eksaComponents.Install(ctx, logger.Get(), cluster, managementComponents, clusterSpec); err != nil {
 		return err
 	}
 
@@ -1097,8 +1098,8 @@ func (c *ClusterManager) InstallCustomComponents(ctx context.Context, clusterSpe
 }
 
 // Upgrade updates the eksa components in a cluster according to a Spec.
-func (c *ClusterManager) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
-	return c.eksaComponents.Upgrade(ctx, logger.Get(), cluster, currentSpec, newSpec)
+func (c *ClusterManager) Upgrade(ctx context.Context, cluster *types.Cluster, currentManagementComponents, newManagementComponents *cluster.ManagementComponents, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
+	return c.eksaComponents.Upgrade(ctx, logger.Get(), cluster, currentManagementComponents, newManagementComponents, newSpec)
 }
 
 func (c *ClusterManager) CreateEKSANamespace(ctx context.Context, cluster *types.Cluster) error {

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -92,7 +92,7 @@ func TestEKSAInstallerInstallSuccessWithRealManifest(t *testing.T) {
 
 func TestEKSAInstallerInstallFailComponentsDeployment(t *testing.T) {
 	tt := newInstallerTest(t)
-	tt.newSpec.VersionsBundles["1.19"].Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
+	tt.newManagementComponents.Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
 	file, err := os.ReadFile("../../config/manifest/eksa-components.yaml")
 	if err != nil {
 		t.Fatalf("could not read eksa-components")
@@ -104,23 +104,23 @@ func TestEKSAInstallerInstallFailComponentsDeployment(t *testing.T) {
 	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.Any()).Times(expectedObjectCount)
 	tt.client.EXPECT().WaitForDeployment(tt.ctx, tt.cluster, "30m0s", "Available", "eksa-controller-manager", "eksa-system").Return(errors.New("test"))
 
-	err = tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newSpec)
+	err = tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newManagementComponents, tt.newSpec)
 	tt.Expect(err.Error()).To(ContainSubstring("waiting for eksa-controller-manager"))
 }
 
 func TestEKSAInstallerInstallFailComponents(t *testing.T) {
 	tt := newInstallerTest(t)
-	tt.newSpec.VersionsBundles["1.19"].Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
+	tt.newManagementComponents.Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
 
 	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Return(errors.New("test"))
 
-	err := tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newSpec)
+	err := tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newManagementComponents, tt.newSpec)
 	tt.Expect(err.Error()).To(ContainSubstring("applying eksa components"))
 }
 
 func TestEKSAInstallerInstallFailBundles(t *testing.T) {
 	tt := newInstallerTest(t)
-	tt.newSpec.VersionsBundles["1.19"].Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
+	tt.newManagementComponents.Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
 	file, err := os.ReadFile("../../config/manifest/eksa-components.yaml")
 	if err != nil {
 		t.Fatalf("could not read eksa-components")
@@ -135,13 +135,13 @@ func TestEKSAInstallerInstallFailBundles(t *testing.T) {
 	tt.client.EXPECT().WaitForDeployment(tt.ctx, tt.cluster, "30m0s", "Available", "eksa-controller-manager", "eksa-system")
 	tt.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, gomock.Any()).Return(errors.New("test"))
 
-	err = tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newSpec)
+	err = tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newManagementComponents, tt.newSpec)
 	tt.Expect(err.Error()).To(ContainSubstring("applying bundle spec"))
 }
 
 func TestEKSAInstallerInstallFailEKSARelease(t *testing.T) {
 	tt := newInstallerTest(t)
-	tt.newSpec.VersionsBundles["1.19"].Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
+	tt.newManagementComponents.Eksa.Components.URI = "../../config/manifest/eksa-components.yaml"
 	file, err := os.ReadFile("../../config/manifest/eksa-components.yaml")
 	if err != nil {
 		t.Fatalf("could not read eksa-components")
@@ -157,7 +157,7 @@ func TestEKSAInstallerInstallFailEKSARelease(t *testing.T) {
 	tt.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, gomock.Any())
 	tt.client.EXPECT().ApplyKubeSpecFromBytes(tt.ctx, tt.cluster, gomock.Any()).Return(errors.New("test"))
 
-	err = tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newSpec)
+	err = tt.installer.Install(tt.ctx, test.NewNullLogger(), tt.cluster, tt.newManagementComponents, tt.newSpec)
 	tt.Expect(err.Error()).To(ContainSubstring("applying EKSA release spec"))
 }
 

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -972,32 +972,32 @@ func (m *MockEKSAComponents) EXPECT() *MockEKSAComponentsMockRecorder {
 }
 
 // Install mocks base method.
-func (m *MockEKSAComponents) Install(arg0 context.Context, arg1 logr.Logger, arg2 *types.Cluster, arg3 *cluster.Spec) error {
+func (m *MockEKSAComponents) Install(arg0 context.Context, arg1 logr.Logger, arg2 *types.Cluster, arg3 *cluster.ManagementComponents, arg4 *cluster.Spec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Install indicates an expected call of Install.
-func (mr *MockEKSAComponentsMockRecorder) Install(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockEKSAComponentsMockRecorder) Install(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockEKSAComponents)(nil).Install), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockEKSAComponents)(nil).Install), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Upgrade mocks base method.
-func (m *MockEKSAComponents) Upgrade(arg0 context.Context, arg1 logr.Logger, arg2 *types.Cluster, arg3, arg4 *cluster.Spec) (*types.ChangeDiff, error) {
+func (m *MockEKSAComponents) Upgrade(arg0 context.Context, arg1 logr.Logger, arg2 *types.Cluster, arg3, arg4 *cluster.ManagementComponents, arg5 *cluster.Spec) (*types.ChangeDiff, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*types.ChangeDiff)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockEKSAComponentsMockRecorder) Upgrade(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockEKSAComponentsMockRecorder) Upgrade(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockEKSAComponents)(nil).Upgrade), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockEKSAComponents)(nil).Upgrade), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // MockKubernetesClient is a mock of KubernetesClient interface.

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -346,7 +346,8 @@ func (s *MoveClusterManagementTask) Checkpoint() *task.CompletedTask {
 func (s *InstallEksaComponentsTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	if commandContext.ClusterSpec.Cluster.IsSelfManaged() {
 		logger.Info("Installing EKS-A custom components (CRD and controller) on workload cluster")
-		err := commandContext.ClusterManager.InstallCustomComponents(ctx, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
+		managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+		err := commandContext.ClusterManager.InstallCustomComponents(ctx, managementComponents, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
 		if err != nil {
 			commandContext.SetError(err)
 			return &CollectDiagnosticsTask{}

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -194,9 +194,10 @@ func (c *createTestSetup) skipMoveManagement() {
 }
 
 func (c *createTestSetup) expectInstallEksaComponents() {
+	managementComponents := cluster.ManagementComponentsFromBundles(c.clusterSpec.Bundles)
 	gomock.InOrder(
 		c.clusterManager.EXPECT().InstallCustomComponents(
-			c.ctx, c.clusterSpec, c.workloadCluster, c.provider),
+			c.ctx, managementComponents, c.clusterSpec, c.workloadCluster, c.provider),
 
 		c.eksd.EXPECT().InstallEksdCRDs(c.ctx, c.clusterSpec, c.workloadCluster),
 
@@ -225,9 +226,10 @@ func (c *createTestSetup) expectInstallEksaComponents() {
 }
 
 func (c *createTestSetup) skipInstallEksaComponents() {
+	managementComponents := cluster.ManagementComponentsFromBundles(c.clusterSpec.Bundles)
 	gomock.InOrder(
 		c.clusterManager.EXPECT().InstallCustomComponents(
-			c.ctx, c.clusterSpec, c.workloadCluster, c.provider).Times(0),
+			c.ctx, managementComponents, c.clusterSpec, c.workloadCluster, c.provider).Times(0),
 
 		c.eksd.EXPECT().InstallEksdCRDs(c.ctx, c.clusterSpec, c.workloadCluster).Times(0),
 
@@ -323,6 +325,7 @@ func TestCreateRunSuccess(t *testing.T) {
 func TestCreateRunInstallEksaComponentsBuildClientFailure(t *testing.T) {
 	wantError := errors.New("test error")
 	test := newCreateTest(t)
+	managementComponents := cluster.ManagementComponentsFromBundles(test.clusterSpec.Bundles)
 
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -332,7 +335,7 @@ func TestCreateRunInstallEksaComponentsBuildClientFailure(t *testing.T) {
 	test.expectMoveManagement()
 	gomock.InOrder(
 		test.clusterManager.EXPECT().InstallCustomComponents(
-			test.ctx, test.clusterSpec, test.workloadCluster, test.provider),
+			test.ctx, managementComponents, test.clusterSpec, test.workloadCluster, test.provider),
 
 		test.eksd.EXPECT().InstallEksdCRDs(test.ctx, test.clusterSpec, test.workloadCluster),
 
@@ -361,6 +364,7 @@ func TestCreateRunInstallEksaComponentsBuildClientFailure(t *testing.T) {
 func TestCreateRunInstallEksaComponentsApplyServerSideFailure(t *testing.T) {
 	wantError := errors.New("test error")
 	test := newCreateTest(t)
+	managementComponents := cluster.ManagementComponentsFromBundles(test.clusterSpec.Bundles)
 
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -370,7 +374,7 @@ func TestCreateRunInstallEksaComponentsApplyServerSideFailure(t *testing.T) {
 	test.expectMoveManagement()
 	gomock.InOrder(
 		test.clusterManager.EXPECT().InstallCustomComponents(
-			test.ctx, test.clusterSpec, test.workloadCluster, test.provider),
+			test.ctx, managementComponents, test.clusterSpec, test.workloadCluster, test.provider),
 
 		test.eksd.EXPECT().InstallEksdCRDs(test.ctx, test.clusterSpec, test.workloadCluster),
 

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -40,7 +40,7 @@ type ClusterManager interface {
 	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, provider providers.Provider) (*types.ChangeDiff, error)
 	SaveLogsManagementCluster(ctx context.Context, spec *cluster.Spec, cluster *types.Cluster) error
 	SaveLogsWorkloadCluster(ctx context.Context, provider providers.Provider, spec *cluster.Spec, cluster *types.Cluster) error
-	InstallCustomComponents(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
+	InstallCustomComponents(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	CreateEKSANamespace(ctx context.Context, cluster *types.Cluster) error
 	CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) error
 	ApplyBundles(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
@@ -51,7 +51,7 @@ type ClusterManager interface {
 	EKSAClusterSpecChanged(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) (bool, error)
 	InstallMachineHealthChecks(ctx context.Context, clusterSpec *cluster.Spec, workloadCluster *types.Cluster) error
 	GetCurrentClusterSpec(ctx context.Context, cluster *types.Cluster, clusterName string) (*cluster.Spec, error)
-	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	Upgrade(ctx context.Context, cluster *types.Cluster, currentManagementComponents, newManagementComponents *cluster.ManagementComponents, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallAwsIamAuth(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
 	CreateAwsIamAuthCaSecret(ctx context.Context, bootstrapCluster *types.Cluster, workloadClusterName string) error
 	DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -104,5 +104,5 @@ type ClusterCreator interface {
 
 // EksaInstaller installs the EKS-A controllers and CRDs.
 type EksaInstaller interface {
-	Install(ctx context.Context, log logr.Logger, cluster *types.Cluster, spec *cluster.Spec) error
+	Install(ctx context.Context, log logr.Logger, cluster *types.Cluster, managementComponents *cluster.ManagementComponents, spec *cluster.Spec) error
 }

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -299,17 +299,17 @@ func (mr *MockClusterManagerMockRecorder) InstallCAPI(arg0, arg1, arg2, arg3 int
 }
 
 // InstallCustomComponents mocks base method.
-func (m *MockClusterManager) InstallCustomComponents(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster, arg3 providers.Provider) error {
+func (m *MockClusterManager) InstallCustomComponents(arg0 context.Context, arg1 *cluster.ManagementComponents, arg2 *cluster.Spec, arg3 *types.Cluster, arg4 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallCustomComponents", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InstallCustomComponents", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallCustomComponents indicates an expected call of InstallCustomComponents.
-func (mr *MockClusterManagerMockRecorder) InstallCustomComponents(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) InstallCustomComponents(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallCustomComponents", reflect.TypeOf((*MockClusterManager)(nil).InstallCustomComponents), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallCustomComponents", reflect.TypeOf((*MockClusterManager)(nil).InstallCustomComponents), arg0, arg1, arg2, arg3, arg4)
 }
 
 // InstallMachineHealthChecks mocks base method.
@@ -472,18 +472,18 @@ func (mr *MockClusterManagerMockRecorder) SaveLogsWorkloadCluster(arg0, arg1, ar
 }
 
 // Upgrade mocks base method.
-func (m *MockClusterManager) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) (*types.ChangeDiff, error) {
+func (m *MockClusterManager) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.ManagementComponents, arg4 *cluster.Spec) (*types.ChangeDiff, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*types.ChangeDiff)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockClusterManagerMockRecorder) Upgrade(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) Upgrade(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockClusterManager)(nil).Upgrade), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockClusterManager)(nil).Upgrade), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UpgradeCluster mocks base method.

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -1029,15 +1029,15 @@ func (m *MockEksaInstaller) EXPECT() *MockEksaInstallerMockRecorder {
 }
 
 // Install mocks base method.
-func (m *MockEksaInstaller) Install(arg0 context.Context, arg1 logr.Logger, arg2 *types.Cluster, arg3 *cluster.Spec) error {
+func (m *MockEksaInstaller) Install(arg0 context.Context, arg1 logr.Logger, arg2 *types.Cluster, arg3 *cluster.ManagementComponents, arg4 *cluster.Spec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Install", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Install indicates an expected call of Install.
-func (mr *MockEksaInstallerMockRecorder) Install(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockEksaInstallerMockRecorder) Install(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockEksaInstaller)(nil).Install), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockEksaInstaller)(nil).Install), arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/workflows/management/core_components.go
+++ b/pkg/workflows/management/core_components.go
@@ -5,6 +5,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
@@ -55,6 +56,20 @@ func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandC
 		return err
 	}
 
+	client, err := commandContext.ClientFactory.BuildClientFromKubeconfig(commandContext.ManagementCluster.KubeconfigFile)
+	if err != nil {
+		commandContext.SetError(err)
+		return err
+	}
+
+	currentManagementComponents, err := cluster.GetManagementComponents(ctx, client, commandContext.CurrentClusterSpec.Cluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return err
+	}
+
+	newManagementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+
 	changeDiff, err := commandContext.CAPIManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.Provider, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
@@ -74,7 +89,7 @@ func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandC
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
-	changeDiff, err = commandContext.ClusterManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
+	changeDiff, err = commandContext.ClusterManager.Upgrade(ctx, commandContext.ManagementCluster, currentManagementComponents, newManagementComponents, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return err
@@ -87,12 +102,6 @@ func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandC
 		return err
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
-
-	client, err := commandContext.ClientFactory.BuildClientFromKubeconfig(commandContext.ManagementCluster.KubeconfigFile)
-	if err != nil {
-		commandContext.SetError(err)
-		return err
-	}
 
 	eksaCluster := &anywherev1.Cluster{}
 	err = client.Get(ctx, commandContext.CurrentClusterSpec.Cluster.Name, commandContext.CurrentClusterSpec.Cluster.Namespace, eksaCluster)

--- a/pkg/workflows/management/create_install_eksa.go
+++ b/pkg/workflows/management/create_install_eksa.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
@@ -44,7 +45,8 @@ func installEKSAComponents(ctx context.Context, commandContext *task.CommandCont
 	}
 
 	logger.Info("Installing EKS-A custom components (CRD and controller)")
-	if err := commandContext.EksaInstaller.Install(ctx, logger.Get(), targetCluster, commandContext.ClusterSpec); err != nil {
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+	if err := commandContext.EksaInstaller.Install(ctx, logger.Get(), targetCluster, managementComponents, commandContext.ClusterSpec); err != nil {
 		commandContext.SetError(err)
 		return err
 	}

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -260,13 +260,6 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
-	changeDiff, err = commandContext.ClusterManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
-	if err != nil {
-		commandContext.SetError(err)
-		return &CollectDiagnosticsTask{}
-	}
-	commandContext.UpgradeChangeDiff.Append(changeDiff)
-
 	changeDiff, err = commandContext.EksdUpgrader.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -165,11 +165,6 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(managementCluster *types.
 		OldVersion:    "v0.0.1",
 		NewVersion:    "v0.0.2",
 	})
-	eksaChangeDiff := types.NewChangeDiff(&types.ComponentChangeDiff{
-		ComponentName: "eks-a",
-		OldVersion:    "v0.0.1",
-		NewVersion:    "v0.0.2",
-	})
 	eksdChangeDiff := types.NewChangeDiff(&types.ComponentChangeDiff{
 		ComponentName: "eks-d",
 		OldVersion:    "v0.0.1",
@@ -180,7 +175,6 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(managementCluster *types.
 		c.capiManager.EXPECT().Upgrade(c.ctx, managementCluster, c.provider, currentSpec, c.newClusterSpec).Return(capiChangeDiff, nil),
 		c.gitOpsManager.EXPECT().Install(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(nil),
 		c.gitOpsManager.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(fluxChangeDiff, nil),
-		c.clusterManager.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(eksaChangeDiff, nil),
 		c.eksdUpgrader.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(eksdChangeDiff, nil),
 	)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes here are split out from [this PR](https://github.com/aws/eks-anywhere/pull/7353) with some changes to use `ManagementComponents`. It also addresses [a particular comment](https://github.com/aws/eks-anywhere/pull/7353#discussion_r1465492542) by passing the ManagementComponents down to where it's need.

Updates the EKSA upgrader to use management components:
- Changes the EKSAChangeDiff method to compare management components
- Gets ManagementComponents for upgrade plan and uses it and the new management components to get the diff
- EKSA Upgrade uses management components to upgrade

*Testing (if applicable):*
- Ran upgrade plan to check the output
- Created a management cluster with v0.18.4 and ran upgrade plan to check the output
- Ran upgrade management-components
- Ran upgrade plan to check the output. The `EKS-Management` entry was gone, indicating the cluster is on the new eks-a management components version

Before  upgrade management-components
```
NAME                 CURRENT VERSION   NEXT VERSION
EKS-A Management     v0.18.4+79b7f58   v0.0.0-dev+build.8246+6407dd0
cert-manager         v1.13.0+343cf30   v1.13.2+a34c207
cluster-api          v1.5.2+ec7ca3a    v1.6.0+5010118
kubeadm              v1.5.2+b0ed140    v1.6.0+329d5a9
vsphere              v1.7.4+8379520    v1.8.5+3330c16
kubeadm              v1.5.2+43f63db    v1.6.0+bb1c4cf
etcdadm-bootstrap    v1.0.10+4806f13   v1.0.10+1ceb898
etcdadm-controller   v1.0.16+a28cb02   v1.0.17+5e33062
cilium               v1.12.15-eksa.1   v1.13.9-eksa.1
```

After  upgrade management-components
```
NAME                 CURRENT VERSION   NEXT VERSION
cert-manager         v1.13.0+343cf30   v1.13.2+a34c207
cluster-api          v1.5.2+ec7ca3a    v1.6.0+5010118
kubeadm              v1.5.2+b0ed140    v1.6.0+329d5a9
vsphere              v1.7.4+8379520    v1.8.5+3330c16
kubeadm              v1.5.2+43f63db    v1.6.0+bb1c4cf
etcdadm-bootstrap    v1.0.10+4806f13   v1.0.10+1ceb898
etcdadm-controller   v1.0.16+a28cb02   v1.0.17+5e33062
cilium               v1.12.15-eksa.1   v1.13.9-eksa.1
```
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

