### PR TITLE
Aggregate validations errors in validator runner

### DIFF
--- a/pkg/validations/runner.go
+++ b/pkg/validations/runner.go
@@ -1,6 +1,11 @@
 package validations
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	eksae "github.com/aws/eks-anywhere/pkg/errors"
+)
 
 var errRunnerValidation = errors.New("validations failed")
 
@@ -19,17 +24,17 @@ func (r *Runner) Register(validations ...Validation) {
 }
 
 func (r *Runner) Run() error {
-	failed := false
+	var errs []error
 	for _, v := range r.validations {
 		result := v()
 		result.Report()
 		if result.Err != nil {
-			failed = true
+			errs = append(errs, result.Err)
 		}
 	}
 
-	if failed {
-		return errRunnerValidation
+	if len(errs) > 0 {
+		return fmt.Errorf("validations failed: %w", eksae.NewAggregate(errs))
 	}
 
 	return nil

--- a/pkg/validations/runner_test.go
+++ b/pkg/validations/runner_test.go
@@ -19,13 +19,12 @@ func TestRunnerRunError(t *testing.T) {
 	})
 	r.Register(func() *validations.ValidationResult {
 		return &validations.ValidationResult{
-			Err: errors.New("failed"),
+			Err: errors.New("one error"),
 		}
 	})
 
-	err := r.Run()
-	g.Expect(err).NotTo(BeNil())
-	g.Expect(err.Error()).To(Equal("validations failed"))
+	g.Expect(r.Run()).To(MatchError(ContainSubstring("validations failed")))
+	g.Expect(r.Run()).To(MatchError(ContainSubstring("one error")))
 }
 
 func TestRunnerRunSuccess(t *testing.T) {

--- a/pkg/workflows/workload/create_test.go
+++ b/pkg/workflows/workload/create_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -182,7 +183,7 @@ func TestCreateRunValidateFail(t *testing.T) {
 	test.expectWrite()
 
 	err := test.run()
-	if err == nil || err.Error() != string("validations failed") {
+	if err == nil || !strings.Contains(err.Error(), "validations failed") {
 		t.Fatalf("Create.Run() err = %v, want err = nil", err)
 	}
 }


### PR DESCRIPTION
*Description of changes:*
This helps debugging since the validation errors are printed at the end of the program. Until now we only printed "validations failed" and the user needed to scroll through previous logs to find the different errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

