### PR TITLE
Extend Snow provider surface API to use management components

### DIFF
--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -68,6 +68,20 @@ func (mr *MockProviderMockRecorder) ChangeDiff(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeDiff", reflect.TypeOf((*MockProvider)(nil).ChangeDiff), arg0, arg1)
 }
 
+// ChangeDiffFromManagementComponents mocks base method.
+func (m *MockProvider) ChangeDiffFromManagementComponents(arg0, arg1 *cluster.ManagementComponents) *types.ComponentChangeDiff {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangeDiffFromManagementComponents", arg0, arg1)
+	ret0, _ := ret[0].(*types.ComponentChangeDiff)
+	return ret0
+}
+
+// ChangeDiffFromManagementComponents indicates an expected call of ChangeDiffFromManagementComponents.
+func (mr *MockProviderMockRecorder) ChangeDiffFromManagementComponents(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeDiffFromManagementComponents", reflect.TypeOf((*MockProvider)(nil).ChangeDiffFromManagementComponents), arg0, arg1)
+}
+
 // DatacenterConfig mocks base method.
 func (m *MockProvider) DatacenterConfig(arg0 *cluster.Spec) providers.DatacenterConfig {
 	m.ctrl.T.Helper()
@@ -183,6 +197,20 @@ func (m *MockProvider) GetInfrastructureBundle(arg0 *cluster.Spec) *types.Infras
 func (mr *MockProviderMockRecorder) GetInfrastructureBundle(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfrastructureBundle", reflect.TypeOf((*MockProvider)(nil).GetInfrastructureBundle), arg0)
+}
+
+// GetInfrastructureBundleFromManagementComponents mocks base method.
+func (m *MockProvider) GetInfrastructureBundleFromManagementComponents(arg0 *cluster.ManagementComponents) *types.InfrastructureBundle {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInfrastructureBundleFromManagementComponents", arg0)
+	ret0, _ := ret[0].(*types.InfrastructureBundle)
+	return ret0
+}
+
+// GetInfrastructureBundleFromManagementComponents indicates an expected call of GetInfrastructureBundleFromManagementComponents.
+func (mr *MockProviderMockRecorder) GetInfrastructureBundleFromManagementComponents(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfrastructureBundleFromManagementComponents", reflect.TypeOf((*MockProvider)(nil).GetInfrastructureBundleFromManagementComponents), arg0)
 }
 
 // InstallCustomProviderComponents mocks base method.
@@ -478,6 +506,20 @@ func (m *MockProvider) Version(arg0 *cluster.Spec) string {
 func (mr *MockProviderMockRecorder) Version(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockProvider)(nil).Version), arg0)
+}
+
+// VersionFromManagementComponents mocks base method.
+func (m *MockProvider) VersionFromManagementComponents(arg0 *cluster.ManagementComponents) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VersionFromManagementComponents", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// VersionFromManagementComponents indicates an expected call of VersionFromManagementComponents.
+func (mr *MockProviderMockRecorder) VersionFromManagementComponents(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VersionFromManagementComponents", reflect.TypeOf((*MockProvider)(nil).VersionFromManagementComponents), arg0)
 }
 
 // MockDatacenterConfig is a mock of DatacenterConfig interface.

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -27,15 +27,18 @@ type Provider interface {
 	BootstrapClusterOpts(clusterSpec *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error)
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	Version(clusterSpec *cluster.Spec) string
+	VersionFromManagementComponents(components *cluster.ManagementComponents) string
 	EnvMap(clusterSpec *cluster.Spec) (map[string]string, error)
 	GetDeployments() map[string][]string
 	GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle
+	GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle
 	DatacenterConfig(clusterSpec *cluster.Spec) DatacenterConfig
 	DatacenterResourceType() string
 	MachineResourceType() string
 	MachineConfigs(clusterSpec *cluster.Spec) []MachineConfig
 	ValidateNewSpec(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff
+	ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff
 	RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error
 	UpgradeNeeded(ctx context.Context, newSpec, currentSpec *cluster.Spec, cluster *types.Cluster) (bool, error)
 	DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -185,6 +185,11 @@ func (p *SnowProvider) Version(clusterSpec *cluster.Spec) string {
 	return versionsBundle.Snow.Version
 }
 
+// VersionFromManagementComponents returns the snow version from the management components.
+func (p *SnowProvider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+	return components.Snow.Version
+}
+
 func (p *SnowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	envMap[snowCredentialsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCredentialsKey])
@@ -212,6 +217,20 @@ func (p *SnowProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types
 		Manifests: []releasev1alpha1.Manifest{
 			versionsBundle.Snow.Components,
 			versionsBundle.Snow.Metadata,
+		},
+	}
+	return &infraBundle
+}
+
+// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle from the management components.
+func (p *SnowProvider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+	folderName := fmt.Sprintf("infrastructure-snow/%s/", components.Snow.Version)
+
+	infraBundle := types.InfrastructureBundle{
+		FolderName: folderName,
+		Manifests: []releasev1alpha1.Manifest{
+			components.Snow.Components,
+			components.Snow.Metadata,
 		},
 	}
 	return &infraBundle
@@ -252,6 +271,19 @@ func (p *SnowProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.Com
 		ComponentName: constants.SnowProviderName,
 		NewVersion:    newVersionsBundle.Snow.Version,
 		OldVersion:    currentVersionsBundle.Snow.Version,
+	}
+}
+
+// ChangeDiffFromManagementComponents returns the change diff from the management components.
+func (p *SnowProvider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+	if currentComponents.Snow.Version == newComponents.Snow.Version {
+		return nil
+	}
+
+	return &types.ComponentChangeDiff{
+		ComponentName: constants.SnowProviderName,
+		NewVersion:    newComponents.Snow.Version,
+		OldVersion:    currentComponents.Snow.Version,
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR extends the snow provider api surface to use management component to gradually introduce the changes outlined in https://github.com/aws/eks-anywhere/pull/7353, split out into multiple. 

After extending all the providers, we also now update the `Provider` interface with the new methods

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

