### PR TITLE
Create workload cluster controller via CLI

### DIFF
--- a/pkg/workflows/management/create_install_eksa.go
+++ b/pkg/workflows/management/create_install_eksa.go
@@ -21,7 +21,7 @@ func (s *installEksaComponentsOnBootstrapTask) Run(ctx context.Context, commandC
 		return &workflows.CollectDiagnosticsTask{}
 	}
 
-	return nil
+	return &createWorkloadClusterTask{}
 }
 
 func (s *installEksaComponentsOnBootstrapTask) Name() string {

--- a/pkg/workflows/management/create_test.go
+++ b/pkg/workflows/management/create_test.go
@@ -172,6 +172,21 @@ func (c *createTestSetup) expectInstallEksaComponentsBootstrap(err1, err2, err3,
 	)
 }
 
+func (c *createTestSetup) expectCreateWorkload(err1, err2, err3, err4 error) {
+	gomock.InOrder(
+		c.clusterCreator.EXPECT().CreateSync(c.ctx, c.clusterSpec, c.bootstrapCluster).Return(c.workloadCluster, err1),
+
+		c.clusterManager.EXPECT().CreateEKSANamespace(
+			c.ctx, c.workloadCluster).Return(err2),
+
+		c.clusterManager.EXPECT().InstallCAPI(
+			c.ctx, c.clusterSpec, c.workloadCluster, c.provider).Return(err3),
+
+		c.provider.EXPECT().UpdateSecrets(
+			c.ctx, c.workloadCluster, c.clusterSpec).Return(err4),
+	)
+}
+
 func TestCreateRunSuccess(t *testing.T) {
 	test := newCreateTest(t)
 	test.expectSetup()
@@ -179,6 +194,7 @@ func TestCreateRunSuccess(t *testing.T) {
 	test.expectCreateBootstrap()
 	test.expectCAPIInstall(nil, nil, nil)
 	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil, nil)
+	test.expectCreateWorkload(nil, nil, nil, nil)
 
 	err := test.run()
 	if err != nil {
@@ -448,5 +464,92 @@ func TestCreateApplyServersideFailure(t *testing.T) {
 	err = c.run()
 	if err == nil {
 		t.Fatalf("Create.Run() expected to return an error %v", err)
+	}
+}
+
+func TestCreateSyncFailure(t *testing.T) {
+	test := newCreateTest(t)
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectCreateBootstrap()
+	test.expectCAPIInstall(nil, nil, nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil, nil)
+
+	test.clusterCreator.EXPECT().CreateSync(test.ctx, test.clusterSpec, test.bootstrapCluster).Return(nil, errors.New("test"))
+	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
+	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Create.Run() expected to return an error %v", err)
+	}
+}
+
+func TestCreateEKSANamespaceFailure(t *testing.T) {
+	test := newCreateTest(t)
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectCreateBootstrap()
+	test.expectCAPIInstall(nil, nil, nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil, nil)
+
+	test.clusterCreator.EXPECT().CreateSync(test.ctx, test.clusterSpec, test.bootstrapCluster).Return(test.workloadCluster, nil)
+	test.clusterManager.EXPECT().CreateEKSANamespace(test.ctx, test.workloadCluster).Return(errors.New("test"))
+	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
+	test.clusterManager.EXPECT().SaveLogsWorkloadCluster(test.ctx, test.provider, test.clusterSpec, test.workloadCluster)
+	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Create.Run() expected to return an error %v", err)
+	}
+}
+
+func TestCreateInstallCAPIWorkloadFailure(t *testing.T) {
+	test := newCreateTest(t)
+	test.expectSetup()
+	test.expectCreateBootstrap()
+	test.expectCAPIInstall(nil, nil, nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil, nil)
+	test.expectPreflightValidationsToPass()
+
+	test.clusterCreator.EXPECT().CreateSync(
+		test.ctx, test.clusterSpec, test.bootstrapCluster).Return(test.workloadCluster, nil)
+
+	test.clusterManager.EXPECT().CreateEKSANamespace(
+		test.ctx, test.workloadCluster)
+
+	test.clusterManager.EXPECT().InstallCAPI(
+		test.ctx, test.clusterSpec, test.workloadCluster, test.provider).Return(errors.New("test"))
+
+	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
+	test.clusterManager.EXPECT().SaveLogsWorkloadCluster(test.ctx, test.provider, test.clusterSpec, test.workloadCluster)
+
+	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("expected error from task")
+	}
+}
+
+func TestCreateUpdateSecretsFailure(t *testing.T) {
+	test := newCreateTest(t)
+	test.expectSetup()
+	test.expectCreateBootstrap()
+	test.expectCAPIInstall(nil, nil, nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil, nil)
+	test.expectPreflightValidationsToPass()
+
+	test.expectCreateWorkload(nil, nil, nil, errors.New("test"))
+
+	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
+	test.clusterManager.EXPECT().SaveLogsWorkloadCluster(test.ctx, test.provider, test.clusterSpec, test.workloadCluster)
+
+	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("expected error from task")
 	}
 }

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -1,0 +1,58 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+)
+
+// createWorkloadClusterTask implementation.
+type createWorkloadClusterTask struct{}
+
+func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Creating new workload cluster")
+
+	workloadCluster, err := commandContext.ClusterCreator.CreateSync(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+	commandContext.WorkloadCluster = workloadCluster
+
+	logger.Info("Creating EKS-A namespace")
+	err = commandContext.ClusterManager.CreateEKSANamespace(ctx, commandContext.WorkloadCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	logger.Info("Installing cluster-api providers on workload cluster")
+	err = commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	logger.Info("Installing EKS-A secrets on workload cluster")
+	err = commandContext.Provider.UpdateSecrets(ctx, commandContext.WorkloadCluster, commandContext.ClusterSpec)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	return nil
+}
+
+func (s *createWorkloadClusterTask) Name() string {
+	return "workload-cluster-init"
+}
+
+func (s *createWorkloadClusterTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *createWorkloadClusterTask) Checkpoint() *task.CompletedTask {
+	return nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Create workload cluster controller via CLI

*Testing (if applicable):*
- unit test

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

