### PR TITLE
Use real version for dev releases

### DIFF
--- a/docs/developer/manifests.md
+++ b/docs/developer/manifests.md
@@ -1,0 +1,37 @@
+# Manifests: Release and Bundles
+
+## Release manifest
+The Release manifest contains all the available EKS-A releases. Each entry contains information about the version (sem ver for the release), URL to the proper Bundles manifest for that release and url to download the CLI binary for the supported architectures and platforms.
+
+## Bundles manifest
+The Bundles manifest contains all the EKS-A components, including management (Cluster-API, EKS-A controller, CRDs, etc.) and cluster components (EKS-D, CNI, CCM, etc.). Each Bundles manifest contains multiple VersionsBundles, once per supported Kubernetes version for that specific release. A VersionsBundles groups together all the components that should be used in a cluster for a particular Kubernetes version.
+
+Each EKS-A release has a unique Bundles manifest. In order to bump a EKS-A component to a new version, a new Bundles needs to be created and shipped through a new EKS-A patch release.
+
+## CLI startup flow
+Each CLI is built with a particular EKS-A semver in its metadata. This pins each binary built to a particular EKS-A release. However, the Release and Bundles manifests are not included or shipped with the binary. These are served through cloudfront and the CLI dynamically fetches them during each command startup. The logic is as follows:
+1. Fetch the Release manifest. As part of its metadata, the CLI is built with a static URL (is the same for all EKS-A releases) pointing to this manifest. Dev CLIs will use a different URL than prod CLIs.
+1. Iterate over the available EKS-A releases in the manifest and look for an exact version match with semver included in the build metadata of the binary.
+1.
+	1. Select the exact match release and continue.
+	1. Or return an error if the release it not found. This should never happen for prod releases. Until now, we keep all releases in the manifest from the beginning of times. At some point we might stop dropping very old releases. That would make those old binaries fail.
+1. Grab the Bundles URL for the selected release and download it. This components in this Bundles will be used to create/upgrade the cluster during this command execution by selecting a VersionsBundle using the desired cluster's `spec.kubernetesVersion`.
+
+### Dev releases
+Dev releases are a bit special: we generate new them all the time, very fast. For this reason, we don't use a simple major.minor.patch semver, but we include build metadata. In particular we use `v{major}.{minor}.{patch}-dev+build.{number}` with `number` being a monotonically increasing integer that is bumped every time a new dev release is built.
+
+The version we use for the first part depends on the HEAD: `main` vs release branches:
+- For `main`, we use the next minor version to the latest tag available. For example, if the latest prod release is `v0.18.5`, the version used for dev releases will be `v0.19.0-dev+build.{number}`. This aligns with the fact that the code in `main` belongs to the next future prod release `v0.19.0`.
+- For `release-*` branches, we use the next patch version to the latest available tag for that minor version. For example, for `release-0.17`, if the latest latest prod release is for v0.17 is `v0.17.7`, dev releases will follow `v0.17.8-dev+build.{number}`.
+
+In order to avoid the dev Release manifest growing forever, we trim the included releases to a max size, dropping always the oldest one. Take this in mind if using a particular version locally. If you do it for too long, it might become unavailable. If it does, just rebuild your CLI.
+
+### E2E tests
+When a CLI is built for dev E2E tests, it's given the latest available EKS-A dev version. This pins that particular binary to one EKS-A version and hence one Bundles manifest. This is important in order to guarantee that the same Bundles is used for the whole execution of the test pipelines and avoids a race condition where a new EKS-A dev release and Bundles are published during an E2E test run.
+
+### Locally building the CLI
+When writing and testing code for the CLI/Controller, most of the time we don't care about particular releases and we just want to use the latest available Bundles that contains the latest available set of components. this verifies that our changes are compatible with the current state of EKS-A dependencies.
+
+To avoid having to rebuild the CLI every time we want to refresh the pulled Bundles or even having to care about fetching the latest version, we introduced a special build metadata identifier `+latest`. This instructs the CLI to not look for an exact match with an EKS-A version, but select the newest one that matches our pre-release. For example: if the release manifest has two releases [`v0.19.0-dev+build.1234`, `v0.19.0-dev+build.1233`], then if the CLI has version `v0.19.0-dev+latest`, then the release `v0.19.0-dev+build.1234` will be selected.
+
+This is the default behavior when building a CLI locally: the Makefile will calculate the appropriate major.minor.patch based on the current HEAD and its closest branch ancestor (either `main` or a `release-*` branch). If you wish to pin your local CLI to a particular version, pass the `DEV_GIT_VERSION` to the make target.

--- a/release/cli/go.mod
+++ b/release/cli/go.mod
@@ -195,9 +195,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace (
-	github.com/aws/eks-anywhere => ../../
-	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/internal/configsources => ./internal/aws-sdk-go-v2/internal/configsources
-	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/internal/endpoints/v2 => ./internal/aws-sdk-go-v2/internal/endpoints/v2
-	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/service/snowballdevice => ./internal/aws-sdk-go-v2/service/snowballdevice
-)
+replace github.com/aws/eks-anywhere => ../../

--- a/release/cli/pkg/bundles/eksctl-anywhere.go
+++ b/release/cli/pkg/bundles/eksctl-anywhere.go
@@ -93,7 +93,7 @@ func GetEksARelease(r *releasetypes.ReleaseConfig) (anywherev1alpha1.EksARelease
 		return anywherev1alpha1.EksARelease{}, fmt.Errorf("artifacts for project eks-a-cli not found in eks-a artifacts table")
 	}
 
-	bundleManifestFilePath := artifactutils.GetManifestFilepaths(r.DevRelease, r.Weekly, r.BundleNumber, constants.BundlesKind, r.BuildRepoBranchName, r.ReleaseDate)
+	bundleManifestFilePath := r.BundlesManifestFilepath()
 	bundleManifestUrl, err := artifactutils.GetURI(r.CDN, bundleManifestFilePath)
 	if err != nil {
 		return anywherev1alpha1.EksARelease{}, errors.Cause(err)

--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -244,20 +244,16 @@ func GetCurrentEksADevReleaseVersion(releaseVersion string, r *releasetypes.Rele
 	fmt.Println("              Dev Release Version Computation")
 	fmt.Println("==========================================================")
 
-	if releaseVersion == "vDev" { // TODO: remove when we update the pipeline
+	if releaseVersion == "" || releaseVersion == "vDev" { // TODO: remove when we update the pipeline
 		releaseVersion = "v0.0.0"
 	}
 	releaseVersionIdentifier := "dev+build"
-
-	if r.BuildRepoBranchName != "main" {
-		releaseVersionIdentifier = fmt.Sprintf("dev-%s+build", r.BuildRepoBranchName)
-	}
 
 	var newDevReleaseVersion string
 	if r.Weekly {
 		newDevReleaseVersion = fmt.Sprintf("v0.0.0-%s.%s", releaseVersionIdentifier, r.ReleaseDate)
 	} else {
-		newDevReleaseVersion = fmt.Sprintf("v0.0.0-%s.%d", releaseVersionIdentifier, buildNumber)
+		newDevReleaseVersion = fmt.Sprintf("%s-%s.%d", releaseVersion, releaseVersionIdentifier, buildNumber)
 	}
 	fmt.Printf("New dev release release version: %s\n", newDevReleaseVersion)
 	fmt.Printf("%s Successfully computed current dev release version\n", constants.SuccessIcon)

--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -33,7 +33,6 @@ import (
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/ecr"
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/ecrpublic"
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/s3"
-	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
 	"github.com/aws/eks-anywhere/release/cli/pkg/filereader"
 	"github.com/aws/eks-anywhere/release/cli/pkg/retrier"
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
@@ -318,7 +317,7 @@ func GetPreviousReleaseImageSemver(r *releasetypes.ReleaseConfig, releaseImageUr
 		semver = "v0.0.0-dev-build.0"
 	} else {
 		bundles := &anywherev1alpha1.Bundles{}
-		bundleReleaseManifestKey := artifactutils.GetManifestFilepaths(r.DevRelease, r.Weekly, r.BundleNumber, constants.BundlesKind, r.BuildRepoBranchName, r.ReleaseDate)
+		bundleReleaseManifestKey := r.BundlesManifestFilepath()
 		bundleManifestUrl := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", r.ReleaseBucket, bundleReleaseManifestKey)
 		if s3.KeyExists(r.ReleaseBucket, bundleReleaseManifestKey) {
 			contents, err := filereader.ReadHttpFile(bundleManifestUrl)

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -55,6 +55,7 @@ type ReleaseConfig struct {
 	BundleArtifactsTable     ArtifactsTable
 	EksAArtifactsTable       ArtifactsTable
 	AwsSignerProfileArn      string
+	MaxReleasesInManifest    int
 }
 
 type ImageTagOverride struct {
@@ -115,6 +116,40 @@ type ArtifactsTable struct {
 
 type ImageDigestsTable struct {
 	imageDigestsMap sync.Map
+}
+
+// BundlesManifestFilepath returns the filepath for the bundles manifest.
+func (r *ReleaseConfig) BundlesManifestFilepath() string {
+	if !r.DevRelease {
+		return fmt.Sprintf("releases/bundles/%d/manifest.yaml", r.BundleNumber)
+	}
+
+	if r.BuildRepoBranchName != "main" {
+		return fmt.Sprintf("%s/%s/bundles.yaml", r.BuildRepoBranchName, r.ReleaseVersion)
+	}
+
+	if r.Weekly {
+		return fmt.Sprintf("weekly-releases/%s/bundle-release.yaml", r.ReleaseDate)
+	}
+
+	return fmt.Sprintf("%s/bundles.yaml", r.ReleaseVersion)
+}
+
+// ReleaseManifestFilepath returns the filepath for the release manifest.
+func (r *ReleaseConfig) ReleaseManifestFilepath() string {
+	if !r.DevRelease {
+		return "releases/eks-a/manifest.yaml"
+	}
+
+	if r.BuildRepoBranchName != "main" {
+		return fmt.Sprintf("%s/eks-a-release.yaml", r.BuildRepoBranchName)
+	}
+
+	if r.Weekly {
+		return fmt.Sprintf("weekly-releases/%s/eks-a-release.yaml", r.ReleaseDate)
+	}
+
+	return "eks-a-release.yaml"
 }
 
 func (a *ArtifactsTable) Load(projectName string) ([]Artifact, error) {

--- a/release/cli/pkg/types/types_test.go
+++ b/release/cli/pkg/types/types_test.go
@@ -1,0 +1,116 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/aws/eks-anywhere/release/cli/pkg/types"
+)
+
+func TestReleaseConfig_BundlesManifestFilepath(t *testing.T) {
+	tests := []struct {
+		name          string
+		releaseConfig *types.ReleaseConfig
+		expected      string
+	}{
+		{
+			name: "Dev Release with non-main branch",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:          true,
+				ReleaseVersion:      "v0.18.10+build.100",
+				BuildRepoBranchName: "release-0.18",
+			},
+			expected: "release-0.18/v0.18.10+build.100/bundles.yaml",
+		},
+		{
+			name: "Dev Release with main branch",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:          true,
+				ReleaseVersion:      "v0.19.0+build.100",
+				Weekly:              false,
+				BuildRepoBranchName: "main",
+			},
+			expected: "v0.19.0+build.100/bundles.yaml",
+		},
+		{
+			name: "Dev weekly Release with main branch",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:          true,
+				ReleaseVersion:      "v0.19.0+build.100",
+				BuildRepoBranchName: "main",
+				Weekly:              true,
+				ReleaseDate:         "2022-01-01",
+			},
+			expected: "weekly-releases/2022-01-01/bundle-release.yaml",
+		},
+		{
+			name: "Prod Release",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:     false,
+				ReleaseVersion: "v0.19.0",
+				BundleNumber:   123,
+			},
+			expected: "releases/bundles/123/manifest.yaml",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.releaseConfig.BundlesManifestFilepath()
+			if result != test.expected {
+				t.Errorf("Unexpected result. Expected: %s, Got: %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestReleaseConfig_ReleaseManifestFilepath(t *testing.T) {
+	tests := []struct {
+		name          string
+		releaseConfig *types.ReleaseConfig
+		expected      string
+	}{
+		{
+			name: "Dev Release with non-main branch",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:          true,
+				BuildRepoBranchName: "feature-branch",
+			},
+			expected: "feature-branch/eks-a-release.yaml",
+		},
+		{
+			name: "Dev Release with main branch",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:          true,
+				Weekly:              false,
+				BuildRepoBranchName: "main",
+			},
+			expected: "eks-a-release.yaml",
+		},
+		{
+			name: "Dev weekly Release with main branch",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease:          true,
+				BuildRepoBranchName: "main",
+				Weekly:              true,
+				ReleaseDate:         "2022-01-01",
+			},
+			expected: "weekly-releases/2022-01-01/eks-a-release.yaml",
+		},
+		{
+			name: "Non-DevRelease",
+			releaseConfig: &types.ReleaseConfig{
+				DevRelease: false,
+			},
+			expected: "releases/eks-a/manifest.yaml",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.releaseConfig.ReleaseManifestFilepath()
+			if result != test.expected {
+				t.Errorf("Unexpected result. Expected: %s, Got: %s", test.expected, result)
+			}
+		})
+	}
+}

--- a/release/cli/pkg/util/artifacts/artifacts.go
+++ b/release/cli/pkg/util/artifacts/artifacts.go
@@ -30,39 +30,6 @@ func IsImageNotFoundError(err error) bool {
 	return err.Error() == "Requested image not found"
 }
 
-func GetManifestFilepaths(devRelease, weekly bool, bundleNumber int, kind, branch, releaseDate string) string {
-	var manifestFilepath string
-	switch kind {
-	case constants.BundlesKind:
-		if devRelease {
-			if branch != "main" {
-				manifestFilepath = fmt.Sprintf("%s/bundle-release.yaml", branch)
-			} else {
-				manifestFilepath = "bundle-release.yaml"
-				if weekly {
-					manifestFilepath = fmt.Sprintf("weekly-releases/%s/bundle-release.yaml", releaseDate)
-				}
-			}
-		} else {
-			manifestFilepath = fmt.Sprintf("releases/bundles/%d/manifest.yaml", bundleNumber)
-		}
-	case constants.ReleaseKind:
-		if devRelease {
-			if branch != "main" {
-				manifestFilepath = fmt.Sprintf("%s/eks-a-release.yaml", branch)
-			} else {
-				manifestFilepath = "eks-a-release.yaml"
-				if weekly {
-					manifestFilepath = fmt.Sprintf("weekly-releases/%s/eks-a-release.yaml", releaseDate)
-				}
-			}
-		} else {
-			manifestFilepath = "releases/eks-a/manifest.yaml"
-		}
-	}
-	return manifestFilepath
-}
-
 func GetFakeSHA(hashType int) (string, error) {
 	if (hashType != 256) && (hashType != 512) {
 		return "", fmt.Errorf("unsupported hash algorithm: %d", hashType)

--- a/release/cli/pkg/util/release/release_test.go
+++ b/release/cli/pkg/util/release/release_test.go
@@ -1,0 +1,133 @@
+package release
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+)
+
+func TestTrim(t *testing.T) {
+	tests := []struct {
+		name     string
+		releases EksAReleases
+		maxSize  int
+		expected EksAReleases
+	}{
+		{
+			name: "maxSize is -1",
+			releases: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+				{Version: "v1.2"},
+			},
+			maxSize: -1,
+			expected: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+				{Version: "v1.2"},
+			},
+		},
+		{
+			name: "maxSize is greater than the number of releases",
+			releases: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+				{Version: "v1.2"},
+			},
+			maxSize: 5,
+			expected: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+				{Version: "v1.2"},
+			},
+		},
+		{
+			name: "maxSize is less than the number of releases",
+			releases: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+				{Version: "v1.2"},
+				{Version: "v1.3"},
+				{Version: "v1.4"},
+			},
+			maxSize: 3,
+			expected: EksAReleases{
+				{Version: "v1.2"},
+				{Version: "v1.3"},
+				{Version: "v1.4"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := Trim(tt.releases, tt.maxSize)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestAppendOrUpdateRelease(t *testing.T) {
+	tests := []struct {
+		name         string
+		releases     EksAReleases
+		releaseToAdd anywherev1alpha1.EksARelease
+		expected     EksAReleases
+	}{
+		{
+			name:     "Adding new release to empty releases",
+			releases: EksAReleases{},
+			releaseToAdd: anywherev1alpha1.EksARelease{
+				Version: "v1.0+build.1",
+			},
+			expected: EksAReleases{
+				{Version: "v1.0+build.1"},
+			},
+		},
+		{
+			name: "Adding new release to non-empty releases",
+			releases: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+			},
+			releaseToAdd: anywherev1alpha1.EksARelease{
+				Version: "v1.1+build.1",
+			},
+			expected: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1"},
+				{Version: "v1.1+build.1"},
+			},
+		},
+		{
+			name: "Updating existing release in releases",
+			releases: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1+build.1"},
+				{Version: "v1.1+build.2", Number: 2},
+				{Version: "v1.1+build.3"},
+			},
+			releaseToAdd: anywherev1alpha1.EksARelease{
+				Version: "v1.1+build.2",
+				Number:  3,
+			},
+			expected: EksAReleases{
+				{Version: "v1.0"},
+				{Version: "v1.1+build.1"},
+				{Version: "v1.1+build.2", Number: 3},
+				{Version: "v1.1+build.3"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := tt.releases.AppendOrUpdateRelease(tt.releaseToAdd)
+			g.Expect(result).To(BeComparableTo(tt.expected))
+		})
+	}
+}

--- a/release/scripts/release.sh
+++ b/release/scripts/release.sh
@@ -22,6 +22,8 @@ export LANG=C.UTF-8
 
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 
+source "$BASE_DIRECTORY"/scripts/eksa_version.sh
+
 ARTIFACTS_DIR="${1?Specify first argument - artifacts path}"
 SOURCE_BUCKET="${2?Specify second argument - source bucket}"
 RELEASE_BUCKET="${3?Specify third argument - release bucket}"
@@ -37,7 +39,10 @@ WEEKLY="${12?Specify twelfth argument - Weekly release}"
 
 mkdir -p "${ARTIFACTS_DIR}"
 
+release_version=$(eksa-version::get_next_eksa_version_for_ancestor "$CLI_REPO_BRANCH_NAME")
+
 ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
+    --release-version "${release_version}" \
     --artifact-dir "${ARTIFACTS_DIR}" \
     --build-repo-url "${BUILD_REPO_URL}" \
     --cli-repo-url "${CLI_REPO_URL}" \

--- a/scripts/eksa_version.sh
+++ b/scripts/eksa_version.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# get_closest_ancestor_branch returns the branch that is the closest ancestor of the current branch.
+# only main and release-* branches are considered as ancestors.
+function eksa-version::get_closest_ancestor_branch() {
+    # Get the name of the current branch
+    local current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+    # Initialize variables to keep track of the closest branch and its merge-base
+    local closest_branch=""
+    local closest_date=""
+
+    # List all branches except the current one, and iterate through them
+    for branch in $(git branch --all | grep upstream | sed 's/\*//g' | sed 's/remotes\/upstream\///g' | sed 's/^[ \t]*//' | grep -e '^main$' -e '^release-' | sort -u); do
+        # Avoid comparing with HEAD or detached states
+        if [[ "$branch" == "HEAD" ]]; then
+            continue
+        fi
+
+        # Find the common ancestor of the current branch and the iterated branch
+        local merge_base=$(git merge-base "$current_branch" "$branch" 2>/dev/null)
+        
+        # Get the commit date of the common ancestor
+        local merge_base_date=$(git show -s --format=%ci "$merge_base" 2>/dev/null)
+
+        # Initialize closest_date if it's empty
+        if [[ -z "$closest_date" ]]; then
+            closest_date="$merge_base_date"
+            closest_branch="$branch"
+        else
+            # Compare dates to find the most recent common ancestor
+            if [[ "$merge_base_date" > "$closest_date" ]]; then
+                closest_date="$merge_base_date"
+                closest_branch="$branch"
+            fi
+        fi
+    done
+
+    echo "$closest_branch"
+
+}
+
+function eksa-version::get_next_eksa_version_for_ancestor() {
+    local ancestor_branch=$1
+    local release_version
+    local latest_tag
+    # This checks if main in the ancestors of the current branch.
+    # If it is, then it is either main or a branch off main.
+    # If it is not, then it is a release branch or a branch off a release branch.
+    if [[ "$ancestor_branch" == "main" ]]; then
+        #  If the branch is main, then get the latest tag by date and
+        # bump one minor version and use patch 0
+        
+        latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+        
+        release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$2++; $3=0; print}')
+    else
+        # For release branhc, get the latest tag that matches current commit
+        # and bump the patch version
+        latest_tag=$(git describe --tags --abbrev=0)
+        release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$3++; print}')
+    fi
+
+    echo "$release_version"
+}
+
+function eksa-version::get_next_eksa_version() {
+    local ancestor_branch
+    ancestor_branch=$(eksa-version::get_closest_ancestor_branch)
+    eksa-version::get_next_eksa_version_for_ancestor "$ancestor_branch"
+}
+
+function eksa-version::latest_release_verison_in_manifest() {
+    local manifest_file=$1
+    local release_version
+    release_version=$(curl -s -L "$manifest_file" | yq '.spec.latestVersion')
+    echo "$release_version"
+}


### PR DESCRIPTION
## Description of changes

### Context on CLI startup flow
Each CLI is built with a particular EKS-A semver in its metadata. This pins each binary built to a particular EKS-A release. However, the Release and Bundles manifests are not included or shipped with the binary. These are served through cloudfront and the CLI dynamically fetches them during each command startup. The logic is as follows:
1. Fetch the Release manifest. As part of its metadata, the CLI is built with a static URL (is the same for all EKS-A releases) pointing to this manifest. Dev CLIs will use a different URL than prod CLIs.
1. Iterate over the available EKS-A releases in the manifest and look for an exact version match with semver included in the build metadata of the binary.
1.
	1. Select the exact match release and continue.
	1. Or return an error if the release it not found. This should never happen for prod releases. Until now, we keep all releases in the manifest from the beginning of times. At some point we might stop dropping very old releases. That would make those old binaries fail.
1. Grab the Bundles URL for the selected release and download it. This components in this Bundles will be used to create/upgrade the cluster during this command execution by selecting a VersionsBundle using the desired cluster's `spec.kubernetesVersion`.

### Dev releases
Dev releases are a bit special: we generate new them all the time, very fast. For this reason, we don't use a simple major.minor.patch semver, but we include build metadata. In particular we use `v{major}.{minor}.{patch}-dev+build.{number}` with `number` being a monotonically increasing integer that is bumped every time a new dev release is built.

Until now we always used `v0.0.0-dev+something`. This PR changes the versioning. The version we use now depends on the HEAD: `main` vs release branches:
- For `main`, we use the next minor version to the latest tag available. For example, if the latest prod release is `v0.18.5`, the version used for dev releases will be `v0.19.0-dev+build.{number}`. This aligns with the fact that the code in `main` belongs to the next future prod release `v0.19.0`.
- For `release-*` branches, we use the next patch version to the latest available tag for that minor version. For example, for `release-0.17`, if the latest latest prod release is for v0.17 is `v0.17.7`, dev releases will follow `v0.17.8-dev+build.{number}`.

In order to avoid the dev Release manifest growing forever, we trim the included releases to a max size, dropping always the oldest one. Take this in mind if using a particular version locally. If you do it for too long, it might become unavailable. If it does, just rebuild your CLI.

### E2E tests
When a CLI is built for dev E2E tests, it's given the latest available EKS-A dev version. This pins that particular binary to one EKS-A version and hence one Bundles manifest. This is important in order to guarantee that the same Bundles is used for the whole execution of the test pipelines and avoids a race condition where a new EKS-A dev release and Bundles are published during an E2E test run.

### Locally building the CLI
When writing and testing code for the CLI/Controller, most of the time we don't care about particular releases and we just want to use the latest available Bundles that contains the latest available set of components. This verifies that our changes are compatible with the current state of EKS-A dependencies.

To avoid having to rebuild the CLI every time we want to refresh the pulled Bundles or even having to care about fetching the latest version, this PR introduces a special build metadata identifier: `+latest`. This instructs the CLI to not look for an exact match with an EKS-A version, but select the newest one that matches our pre-release. For example: if the release manifest has two releases [`v0.19.0-dev+build.1234`, `v0.19.0-dev+build.1233`], then if the CLI has version `v0.19.0-dev+latest`, then the release `v0.19.0-dev+build.1234` will be selected.

This is the default behavior when building a CLI locally: the Makefile will calculate the appropriate major.minor.patch based on the current HEAD and its closest branch ancestor (either `main` or a `release-*` branch). If you wish to pin your local CLI to a particular version, pass the `DEV_GIT_VERSION` to the make target.

This will be merged in a different PR in order to not break main builds: #7497

## Why this
The main issue I was trying to solve is a race condition in the e2e test:
1. Test starts creating a management cluster. Bundle 1 is used
2. While the cluster is created, a new bundle is published and the release entry in the releases manifest is overwritten.
3. The test finishes creating the mangement cluster and goes to create the workload cluster.
4. The CLI reads the release manifest and grabs the latest published bundle. It goes and tries to use this in the workload cluster by setting the eksa version.
5. After it defaults the version, it runs a validation checking if the EKSARelease exists for that version. Since this is a different Bundle than the one used for the management cluster creation, the release object doesn't exist (there is one, but has a different name).
6. The validation fails and the test fails.

Aside from fixing the race condition, this change has the added benefit of removing some assumptions and making dev releases closer to staging and prod releases. The idea is that making dev and prod release as similar as possible reduces the amount of edge cases we need to know about and take into account when writing e2e tests.

## TODO
- [x] Create a unique URL for dev Bundles so they don't get overwritten.
- [x] Split the PR into individual changes
- [x] Make sure binary built for e2e tests has a fixed build metadata and not just use `latest`.
- [x] Write some md doc explaining how dev releases work now

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

