### PR TITLE
Create config folder when update name in e2e test

### DIFF
--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -31,9 +30,7 @@ func NewMulticlusterE2ETest(t *testing.T, managementCluster *ClusterE2ETest, wor
 	m.WorkloadClusters = make(WorkloadClusters, len(workloadClusters))
 	for _, c := range workloadClusters {
 		c.clusterFillers = append(c.clusterFillers, api.WithManagementCluster(managementCluster.ClusterName))
-		c.ClusterName = m.NewWorkloadClusterName()
-		c.ClusterConfigFolder = c.ClusterName
-		c.ClusterConfigLocation = filepath.Join(c.ClusterConfigFolder, c.ClusterName+"-eks-a.yaml")
+		c.UpdateClusterName(m.NewWorkloadClusterName())
 		m.WithWorkloadClusters(c)
 	}
 


### PR DESCRIPTION
*Description of changes:*
Another bug discovered by changing the cluster name on the fly. The folder for the cluster config is not created on the fly.

*Testing (if applicable):*
I ran a new e2e test i wrote that hits this scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

