### PR TITLE
Add doc on verifying container images from the bundle manifest file

### DIFF
--- a/docs/content/en/docs/clustermgmt/verify-cluster-image.md
+++ b/docs/content/en/docs/clustermgmt/verify-cluster-image.md
@@ -1,0 +1,61 @@
+---
+title: "Verify Cluster Images"
+linkTitle: "Verify Cluster Images"
+weight: 90
+date: 2017-01-05
+description: >
+  How to verify cluster images 
+---
+
+### Verify Cluster Images
+
+Starting from v0.19.0 release, all the images used in cluster operations are signed using AWS Signer and Notation CLI. Anyone can verify signatures associated with the container images EKS Anywhere uses. Signatures are valid for two years. To verify container images, one would have to perform the following steps:
+
+1. Install and configure the latest version of the AWS CLI. For more information, see [Installing or updating the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) in the AWS Command Line Interface User Guide.
+
+2. Download the container-signing tools from [this page](https://docs.aws.amazon.com/signer/latest/developerguide/image-signing-prerequisites.html) by following step 3.
+
+3. Make sure notation CLI is configured along with the AWS Signer plugin and AWS CLI. Create a JSON file with the following trust policy. 
+
+   ```bash
+   {
+      "version":"1.0",
+      "trustPolicies":[
+         {
+            "name":"aws-signer-tp",
+            "registryScopes":[
+               "*"
+            ],
+            "signatureVerification":{
+               "level":"strict"
+            },
+            "trustStores":[
+               "signingAuthority:aws-signer-ts"
+            ],
+            "trustedIdentities":[
+               "arn:aws:signer:us-west-2:857151390494:/signing-profiles/notationimageSigningProfileECR_rGorpoAE4o0o"
+            ]
+         }
+      ]
+   }
+   ```
+
+4. Import above trust policy using:
+   ```bash
+   notation policy import <json-file>
+   ```
+
+5. Get the bundle of the version for which you want to verify an image:
+   ```bash
+   export EKSA_RELEASE_VERSION=v0.19.0
+   BUNDLE_MANIFEST_URL=$(curl -sL https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.releases[] | select(.version==\"$EKSA_RELEASE_VERSION\").bundleManifestUrl")
+   ```
+
+6. Get the image you want to verify by downloading BUNDLE_MANIFEST_URL file.
+7. Run the following command to verify the image signature:
+   ```bash
+   notation verify <image-uri>@<sha256-image-digest>
+   ```
+
+
+

--- a/docs/content/en/docs/getting-started/baremetal/baremetal-getstarted.md
+++ b/docs/content/en/docs/getting-started/baremetal/baremetal-getstarted.md
@@ -12,6 +12,8 @@ EKS Anywhere allows you to provision and manage Kubernetes clusters based on Ama
 This document walks you through setting up EKS Anywhere on Bare Metal as a standalone, self-managed cluster or combined set of management/workload clusters.
 See [Cluster topologies]({{< relref "../../concepts/architecture" >}}) for details.
 
+**Note:** Before you create your cluster, you have the option of validating the EKS Anywhere bundle manifest container images by following instructions in the [Verify Cluster Images]({{< relref "../../clustermgmt/verify-cluster-image.md" >}}) page.
+
 ## Prerequisite checklist
 
 EKS Anywhere needs:

--- a/docs/content/en/docs/getting-started/cloudstack/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloudstack-getstarted.md
@@ -27,6 +27,8 @@ This approach also reduces provider permissions for workload clusters.
 
 {{% /alert %}}
 
+**Note:** Before you create your cluster, you have the option of validating the EKS Anywhere bundle manifest container images by following instructions in the [Verify Cluster Images]({{< relref "../../clustermgmt/verify-cluster-image.md" >}}) page.
+
 ## Prerequisite Checklist
 
 EKS Anywhere needs to:

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-getstarted.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-getstarted.md
@@ -27,6 +27,8 @@ This approach also reduces provider permissions for workload clusters.
 
 {{% /alert %}}
 
+**Note:** Before you create your cluster, you have the option of validating the EKS Anywhere bundle manifest container images by following instructions in the [Verify Cluster Images]({{< relref "../../clustermgmt/verify-cluster-image.md" >}}) page.
+
 ## Prerequisite Checklist
 
 EKS Anywhere needs to:

--- a/docs/content/en/docs/getting-started/snow/snow-getstarted.md
+++ b/docs/content/en/docs/getting-started/snow/snow-getstarted.md
@@ -11,6 +11,8 @@ EKS Anywhere supports an AWS Snow provider for EKS Anywhere deployments.
 This document walks you through setting up EKS Anywhere on Snow as a standalone, self-managed cluster or combined set of management/workload clusters.
 See [Cluster topologies]({{< relref "../../concepts/architecture" >}}) for details.
 
+**Note:** Before you create your cluster, you have the option of validating the EKS Anywhere bundle manifest container images by following instructions in the [Verify Cluster Images]({{< relref "../../clustermgmt/verify-cluster-image.md" >}}) page.
+
 ## Prerequisite checklist
 
 EKS Anywhere on Snow needs:

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
@@ -27,6 +27,9 @@ This approach also reduces provider permissions for workload clusters.
 
 {{% /alert %}}
 
+**Note:** Before you create your cluster, you have the option of validating the EKS Anywhere bundle manifest container images by following instructions in the [Verify Cluster Images]({{< relref "../../clustermgmt/verify-cluster-image.md" >}}) page.
+
+
 ## Prerequisite Checklist
 
 EKS Anywhere needs to:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1257

*Description of changes:*
We are going to sign all the container images that we use using AWS CLI and notation CLI. Adding a doc on how to verify container images from the bundle manifest file.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

