### PR TITLE
Delete Cluster Defaulter

### DIFF
--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -225,6 +225,13 @@ func buildUpgradeCliConfig(clusterOptions *upgradeClusterOptions) (*config.Upgra
 	return &upgradeCliConfig, nil
 }
 
+func buildDeleteCliConfig() *config.DeleteClusterCLIConfig {
+	deleteCliConfig := &config.DeleteClusterCLIConfig{
+		ClusterNamespace: "default",
+	}
+	return deleteCliConfig
+}
+
 func getManagementClusterKubeconfig(clusterName string) (string, error) {
 	envKubeconfig := kubeconfig.FromEnvironment()
 	if envKubeconfig != "" {

--- a/pkg/cli/deleteclusterdefaulter.go
+++ b/pkg/cli/deleteclusterdefaulter.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/defaulting"
+)
+
+// DeleteClusterDefaulter defines the cluster defaulter for delete cluster command defaults.
+type DeleteClusterDefaulter struct {
+	runner *defaulting.Runner[*cluster.Spec]
+}
+
+// NewDeleteClusterDefaulter to instantiate and register defaults.
+func NewDeleteClusterDefaulter(nsDefaulter cluster.NamespaceDefaulter) DeleteClusterDefaulter {
+	r := defaulting.NewRunner[*cluster.Spec]()
+	r.Register(
+		nsDefaulter.NamespaceDefault,
+	)
+
+	return DeleteClusterDefaulter{
+		runner: r,
+	}
+}
+
+// Run will run all the defaults registered to the Delete Cluster Defaulter.
+func (v DeleteClusterDefaulter) Run(ctx context.Context, spec *cluster.Spec) (*cluster.Spec, error) {
+	return v.runner.RunAll(ctx, spec)
+}

--- a/pkg/cli/deleteclusterdefaulter_test.go
+++ b/pkg/cli/deleteclusterdefaulter_test.go
@@ -1,0 +1,41 @@
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/eks-anywhere/pkg/cli"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/defaulting"
+)
+
+func TestNewDeleteClusterDefaulter(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := "test-ns"
+	nsDefaulter := cluster.NewNamespaceDefaulter(ns)
+
+	c := baseCluster()
+
+	clusterSpec := &cluster.Spec{
+		Config: &cluster.Config{
+			Cluster: c,
+		},
+	}
+
+	r := defaulting.NewRunner[*cluster.Spec]()
+	r.Register(
+		nsDefaulter.NamespaceDefault,
+	)
+
+	got := cli.NewDeleteClusterDefaulter(nsDefaulter)
+
+	g.Expect(got).NotTo(BeNil())
+
+	clusterSpec, err := got.Run(context.Background(), clusterSpec)
+
+	g.Expect(err).To(BeNil())
+	g.Expect(clusterSpec.Cluster.Namespace).To(ContainSubstring(ns))
+}

--- a/pkg/cluster/defaults.go
+++ b/pkg/cluster/defaults.go
@@ -88,3 +88,26 @@ func setMachineHealthCheckTimeoutDefaults(cluster *anywherev1.Cluster, nodeStart
 		}
 	}
 }
+
+// NamespaceDefaulter is the defaulter created to configure the cluster's namespace.
+type NamespaceDefaulter struct {
+	defaultClusterNamespace string
+}
+
+// NewNamespaceDefaulter allows to create a new ClusterNamespaceDefaulter.
+func NewNamespaceDefaulter(namespace string) NamespaceDefaulter {
+	return NamespaceDefaulter{
+		defaultClusterNamespace: namespace,
+	}
+}
+
+// NamespaceDefault sets the defaults for cluster's namespace.
+func (c NamespaceDefaulter) NamespaceDefault(ctx context.Context, spec *Spec) (*Spec, error) {
+	for _, obj := range spec.ClusterAndChildren() {
+		if obj.GetNamespace() == "" {
+			obj.SetNamespace(c.defaultClusterNamespace)
+		}
+	}
+
+	return spec, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,3 +33,8 @@ type UpgradeClusterCLIConfig struct {
 	NodeStartupTimeout      time.Duration
 	UnhealthyMachineTimeout time.Duration
 }
+
+// DeleteClusterCLIConfig is the config we use for delete cluster specific configurations.
+type DeleteClusterCLIConfig struct {
+	ClusterNamespace string
+}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -116,6 +116,7 @@ type Dependencies struct {
 	KubeconfigWriter            kubeconfig.Writer
 	ClusterCreator              *clustermanager.ClusterCreator
 	EksaInstaller               *clustermanager.EKSAInstaller
+	DeleteClusterDefaulter      cli.DeleteClusterDefaulter
 }
 
 // KubeClients defines super struct that exposes all behavior.
@@ -1179,6 +1180,20 @@ func (f *Factory) WithUpgradeClusterDefaulter(upgradeCliConfig *cliconfig.Upgrad
 		upgradeClusterDefaulter := cli.NewUpgradeClusterDefaulter(machineHealthCheckDefaulter)
 
 		f.dependencies.UpgradeClusterDefaulter = upgradeClusterDefaulter
+
+		return nil
+	})
+
+	return f
+}
+
+// WithDeleteClusterDefaulter builds a delete cluster defaulter that builds defaulter dependencies specific to the delete cluster command. The defaulter is then run once the factory is built in the delete cluster command.
+func (f *Factory) WithDeleteClusterDefaulter(deleteCliConfig *cliconfig.DeleteClusterCLIConfig) *Factory {
+	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
+		nsDefaulter := cluster.NewNamespaceDefaulter(deleteCliConfig.ClusterNamespace)
+		deleteClusterDefaulter := cli.NewDeleteClusterDefaulter(nsDefaulter)
+
+		f.dependencies.DeleteClusterDefaulter = deleteClusterDefaulter
 
 		return nil
 	})

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -35,6 +35,7 @@ type factoryTest struct {
 	createCLIConfig       config.CreateClusterCLIConfig
 	upgradeCLIConfig      config.UpgradeClusterCLIConfig
 	providerOptions       *dependencies.ProviderOptions
+	deleteCLIConfig       config.DeleteClusterCLIConfig
 }
 
 type provider string
@@ -57,6 +58,9 @@ func newTest(t *testing.T, p provider) *factoryTest {
 		upgradeCLIConfig: config.UpgradeClusterCLIConfig{
 			NodeStartupTimeout:      5 * time.Minute,
 			UnhealthyMachineTimeout: 5 * time.Minute,
+		},
+		deleteCLIConfig: config.DeleteClusterCLIConfig{
+			ClusterNamespace: "test-ns",
 		},
 	}
 
@@ -324,6 +328,7 @@ func TestFactoryBuildWithMultipleDependencies(t *testing.T) {
 		WithValidatorClients().
 		WithCreateClusterDefaulter(&tt.createCLIConfig).
 		WithUpgradeClusterDefaulter(&tt.upgradeCLIConfig).
+		WithDeleteClusterDefaulter(&tt.deleteCLIConfig).
 		WithKubernetesRetrierClient().
 		Build(context.Background())
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a defaulter (for cluster namespace) in delete cluster command

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

