### PR TITLE
Delete bootstrap cluster for create management controller via CLI

### DIFF
--- a/pkg/workflows/management/create_delete_bootstrap.go
+++ b/pkg/workflows/management/create_delete_bootstrap.go
@@ -1,0 +1,35 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+)
+
+type deleteBootstrapClusterTask struct{}
+
+func (s *deleteBootstrapClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Deleting bootstrap cluster")
+	err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, constants.Create, false)
+	if err != nil {
+		commandContext.SetError(err)
+	}
+	if commandContext.OriginalError == nil {
+		logger.MarkSuccess("Cluster created!")
+	}
+	return nil
+}
+
+func (s *deleteBootstrapClusterTask) Name() string {
+	return "delete-kind-cluster"
+}
+
+func (s *deleteBootstrapClusterTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *deleteBootstrapClusterTask) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/management/write_cluster_config.go
+++ b/pkg/workflows/management/write_cluster_config.go
@@ -49,7 +49,7 @@ func (s *writeCreateClusterConfig) Run(ctx context.Context, commandContext *task
 		commandContext.SetError(err)
 		return &workflows.CollectDiagnosticsTask{}
 	}
-	return nil
+	return &deleteBootstrapClusterTask{}
 }
 
 func (s *writeCreateClusterConfig) Name() string {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Delete bootstrap cluster for create management controller via CLI
*Testing (if applicable):*
- unit test

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

