### PR TITLE
Add additional validations for in place upgrades

### DIFF
--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3385,6 +3385,31 @@ func TestValidateCPUpgradeRolloutStrategy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "in place upgrade - tinkerbell",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: TinkerbellDatacenterKind,
+					},
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "InPlace"},
+					},
+				},
+			},
+		},
+		{
+			name:    "in place upgrade - provider not supported",
+			wantErr: "ControlPlaneConfiguration: 'InPlace' upgrade rollout strategy type is only supported on Bare Metal",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					ControlPlaneConfiguration: ControlPlaneConfiguration{
+						UpgradeRolloutStrategy: &ControlPlaneUpgradeRolloutStrategy{Type: "InPlace"},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3515,11 +3540,36 @@ func TestValidateMDUpgradeRolloutStrategy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "in place upgrade - tinkerbell",
+			wantErr: "",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					DatacenterRef: Ref{
+						Kind: TinkerbellDatacenterKind,
+					},
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "InPlace"},
+					}},
+				},
+			},
+		},
+		{
+			name:    "in place upgrade - provider not supported",
+			wantErr: "WorkerNodeGroupConfiguration: 'InPlace' upgrade rollout strategy type is only supported on Bare Metal",
+			cluster: &Cluster{
+				Spec: ClusterSpec{
+					WorkerNodeGroupConfigurations: []WorkerNodeGroupConfiguration{{
+						UpgradeRolloutStrategy: &WorkerNodesUpgradeRolloutStrategy{Type: "InPlace"},
+					}},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := validateMDUpgradeRolloutStrategy(&tt.cluster.Spec.WorkerNodeGroupConfigurations[0])
+			err := validateMDUpgradeRolloutStrategy(&tt.cluster.Spec.WorkerNodeGroupConfigurations[0], tt.cluster.Spec.DatacenterRef.Kind)
 			if tt.wantErr == "" {
 				g.Expect(err).To(BeNil())
 			} else {

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1219,9 +1219,20 @@ func (a *AutoScalingConfiguration) Equal(other *AutoScalingConfiguration) bool {
 	return a.MaxCount == other.MaxCount && a.MinCount == other.MinCount
 }
 
+// UpgradeRolloutStrategyType defines the types of upgrade rollout strategies.
+type UpgradeRolloutStrategyType string
+
+const (
+	// RollingUpdateStrategyType replaces the old machine by new one using rolling update.
+	RollingUpdateStrategyType UpgradeRolloutStrategyType = "RollingUpdate"
+
+	// InPlaceStrategyType upgrades the machines in-place without rolling out any new nodes.
+	InPlaceStrategyType UpgradeRolloutStrategyType = "InPlace"
+)
+
 // ControlPlaneUpgradeRolloutStrategy indicates rollout strategy for cluster.
 type ControlPlaneUpgradeRolloutStrategy struct {
-	Type          string                          `json:"type,omitempty"`
+	Type          UpgradeRolloutStrategyType      `json:"type,omitempty"`
 	RollingUpdate ControlPlaneRollingUpdateParams `json:"rollingUpdate,omitempty"`
 }
 
@@ -1232,7 +1243,7 @@ type ControlPlaneRollingUpdateParams struct {
 
 // WorkerNodesUpgradeRolloutStrategy indicates rollout strategy for cluster.
 type WorkerNodesUpgradeRolloutStrategy struct {
-	Type          string                         `json:"type,omitempty"`
+	Type          UpgradeRolloutStrategyType     `json:"type,omitempty"`
 	RollingUpdate WorkerNodesRollingUpdateParams `json:"rollingUpdate,omitempty"`
 }
 

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -90,6 +90,11 @@ func AssertOsFamilyValid(spec *ClusterSpec) error {
 	return validateOsFamily(spec)
 }
 
+// AssertUpgradeRolloutStrategyValid ensures that the upgrade rollout strategy is valid for both CP and worker node configurations.
+func AssertUpgradeRolloutStrategyValid(spec *ClusterSpec) error {
+	return validateUpgradeRolloutStrategy(spec)
+}
+
 // AssertOSImageURL ensures that the OSImageURL value is either set at the datacenter config level or set for each machine config and not at both levels.
 func AssertOSImageURL(spec *ClusterSpec) error {
 	return validateOSImageURL(spec)

--- a/pkg/providers/tinkerbell/cluster.go
+++ b/pkg/providers/tinkerbell/cluster.go
@@ -111,6 +111,7 @@ func NewClusterSpecValidator(assertions ...ClusterSpecAssertion) *ClusterSpecVal
 		AssertOSImageURL,
 		AssertTinkerbellIPAndControlPlaneIPNotSame,
 		AssertHookRetrievableWithoutProxy,
+		AssertUpgradeRolloutStrategyValid,
 	)
 	v.Register(assertions...)
 	return &v

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -40,7 +40,6 @@ var defaultClusterConfigMD string
 const (
 	TinkerbellMachineTemplateKind = "TinkerbellMachineTemplate"
 	defaultRegistry               = "public.ecr.aws"
-	inPlaceUpgradeRolloutStrategy = "InPlace"
 )
 
 type TemplateBuilder struct {
@@ -162,7 +161,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 
 		if workerNodeGroupConfiguration.UpgradeRolloutStrategy != nil {
 			values["upgradeRolloutStrategy"] = true
-			if workerNodeGroupConfiguration.UpgradeRolloutStrategy.Type == inPlaceUpgradeRolloutStrategy {
+			if workerNodeGroupConfiguration.UpgradeRolloutStrategy.Type == v1alpha1.InPlaceStrategyType {
 				values["upgradeRolloutStrategyType"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.Type
 			} else {
 				values["maxSurge"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
@@ -438,7 +437,7 @@ func buildTemplateMapCP(
 
 	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy != nil {
 		values["upgradeRolloutStrategy"] = true
-		if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type == inPlaceUpgradeRolloutStrategy {
+		if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type == v1alpha1.InPlaceStrategyType {
 			values["upgradeRolloutStrategyType"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type
 		} else {
 			values["maxSurge"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds more validations for in place upgrades to ensure that:
- InPlace can only be specified for Tinkerbell provider with the Ubuntu OS family
- Cp and workers must have the same upgrade rollout strategy specified.

*Testing (if applicable):*
Unit tests

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

