### PR TITLE
Update log to use fallback registry when not authorized to access regionalized packages

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -279,7 +279,8 @@ func (pc *PackageControllerClient) GetCuratedPackagesRegistries(ctx context.Cont
 			defaultRegistry = regionalRegistry
 			defaultImageRegistry = regionalRegistry
 		} else {
-			logger.V(6).Info("Using fallback registry", "Registry", defaultRegistry, "RegionalRegistryAccessIssue", err)
+			logger.V(6).Info("Error pulling from regional registry", "Registry", regionalRegistry, "RegionalRegistryAccessIssue", err)
+			logger.V(6).Info("Using fallback registry", "Registry", defaultRegistry)
 		}
 	}
 	return sourceRegistry, defaultRegistry, defaultImageRegistry


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/7336

*Description of changes:*
The current log message mentioned on the issue #7336  doesn't properly mention what command is being used to use the fallback registry instead, and is just showing the command that failed with the regional access. 

Currently, we do not run any commands [here](https://github.com/aws/eks-anywhere/blob/main/pkg/curatedpackages/packagecontrollerclient.go#L282) while using the fallback registry. Changed the log message as below. 

```
Error pulling from regional registry    {"Registry": "067575901363.dkr.ecr.us-west-2.amazonaws.com", "RegionalRegistryAccessIssue": "{\"errors\":[{\"code\":\"DENIED\",\"message\":\"User: arn:aws:iam::189183948571:user/packagesECRRead is not authorized to perform: ecr:BatchGetImage on resource: arn:aws:ecr:us-west-2:067575901363:repository/eks-anywhere-packages because no resource-based policy allows the ecr:BatchGetImage action\"}]}\n\n, <nil>"}

Using fallback registry {"Registry": "public.ecr.aws/l0g8r8j6"}

Installing helm chart on cluster        {"chart": "eks-anywhere-packages", "version": "0.0.0-95edb1a9dee9ff70d3e18150eadebee024794dc4-release-0.18-helm"}
```


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

