### PR TITLE
Add kubernetes entry to upgrade plan

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"github.com/aws/eks-anywhere/pkg/eksd"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/networking/cilium"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -96,6 +97,7 @@ func (uc *upgradeClusterOptions) upgradePlanCluster(ctx context.Context) error {
 	}
 
 	componentChangeDiffs.Append(cilium.ChangeDiff(currentSpec, newClusterSpec))
+	componentChangeDiffs.Append(eksd.ChangeDiff(currentSpec, newClusterSpec))
 
 	serializedDiff, err := serialize(componentChangeDiffs, output)
 	if err != nil {

--- a/pkg/eksd/upgrader.go
+++ b/pkg/eksd/upgrader.go
@@ -3,10 +3,12 @@ package eksd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/types"
+	releavev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 type Upgrader struct {
@@ -23,34 +25,41 @@ func NewUpgrader(client EksdInstallerClient, reader Reader, opts ...UpgraderOpt)
 	}
 }
 
-func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
-	logger.V(1).Info("Checking for EKS-D components upgrade")
-	changeDiff := EksdChangeDiff(currentSpec, newSpec)
+// Upgrade checks for EKS-D updates, and if there are updates the EKS-D CRDs in the cluster.
+func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error {
+	logger.V(1).Info("Checking for EKS-D CRD updates")
+	changeDiff := ChangeDiff(currentSpec, newSpec)
 	if changeDiff == nil {
-		logger.V(1).Info("Nothing to upgrade for EKS-D components")
-		return nil, nil
+		logger.V(1).Info("Nothing to update for EKS-D.")
+		return nil
 	}
-	logger.V(1).Info("Starting EKS-D components upgrade")
+	logger.V(1).Info("Updating EKS-D CRDs")
 	if err := u.InstallEksdCRDs(ctx, newSpec, cluster); err != nil {
-		return nil, fmt.Errorf("upgrading EKS-D components from version %s to version %s: %v", changeDiff.ComponentReports[0].OldVersion, changeDiff.ComponentReports[0].NewVersion, err)
+		return fmt.Errorf("updating EKS-D crds from bundles %d to bundles %d: %v", currentSpec.Bundles.Spec.Number, newSpec.Bundles.Spec.Number, err)
 	}
-	return changeDiff, nil
+	return nil
 }
 
-func EksdChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
+// ChangeDiff returns the change diff between the current and new EKS-D versions.
+func ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 	currentVersionsBundle := currentSpec.RootVersionsBundle()
 	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.EksD.Name != newVersionsBundle.EksD.Name {
-		logger.V(1).Info("EKS-D change diff ", "oldVersion ", currentVersionsBundle.EksD.Name, "newVersion ", newVersionsBundle.EksD.Name)
 		return &types.ChangeDiff{
 			ComponentReports: []types.ComponentChangeDiff{
 				{
-					ComponentName: "EKS-D",
-					NewVersion:    newVersionsBundle.EksD.Name,
-					OldVersion:    currentVersionsBundle.EksD.Name,
+					ComponentName: "kubernetes",
+					NewVersion:    eksdKubernetesVersionTag(newVersionsBundle.EksD),
+					OldVersion:    eksdKubernetesVersionTag(currentVersionsBundle.EksD),
 				},
 			},
 		}
 	}
 	return nil
+}
+
+func eksdKubernetesVersionTag(eksd releavev1alpha1.EksDRelease) string {
+	parts := strings.Split(eksd.Name, "-")
+	releaseNumber := strings.Split(eksd.Name, "-")[len(parts)-1]
+	return fmt.Sprintf("%s-eks-%s-%s", eksd.KubeVersion, eksd.ReleaseChannel, releaseNumber)
 }

--- a/pkg/eksd/upgrader_test.go
+++ b/pkg/eksd/upgrader_test.go
@@ -34,7 +34,9 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 	client := mocks.NewMockEksdInstallerClient(ctrl)
 	reader := m.NewMockReader(ctrl)
 	currentSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.VersionsBundles["1.19"].EksD.Name = "eks-d-1"
+		s.VersionsBundles["1.19"].EksD.Name = "kubernetes-1-19-eks-1"
+		s.VersionsBundles["1.19"].EksD.ReleaseChannel = "1-19"
+		s.VersionsBundles["1.19"].EksD.KubeVersion = "v1.19.1"
 	})
 
 	return &upgraderTest{
@@ -68,34 +70,43 @@ func TestEksdUpgradeNoChanges(t *testing.T) {
 func TestEksdUpgradeSuccess(t *testing.T) {
 	tt := newUpgraderTest(t)
 
-	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "eks-d-2"
+	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "kubernetes-1-19-eks-2"
 	tt.newSpec.Bundles = bundle()
-
-	wantDiff := &types.ChangeDiff{
-		ComponentReports: []types.ComponentChangeDiff{
-			{
-				ComponentName: "EKS-D",
-				NewVersion:    "eks-d-2",
-				OldVersion:    "eks-d-1",
-			},
-		},
-	}
 
 	tt.reader.EXPECT().ReadFile(testdataFile).Return([]byte("test data"), nil)
 	tt.client.EXPECT().ApplyKubeSpecFromBytesWithNamespace(tt.ctx, tt.cluster, []byte("test data"), constants.EksaSystemNamespace).Return(nil)
-	tt.Expect(tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
+	tt.Expect(tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil())
 }
 
 func TestUpgraderEksdUpgradeInstallError(t *testing.T) {
 	tt := newUpgraderTest(t)
 	tt.eksdUpgrader.SetRetrier(retrier.NewWithMaxRetries(1, 0))
-	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "eks-d-2"
+	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "kubernetes-1-19-eks-2"
 	tt.newSpec.Bundles = bundle()
 	tt.newSpec.Bundles.Spec.VersionsBundles[0].EksD.Components = ""
 	tt.newSpec.Bundles.Spec.VersionsBundles[1].EksD.Components = ""
 
 	tt.reader.EXPECT().ReadFile(tt.newSpec.Bundles.Spec.VersionsBundles[0].EksD.Components).Return([]byte(""), fmt.Errorf("error"))
 	// components file not set so this should return an error in failing to load manifest
-	_, err := tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)
+	err := tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)
 	tt.Expect(err).NotTo(BeNil())
+}
+
+func TestChangeDiff(t *testing.T) {
+	tt := newUpgraderTest(t)
+
+	tt.newSpec.VersionsBundles["1.19"].EksD.Name = "kubernetes-1-19-eks-2"
+	tt.newSpec.Bundles = bundle()
+
+	wantDiff := &types.ChangeDiff{
+		ComponentReports: []types.ComponentChangeDiff{
+			{
+				ComponentName: "kubernetes",
+				OldVersion:    "v1.19.1-eks-1-19-1",
+				NewVersion:    "v1.19.1-eks-1-19-2",
+			},
+		},
+	}
+
+	tt.Expect(eksd.ChangeDiff(tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
 }

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -84,7 +84,7 @@ type EksdInstaller interface {
 }
 
 type EksdUpgrader interface {
-	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error
 }
 
 type PackageInstaller interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -829,12 +829,11 @@ func (m *MockEksdUpgrader) EXPECT() *MockEksdUpgraderMockRecorder {
 }
 
 // Upgrade mocks base method.
-func (m *MockEksdUpgrader) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) (*types.ChangeDiff, error) {
+func (m *MockEksdUpgrader) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2, arg3 *cluster.Spec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*types.ChangeDiff)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade.

--- a/pkg/workflows/management/core_components.go
+++ b/pkg/workflows/management/core_components.go
@@ -96,12 +96,11 @@ func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandC
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
-	changeDiff, err = commandContext.EksdUpgrader.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
+	err = commandContext.EksdUpgrader.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return err
 	}
-	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
 	eksaCluster := &anywherev1.Cluster{}
 	err = client.Get(ctx, commandContext.CurrentClusterSpec.Cluster.Name, commandContext.CurrentClusterSpec.Cluster.Namespace, eksaCluster)

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -37,12 +37,6 @@ var eksaChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
 	NewVersion:    "v0.0.2",
 })
 
-var eksdChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
-	ComponentName: "eks-d",
-	OldVersion:    "v0.0.1",
-	NewVersion:    "v0.0.2",
-})
-
 var managementComponentsVersionAnnotation = map[string]string{
 	"anywhere.eks.amazonaws.com/management-components-version": "v0.0.0-dev",
 }
@@ -121,7 +115,7 @@ func TestRunnerHappyPath(t *testing.T) {
 		mocks.gitOpsManager.EXPECT().Install(ctx, managementCluster, newManagementComponents, curSpec, newSpec).Return(nil),
 		mocks.gitOpsManager.EXPECT().Upgrade(ctx, managementCluster, currentManagementComponents, newManagementComponents, curSpec, newSpec).Return(fluxChangeDiff, nil),
 		mocks.clusterManager.EXPECT().Upgrade(ctx, managementCluster, currentManagementComponents, newManagementComponents, newSpec).Return(eksaChangeDiff, nil),
-		mocks.eksdUpgrader.EXPECT().Upgrade(ctx, managementCluster, curSpec, newSpec).Return(eksdChangeDiff, nil),
+		mocks.eksdUpgrader.EXPECT().Upgrade(ctx, managementCluster, curSpec, newSpec).Return(nil),
 		mocks.clusterManager.EXPECT().ApplyBundles(
 			ctx, newSpec, managementCluster,
 		).Return(nil),

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -177,11 +177,6 @@ func (c *upgradeManagementTestSetup) expectUpgradeCoreComponents() {
 		OldVersion:    "v0.0.1",
 		NewVersion:    "v0.0.2",
 	})
-	eksdChangeDiff := types.NewChangeDiff(&types.ComponentChangeDiff{
-		ComponentName: "eks-d",
-		OldVersion:    "v0.0.1",
-		NewVersion:    "v0.0.2",
-	})
 
 	gomock.InOrder(
 		c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any()),
@@ -190,7 +185,7 @@ func (c *upgradeManagementTestSetup) expectUpgradeCoreComponents() {
 		c.gitOpsManager.EXPECT().Install(c.ctx, c.managementCluster, c.newManagementComponents, currentSpec, c.newClusterSpec).Return(nil),
 		c.gitOpsManager.EXPECT().Upgrade(c.ctx, c.managementCluster, c.currentManagementComponents, c.newManagementComponents, currentSpec, c.newClusterSpec).Return(fluxChangeDiff, nil),
 		c.clusterManager.EXPECT().Upgrade(c.ctx, c.managementCluster, c.currentManagementComponents, c.newManagementComponents, c.newClusterSpec).Return(eksaChangeDiff, nil),
-		c.eksdUpgrader.EXPECT().Upgrade(c.ctx, c.managementCluster, currentSpec, c.newClusterSpec).Return(eksdChangeDiff, nil),
+		c.eksdUpgrader.EXPECT().Upgrade(c.ctx, c.managementCluster, currentSpec, c.newClusterSpec).Return(nil),
 	)
 }
 

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -248,12 +248,11 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 	}
 	commandContext.UpgradeChangeDiff.Append(changeDiff)
 
-	changeDiff, err = commandContext.EksdUpgrader.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
+	err = commandContext.EksdUpgrader.Upgrade(ctx, commandContext.ManagementCluster, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
-	commandContext.UpgradeChangeDiff.Append(changeDiff)
 	s.UpgradeChangeDiff = commandContext.UpgradeChangeDiff
 
 	return &upgradeNeeded{}
@@ -510,16 +509,14 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 		return &CollectDiagnosticsTask{}
 	}
 
-	if commandContext.UpgradeChangeDiff.Changed() {
-		if err = commandContext.ClusterManager.ApplyBundles(ctx, commandContext.ClusterSpec, eksaManagementCluster); err != nil {
-			commandContext.SetError(err)
-			return &CollectDiagnosticsTask{}
-		}
+	if err = commandContext.ClusterManager.ApplyBundles(ctx, commandContext.ClusterSpec, eksaManagementCluster); err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
+	}
 
-		if err = commandContext.ClusterManager.ApplyReleases(ctx, commandContext.ClusterSpec, eksaManagementCluster); err != nil {
-			commandContext.SetError(err)
-			return &CollectDiagnosticsTask{}
-		}
+	if err = commandContext.ClusterManager.ApplyReleases(ctx, commandContext.ClusterSpec, eksaManagementCluster); err != nil {
+		commandContext.SetError(err)
+		return &CollectDiagnosticsTask{}
 	}
 
 	return &moveManagementToWorkloadTask{}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -160,15 +160,10 @@ func (c *upgradeTestSetup) expectUpgradeCoreComponents(managementCluster *types.
 		OldVersion:    "v0.0.1",
 		NewVersion:    "v0.0.2",
 	})
-	eksdChangeDiff := types.NewChangeDiff(&types.ComponentChangeDiff{
-		ComponentName: "eks-d",
-		OldVersion:    "v0.0.1",
-		NewVersion:    "v0.0.2",
-	})
 	gomock.InOrder(
 		c.clusterManager.EXPECT().UpgradeNetworking(c.ctx, workloadCluster, currentSpec, c.newClusterSpec, c.provider).Return(networkingChangeDiff, nil),
 		c.capiManager.EXPECT().Upgrade(c.ctx, managementCluster, c.provider, currentSpec, c.newClusterSpec).Return(capiChangeDiff, nil),
-		c.eksdUpgrader.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(eksdChangeDiff, nil),
+		c.eksdUpgrader.EXPECT().Upgrade(c.ctx, managementCluster, currentSpec, c.newClusterSpec).Return(nil),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes here are split out from #7353 with some changes, passing the `ManagementComponents` object down to where it's needed to make comparisons.

Adds "kubernete" change entry as a cluster component to the upgrade plan:
- Change messaging  and interface of the EKSD upgrader to less confusing as to what it does: updates eks-d crds, not upgrading eks-d from one version to another.
- Remove types.ChangeDiff as a return from the EKSDUpgrader interface because it's unneeded.

*Testing (if applicable):*
- Created management cluster with v0.18.4 and check upgrade plan output
- Upgrade management-components and check the output upgrade plan

Before upgrade management-components
```
NAME                 CURRENT VERSION       NEXT VERSION
...
cilium               v1.12.15-eksa.1       v1.13.9-eksa.1
kubernetes           v1.27.8-eks-1-27-19   v1.27.8-eks-1-27-21

```

After upgrade management-components (kubernetes and cilium are still there because cluster has not been upgraded yet)
```
NAME                 CURRENT VERSION       NEXT VERSION
...
cilium               v1.12.15-eksa.1       v1.13.9-eksa.1
kubernetes           v1.27.8-eks-1-27-19   v1.27.8-eks-1-27-21
```

After upgrade cluster
```
NAME      CURRENT VERSION   NEXT VERSION
```
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

