### PR TITLE
Compute docs checksum and upload it to artifacts bucket

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -81,4 +81,4 @@ compute-checksum: ## Compute docs checksum
 	sha256sum public/index.html > DOCS_CHECKSUM
 
 upload-checksum: compute-checksum ## Upload the checksum to artifacts bucket
-	aws s3 cp DOCS_CHECKSUM s3://artifactsstack-1532887287-artifactsbucket2aac5544-exgxrmntr4id --acl public-read
+	aws s3 cp DOCS_CHECKSUM s3://$(ARTIFACTS_BUCKET) --acl public-read

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,13 +26,13 @@ build-docs: submodule ## Generate the static site into the /public folder
 
 release: build
 
-submodule: ## initialize the docsy theme submodule
+submodule: ## Initialize the docsy theme submodule
 	git submodule update --init --recursive
 
-submodule-apply-patches: submodule ## apply submodule patches
+submodule-apply-patches: submodule ## Apply submodule patches
 	cd themes/docsy; git am ../../patches/0001-Make-docsy-js-files-static.patch; cd ../..
 
-submodule-reset: ## reset submodules to tracked commit
+submodule-reset: ## Reset submodules to tracked commit
 	git submodule update --init --recursive --force
 
 htmltest: install-htmltest
@@ -76,3 +76,9 @@ container-server: container-serve
 
 clean: ## Delete generated content. (requires sudo if using container-serve)
 	rm -rf public resources node_modules public.zip
+
+compute-checksum: ## Compute docs checksum
+	sha256sum public/index.html > DOCS_CHECKSUM
+
+upload-checksum: compute-checksum ## Upload the checksum to artifacts bucket
+	aws s3 cp DOCS_CHECKSUM s3://artifactsstack-1532887287-artifactsbucket2aac5544-exgxrmntr4id --acl public-read

--- a/docs/amplify.yml
+++ b/docs/amplify.yml
@@ -5,6 +5,9 @@ applications:
         build:
           commands:
             - make release
+        postBuild:
+          commands:
+            - make upload-checksum
       artifacts:
         baseDirectory: public
         files:


### PR DESCRIPTION
*Issue #, if available:*
[#1931](https://github.com/aws/eks-anywhere-internal/issues/1931)

*Description of changes:*
Added a make target to compute the eks anywhere docs checksum from `public/index.html` and upload it to artifacts bucket with public access so that the docs canary can verify with the latest version

*Testing (if applicable):*
Tested locally in personal isengard account

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

