### PR TITLE
Separate docker MetalLB e2e test to avoid timeouts

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -362,8 +362,20 @@ func TestDockerKubernetes128CuratedPackagesDisabled(t *testing.T) {
 	runDisabledCuratedPackageInstallSimpleFlow(test) // other args as necessary
 }
 
-func TestDockerCuratedPackagesMetalLB(t *testing.T) {
-	RunMetalLBDockerTests(t)
+func TestDockerKubernetes125CuratedPackagesMetalLB(t *testing.T) {
+	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube125)
+}
+
+func TestDockerKubernetes126CuratedPackagesMetalLB(t *testing.T) {
+	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube126)
+}
+
+func TestDockerKubernetes127CuratedPackagesMetalLB(t *testing.T) {	
+	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube127)
+}
+
+func TestDockerKubernetes128CuratedPackagesMetalLB(t *testing.T) {
+	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube128)
 }
 
 // AWS IAM Auth

--- a/test/e2e/metallb.go
+++ b/test/e2e/metallb.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,14 +28,11 @@ type MetalLBSuite struct {
 	provider          framework.Provider
 }
 
-func RunMetalLBDockerTests(t *testing.T) {
-	for i, v := range KubeVersions {
-		s := new(MetalLBSuite)
-		s.provider = framework.NewDocker(t)
-		s.kubernetesVersion = v
-		os.Setenv(framework.ClusterPrefixVar, fmt.Sprintf("%s-%d", EksaPackagesNamespace, i))
-		suite.Run(t, s)
-	}
+func RunMetalLBDockerTestsForKubeVersion(t *testing.T, kubeVersion v1alpha1.KubernetesVersion) {
+	s := new(MetalLBSuite)
+	s.provider = framework.NewDocker(t)
+	s.kubernetesVersion = kubeVersion
+	suite.Run(t, s)
 }
 
 func (suite *MetalLBSuite) SetupSuite() {


### PR DESCRIPTION
*Description of changes:*

This should help with test failing due to taking too long. Now every k8s version will run in its own test, hence in a different instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

