### PR TITLE
Add feature flag for in place upgrades on vSphere

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,6 +7,7 @@ const (
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
 	K8s129SupportEnvVar             = "K8S_1_29_SUPPORT"
+	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 )
 
 func FeedGates(featureGates []string) {
@@ -61,5 +62,13 @@ func K8s129Support() Feature {
 	return Feature{
 		Name:     "Kubernetes version 1.29 support",
 		IsActive: globalFeatures.isActiveForEnvVar(K8s129SupportEnvVar),
+	}
+}
+
+// VSphereInPlaceUpgradeEnabled is the feature flag for performing in-place upgrades with the vSphere provider.
+func VSphereInPlaceUpgradeEnabled() Feature {
+	return Feature{
+		Name:     "Perform in-place upgrades with the vSphere provider",
+		IsActive: globalFeatures.isActiveForEnvVar(VSphereInPlaceEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -93,3 +93,11 @@ func TestWithK8s129FeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(K8s129SupportEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(K8s129Support())).To(BeTrue())
 }
+
+func TestVSphereInPlaceUpgradeEnabledFeatureFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(VSphereInPlaceEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(VSphereInPlaceUpgradeEnabled())).To(BeTrue())
+}

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -482,8 +482,12 @@ spec:
   replicas: {{.controlPlaneReplicas}}
 {{- if .upgradeRolloutStrategy }}
   rolloutStrategy:
+{{- if (eq .upgradeRolloutStrategyType "InPlace") }}
+    type: {{.upgradeRolloutStrategyType}}
+{{- else}}
     rollingUpdate:
       maxSurge: {{.maxSurge}} 
+{{- end }}
 {{- end }}
   version: {{.kubernetesVersion}}
 ---

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -172,9 +172,13 @@ spec:
       version: {{.kubernetesVersion}}
 {{- if .upgradeRolloutStrategy }}
   strategy:
+{{- if (eq .upgradeRolloutStrategyType "InPlace") }}
+    type: {{.upgradeRolloutStrategyType}}
+{{- else}}
     rollingUpdate:
       maxSurge: {{.maxSurge}}
       maxUnavailable: {{.maxUnavailable}}
+{{- end }}
 {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -111,8 +111,12 @@ func (vs *VsphereTemplateBuilder) GenerateCAPISpecWorkers(
 
 		if workerNodeGroupConfiguration.UpgradeRolloutStrategy != nil {
 			values["upgradeRolloutStrategy"] = true
-			values["maxSurge"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
-			values["maxUnavailable"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxUnavailable
+			if workerNodeGroupConfiguration.UpgradeRolloutStrategy.Type == anywherev1.InPlaceStrategyType {
+				values["upgradeRolloutStrategyType"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.Type
+			} else {
+				values["maxSurge"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
+				values["maxUnavailable"] = workerNodeGroupConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxUnavailable
+			}
 		}
 
 		bytes, err := templater.Execute(defaultClusterConfigMD, values)
@@ -345,7 +349,11 @@ func buildTemplateMapCP(
 
 	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy != nil {
 		values["upgradeRolloutStrategy"] = true
-		values["maxSurge"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
+		if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type == anywherev1.InPlaceStrategyType {
+			values["upgradeRolloutStrategyType"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type
+		} else {
+			values["maxSurge"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
+		}
 	}
 
 	return values, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a feature flag because we are using this provider to test in place upgrade changes, but it will only be supported on bare metal when the feature is initially released.

This PR also updates the vsphere capi specs to specify inplace if it is specified in the clusterspec

*Testing (if applicable):*
Unit test
Manual test for the validations step

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

