### PR TITLE
Scope down lint and test coverage GitHub workflows on PRs

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+    - 'release/**'
+
 
 jobs:
   build:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+    - '**.go'
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
There are several automated PRs to the repo that update attribution text files or other YAML files that are not part of the source code. But we still run linter and test coverage on them which sometimes fails on unrelated issues and causes churn. This PR scopes down the `lint` Github action to only PRs containing Go code, and the test coverage Github action to only the code outside the `release` submodule.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

