### PR TITLE
Add upgrade plan management-components subcommand

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	capiupgrader "github.com/aws/eks-anywhere/pkg/clusterapi"
+	eksaupgrader "github.com/aws/eks-anywhere/pkg/clustermanager"
+	"github.com/aws/eks-anywhere/pkg/dependencies"
+	fluxupgrader "github.com/aws/eks-anywhere/pkg/gitops/flux"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
+)
+
+var upgradePlanManagementComponentsCmd = &cobra.Command{
+	Use:          "management-components",
+	Short:        "Lists the current and target versions for upgrading the management components in a management cluster",
+	Long:         "Provides a list of current and target versions for upgrading the management components in a management cluster. The term 'management components' encompasses all Kubernetes controllers and their CRDs present in the management cluster that are responsible for reconciling your EKS Anywhere (EKS-A) cluster.",
+	PreRunE:      bindFlagsToViper,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := uc.upgradePlanManagementComponents(cmd.Context()); err != nil {
+			return fmt.Errorf("failed to display upgrade plan: %v", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	upgradePlanCmd.AddCommand(upgradePlanManagementComponentsCmd)
+	upgradePlanManagementComponentsCmd.Flags().StringVarP(&uc.fileName, "filename", "f", "", "Filename that contains EKS-A cluster configuration")
+	upgradePlanManagementComponentsCmd.Flags().StringVar(&uc.bundlesOverride, "bundles-override", "", "Override default Bundles manifest (not recommended)")
+	upgradePlanManagementComponentsCmd.Flags().StringVarP(&output, outputFlagName, "o", outputDefault, "Output format: text|json")
+	upgradePlanManagementComponentsCmd.Flags().StringVar(&uc.managementKubeconfig, "kubeconfig", "", "Management cluster kubeconfig file")
+	err := upgradePlanManagementComponentsCmd.MarkFlagRequired("filename")
+	if err != nil {
+		log.Fatalf("Error marking flag as required: %v", err)
+	}
+}
+
+func (uc *upgradeClusterOptions) upgradePlanManagementComponents(ctx context.Context) error {
+	if _, err := uc.commonValidations(ctx); err != nil {
+		return fmt.Errorf("common validations failed due to: %v", err)
+	}
+
+	newClusterSpec, err := newClusterSpec(uc.clusterOptions)
+	if err != nil {
+		return err
+	}
+
+	deps, err := dependencies.ForSpec(newClusterSpec).
+		WithClusterManager(newClusterSpec.Cluster, nil).
+		WithProvider(uc.fileName, newClusterSpec.Cluster, false, uc.hardwareCSVPath, uc.forceClean, uc.tinkerbellBootstrapIP, map[string]bool{}, uc.providerOptions).
+		WithGitOpsFlux(newClusterSpec.Cluster, newClusterSpec.FluxConfig, nil).
+		WithCAPIManager().
+		Build(ctx)
+	if err != nil {
+		return err
+	}
+
+	managementCluster := &types.Cluster{
+		Name:           newClusterSpec.Cluster.Name,
+		KubeconfigFile: getKubeconfigPath(newClusterSpec.Cluster.Name, uc.wConfig),
+	}
+
+	if newClusterSpec.ManagementCluster != nil {
+		managementCluster = newClusterSpec.ManagementCluster
+	}
+
+	logger.V(0).Info("Checking new release availability...")
+	currentSpec, err := deps.ClusterManager.GetCurrentClusterSpec(ctx, managementCluster, newClusterSpec.Cluster.Name)
+	if err != nil {
+		return err
+	}
+
+	if !newClusterSpec.Cluster.IsSelfManaged() {
+		logger.V(0).Info("No management components to plan. Cluster %s is not a self-managed cluster.\n", newClusterSpec.Cluster.Name)
+		return nil
+	}
+
+	var componentChangeDiffs *types.ChangeDiff
+	componentChangeDiffs, err = getManagementComponentsChangeDiffs(ctx, deps.UnAuthKubeClient, managementCluster, currentSpec, newClusterSpec, deps.Provider)
+	if err != nil {
+		return err
+	}
+
+	serializedDiff, err := serialize(componentChangeDiffs, output)
+	if err != nil {
+		return err
+	}
+
+	logger.V(0).Info(serializedDiff)
+
+	return nil
+}
+
+func getManagementComponentsChangeDiffs(ctx context.Context, clientFactory interfaces.ClientFactory, managementCluster *types.Cluster, currentSpec *cluster.Spec, newClusterSpec *cluster.Spec, provider providers.Provider) (*types.ChangeDiff, error) {
+	client, err := clientFactory.BuildClientFromKubeconfig(managementCluster.KubeconfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	currentManagementComponents, err := cluster.GetManagementComponents(ctx, client, currentSpec.Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	componentChangeDiffs := &types.ChangeDiff{}
+	newManagementComponents := cluster.ManagementComponentsFromBundles(newClusterSpec.Bundles)
+	componentChangeDiffs.Append(eksaupgrader.EksaChangeDiff(currentManagementComponents, newManagementComponents))
+	componentChangeDiffs.Append(fluxupgrader.FluxChangeDiff(currentSpec, newClusterSpec))
+	componentChangeDiffs.Append(capiupgrader.CapiChangeDiff(currentSpec, newClusterSpec, provider))
+
+	return componentChangeDiffs, nil
+}


### PR DESCRIPTION
*Issue #, if available:*
[#2133
](https://github.com/aws/eks-anywhere-internal/issues/2133)
*Description of changes:*
This PR adds an `upgrade plan management-components` subcommand, so that users may see the management components that would be upgraded when they run the new `upgrade management-components` subcommand.

*Testing (if applicable):*

**Created a management cluster with v0.18.4 and ran the follow checks**

*upgrade plan management-components on management cluster*

```
./bin/eksctl-anywhere upgrade plan management-components -f mgmt/mgmt-eks-a-cluster.yaml 
...
Checking new release availability...
NAME                 CURRENT VERSION   NEXT VERSION
EKS-A Management     v0.18.4+79b7f58   v0.0.0-dev+build.8277+49bcdf6
cert-manager         v1.13.0+343cf30   v1.13.2+a34c207
cluster-api          v1.5.2+ec7ca3a    v1.6.0+315daa8
kubeadm              v1.5.2+b0ed140    v1.6.0+efa1b8c
vsphere              v1.7.4+8379520    v1.8.5+3330c16
kubeadm              v1.5.2+43f63db    v1.6.0+3168308
etcdadm-bootstrap    v1.0.10+4806f13   v1.0.10+1ceb898
etcdadm-controller   v1.0.16+a28cb02   v1.0.17+5e33062
```

*upgrade plan cluster  on management cluster (notice the additional cluster components like cilium)*

```
./bin/eksctl-anywhere upgrade plan cluster -f mgmt/mgmt-eks-a-cluster.yaml 
...
Checking new release availability...
NAME                 CURRENT VERSION   NEXT VERSION
EKS-A Management     v0.18.4+79b7f58   v0.0.0-dev+build.8277+49bcdf6
cert-manager         v1.13.0+343cf30   v1.13.2+a34c207
cluster-api          v1.5.2+ec7ca3a    v1.6.0+315daa8
kubeadm              v1.5.2+b0ed140    v1.6.0+efa1b8c
vsphere              v1.7.4+8379520    v1.8.5+3330c16
kubeadm              v1.5.2+43f63db    v1.6.0+3168308
etcdadm-bootstrap    v1.0.10+4806f13   v1.0.10+1ceb898
etcdadm-controller   v1.0.16+a28cb02   v1.0.17+5e33062
cilium               v1.12.15-eksa.1   v1.13.9-eksa.1
```

**Created a workoad cluster with v0.18.4 and ran the following checks**

*upgrade plan management-components on workload cluster*

```
./bin/eksctl-anywhere upgrade plan management-components -f w01/w01-eks-a-cluster.yaml 
...
Checking new release availability...
No management components to plan. Cluster w01 is not a self-managed cluster.
```

*upgrade plan cluster on workload cluster*
````
./bin/eksctl-anywhere upgrade plan cluster -f w01/w01-eks-a-cluster.yaml 
Checking new release availability...
NAME      CURRENT VERSION   NEXT VERSION
cilium    v1.12.15-eksa.1   v1.13.9-eksa.1
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

