### PR TITLE
Update infra machine annotation for cp in place upgrade

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -7330,6 +7330,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - tinkerbellmachines
+  - vspheremachines
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - packages.eks.amazonaws.com
   resources:
   - packages

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -412,6 +412,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - tinkerbellmachines
+  - vspheremachines
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - packages.eks.amazonaws.com
   resources:
   - packages


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the owned by annotation in the infra machine to match the name specified by the new kcp. This signifies to capi that a machine was rolled out due to it being an inplace upgrade.

*Testing (if applicable):*
unit testing and functional testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

