### PR TITLE
Remove nginx from upgrader pod

### DIFF
--- a/controllers/nodeupgrade_controller.go
+++ b/controllers/nodeupgrade_controller.go
@@ -313,7 +313,7 @@ func updateComponentsConditions(pod *corev1.Pod, nodeUpgrade *anywherev1.NodeUpg
 
 	completed := true
 	for _, container := range containersMap {
-		status, err := getInitContainerStatus(pod, container.name)
+		status, err := getContainerStatus(pod, container.name)
 		if err != nil {
 			conditions.MarkFalse(nodeUpgrade, container.condition, "Container status not available yet", clusterv1.ConditionSeverityWarning, "")
 			completed = false
@@ -341,8 +341,13 @@ func updateComponentsConditions(pod *corev1.Pod, nodeUpgrade *anywherev1.NodeUpg
 	nodeUpgrade.Status.Completed = completed
 }
 
-func getInitContainerStatus(pod *corev1.Pod, containerName string) (*corev1.ContainerStatus, error) {
+func getContainerStatus(pod *corev1.Pod, containerName string) (*corev1.ContainerStatus, error) {
 	for _, status := range pod.Status.InitContainerStatuses {
+		if status.Name == containerName {
+			return &status, nil
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
 		if status.Name == containerName {
 			return &status, nil
 		}

--- a/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
@@ -6,9 +6,22 @@ metadata:
   namespace: eksa-system
 spec:
   containers:
-  - image: nginx
-    name: done
+  - args:
+    - --target
+    - "1"
+    - --mount
+    - --uts
+    - --ipc
+    - --net
+    - /foo/eksa-upgrades/scripts/upgrade.sh
+    - print_status_and_cleanup
+    command:
+    - nsenter
+    image: public.ecr.aws/eks-anywhere/node-upgrader:latest
+    name: post-upgrade-status
     resources: {}
+    securityContext:
+      privileged: true
   hostPID: true
   initContainers:
   - args:
@@ -89,23 +102,8 @@ spec:
     resources: {}
     securityContext:
       privileged: true
-  - args:
-    - --target
-    - "1"
-    - --mount
-    - --uts
-    - --ipc
-    - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - print_status_and_cleanup
-    command:
-    - nsenter
-    image: public.ecr.aws/eks-anywhere/node-upgrader:latest
-    name: post-upgrade-status
-    resources: {}
-    securityContext:
-      privileged: true
   nodeName: my-node
+  restartPolicy: Never
   volumes:
   - hostPath:
       path: /foo

--- a/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
@@ -6,9 +6,22 @@ metadata:
   namespace: eksa-system
 spec:
   containers:
-  - image: nginx
-    name: done
+  - args:
+    - --target
+    - "1"
+    - --mount
+    - --uts
+    - --ipc
+    - --net
+    - /foo/eksa-upgrades/scripts/upgrade.sh
+    - print_status_and_cleanup
+    command:
+    - nsenter
+    image: public.ecr.aws/eks-anywhere/node-upgrader:latest
+    name: post-upgrade-status
     resources: {}
+    securityContext:
+      privileged: true
   hostPID: true
   initContainers:
   - args:
@@ -87,23 +100,8 @@ spec:
     resources: {}
     securityContext:
       privileged: true
-  - args:
-    - --target
-    - "1"
-    - --mount
-    - --uts
-    - --ipc
-    - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - print_status_and_cleanup
-    command:
-    - nsenter
-    image: public.ecr.aws/eks-anywhere/node-upgrader:latest
-    name: post-upgrade-status
-    resources: {}
-    securityContext:
-      privileged: true
   nodeName: my-node
+  restartPolicy: Never
   volumes:
   - hostPath:
       path: /foo

--- a/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
@@ -6,9 +6,22 @@ metadata:
   namespace: eksa-system
 spec:
   containers:
-  - image: nginx
-    name: done
+  - args:
+    - --target
+    - "1"
+    - --mount
+    - --uts
+    - --ipc
+    - --net
+    - /foo/eksa-upgrades/scripts/upgrade.sh
+    - print_status_and_cleanup
+    command:
+    - nsenter
+    image: public.ecr.aws/eks-anywhere/node-upgrader:latest
+    name: post-upgrade-status
     resources: {}
+    securityContext:
+      privileged: true
   hostPID: true
   initContainers:
   - args:
@@ -87,23 +100,8 @@ spec:
     resources: {}
     securityContext:
       privileged: true
-  - args:
-    - --target
-    - "1"
-    - --mount
-    - --uts
-    - --ipc
-    - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - print_status_and_cleanup
-    command:
-    - nsenter
-    image: public.ecr.aws/eks-anywhere/node-upgrader:latest
-    name: post-upgrade-status
-    resources: {}
-    securityContext:
-      privileged: true
   nodeName: my-node
+  restartPolicy: Never
   volumes:
   - hostPath:
       path: /foo

--- a/pkg/nodeupgrader/upgrader.go
+++ b/pkg/nodeupgrader/upgrader.go
@@ -82,16 +82,10 @@ func upgraderPod(nodeName, image string) *corev1.Pod {
 					},
 				},
 			},
-			// TODO(in-place): currently, the pod requires atleast one container.
-			// For the time being, I have added an nginx container but
-			// this should be replaced with something that makes more
-			// sense in in-place context.
 			Containers: []corev1.Container{
-				{
-					Name:  "done",
-					Image: "nginx",
-				},
+				nsenterContainer(image, PostUpgradeContainerName, upgradeScript, "print_status_and_cleanup"),
 			},
+			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
 }
@@ -103,7 +97,6 @@ func containersForUpgrade(image, nodeName string, kubeadmUpgradeCommand ...strin
 		nsenterContainer(image, CNIPluginsUpgraderContainerName, upgradeScript, "cni_plugins"),
 		nsenterContainer(image, KubeadmUpgraderContainerName, append([]string{upgradeScript}, kubeadmUpgradeCommand...)...),
 		nsenterContainer(image, KubeletUpgradeContainerName, upgradeScript, "kubelet_and_kubectl"),
-		nsenterContainer(image, PostUpgradeContainerName, upgradeScript, "print_status_and_cleanup"),
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*
This PR removes nginx container from the upgrader pod and replaces it with the upgrader container that prints out the status and performs cleanup.
Also sets the pod `restartPolicy` to never so the cleanup container doesn't try to restart every time and run into a crashloop backoff.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

