### PR TITLE
Give e2e workload cluster config a unique name

### DIFF
--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ func NewMulticlusterE2ETest(t *testing.T, managementCluster *ClusterE2ETest, wor
 	for _, c := range workloadClusters {
 		c.clusterFillers = append(c.clusterFillers, api.WithManagementCluster(managementCluster.ClusterName))
 		c.ClusterName = m.NewWorkloadClusterName()
+		c.ClusterConfigLocation = filepath.Join(managementCluster.ClusterConfigFolder, c.ClusterName+"-eks-a.yaml")
 		m.WithWorkloadClusters(c)
 	}
 


### PR DESCRIPTION
## Description of changes
Before, workload clusters added through the multicluster constructor had an already set config path that defaulted to the management cluster's config file. This meand workload cluster operations overwrote the same file.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

