### PR TITLE
Fix e2e tests to search the kubeconfig consistently

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1046,7 +1046,7 @@ func (e *ClusterE2ETest) managementCluster() *types.Cluster {
 
 // KubeconfigFilePath retrieves the Kubeconfig path used for the workload cluster.
 func (e *ClusterE2ETest) KubeconfigFilePath() string {
-	return filepath.Join(e.ClusterName, fmt.Sprintf("%s-eks-a-cluster.kubeconfig", e.ClusterName))
+	return filepath.Join(e.ClusterConfigFolder, fmt.Sprintf("%s-eks-a-cluster.kubeconfig", e.ClusterName))
 }
 
 // BuildWorkloadClusterClient creates a client for the workload cluster created by e.

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -32,7 +32,8 @@ func NewMulticlusterE2ETest(t *testing.T, managementCluster *ClusterE2ETest, wor
 	for _, c := range workloadClusters {
 		c.clusterFillers = append(c.clusterFillers, api.WithManagementCluster(managementCluster.ClusterName))
 		c.ClusterName = m.NewWorkloadClusterName()
-		c.ClusterConfigLocation = filepath.Join(managementCluster.ClusterConfigFolder, c.ClusterName+"-eks-a.yaml")
+		c.ClusterConfigFolder = c.ClusterName
+		c.ClusterConfigLocation = filepath.Join(c.ClusterConfigFolder, c.ClusterName+"-eks-a.yaml")
 		m.WithWorkloadClusters(c)
 	}
 

--- a/test/framework/workload.go
+++ b/test/framework/workload.go
@@ -123,7 +123,7 @@ func (w *WorkloadCluster) writeKubeconfigToDisk(ctx context.Context, secretName 
 	if err := w.Provider.UpdateKubeConfig(&kubeconfig, w.ClusterName); err != nil {
 		return fmt.Errorf("failed to update kubeconfig for cluster: %s", err)
 	}
-	writer, err := filewriter.NewWriter(w.ClusterConfigFolder)
+	writer, err := filewriter.NewWriter(filepath.Dir(filePath))
 	if err != nil {
 		return fmt.Errorf("failed to write kubeconfig to disk: %v", err)
 	}


### PR DESCRIPTION
## Description of changes
The reading code was making assumptions about what the writing code did. This worked when the workload clusters were setup in a very specific way, but if custom folders were used, the assumptions were broken and the test can't find the kubeconfig file.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

