### PR TITLE
Add kubebuilder tags to print meaningful columns for in-place CRDs

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -235,6 +235,8 @@ spec:
                         - maxSurge
                         type: object
                       type:
+                        description: UpgradeRolloutStrategyType defines the types
+                          of upgrade rollout strategies.
                         type: string
                     type: object
                 type: object
@@ -584,6 +586,8 @@ spec:
                           - maxUnavailable
                           type: object
                         type:
+                          description: UpgradeRolloutStrategyType defines the types
+                            of upgrade rollout strategies.
                           type: string
                       type: object
                   type: object

--- a/config/crd/bases/anywhere.eks.amazonaws.com_controlplaneupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_controlplaneupgrades.yaml
@@ -13,10 +13,37 @@ spec:
     kind: ControlPlaneUpgrade
     listKind: ControlPlaneUpgradeList
     plural: controlplaneupgrades
+    shortNames:
+    - cpu
     singular: controlplaneupgrade
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: KubeadmControlPlane
+      jsonPath: .spec.controlPlane.name
+      name: KubeadmControlPlane
+      type: string
+    - description: Control Plane machines that are already upgraded
+      jsonPath: .status.upgraded
+      name: Upgraded
+      type: string
+    - description: Control Plane machines that still require upgrade
+      jsonPath: .status.requireUpgrade
+      name: PendingUpgrade
+      type: string
+    - description: Denotes whether the upgrade has finished or not
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of Control Plane Upgrade
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Requested Kubernetes version
+      jsonPath: .spec.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ControlPlaneUpgrade is the Schema for the controlplaneupgrade
@@ -177,6 +204,9 @@ spec:
                 description: Upgraded is the number of machines that have been upgraded.
                 format: int64
                 type: integer
+            required:
+            - requireUpgrade
+            - upgraded
             type: object
         type: object
     served: true

--- a/config/crd/bases/anywhere.eks.amazonaws.com_machinedeploymentupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_machinedeploymentupgrades.yaml
@@ -13,10 +13,37 @@ spec:
     kind: MachineDeploymentUpgrade
     listKind: MachineDeploymentUpgradeList
     plural: machinedeploymentupgrades
+    shortNames:
+    - mdu
     singular: machinedeploymentupgrade
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Machine Deployment
+      jsonPath: .spec.machineDeployment.name
+      name: Machine Deployment
+      type: string
+    - description: Worker machines that are already upgraded
+      jsonPath: .status.upgraded
+      name: Upgraded
+      type: string
+    - description: Worker machines that still require upgrade
+      jsonPath: .status.requireUpgrade
+      name: PendingUpgrade
+      type: string
+    - description: Denotes whether the upgrade has finished or not
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of Control Plane Upgrade
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Requested Kubernetes version
+      jsonPath: .spec.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MachineDeploymentUpgrade is the Schema for the machinedeploymentupgrades
@@ -172,6 +199,9 @@ spec:
                   that have been upgraded.
                 format: int64
                 type: integer
+            required:
+            - requireUpgrade
+            - upgraded
             type: object
         type: object
     served: true

--- a/config/crd/bases/anywhere.eks.amazonaws.com_nodeupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_nodeupgrades.yaml
@@ -13,10 +13,29 @@ spec:
     kind: NodeUpgrade
     listKind: NodeUpgradeList
     plural: nodeupgrades
+    shortNames:
+    - nu
     singular: nodeupgrade
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Machine
+      jsonPath: .spec.machine.name
+      name: Machine
+      type: string
+    - description: Denotes whether the upgrade has finished or not
+      jsonPath: .status.completed
+      name: Ready
+      type: string
+    - description: Time duration since creation of Control Plane Upgrade
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Requested Kubernetes version
+      jsonPath: .spec.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NodeUpgrade is the Schema for the nodeupgrades API.

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -3938,6 +3938,8 @@ spec:
                         - maxSurge
                         type: object
                       type:
+                        description: UpgradeRolloutStrategyType defines the types
+                          of upgrade rollout strategies.
                         type: string
                     type: object
                 type: object
@@ -4287,6 +4289,8 @@ spec:
                           - maxUnavailable
                           type: object
                         type:
+                          description: UpgradeRolloutStrategyType defines the types
+                            of upgrade rollout strategies.
                           type: string
                       type: object
                   type: object
@@ -4420,10 +4424,37 @@ spec:
     kind: ControlPlaneUpgrade
     listKind: ControlPlaneUpgradeList
     plural: controlplaneupgrades
+    shortNames:
+    - cpu
     singular: controlplaneupgrade
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: KubeadmControlPlane
+      jsonPath: .spec.controlPlane.name
+      name: KubeadmControlPlane
+      type: string
+    - description: Control Plane machines that are already upgraded
+      jsonPath: .status.upgraded
+      name: Upgraded
+      type: string
+    - description: Control Plane machines that still require upgrade
+      jsonPath: .status.requireUpgrade
+      name: PendingUpgrade
+      type: string
+    - description: Denotes whether the upgrade has finished or not
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of Control Plane Upgrade
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Requested Kubernetes version
+      jsonPath: .spec.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ControlPlaneUpgrade is the Schema for the controlplaneupgrade
@@ -4584,6 +4615,9 @@ spec:
                 description: Upgraded is the number of machines that have been upgraded.
                 format: int64
                 type: integer
+            required:
+            - requireUpgrade
+            - upgraded
             type: object
         type: object
     served: true
@@ -4938,10 +4972,37 @@ spec:
     kind: MachineDeploymentUpgrade
     listKind: MachineDeploymentUpgradeList
     plural: machinedeploymentupgrades
+    shortNames:
+    - mdu
     singular: machinedeploymentupgrade
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Machine Deployment
+      jsonPath: .spec.machineDeployment.name
+      name: Machine Deployment
+      type: string
+    - description: Worker machines that are already upgraded
+      jsonPath: .status.upgraded
+      name: Upgraded
+      type: string
+    - description: Worker machines that still require upgrade
+      jsonPath: .status.requireUpgrade
+      name: PendingUpgrade
+      type: string
+    - description: Denotes whether the upgrade has finished or not
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of Control Plane Upgrade
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Requested Kubernetes version
+      jsonPath: .spec.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MachineDeploymentUpgrade is the Schema for the machinedeploymentupgrades
@@ -5097,6 +5158,9 @@ spec:
                   that have been upgraded.
                 format: int64
                 type: integer
+            required:
+            - requireUpgrade
+            - upgraded
             type: object
         type: object
     served: true
@@ -5123,10 +5187,29 @@ spec:
     kind: NodeUpgrade
     listKind: NodeUpgradeList
     plural: nodeupgrades
+    shortNames:
+    - nu
     singular: nodeupgrade
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Machine
+      jsonPath: .spec.machine.name
+      name: Machine
+      type: string
+    - description: Denotes whether the upgrade has finished or not
+      jsonPath: .status.completed
+      name: Ready
+      type: string
+    - description: Time duration since creation of Control Plane Upgrade
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Requested Kubernetes version
+      jsonPath: .spec.kubernetesVersion
+      name: KubernetesVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NodeUpgrade is the Schema for the nodeupgrades API.

--- a/pkg/api/v1alpha1/controlplaneupgrade_types.go
+++ b/pkg/api/v1alpha1/controlplaneupgrade_types.go
@@ -33,17 +33,24 @@ type ControlPlaneUpgradeSpec struct {
 // ControlPlaneUpgradeStatus defines the observed state of ControlPlaneUpgrade.
 type ControlPlaneUpgradeStatus struct {
 	// RequireUpgrade is the number of machines that still need to be upgraded.
-	RequireUpgrade int64 `json:"requireUpgrade,omitempty"`
+	RequireUpgrade int64 `json:"requireUpgrade"`
 
 	// Upgraded is the number of machines that have been upgraded.
-	Upgraded int64 `json:"upgraded,omitempty"`
+	Upgraded int64 `json:"upgraded"`
 
 	// Ready denotes that the all control planes have finished upgrading and are ready.
 	Ready bool `json:"ready,omitempty"`
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:path=controlplaneupgrades,shortName=cpu,scope=Namespaced,singular=controlplaneupgrade
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="KubeadmControlPlane",type="string",JSONPath=".spec.controlPlane.name",description="KubeadmControlPlane"
+//+kubebuilder:printcolumn:name="Upgraded",type="string",JSONPath=".status.upgraded",description="Control Plane machines that are already upgraded"
+//+kubebuilder:printcolumn:name="PendingUpgrade",type="string",JSONPath=".status.requireUpgrade",description="Control Plane machines that still require upgrade"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Denotes whether the upgrade has finished or not"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Control Plane Upgrade"
+//+kubebuilder:printcolumn:name="KubernetesVersion",type="string",JSONPath=".spec.kubernetesVersion",description="Requested Kubernetes version"
 
 // ControlPlaneUpgrade is the Schema for the controlplaneupgrade API.
 type ControlPlaneUpgrade struct {

--- a/pkg/api/v1alpha1/machinedeploymentupgrade_types.go
+++ b/pkg/api/v1alpha1/machinedeploymentupgrade_types.go
@@ -26,17 +26,24 @@ type MachineDeploymentUpgradeSpec struct {
 // MachineDeploymentUpgradeStatus defines the observed state of MachineDeploymentUpgrade.
 type MachineDeploymentUpgradeStatus struct {
 	// RequireUpgrade is the number of machines in the MachineDeployment that still need to be upgraded.
-	RequireUpgrade int64 `json:"requireUpgrade,omitempty"`
+	RequireUpgrade int64 `json:"requireUpgrade"`
 
 	// Upgraded is the number of machines in the MachineDeployment that have been upgraded.
-	Upgraded int64 `json:"upgraded,omitempty"`
+	Upgraded int64 `json:"upgraded"`
 
 	// Ready denotes that the all machines in the MachineDeployment have finished upgrading and are ready.
 	Ready bool `json:"ready,omitempty"`
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:path=machinedeploymentupgrades,shortName=mdu,scope=Namespaced,singular=machinedeploymentupgrade
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Machine Deployment",type="string",JSONPath=".spec.machineDeployment.name",description="Machine Deployment"
+//+kubebuilder:printcolumn:name="Upgraded",type="string",JSONPath=".status.upgraded",description="Worker machines that are already upgraded"
+//+kubebuilder:printcolumn:name="PendingUpgrade",type="string",JSONPath=".status.requireUpgrade",description="Worker machines that still require upgrade"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Denotes whether the upgrade has finished or not"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Control Plane Upgrade"
+//+kubebuilder:printcolumn:name="KubernetesVersion",type="string",JSONPath=".spec.kubernetesVersion",description="Requested Kubernetes version"
 
 // MachineDeploymentUpgrade is the Schema for the machinedeploymentupgrades API.
 type MachineDeploymentUpgrade struct {

--- a/pkg/api/v1alpha1/nodeupgrade_types.go
+++ b/pkg/api/v1alpha1/nodeupgrade_types.go
@@ -61,14 +61,19 @@ type NodeUpgradeStatus struct {
 	// Completed denotes that the upgrader has completed running all the operations
 	// and the node is successfully upgraded.
 	// +optional
-	Completed bool `json:"completed,omitempty"`
+	Completed bool `json:"completed"`
 
 	// ObservedGeneration is the latest generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:resource:path=nodeupgrades,shortName=nu,scope=Namespaced,singular=nodeupgrade
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".spec.machine.name",description="Machine"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.completed",description="Denotes whether the upgrade has finished or not"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Control Plane Upgrade"
+//+kubebuilder:printcolumn:name="KubernetesVersion",type="string",JSONPath=".spec.kubernetesVersion",description="Requested Kubernetes version"
 
 // NodeUpgrade is the Schema for the nodeupgrades API.
 type NodeUpgrade struct {


### PR DESCRIPTION
*Description of changes:*
Add kubebuilder tags to print meaningful columns for in-place upgrade CRDs.
Also add shortnames for CRDs: `cpu` for `controlplaneupgrades`, `mdu` for `machinedeploymentupgrades`, and `nu` for `nodeupgrades`
```bash
k get cpu,mdu,nu -A                               
NAMESPACE     NAME                                                                               KUBEADMCONTROLPLANE      UPGRADED   PENDINGUPGRADE   READY   AGE   KUBERNETESVERSION
eksa-system   controlplaneupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-cp-upgrade   abhnvp-workload-ubuntu   3          0                true    14m   v1.29.0-eks-1-29-3

NAMESPACE     NAME                                                                                         MACHINE DEPLOYMENT            UPGRADED   PENDINGUPGRADE   READY   AGE   KUBERNETESVERSION
eksa-system   machinedeploymentupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-md-0-md-upgrade   abhnvp-workload-ubuntu-md-0   2                           true    14m   v1.29.0-eks-1-29-3

NAMESPACE     NAME                                                                                           MACHINE                                   READY   AGE     KUBERNETESVERSION
eksa-system   nodeupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-4r4mb-node-upgrader              abhnvp-workload-ubuntu-4r4mb              true    14m     v1.29.0-eks-1-29-3
eksa-system   nodeupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-76ntn-node-upgrader              abhnvp-workload-ubuntu-76ntn              true    12m     v1.29.0-eks-1-29-3
eksa-system   nodeupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-md-0-5cxz9-f4stb-node-upgrader   abhnvp-workload-ubuntu-md-0-5cxz9-f4stb   true    14m     v1.29.0-eks-1-29-3
eksa-system   nodeupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-md-0-5cxz9-lrcbb-node-upgrader   abhnvp-workload-ubuntu-md-0-5cxz9-lrcbb   true    13m     v1.29.0-eks-1-29-3
eksa-system   nodeupgrade.anywhere.eks.amazonaws.com/abhnvp-workload-ubuntu-mm9hp-node-upgrader              abhnvp-workload-ubuntu-mm9hp              true    8m15s   v1.29.0-eks-1-29-3
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

