### PR TITLE
Remove old provider methods to use new methods with management components

### DIFF
--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -144,7 +144,7 @@ func capiChangeDiff(currentSpec, newSpec *cluster.Spec, provider providers.Provi
 	currentManagementComponents := cluster.NewManagementComponents(currentSpec.RootVersionsBundle().VersionsBundle)
 	newManagementComponents := cluster.NewManagementComponents(newSpec.RootVersionsBundle().VersionsBundle)
 
-	if providerChangeDiff := provider.ChangeDiffFromManagementComponents(currentManagementComponents, newManagementComponents); providerChangeDiff != nil {
+	if providerChangeDiff := provider.ChangeDiff(currentManagementComponents, newManagementComponents); providerChangeDiff != nil {
 		changeDiff.InfrastructureProvider = providerChangeDiff
 		logger.V(1).Info("CAPI Infrastrcture Provider change diff", "provider", providerChangeDiff.ComponentName, "oldVersion", providerChangeDiff.OldVersion, "newVersion", providerChangeDiff.NewVersion)
 		componentChanged = true

--- a/pkg/clusterapi/upgrader_test.go
+++ b/pkg/clusterapi/upgrader_test.go
@@ -84,7 +84,7 @@ func TestUpgraderUpgradeNoSelfManaged(t *testing.T) {
 
 func TestUpgraderUpgradeNoChanges(t *testing.T) {
 	tt := newUpgraderTest(t)
-	tt.provider.EXPECT().ChangeDiffFromManagementComponents(tt.currentManagementComponents, tt.newManagementComponents).Return(nil)
+	tt.provider.EXPECT().ChangeDiff(tt.currentManagementComponents, tt.newManagementComponents).Return(nil)
 
 	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)).To(BeNil())
 }
@@ -99,7 +99,7 @@ func TestUpgraderUpgradeProviderChanges(t *testing.T) {
 		ComponentReports: []types.ComponentChangeDiff{*tt.providerChangeDiff},
 	}
 
-	tt.provider.EXPECT().ChangeDiffFromManagementComponents(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
+	tt.provider.EXPECT().ChangeDiff(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
 	tt.capiClient.EXPECT().Upgrade(tt.ctx, tt.cluster, tt.provider, tt.newSpec, changeDiff)
 
 	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
@@ -122,7 +122,7 @@ func TestUpgraderUpgradeCoreChanges(t *testing.T) {
 		ComponentReports: []types.ComponentChangeDiff{*changeDiff.Core},
 	}
 
-	tt.provider.EXPECT().ChangeDiffFromManagementComponents(tt.currentManagementComponents, tt.newManagementComponents).Return(nil)
+	tt.provider.EXPECT().ChangeDiff(tt.currentManagementComponents, tt.newManagementComponents).Return(nil)
 	tt.capiClient.EXPECT().Upgrade(tt.ctx, tt.cluster, tt.provider, tt.newSpec, changeDiff)
 
 	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
@@ -180,7 +180,7 @@ func TestUpgraderUpgradeEverythingChangesStackedEtcd(t *testing.T) {
 		ComponentReports: bootstrapProviders,
 	}
 
-	tt.provider.EXPECT().ChangeDiffFromManagementComponents(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
+	tt.provider.EXPECT().ChangeDiff(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
 	tt.capiClient.EXPECT().Upgrade(tt.ctx, tt.cluster, tt.provider, tt.newSpec, changeDiff)
 
 	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
@@ -241,7 +241,7 @@ func TestUpgraderUpgradeEverythingChangesExternalEtcd(t *testing.T) {
 		},
 	}
 
-	tt.provider.EXPECT().ChangeDiffFromManagementComponents(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
+	tt.provider.EXPECT().ChangeDiff(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
 	tt.capiClient.EXPECT().Upgrade(tt.ctx, tt.cluster, tt.provider, tt.newSpec, changeDiff)
 
 	tt.Expect(tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)).To(Equal(wantDiff))
@@ -253,7 +253,7 @@ func TestUpgraderUpgradeCAPIClientError(t *testing.T) {
 		InfrastructureProvider: tt.providerChangeDiff,
 	}
 
-	tt.provider.EXPECT().ChangeDiffFromManagementComponents(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
+	tt.provider.EXPECT().ChangeDiff(tt.currentManagementComponents, tt.newManagementComponents).Return(tt.providerChangeDiff)
 	tt.capiClient.EXPECT().Upgrade(tt.ctx, tt.cluster, tt.provider, tt.newSpec, changeDiff).Return(errors.New("error from client"))
 
 	_, err := tt.upgrader.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.currentSpec, tt.newSpec)

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -118,7 +118,7 @@ func (c *Clusterctl) buildOverridesLayer(managementComponents *cluster.Managemen
 		},
 	}
 
-	infraBundles = append(infraBundles, *provider.GetInfrastructureBundleFromManagementComponents(managementComponents))
+	infraBundles = append(infraBundles, *provider.GetInfrastructureBundle(managementComponents))
 	for _, infraBundle := range infraBundles {
 		if err := c.writeInfrastructureBundle(prefix, &infraBundle); err != nil {
 			return err
@@ -224,7 +224,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluste
 		"--core", clusterctlConfig.coreVersion,
 		"--bootstrap", clusterctlConfig.bootstrapVersion,
 		"--control-plane", clusterctlConfig.controlPlaneVersion,
-		"--infrastructure", fmt.Sprintf("%s:%s", provider.Name(), provider.VersionFromManagementComponents(managementComponents)),
+		"--infrastructure", fmt.Sprintf("%s:%s", provider.Name(), provider.Version(managementComponents)),
 		"--config", clusterctlConfig.configFile,
 		"--bootstrap", clusterctlConfig.etcdadmBootstrapVersion,
 		"--bootstrap", clusterctlConfig.etcdadmControllerVersion,

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -62,7 +62,7 @@ func newClusterctlTest(t *testing.T) *clusterctlTest {
 }
 
 func (ct *clusterctlTest) expectBuildOverrideLayer() {
-	ct.provider.EXPECT().GetInfrastructureBundleFromManagementComponents(ct.managementComponents).Return(&types.InfrastructureBundle{})
+	ct.provider.EXPECT().GetInfrastructureBundle(ct.managementComponents).Return(&types.InfrastructureBundle{})
 }
 
 func (ct *clusterctlTest) expectGetProviderEnvMap() {
@@ -133,9 +133,9 @@ func TestClusterctlInitInfrastructure(t *testing.T) {
 			gotConfig := ""
 
 			tc.provider.EXPECT().Name().Return(tt.providerName)
-			tc.provider.EXPECT().VersionFromManagementComponents(tc.managementComponents).Return(tt.providerVersion)
+			tc.provider.EXPECT().Version(tc.managementComponents).Return(tt.providerVersion)
 			tc.provider.EXPECT().EnvMap(clusterSpec).Return(tt.env, nil)
-			tc.provider.EXPECT().GetInfrastructureBundleFromManagementComponents(tc.managementComponents).Return(&types.InfrastructureBundle{})
+			tc.provider.EXPECT().GetInfrastructureBundle(tc.managementComponents).Return(&types.InfrastructureBundle{})
 
 			tc.e.EXPECT().ExecuteWithEnv(tc.ctx, tt.env, tt.wantExecArgs...).Return(bytes.Buffer{}, nil).Times(1).Do(
 				func(ctx context.Context, envs map[string]string, args ...string) (stdout bytes.Buffer, err error) {
@@ -181,9 +181,9 @@ func TestClusterctlInitInfrastructureEnvMapError(t *testing.T) {
 	tt := newClusterctlTest(t)
 
 	tt.provider.EXPECT().Name()
-	tt.provider.EXPECT().VersionFromManagementComponents(tt.managementComponents)
+	tt.provider.EXPECT().Version(tt.managementComponents)
 	tt.provider.EXPECT().EnvMap(clusterSpec).Return(nil, errors.New("error with env map"))
-	tt.provider.EXPECT().GetInfrastructureBundleFromManagementComponents(tt.managementComponents).Return(&types.InfrastructureBundle{})
+	tt.provider.EXPECT().GetInfrastructureBundle(tt.managementComponents).Return(&types.InfrastructureBundle{})
 
 	if err := tt.clusterctl.InitInfrastructure(tt.ctx, clusterSpec, cluster, tt.provider); err == nil {
 		t.Fatal("Clusterctl.InitInfrastructure() error = nil")
@@ -200,9 +200,9 @@ func TestClusterctlInitInfrastructureExecutableError(t *testing.T) {
 	tt := newClusterctlTest(t)
 
 	tt.provider.EXPECT().Name()
-	tt.provider.EXPECT().VersionFromManagementComponents(tt.managementComponents)
+	tt.provider.EXPECT().Version(tt.managementComponents)
 	tt.provider.EXPECT().EnvMap(clusterSpec)
-	tt.provider.EXPECT().GetInfrastructureBundleFromManagementComponents(tt.managementComponents).Return(&types.InfrastructureBundle{})
+	tt.provider.EXPECT().GetInfrastructureBundle(tt.managementComponents).Return(&types.InfrastructureBundle{})
 
 	tt.e.EXPECT().ExecuteWithEnv(tt.ctx, nil, gomock.Any()).Return(bytes.Buffer{}, errors.New("error from execute with env"))
 

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -202,22 +202,8 @@ func (p *cloudstackProvider) ValidateNewSpec(ctx context.Context, cluster *types
 	return nil
 }
 
-func (p *cloudstackProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-	if currentVersionsBundle.CloudStack.Version == newVersionsBundle.CloudStack.Version {
-		return nil
-	}
-
-	return &types.ComponentChangeDiff{
-		ComponentName: constants.CloudStackProviderName,
-		NewVersion:    newVersionsBundle.CloudStack.Version,
-		OldVersion:    currentVersionsBundle.CloudStack.Version,
-	}
-}
-
-// ChangeDiffFromManagementComponents returns the component change diff for the provider.
-func (p *cloudstackProvider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+// ChangeDiff returns the component change diff for the provider.
+func (p *cloudstackProvider) ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	if currentComponents.CloudStack.Version == newComponents.CloudStack.Version {
 		return nil
 	}
@@ -824,13 +810,8 @@ func (p *cloudstackProvider) BootstrapSetup(ctx context.Context, clusterConfig *
 	return nil
 }
 
-func (p *cloudstackProvider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	return versionsBundle.CloudStack.Version
-}
-
-// VersionFromManagementComponents returns the version of the provider.
-func (p *cloudstackProvider) VersionFromManagementComponents(componnets *cluster.ManagementComponents) string {
+// Version returns the version of the provider.
+func (p *cloudstackProvider) Version(componnets *cluster.ManagementComponents) string {
 	return componnets.CloudStack.Version
 }
 
@@ -850,22 +831,8 @@ func (p *cloudstackProvider) GetDeployments() map[string][]string {
 	return map[string][]string{"capc-system": {"capc-controller-manager"}}
 }
 
-func (p *cloudstackProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	folderName := fmt.Sprintf("infrastructure-cloudstack/%s/", versionsBundle.CloudStack.Version)
-
-	infraBundle := types.InfrastructureBundle{
-		FolderName: folderName,
-		Manifests: []releasev1alpha1.Manifest{
-			versionsBundle.CloudStack.Components,
-			versionsBundle.CloudStack.Metadata,
-		},
-	}
-	return &infraBundle
-}
-
-// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle for the provider.
-func (p *cloudstackProvider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+// GetInfrastructureBundle returns the infrastructure bundle for the provider.
+func (p *cloudstackProvider) GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle {
 	folderName := fmt.Sprintf("infrastructure-cloudstack/%s/", components.CloudStack.Version)
 
 	infraBundle := types.InfrastructureBundle{

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -627,13 +627,7 @@ func updateKubeconfig(content *[]byte, dockerLbPort string) {
 }
 
 // Version returns the version of the provider.
-func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	return versionsBundle.Docker.Version
-}
-
-// VersionFromManagementComponents returns the version of the provider.
-func (p *Provider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+func (p *Provider) Version(components *cluster.ManagementComponents) string {
 	return components.Docker.Version
 }
 
@@ -654,24 +648,7 @@ func (p *Provider) GetDeployments() map[string][]string {
 }
 
 // GetInfrastructureBundle returns the infrastructure bundle for the provider.
-func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	folderName := fmt.Sprintf("infrastructure-docker/%s/", versionsBundle.Docker.Version)
-
-	infraBundle := types.InfrastructureBundle{
-		FolderName: folderName,
-		Manifests: []releasev1alpha1.Manifest{
-			versionsBundle.Docker.Components,
-			versionsBundle.Docker.Metadata,
-			versionsBundle.Docker.ClusterTemplate,
-		},
-	}
-
-	return &infraBundle
-}
-
-// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle for the provider.
-func (p *Provider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+func (p *Provider) GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle {
 	folderName := fmt.Sprintf("infrastructure-docker/%s/", components.Docker.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -702,22 +679,7 @@ func (p *Provider) ValidateNewSpec(_ context.Context, _ *types.Cluster, _ *clust
 }
 
 // ChangeDiff returns the component change diff for the provider.
-func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-	if currentVersionsBundle.Docker.Version == newVersionsBundle.Docker.Version {
-		return nil
-	}
-
-	return &types.ComponentChangeDiff{
-		ComponentName: constants.DockerProviderName,
-		NewVersion:    newVersionsBundle.Docker.Version,
-		OldVersion:    currentVersionsBundle.Docker.Version,
-	}
-}
-
-// ChangeDiffFromManagementComponents returns the component change diff for the provider.
-func (p *Provider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+func (p *Provider) ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	if currentComponents.Docker.Version == newComponents.Docker.Version {
 		return nil
 	}

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -55,7 +55,7 @@ func (mr *MockProviderMockRecorder) BootstrapClusterOpts(arg0 interface{}) *gomo
 }
 
 // ChangeDiff mocks base method.
-func (m *MockProvider) ChangeDiff(arg0, arg1 *cluster.Spec) *types.ComponentChangeDiff {
+func (m *MockProvider) ChangeDiff(arg0, arg1 *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeDiff", arg0, arg1)
 	ret0, _ := ret[0].(*types.ComponentChangeDiff)
@@ -66,20 +66,6 @@ func (m *MockProvider) ChangeDiff(arg0, arg1 *cluster.Spec) *types.ComponentChan
 func (mr *MockProviderMockRecorder) ChangeDiff(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeDiff", reflect.TypeOf((*MockProvider)(nil).ChangeDiff), arg0, arg1)
-}
-
-// ChangeDiffFromManagementComponents mocks base method.
-func (m *MockProvider) ChangeDiffFromManagementComponents(arg0, arg1 *cluster.ManagementComponents) *types.ComponentChangeDiff {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeDiffFromManagementComponents", arg0, arg1)
-	ret0, _ := ret[0].(*types.ComponentChangeDiff)
-	return ret0
-}
-
-// ChangeDiffFromManagementComponents indicates an expected call of ChangeDiffFromManagementComponents.
-func (mr *MockProviderMockRecorder) ChangeDiffFromManagementComponents(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeDiffFromManagementComponents", reflect.TypeOf((*MockProvider)(nil).ChangeDiffFromManagementComponents), arg0, arg1)
 }
 
 // DatacenterConfig mocks base method.
@@ -186,7 +172,7 @@ func (mr *MockProviderMockRecorder) GetDeployments() *gomock.Call {
 }
 
 // GetInfrastructureBundle mocks base method.
-func (m *MockProvider) GetInfrastructureBundle(arg0 *cluster.Spec) *types.InfrastructureBundle {
+func (m *MockProvider) GetInfrastructureBundle(arg0 *cluster.ManagementComponents) *types.InfrastructureBundle {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInfrastructureBundle", arg0)
 	ret0, _ := ret[0].(*types.InfrastructureBundle)
@@ -197,20 +183,6 @@ func (m *MockProvider) GetInfrastructureBundle(arg0 *cluster.Spec) *types.Infras
 func (mr *MockProviderMockRecorder) GetInfrastructureBundle(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfrastructureBundle", reflect.TypeOf((*MockProvider)(nil).GetInfrastructureBundle), arg0)
-}
-
-// GetInfrastructureBundleFromManagementComponents mocks base method.
-func (m *MockProvider) GetInfrastructureBundleFromManagementComponents(arg0 *cluster.ManagementComponents) *types.InfrastructureBundle {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInfrastructureBundleFromManagementComponents", arg0)
-	ret0, _ := ret[0].(*types.InfrastructureBundle)
-	return ret0
-}
-
-// GetInfrastructureBundleFromManagementComponents indicates an expected call of GetInfrastructureBundleFromManagementComponents.
-func (mr *MockProviderMockRecorder) GetInfrastructureBundleFromManagementComponents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfrastructureBundleFromManagementComponents", reflect.TypeOf((*MockProvider)(nil).GetInfrastructureBundleFromManagementComponents), arg0)
 }
 
 // InstallCustomProviderComponents mocks base method.
@@ -495,7 +467,7 @@ func (mr *MockProviderMockRecorder) ValidateNewSpec(arg0, arg1, arg2 interface{}
 }
 
 // Version mocks base method.
-func (m *MockProvider) Version(arg0 *cluster.Spec) string {
+func (m *MockProvider) Version(arg0 *cluster.ManagementComponents) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version", arg0)
 	ret0, _ := ret[0].(string)
@@ -506,20 +478,6 @@ func (m *MockProvider) Version(arg0 *cluster.Spec) string {
 func (mr *MockProviderMockRecorder) Version(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockProvider)(nil).Version), arg0)
-}
-
-// VersionFromManagementComponents mocks base method.
-func (m *MockProvider) VersionFromManagementComponents(arg0 *cluster.ManagementComponents) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VersionFromManagementComponents", arg0)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// VersionFromManagementComponents indicates an expected call of VersionFromManagementComponents.
-func (mr *MockProviderMockRecorder) VersionFromManagementComponents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VersionFromManagementComponents", reflect.TypeOf((*MockProvider)(nil).VersionFromManagementComponents), arg0)
 }
 
 // MockDatacenterConfig is a mock of DatacenterConfig interface.

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -520,14 +520,8 @@ func (p *Provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 	return nil
 }
 
-// Version returns the nutanix version from the VersionsBundle.
-func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	return versionsBundle.Nutanix.Version
-}
-
-// VersionFromManagementComponents returns the version of the provider.
-func (p *Provider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+// Version returns the version of the provider.
+func (p *Provider) Version(components *cluster.ManagementComponents) string {
 	return components.Nutanix.Version
 }
 
@@ -550,23 +544,8 @@ func (p *Provider) GetDeployments() map[string][]string {
 	}
 }
 
-func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	manifests := []releasev1alpha1.Manifest{
-		versionsBundle.Nutanix.Components,
-		versionsBundle.Nutanix.Metadata,
-		versionsBundle.Nutanix.ClusterTemplate,
-	}
-	folderName := fmt.Sprintf("infrastructure-nutanix/%s/", p.Version(clusterSpec))
-	infraBundle := types.InfrastructureBundle{
-		FolderName: folderName,
-		Manifests:  manifests,
-	}
-	return &infraBundle
-}
-
-// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle for the provider.
-func (p *Provider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+// GetInfrastructureBundle returns the infrastructure bundle for the provider.
+func (p *Provider) GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle {
 	manifests := []releasev1alpha1.Manifest{
 		components.Nutanix.Components,
 		components.Nutanix.Metadata,
@@ -631,22 +610,8 @@ func (p *Provider) ValidateNewSpec(_ context.Context, _ *types.Cluster, _ *clust
 	return nil
 }
 
-func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-	if currentVersionsBundle.Nutanix.Version == newVersionsBundle.Nutanix.Version {
-		return nil
-	}
-
-	return &types.ComponentChangeDiff{
-		ComponentName: constants.NutanixProviderName,
-		NewVersion:    newVersionsBundle.Nutanix.Version,
-		OldVersion:    currentVersionsBundle.Nutanix.Version,
-	}
-}
-
-// ChangeDiffFromManagementComponents returns the component change diff for the provider.
-func (p *Provider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+// ChangeDiff returns the component change diff for the provider.
+func (p *Provider) ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	if currentComponents.Nutanix.Version == newComponents.Nutanix.Version {
 		return nil
 	}

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -894,8 +894,8 @@ func TestNutanixProviderUpdateKubeconfig(t *testing.T) {
 
 func TestNutanixProviderVersion(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
-	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-	v := provider.Version(clusterSpec)
+	managementComponents := givenManagementComponents()
+	v := provider.Version(managementComponents)
 	assert.NotNil(t, v)
 }
 
@@ -930,13 +930,6 @@ func TestNutanixProviderGetDeployments(t *testing.T) {
 
 func TestNutanixProviderGetInfrastructureBundle(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
-	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-	bundle := provider.GetInfrastructureBundle(clusterSpec)
-	assert.NotNil(t, bundle)
-}
-
-func TestNutanixProviderGetInfrastructureBundleFromManagementComponents(t *testing.T) {
-	provider := testDefaultNutanixProvider(t)
 	managementComponents := givenManagementComponents()
 	wantInfraBundle := &types.InfrastructureBundle{
 		FolderName: "infrastructure-nutanix/1.0.0/",
@@ -947,7 +940,7 @@ func TestNutanixProviderGetInfrastructureBundleFromManagementComponents(t *testi
 		},
 	}
 
-	assert.Equal(t, wantInfraBundle, provider.GetInfrastructureBundleFromManagementComponents(managementComponents))
+	assert.Equal(t, wantInfraBundle, provider.GetInfrastructureBundle(managementComponents))
 }
 
 func TestNutanixProviderDatacenterConfig(t *testing.T) {
@@ -972,36 +965,7 @@ func TestNutanixProviderValidateNewSpec(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNutanixProviderChangeDiff(t *testing.T) {
-	provider := testDefaultNutanixProvider(t)
-	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-	cd := provider.ChangeDiff(clusterSpec, clusterSpec)
-	assert.Nil(t, cd)
-}
-
-func TestNutanixProviderChangeDiffFromManagementComponentsNoChange(t *testing.T) {
-	provider := testDefaultNutanixProvider(t)
-	managementComponents := givenManagementComponents()
-	got := provider.ChangeDiffFromManagementComponents(managementComponents, managementComponents)
-	assert.Nil(t, got)
-}
-
 func TestNutanixProviderChangeDiffWithChange(t *testing.T) {
-	provider := testDefaultNutanixProvider(t)
-	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
-	newClusterSpec := clusterSpec.DeepCopy()
-	clusterSpec.VersionsBundles["1.19"].Nutanix.Version = "v0.5.2"
-	newClusterSpec.VersionsBundles["1.19"].Nutanix.Version = "v1.0.0"
-	want := &types.ComponentChangeDiff{
-		ComponentName: "nutanix",
-		NewVersion:    "v1.0.0",
-		OldVersion:    "v0.5.2",
-	}
-	cd := provider.ChangeDiff(clusterSpec, newClusterSpec)
-	assert.Equal(t, cd, want)
-}
-
-func TestNutanixProviderChangeDiffFromManagementComponentsWithChange(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	managementComponents := givenManagementComponents()
 	managementComponents.Nutanix.Version = "v0.5.2"
@@ -1014,7 +978,7 @@ func TestNutanixProviderChangeDiffFromManagementComponentsWithChange(t *testing.
 		OldVersion:    "v0.5.2",
 	}
 
-	got := provider.ChangeDiffFromManagementComponents(managementComponents, newManagementComponents)
+	got := provider.ChangeDiff(managementComponents, newManagementComponents)
 	assert.Equal(t, got, want)
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -26,19 +26,16 @@ type Provider interface {
 	PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	BootstrapClusterOpts(clusterSpec *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error)
 	UpdateKubeConfig(content *[]byte, clusterName string) error
-	Version(clusterSpec *cluster.Spec) string
-	VersionFromManagementComponents(components *cluster.ManagementComponents) string
+	Version(components *cluster.ManagementComponents) string
 	EnvMap(clusterSpec *cluster.Spec) (map[string]string, error)
 	GetDeployments() map[string][]string
-	GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle
-	GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle
+	GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle
 	DatacenterConfig(clusterSpec *cluster.Spec) DatacenterConfig
 	DatacenterResourceType() string
 	MachineResourceType() string
 	MachineConfigs(clusterSpec *cluster.Spec) []MachineConfig
 	ValidateNewSpec(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
-	ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff
-	ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff
+	ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff
 	RunPostControlPlaneUpgrade(ctx context.Context, oldClusterSpec *cluster.Spec, clusterSpec *cluster.Spec, workloadCluster *types.Cluster, managementCluster *types.Cluster) error
 	UpgradeNeeded(ctx context.Context, newSpec, currentSpec *cluster.Spec, cluster *types.Cluster) (bool, error)
 	DeleteResources(ctx context.Context, clusterSpec *cluster.Spec) error

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -180,13 +180,8 @@ func (p *SnowProvider) UpdateKubeConfig(content *[]byte, clusterName string) err
 	return nil
 }
 
-func (p *SnowProvider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	return versionsBundle.Snow.Version
-}
-
-// VersionFromManagementComponents returns the snow version from the management components.
-func (p *SnowProvider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+// Version returns the snow version from the management components.
+func (p *SnowProvider) Version(components *cluster.ManagementComponents) string {
 	return components.Snow.Version
 }
 
@@ -208,22 +203,8 @@ func (p *SnowProvider) GetDeployments() map[string][]string {
 	}
 }
 
-func (p *SnowProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	folderName := fmt.Sprintf("infrastructure-snow/%s/", versionsBundle.Snow.Version)
-
-	infraBundle := types.InfrastructureBundle{
-		FolderName: folderName,
-		Manifests: []releasev1alpha1.Manifest{
-			versionsBundle.Snow.Components,
-			versionsBundle.Snow.Metadata,
-		},
-	}
-	return &infraBundle
-}
-
-// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle from the management components.
-func (p *SnowProvider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+// GetInfrastructureBundle returns the infrastructure bundle from the management components.
+func (p *SnowProvider) GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle {
 	folderName := fmt.Sprintf("infrastructure-snow/%s/", components.Snow.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -260,22 +241,8 @@ func (p *SnowProvider) ValidateNewSpec(ctx context.Context, cluster *types.Clust
 	return nil
 }
 
-func (p *SnowProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-	if currentVersionsBundle.Snow.Version == newVersionsBundle.Snow.Version {
-		return nil
-	}
-
-	return &types.ComponentChangeDiff{
-		ComponentName: constants.SnowProviderName,
-		NewVersion:    newVersionsBundle.Snow.Version,
-		OldVersion:    currentVersionsBundle.Snow.Version,
-	}
-}
-
-// ChangeDiffFromManagementComponents returns the change diff from the management components.
-func (p *SnowProvider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+// ChangeDiff returns the change diff from the management components.
+func (p *SnowProvider) ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	if currentComponents.Snow.Version == newComponents.Snow.Version {
 		return nil
 	}

--- a/pkg/providers/snow/snow_test.go
+++ b/pkg/providers/snow/snow_test.go
@@ -855,38 +855,14 @@ func TestGenerateCAPISpecForUpgradeWorkerVersion(t *testing.T) {
 func TestVersion(t *testing.T) {
 	snowVersion := "v1.0.2"
 	provider := givenProvider(t)
-	clusterSpec := givenEmptyClusterSpec()
-	clusterSpec.VersionsBundles["1.19"].Snow.Version = snowVersion
-	g := NewWithT(t)
-	result := provider.Version(clusterSpec)
-	g.Expect(result).To(Equal(snowVersion))
-}
-
-func TestVersionFromManagementComponents(t *testing.T) {
-	snowVersion := "v1.0.2"
-	provider := givenProvider(t)
 	managementComponents := givenManagementComponents()
 	managementComponents.Snow.Version = snowVersion
 	g := NewWithT(t)
-	result := provider.VersionFromManagementComponents(managementComponents)
+	result := provider.Version(managementComponents)
 	g.Expect(result).To(Equal(snowVersion))
 }
 
 func TestGetInfrastructureBundle(t *testing.T) {
-	tt := newSnowTest(t)
-	bundle := tt.clusterSpec.RootVersionsBundle()
-	want := &types.InfrastructureBundle{
-		FolderName: "infrastructure-snow/v1.0.2/",
-		Manifests: []releasev1alpha1.Manifest{
-			bundle.Snow.Components,
-			bundle.Snow.Metadata,
-		},
-	}
-	got := tt.provider.GetInfrastructureBundle(tt.clusterSpec)
-	tt.Expect(got).To(Equal(want))
-}
-
-func TestGetInfrastructureBundleFromManagementComponents(t *testing.T) {
 	tt := newSnowTest(t)
 	managementComponents := givenManagementComponents()
 
@@ -897,7 +873,7 @@ func TestGetInfrastructureBundleFromManagementComponents(t *testing.T) {
 			managementComponents.Snow.Metadata,
 		},
 	}
-	got := tt.provider.GetInfrastructureBundleFromManagementComponents(managementComponents)
+	got := tt.provider.GetInfrastructureBundle(managementComponents)
 	tt.Expect(got).To(Equal(want))
 }
 
@@ -1273,33 +1249,11 @@ func TestUpgradeNeededBundle(t *testing.T) {
 func TestChangeDiffNoChange(t *testing.T) {
 	g := NewWithT(t)
 	provider := givenProvider(t)
-	clusterSpec := givenEmptyClusterSpec()
-	g.Expect(provider.ChangeDiff(clusterSpec, clusterSpec)).To(BeNil())
+	managementComponents := givenManagementComponents()
+	g.Expect(provider.ChangeDiff(managementComponents, managementComponents)).To(BeNil())
 }
 
 func TestChangeDiffWithChange(t *testing.T) {
-	g := NewWithT(t)
-	provider := givenProvider(t)
-	clusterSpec := givenEmptyClusterSpec()
-	newClusterSpec := clusterSpec.DeepCopy()
-	clusterSpec.VersionsBundles["1.19"].Snow.Version = "v1.0.2"
-	newClusterSpec.VersionsBundles["1.19"].Snow.Version = "v1.0.3"
-	want := &types.ComponentChangeDiff{
-		ComponentName: "snow",
-		NewVersion:    "v1.0.3",
-		OldVersion:    "v1.0.2",
-	}
-	g.Expect(provider.ChangeDiff(clusterSpec, newClusterSpec)).To(Equal(want))
-}
-
-func TestChangeDiffFromManagementComponentsNoChange(t *testing.T) {
-	g := NewWithT(t)
-	provider := givenProvider(t)
-	managementComponents := givenManagementComponents()
-	g.Expect(provider.ChangeDiffFromManagementComponents(managementComponents, managementComponents)).To(BeNil())
-}
-
-func TestChangeDiffFromManagementComponentsWithChange(t *testing.T) {
 	g := NewWithT(t)
 	provider := givenProvider(t)
 	managementComponents := givenManagementComponents()
@@ -1312,7 +1266,7 @@ func TestChangeDiffFromManagementComponentsWithChange(t *testing.T) {
 		NewVersion:    "v1.0.3",
 		OldVersion:    "v1.0.2",
 	}
-	g.Expect(provider.ChangeDiffFromManagementComponents(managementComponents, newManagementComponents)).To(Equal(want))
+	g.Expect(provider.ChangeDiff(managementComponents, newManagementComponents)).To(Equal(want))
 }
 
 func TestUpdateSecrets(t *testing.T) {

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -216,13 +216,8 @@ func (p *Provider) UpdateKubeConfig(content *[]byte, clusterName string) error {
 	return nil
 }
 
-func (p *Provider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	return versionsBundle.Tinkerbell.Version
-}
-
-// VersionFromManagementComponents returns the version of the provider.
-func (p *Provider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+// Version returns the version of the provider.
+func (p *Provider) Version(components *cluster.ManagementComponents) string {
 	return components.Tinkerbell.Version
 }
 
@@ -256,23 +251,8 @@ func (p *Provider) GetDeployments() map[string][]string {
 	}
 }
 
-func (p *Provider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	folderName := fmt.Sprintf("infrastructure-tinkerbell/%s/", versionsBundle.Tinkerbell.Version)
-
-	infraBundle := types.InfrastructureBundle{
-		FolderName: folderName,
-		Manifests: []releasev1alpha1.Manifest{
-			versionsBundle.Tinkerbell.Components,
-			versionsBundle.Tinkerbell.Metadata,
-			versionsBundle.Tinkerbell.ClusterTemplate,
-		},
-	}
-	return &infraBundle
-}
-
-// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle for the provider.
-func (p *Provider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+// GetInfrastructureBundle returns the infrastructure bundle for the provider.
+func (p *Provider) GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle {
 	folderName := fmt.Sprintf("infrastructure-tinkerbell/%s/", components.Tinkerbell.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -324,22 +304,8 @@ func (p *Provider) MachineConfigs(_ *cluster.Spec) []providers.MachineConfig {
 	return providers.ConfigsMapToSlice(configs)
 }
 
-func (p *Provider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-	if currentVersionsBundle.Tinkerbell.Version == newVersionsBundle.Tinkerbell.Version {
-		return nil
-	}
-
-	return &types.ComponentChangeDiff{
-		ComponentName: constants.TinkerbellProviderName,
-		NewVersion:    newVersionsBundle.Tinkerbell.Version,
-		OldVersion:    currentVersionsBundle.Tinkerbell.Version,
-	}
-}
-
-// ChangeDiffFromManagementComponents returns the component change diff for the provider.
-func (p *Provider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+// ChangeDiff returns the component change diff for the provider.
+func (p *Provider) ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	if currentComponents.Tinkerbell.Version == newComponents.Tinkerbell.Version {
 		return nil
 	}

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -2394,7 +2394,7 @@ func getVersionBundle() *cluster.VersionsBundle {
 	}
 }
 
-func TestGetInfrastructureBundleFromManagementComponents(t *testing.T) {
+func TestGetInfrastructureBundle(t *testing.T) {
 	g := NewWithT(t)
 	clusterSpecManifest := "cluster_tinkerbell_external_etcd.yaml"
 	mockCtrl := gomock.NewController(t)
@@ -2423,27 +2423,27 @@ func TestGetInfrastructureBundleFromManagementComponents(t *testing.T) {
 		},
 	}
 
-	infraBundle := p.GetInfrastructureBundleFromManagementComponents(managementComponents)
+	infraBundle := p.GetInfrastructureBundle(managementComponents)
 	g.Expect(infraBundle).To(Equal(wantInfraBundle))
 }
 
-func TestVersionFromManagementComponents(t *testing.T) {
+func TestVersion(t *testing.T) {
 	tt := newProviderTest(t)
 	tinkerbellVersion := "v1.2.3"
 	managementComponents := givenManagementComponents()
 	managementComponents.Tinkerbell.Version = tinkerbellVersion
-	got := tt.provider.VersionFromManagementComponents(managementComponents)
+	got := tt.provider.Version(managementComponents)
 	tt.Expect(got).To(Equal(tinkerbellVersion))
 }
 
-func TestChangeDiffFromManagementComponentsNoChange(t *testing.T) {
+func TestChangeDiffNoChange(t *testing.T) {
 	tt := newProviderTest(t)
 	managementComponents := givenManagementComponents()
-	got := tt.provider.ChangeDiffFromManagementComponents(managementComponents, managementComponents)
+	got := tt.provider.ChangeDiff(managementComponents, managementComponents)
 	tt.Expect(got).To(BeNil())
 }
 
-func TestChangeDiffFromManagementComponentsWithChange(t *testing.T) {
+func TestChangeDiffWithChange(t *testing.T) {
 	tt := newProviderTest(t)
 	managementComponents := givenManagementComponents()
 	managementComponents.Tinkerbell.Version = "v1.2.2"
@@ -2457,6 +2457,6 @@ func TestChangeDiffFromManagementComponentsWithChange(t *testing.T) {
 		OldVersion:    "v1.2.2",
 	}
 
-	got := tt.provider.ChangeDiffFromManagementComponents(managementComponents, newManagementComponents)
+	got := tt.provider.ChangeDiff(managementComponents, newManagementComponents)
 	tt.Expect(got).To(Equal(wantDiff))
 }

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -977,11 +977,6 @@ func (p *vsphereProvider) PostWorkloadInit(ctx context.Context, cluster *types.C
 	return nil
 }
 
-func (p *vsphereProvider) Version(clusterSpec *cluster.Spec) string {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	return versionsBundle.VSphere.Version
-}
-
 func (p *vsphereProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {
@@ -998,21 +993,6 @@ func (p *vsphereProvider) GetDeployments() map[string][]string {
 	return map[string][]string{
 		"capv-system": {"capv-controller-manager"},
 	}
-}
-
-func (p *vsphereProvider) GetInfrastructureBundle(clusterSpec *cluster.Spec) *types.InfrastructureBundle {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	folderName := fmt.Sprintf("infrastructure-vsphere/%s/", versionsBundle.VSphere.Version)
-
-	infraBundle := types.InfrastructureBundle{
-		FolderName: folderName,
-		Manifests: []releasev1alpha1.Manifest{
-			versionsBundle.VSphere.Components,
-			versionsBundle.VSphere.Metadata,
-			versionsBundle.VSphere.ClusterTemplate,
-		},
-	}
-	return &infraBundle
 }
 
 func (p *vsphereProvider) DatacenterConfig(spec *cluster.Spec) providers.DatacenterConfig {
@@ -1186,22 +1166,8 @@ func (p *vsphereProvider) secretContentsChanged(ctx context.Context, workloadClu
 	return false, nil
 }
 
-func (p *vsphereProvider) ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ComponentChangeDiff {
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-	if currentVersionsBundle.VSphere.Version == newVersionsBundle.VSphere.Version {
-		return nil
-	}
-
-	return &types.ComponentChangeDiff{
-		ComponentName: constants.VSphereProviderName,
-		NewVersion:    newVersionsBundle.VSphere.Version,
-		OldVersion:    currentVersionsBundle.VSphere.Version,
-	}
-}
-
-// ChangeDiffFromManagementComponents returns the component change diff for the provider.
-func (p *vsphereProvider) ChangeDiffFromManagementComponents(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
+// ChangeDiff returns the component change diff for the provider.
+func (p *vsphereProvider) ChangeDiff(currentComponents, newComponents *cluster.ManagementComponents) *types.ComponentChangeDiff {
 	if currentComponents.VSphere.Version == newComponents.VSphere.Version {
 		return nil
 	}
@@ -1213,8 +1179,8 @@ func (p *vsphereProvider) ChangeDiffFromManagementComponents(currentComponents, 
 	}
 }
 
-// GetInfrastructureBundleFromManagementComponents returns the infrastructure bundle for the provider.
-func (p *vsphereProvider) GetInfrastructureBundleFromManagementComponents(components *cluster.ManagementComponents) *types.InfrastructureBundle {
+// GetInfrastructureBundle returns the infrastructure bundle for the provider.
+func (p *vsphereProvider) GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle {
 	folderName := fmt.Sprintf("infrastructure-vsphere/%s/", components.VSphere.Version)
 
 	infraBundle := types.InfrastructureBundle{
@@ -1229,8 +1195,8 @@ func (p *vsphereProvider) GetInfrastructureBundleFromManagementComponents(compon
 	return &infraBundle
 }
 
-// VersionFromManagementComponents returns the version of the provider.
-func (p *vsphereProvider) VersionFromManagementComponents(components *cluster.ManagementComponents) string {
+// Version returns the version of the provider.
+func (p *vsphereProvider) Version(components *cluster.ManagementComponents) string {
 	return components.VSphere.Version
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Review #7462 first for a focused change.

The following changes and method are to split out the corresponding changes from the original PR [here](https://github.com/aws/eks-anywhere/pull/7353), without introducing bugs.

This is final step in refactoring the providers to use *cluster.ManagementComponents to reference management components. After expanding provider apis (#7376, #7390, #7391, #7393, #7395, and #7457), and using the new ones. We are now contracting the provider apis, removing the old methods and renaming the new ones.

This PR replaces the old:
- Deleted all the old `GetInfrastructureBundle(..)`, `Version(..)`, and `ChangeDiff(..)` methods
- Renamed the corresponding `*FromManagementComponents(..)` methods to the what they were originally

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

