### PR TITLE
Change CAPI upgrader to use management components

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
@@ -115,7 +115,7 @@ func getManagementComponentsChangeDiffs(ctx context.Context, clientFactory inter
 	newManagementComponents := cluster.ManagementComponentsFromBundles(newClusterSpec.Bundles)
 	componentChangeDiffs.Append(eksaupgrader.EksaChangeDiff(currentManagementComponents, newManagementComponents))
 	componentChangeDiffs.Append(fluxupgrader.ChangeDiff(currentManagementComponents, newManagementComponents, currentSpec, newClusterSpec))
-	componentChangeDiffs.Append(capiupgrader.CapiChangeDiff(currentSpec, newClusterSpec, provider))
+	componentChangeDiffs.Append(capiupgrader.ChangeDiff(currentManagementComponents, newManagementComponents, provider))
 
 	return componentChangeDiffs, nil
 }

--- a/pkg/cluster/fetch.go
+++ b/pkg/cluster/fetch.go
@@ -41,11 +41,11 @@ type ManagementComponents struct {
 // that indicates an upgrade is required. In the future, we might change the bundles API to remove the assumption
 // and make this explicit. When that happens, this method will need to change.
 func ManagementComponentsFromBundles(bundles *v1alpha1release.Bundles) *ManagementComponents {
-	return NewManagementComponents(&bundles.Spec.VersionsBundles[0])
+	return newManagementComponents(&bundles.Spec.VersionsBundles[0])
 }
 
-// NewManagementComponents returns a ManagementComponents object built from a VersionsBundle.
-func NewManagementComponents(vb *v1alpha1release.VersionsBundle) *ManagementComponents {
+// newManagementComponents returns a ManagementComponents object built from a VersionsBundle.
+func newManagementComponents(vb *v1alpha1release.VersionsBundle) *ManagementComponents {
 	return &ManagementComponents{
 		EksD:                   vb.EksD,
 		CertManager:            vb.CertManager,

--- a/pkg/clusterapi/installer.go
+++ b/pkg/clusterapi/installer.go
@@ -23,7 +23,8 @@ func NewInstaller(capiClient CAPIClient, kubectlClient KubectlClient) *Installer
 	}
 }
 
-func (i *Installer) EnsureEtcdProvidersInstallation(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currSpec *cluster.Spec) error {
+// EnsureEtcdProvidersInstallation ensures that the CAPI etcd providers are installed in the management cluster.
+func (i *Installer) EnsureEtcdProvidersInstallation(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, managementComponents *cluster.ManagementComponents, currSpec *cluster.Spec) error {
 	if !currSpec.Cluster.IsSelfManaged() {
 		logger.V(1).Info("Not a management cluster, skipping check for CAPI etcd providers")
 		return nil
@@ -46,7 +47,7 @@ func (i *Installer) EnsureEtcdProvidersInstallation(ctx context.Context, managem
 	}
 
 	if len(installProviders) > 0 {
-		return i.capiClient.InstallEtcdadmProviders(ctx, currSpec, managementCluster, provider, installProviders)
+		return i.capiClient.InstallEtcdadmProviders(ctx, managementComponents, currSpec, managementCluster, provider, installProviders)
 	}
 	return nil
 }

--- a/pkg/clusterapi/manager.go
+++ b/pkg/clusterapi/manager.go
@@ -26,8 +26,8 @@ func NewManager(capiClient CAPIClient, kubectlClient KubectlClient) *Manager {
 }
 
 type CAPIClient interface {
-	Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, newSpec *cluster.Spec, changeDiff *CAPIChangeDiff) error
-	InstallEtcdadmProviders(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider, installProviders []string) error
+	Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, managementComponents *cluster.ManagementComponents, newSpec *cluster.Spec, changeDiff *CAPIChangeDiff) error
+	InstallEtcdadmProviders(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider, installProviders []string) error
 }
 
 type KubectlClient interface {

--- a/pkg/clusterapi/mocks/capiclient.go
+++ b/pkg/clusterapi/mocks/capiclient.go
@@ -39,31 +39,31 @@ func (m *MockCAPIClient) EXPECT() *MockCAPIClientMockRecorder {
 }
 
 // InstallEtcdadmProviders mocks base method.
-func (m *MockCAPIClient) InstallEtcdadmProviders(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider, installProviders []string) error {
+func (m *MockCAPIClient) InstallEtcdadmProviders(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider, installProviders []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallEtcdadmProviders", ctx, clusterSpec, cluster, provider, installProviders)
+	ret := m.ctrl.Call(m, "InstallEtcdadmProviders", ctx, managementComponents, clusterSpec, cluster, provider, installProviders)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallEtcdadmProviders indicates an expected call of InstallEtcdadmProviders.
-func (mr *MockCAPIClientMockRecorder) InstallEtcdadmProviders(ctx, clusterSpec, cluster, provider, installProviders interface{}) *gomock.Call {
+func (mr *MockCAPIClientMockRecorder) InstallEtcdadmProviders(ctx, managementComponents, clusterSpec, cluster, provider, installProviders interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallEtcdadmProviders", reflect.TypeOf((*MockCAPIClient)(nil).InstallEtcdadmProviders), ctx, clusterSpec, cluster, provider, installProviders)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallEtcdadmProviders", reflect.TypeOf((*MockCAPIClient)(nil).InstallEtcdadmProviders), ctx, managementComponents, clusterSpec, cluster, provider, installProviders)
 }
 
 // Upgrade mocks base method.
-func (m *MockCAPIClient) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, newSpec *cluster.Spec, changeDiff *clusterapi.CAPIChangeDiff) error {
+func (m *MockCAPIClient) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, managementComponents *cluster.ManagementComponents, newSpec *cluster.Spec, changeDiff *clusterapi.CAPIChangeDiff) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", ctx, managementCluster, provider, newSpec, changeDiff)
+	ret := m.ctrl.Call(m, "Upgrade", ctx, managementCluster, provider, managementComponents, newSpec, changeDiff)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockCAPIClientMockRecorder) Upgrade(ctx, managementCluster, provider, newSpec, changeDiff interface{}) *gomock.Call {
+func (mr *MockCAPIClientMockRecorder) Upgrade(ctx, managementCluster, provider, managementComponents, newSpec, changeDiff interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockCAPIClient)(nil).Upgrade), ctx, managementCluster, provider, newSpec, changeDiff)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockCAPIClient)(nil).Upgrade), ctx, managementCluster, provider, managementComponents, newSpec, changeDiff)
 }
 
 // MockKubectlClient is a mock of KubectlClient interface.

--- a/pkg/clusterapi/upgrader.go
+++ b/pkg/clusterapi/upgrader.go
@@ -23,22 +23,23 @@ func NewUpgrader(capiClient CAPIClient, kubectlClient KubectlClient) *Upgrader {
 	}
 }
 
-func (u *Upgrader) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
+// Upgrade checks whether upgrading the CAPI components is necessary and, if so, upgrades them the new versions.
+func (u *Upgrader) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currentManagementComponents, newManagementComponents *cluster.ManagementComponents, newSpec *cluster.Spec) (*types.ChangeDiff, error) {
 	logger.V(1).Info("Checking for CAPI upgrades")
 	if !newSpec.Cluster.IsSelfManaged() {
 		logger.V(1).Info("Skipping CAPI upgrades, not a self-managed cluster")
 		return nil, nil
 	}
 
-	capiChangeDiff := capiChangeDiff(currentSpec, newSpec, provider)
+	capiChangeDiff := capiChangeDiff(currentManagementComponents, newManagementComponents, provider)
 	if capiChangeDiff == nil {
 		logger.V(1).Info("Nothing to upgrade for CAPI")
 		return nil, nil
 	}
 
 	logger.V(1).Info("Starting CAPI upgrades")
-	if err := u.capiClient.Upgrade(ctx, managementCluster, provider, newSpec, capiChangeDiff); err != nil {
-		return nil, fmt.Errorf("failed upgrading ClusterAPI from bundles %d to bundles %d: %v", currentSpec.Bundles.Spec.Number, newSpec.Bundles.Spec.Number, err)
+	if err := u.capiClient.Upgrade(ctx, managementCluster, provider, newManagementComponents, newSpec, capiChangeDiff); err != nil {
+		return nil, fmt.Errorf("failed upgrading ClusterAPI from EKS-A version %s to EKS-A version %s: %v", currentManagementComponents.Eksa.Version, newManagementComponents.Eksa.Version, err)
 	}
 
 	return capiChangeDiff.toChangeDiff(), nil
@@ -67,82 +68,77 @@ func (c *CAPIChangeDiff) toChangeDiff() *types.ChangeDiff {
 	return types.NewChangeDiff(r...)
 }
 
-func CapiChangeDiff(currentSpec, newSpec *cluster.Spec, provider providers.Provider) *types.ChangeDiff {
-	return capiChangeDiff(currentSpec, newSpec, provider).toChangeDiff()
+// ChangeDiff generates a version change diff for the CAPI components.
+func ChangeDiff(currentManagementComponents, newManagementComponents *cluster.ManagementComponents, provider providers.Provider) *types.ChangeDiff {
+	return capiChangeDiff(currentManagementComponents, newManagementComponents, provider).toChangeDiff()
 }
 
-func capiChangeDiff(currentSpec, newSpec *cluster.Spec, provider providers.Provider) *CAPIChangeDiff {
+func capiChangeDiff(currentManagementComponents, newManagementComponents *cluster.ManagementComponents, provider providers.Provider) *CAPIChangeDiff {
 	changeDiff := &CAPIChangeDiff{}
 	componentChanged := false
 
-	currentVersionsBundle := currentSpec.RootVersionsBundle()
-	newVersionsBundle := newSpec.RootVersionsBundle()
-
-	if currentVersionsBundle.CertManager.Version != newVersionsBundle.CertManager.Version {
+	if currentManagementComponents.CertManager.Version != newManagementComponents.CertManager.Version {
 		changeDiff.CertManager = &types.ComponentChangeDiff{
 			ComponentName: "cert-manager",
-			NewVersion:    newVersionsBundle.CertManager.Version,
-			OldVersion:    currentVersionsBundle.CertManager.Version,
+			NewVersion:    newManagementComponents.CertManager.Version,
+			OldVersion:    currentManagementComponents.CertManager.Version,
 		}
 		logger.V(1).Info("Cert-manager change diff", "oldVersion", changeDiff.CertManager.OldVersion, "newVersion", changeDiff.CertManager.NewVersion)
 		componentChanged = true
 	}
 
-	if currentVersionsBundle.ClusterAPI.Version != newVersionsBundle.ClusterAPI.Version {
+	if currentManagementComponents.ClusterAPI.Version != newManagementComponents.ClusterAPI.Version {
 		changeDiff.Core = &types.ComponentChangeDiff{
 			ComponentName: "cluster-api",
-			NewVersion:    newVersionsBundle.ClusterAPI.Version,
-			OldVersion:    currentVersionsBundle.ClusterAPI.Version,
+			NewVersion:    newManagementComponents.ClusterAPI.Version,
+			OldVersion:    currentManagementComponents.ClusterAPI.Version,
 		}
 		logger.V(1).Info("CAPI Core change diff", "oldVersion", changeDiff.Core.OldVersion, "newVersion", changeDiff.Core.NewVersion)
 		componentChanged = true
 	}
 
-	if currentVersionsBundle.ControlPlane.Version != newVersionsBundle.ControlPlane.Version {
+	if currentManagementComponents.ControlPlane.Version != newManagementComponents.ControlPlane.Version {
 		changeDiff.ControlPlane = &types.ComponentChangeDiff{
 			ComponentName: "kubeadm",
-			NewVersion:    newVersionsBundle.ControlPlane.Version,
-			OldVersion:    currentVersionsBundle.ControlPlane.Version,
+			NewVersion:    newManagementComponents.ControlPlane.Version,
+			OldVersion:    currentManagementComponents.ControlPlane.Version,
 		}
 		logger.V(1).Info("CAPI Control Plane provider change diff", "oldVersion", changeDiff.ControlPlane.OldVersion, "newVersion", changeDiff.ControlPlane.NewVersion)
 		componentChanged = true
 	}
 
-	if currentVersionsBundle.Bootstrap.Version != newVersionsBundle.Bootstrap.Version {
+	if currentManagementComponents.Bootstrap.Version != newManagementComponents.Bootstrap.Version {
 		componentChangeDiff := types.ComponentChangeDiff{
 			ComponentName: "kubeadm",
-			NewVersion:    newVersionsBundle.Bootstrap.Version,
-			OldVersion:    currentVersionsBundle.Bootstrap.Version,
+			NewVersion:    newManagementComponents.Bootstrap.Version,
+			OldVersion:    currentManagementComponents.Bootstrap.Version,
 		}
 		changeDiff.BootstrapProviders = append(changeDiff.BootstrapProviders, componentChangeDiff)
 		logger.V(1).Info("CAPI Kubeadm Bootstrap Provider change diff", "oldVersion", componentChangeDiff.OldVersion, "newVersion", componentChangeDiff.NewVersion)
 		componentChanged = true
 	}
 
-	if currentVersionsBundle.ExternalEtcdBootstrap.Version != newVersionsBundle.ExternalEtcdBootstrap.Version {
+	if currentManagementComponents.ExternalEtcdBootstrap.Version != newManagementComponents.ExternalEtcdBootstrap.Version {
 		componentChangeDiff := types.ComponentChangeDiff{
 			ComponentName: "etcdadm-bootstrap",
-			NewVersion:    newVersionsBundle.ExternalEtcdBootstrap.Version,
-			OldVersion:    currentVersionsBundle.ExternalEtcdBootstrap.Version,
+			NewVersion:    newManagementComponents.ExternalEtcdBootstrap.Version,
+			OldVersion:    currentManagementComponents.ExternalEtcdBootstrap.Version,
 		}
 		changeDiff.BootstrapProviders = append(changeDiff.BootstrapProviders, componentChangeDiff)
 		logger.V(1).Info("CAPI Etcdadm Bootstrap Provider change diff", "oldVersion", componentChangeDiff.OldVersion, "newVersion", componentChangeDiff.NewVersion)
 		componentChanged = true
 	}
 
-	if currentVersionsBundle.ExternalEtcdController.Version != newVersionsBundle.ExternalEtcdController.Version {
+	if currentManagementComponents.ExternalEtcdController.Version != newManagementComponents.ExternalEtcdController.Version {
 		componentChangeDiff := types.ComponentChangeDiff{
 			ComponentName: "etcdadm-controller",
-			NewVersion:    newVersionsBundle.ExternalEtcdController.Version,
-			OldVersion:    currentVersionsBundle.ExternalEtcdController.Version,
+			NewVersion:    newManagementComponents.ExternalEtcdController.Version,
+			OldVersion:    currentManagementComponents.ExternalEtcdController.Version,
 		}
 		changeDiff.BootstrapProviders = append(changeDiff.BootstrapProviders, componentChangeDiff)
 		logger.V(1).Info("CAPI Etcdadm Controller Provider change diff", "oldVersion", componentChangeDiff.OldVersion, "newVersion", componentChangeDiff.NewVersion)
 		componentChanged = true
 	}
-
-	currentManagementComponents := cluster.NewManagementComponents(currentSpec.RootVersionsBundle().VersionsBundle)
-	newManagementComponents := cluster.NewManagementComponents(newSpec.RootVersionsBundle().VersionsBundle)
 
 	if providerChangeDiff := provider.ChangeDiff(currentManagementComponents, newManagementComponents); providerChangeDiff != nil {
 		changeDiff.InfrastructureProvider = providerChangeDiff

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -107,7 +107,7 @@ type ClientFactory interface {
 type CAPIClient interface {
 	BackupManagement(ctx context.Context, cluster *types.Cluster, managementStatePath, clusterName string) error
 	MoveManagement(ctx context.Context, from, target *types.Cluster, clusterName string) error
-	InitInfrastructure(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
+	InitInfrastructure(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	GetWorkloadKubeconfig(ctx context.Context, clusterName string, cluster *types.Cluster) ([]byte, error)
 }
 
@@ -738,8 +738,9 @@ func compareEKSAClusterSpec(ctx context.Context, currentClusterSpec, newClusterS
 	return false, nil
 }
 
-func (c *ClusterManager) InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
-	err := c.clusterClient.InitInfrastructure(ctx, clusterSpec, cluster, provider)
+// InstallCAPI installs the cluster-api components in a cluster.
+func (c *ClusterManager) InstallCAPI(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
+	err := c.clusterClient.InitInfrastructure(ctx, managementComponents, clusterSpec, cluster, provider)
 	if err != nil {
 		return fmt.Errorf("initializing capi resources in cluster: %v", err)
 	}

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -97,8 +97,9 @@ func TestClusterManagerCAPIWaitForDeploymentStackedEtcd(t *testing.T) {
 	clusterObj := &types.Cluster{}
 	c, m := newClusterManager(t)
 	clusterSpecStackedEtcd := test.NewClusterSpec()
+	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpecStackedEtcd.Bundles)
 
-	m.client.EXPECT().InitInfrastructure(ctx, clusterSpecStackedEtcd, clusterObj, m.provider)
+	m.client.EXPECT().InitInfrastructure(ctx, managementComponents, clusterSpecStackedEtcd, clusterObj, m.provider)
 	for namespace, deployments := range internal.CAPIDeployments {
 		for _, deployment := range deployments {
 			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
@@ -111,7 +112,8 @@ func TestClusterManagerCAPIWaitForDeploymentStackedEtcd(t *testing.T) {
 			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
-	if err := c.InstallCAPI(ctx, clusterSpecStackedEtcd, clusterObj, m.provider); err != nil {
+
+	if err := c.InstallCAPI(ctx, managementComponents, clusterSpecStackedEtcd, clusterObj, m.provider); err != nil {
 		t.Errorf("ClusterManager.InstallCAPI() error = %v, wantErr nil", err)
 	}
 }
@@ -123,7 +125,9 @@ func TestClusterManagerCAPIWaitForDeploymentExternalEtcd(t *testing.T) {
 	clusterSpecExternalEtcd := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{Count: 1}
 	})
-	m.client.EXPECT().InitInfrastructure(ctx, clusterSpecExternalEtcd, clusterObj, m.provider)
+	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpecExternalEtcd.Bundles)
+
+	m.client.EXPECT().InitInfrastructure(ctx, managementComponents, clusterSpecExternalEtcd, clusterObj, m.provider)
 	for namespace, deployments := range internal.CAPIDeployments {
 		for _, deployment := range deployments {
 			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
@@ -141,7 +145,7 @@ func TestClusterManagerCAPIWaitForDeploymentExternalEtcd(t *testing.T) {
 			m.client.EXPECT().WaitForDeployment(ctx, clusterObj, "30m0s", "Available", deployment, namespace)
 		}
 	}
-	if err := c.InstallCAPI(ctx, clusterSpecExternalEtcd, clusterObj, m.provider); err != nil {
+	if err := c.InstallCAPI(ctx, managementComponents, clusterSpecExternalEtcd, clusterObj, m.provider); err != nil {
 		t.Errorf("ClusterManager.InstallCAPI() error = %v, wantErr nil", err)
 	}
 }

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -537,17 +537,17 @@ func (mr *MockClusterClientMockRecorder) GetWorkloadKubeconfig(arg0, arg1, arg2 
 }
 
 // InitInfrastructure mocks base method.
-func (m *MockClusterClient) InitInfrastructure(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster, arg3 providers.Provider) error {
+func (m *MockClusterClient) InitInfrastructure(arg0 context.Context, arg1 *cluster.ManagementComponents, arg2 *cluster.Spec, arg3 *types.Cluster, arg4 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitInfrastructure", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InitInfrastructure", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitInfrastructure indicates an expected call of InitInfrastructure.
-func (mr *MockClusterClientMockRecorder) InitInfrastructure(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) InitInfrastructure(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitInfrastructure", reflect.TypeOf((*MockClusterClient)(nil).InitInfrastructure), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitInfrastructure", reflect.TypeOf((*MockClusterClient)(nil).InitInfrastructure), arg0, arg1, arg2, arg3, arg4)
 }
 
 // KubeconfigSecretAvailable mocks base method.
@@ -1863,17 +1863,17 @@ func (mr *MockCAPIClientMockRecorder) GetWorkloadKubeconfig(arg0, arg1, arg2 int
 }
 
 // InitInfrastructure mocks base method.
-func (m *MockCAPIClient) InitInfrastructure(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster, arg3 providers.Provider) error {
+func (m *MockCAPIClient) InitInfrastructure(arg0 context.Context, arg1 *cluster.ManagementComponents, arg2 *cluster.Spec, arg3 *types.Cluster, arg4 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitInfrastructure", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InitInfrastructure", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitInfrastructure indicates an expected call of InitInfrastructure.
-func (mr *MockCAPIClientMockRecorder) InitInfrastructure(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCAPIClientMockRecorder) InitInfrastructure(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitInfrastructure", reflect.TypeOf((*MockCAPIClient)(nil).InitInfrastructure), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitInfrastructure", reflect.TypeOf((*MockCAPIClient)(nil).InitInfrastructure), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MoveManagement mocks base method.

--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -206,14 +206,14 @@ func (c *Clusterctl) GetWorkloadKubeconfig(ctx context.Context, clusterName stri
 	return stdOut.Bytes(), nil
 }
 
-func (c *Clusterctl) InitInfrastructure(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
+// InitInfrastructure initializes the infrastructure for the cluster using clusterctl.
+func (c *Clusterctl) InitInfrastructure(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error {
 	if cluster == nil {
 		return fmt.Errorf("invalid cluster (nil)")
 	}
 	if cluster.Name == "" {
 		return fmt.Errorf("invalid cluster name '%s'", cluster.Name)
 	}
-	managementComponents := anywherecluster.NewManagementComponents(clusterSpec.RootVersionsBundle().VersionsBundle)
 	clusterctlConfig, err := c.buildConfig(managementComponents, cluster.Name, provider)
 	if err != nil {
 		return err
@@ -342,8 +342,8 @@ var providerNamespaces = map[string]string{
 	kubeadmBootstrapProviderName:     constants.CapiKubeadmBootstrapSystemNamespace,
 }
 
-func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, newSpec *cluster.Spec, changeDiff *clusterapi.CAPIChangeDiff) error {
-	managementComponents := anywherecluster.NewManagementComponents(newSpec.RootVersionsBundle().VersionsBundle)
+// Upgrade executes an upgrade of the cluster to the new management components and the spec.
+func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, managementComponents *cluster.ManagementComponents, newSpec *cluster.Spec, changeDiff *clusterapi.CAPIChangeDiff) error {
 	clusterctlConfig, err := c.buildConfig(managementComponents, managementCluster.Name, provider)
 	if err != nil {
 		return err
@@ -385,7 +385,8 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 	return nil
 }
 
-func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, infraProvider providers.Provider, installProviders []string) error {
+// InstallEtcdadmProviders installs the etcdadm providers for the cluster using clusterctl.
+func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, infraProvider providers.Provider, installProviders []string) error {
 	if cluster == nil {
 		return fmt.Errorf("invalid cluster (nil)")
 	}
@@ -393,7 +394,6 @@ func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, clusterSpec *c
 		return fmt.Errorf("invalid cluster name '%s'", cluster.Name)
 	}
 
-	managementComponents := anywherecluster.NewManagementComponents(clusterSpec.RootVersionsBundle().VersionsBundle)
 	clusterctlConfig, err := c.buildConfig(managementComponents, cluster.Name, infraProvider)
 	if err != nil {
 		return err

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -164,7 +164,7 @@ func TestClusterctlInitInfrastructure(t *testing.T) {
 				},
 			)
 
-			if err := tc.clusterctl.InitInfrastructure(tc.ctx, clusterSpec, tt.cluster, tc.provider); err != nil {
+			if err := tc.clusterctl.InitInfrastructure(tc.ctx, tc.managementComponents, clusterSpec, tt.cluster, tc.provider); err != nil {
 				t.Fatalf("Clusterctl.InitInfrastructure() error = %v, want nil", err)
 			}
 		})
@@ -185,7 +185,7 @@ func TestClusterctlInitInfrastructureEnvMapError(t *testing.T) {
 	tt.provider.EXPECT().EnvMap(clusterSpec).Return(nil, errors.New("error with env map"))
 	tt.provider.EXPECT().GetInfrastructureBundle(tt.managementComponents).Return(&types.InfrastructureBundle{})
 
-	if err := tt.clusterctl.InitInfrastructure(tt.ctx, clusterSpec, cluster, tt.provider); err == nil {
+	if err := tt.clusterctl.InitInfrastructure(tt.ctx, tt.managementComponents, clusterSpec, cluster, tt.provider); err == nil {
 		t.Fatal("Clusterctl.InitInfrastructure() error = nil")
 	}
 }
@@ -206,7 +206,7 @@ func TestClusterctlInitInfrastructureExecutableError(t *testing.T) {
 
 	tt.e.EXPECT().ExecuteWithEnv(tt.ctx, nil, gomock.Any()).Return(bytes.Buffer{}, errors.New("error from execute with env"))
 
-	if err := tt.clusterctl.InitInfrastructure(tt.ctx, clusterSpec, cluster, tt.provider); err == nil {
+	if err := tt.clusterctl.InitInfrastructure(tt.ctx, tt.managementComponents, clusterSpec, cluster, tt.provider); err == nil {
 		t.Fatal("Clusterctl.InitInfrastructure() error = nil")
 	}
 }
@@ -214,7 +214,7 @@ func TestClusterctlInitInfrastructureExecutableError(t *testing.T) {
 func TestClusterctlInitInfrastructureInvalidClusterNameError(t *testing.T) {
 	tt := newClusterctlTest(t)
 
-	if err := tt.clusterctl.InitInfrastructure(tt.ctx, clusterSpec, &types.Cluster{Name: ""}, tt.provider); err == nil {
+	if err := tt.clusterctl.InitInfrastructure(tt.ctx, tt.managementComponents, clusterSpec, &types.Cluster{Name: ""}, tt.provider); err == nil {
 		t.Fatal("Clusterctl.InitInfrastructure() error != nil")
 	}
 }
@@ -380,7 +380,7 @@ func TestClusterctlUpgradeAllProvidersSucess(t *testing.T) {
 		"--bootstrap", "etcdadm-controller-system/etcdadm-controller:v0.1.0",
 	)
 
-	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).To(Succeed())
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.managementComponents, clusterSpec, changeDiff)).To(Succeed())
 }
 
 func TestClusterctlUpgradeInfrastructureProvidersSucess(t *testing.T) {
@@ -402,7 +402,7 @@ func TestClusterctlUpgradeInfrastructureProvidersSucess(t *testing.T) {
 		"--infrastructure", "capv-system/vsphere:v0.4.1",
 	)
 
-	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).To(Succeed())
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.managementComponents, clusterSpec, changeDiff)).To(Succeed())
 }
 
 func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
@@ -424,7 +424,7 @@ func TestClusterctlUpgradeInfrastructureProvidersError(t *testing.T) {
 		"--infrastructure", "capv-system/vsphere:v0.4.1",
 	).Return(bytes.Buffer{}, errors.New("error in exec"))
 
-	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, clusterSpec, changeDiff)).NotTo(Succeed())
+	tt.Expect(tt.clusterctl.Upgrade(tt.ctx, tt.cluster, tt.provider, tt.managementComponents, clusterSpec, changeDiff)).NotTo(Succeed())
 }
 
 var clusterSpec = test.NewClusterSpec(func(s *cluster.Spec) {

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -136,7 +136,8 @@ func (s *CreateBootStrapClusterTask) Run(ctx context.Context, commandContext *ta
 	}
 
 	logger.Info("Installing cluster-api providers on bootstrap cluster")
-	if err = commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, bootstrapCluster, commandContext.Provider); err != nil {
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+	if err = commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, bootstrapCluster, commandContext.Provider); err != nil {
 		commandContext.SetError(err)
 		return &CollectMgmtClusterDiagnosticsTask{}
 	}
@@ -258,7 +259,8 @@ func (s *CreateWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 		}
 
 		logger.Info("Installing cluster-api providers on workload cluster")
-		err = commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
+		managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+		err = commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
 		if err != nil {
 			commandContext.SetError(err)
 			return &CollectDiagnosticsTask{}

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -127,7 +127,7 @@ func (c *createTestSetup) expectCreateBootstrap() {
 
 		c.provider.EXPECT().PreCAPIInstallOnBootstrap(c.ctx, c.bootstrapCluster, c.clusterSpec),
 
-		c.clusterManager.EXPECT().InstallCAPI(c.ctx, c.clusterSpec, c.bootstrapCluster, c.provider),
+		c.clusterManager.EXPECT().InstallCAPI(c.ctx, c.managementComponents, c.clusterSpec, c.bootstrapCluster, c.provider),
 
 		c.provider.EXPECT().PostBootstrapSetup(c.ctx, c.clusterSpec.Cluster, c.bootstrapCluster),
 	)
@@ -151,7 +151,7 @@ func (c *createTestSetup) expectCreateWorkload() {
 			c.ctx, c.workloadCluster,
 		),
 		c.clusterManager.EXPECT().InstallCAPI(
-			c.ctx, c.clusterSpec, c.workloadCluster, c.provider,
+			c.ctx, c.managementComponents, c.clusterSpec, c.workloadCluster, c.provider,
 		),
 		c.provider.EXPECT().UpdateSecrets(c.ctx, c.workloadCluster, c.clusterSpec),
 	)
@@ -180,7 +180,7 @@ func (c *createTestSetup) expectCreateWorkloadSkipCAPI() {
 		),
 	)
 	c.clusterManager.EXPECT().InstallCAPI(
-		c.ctx, c.clusterSpec, c.workloadCluster, c.provider,
+		c.ctx, c.managementComponents, c.clusterSpec, c.workloadCluster, c.provider,
 	).Times(0)
 	c.provider.EXPECT().UpdateSecrets(c.ctx, c.workloadCluster, c.clusterSpec).Times(0)
 }
@@ -421,7 +421,7 @@ func TestCreateRunAWSIamConfigFail(t *testing.T) {
 	test.provider.EXPECT().BootstrapClusterOpts(test.clusterSpec).Return([]bootstrapper.BootstrapClusterOption{bootstrapper.WithExtraDockerMounts()}, nil)
 	test.bootstrapper.EXPECT().CreateBootstrapCluster(test.ctx, test.clusterSpec, gomock.Not(gomock.Nil())).Return(test.bootstrapCluster, nil)
 	test.provider.EXPECT().PreCAPIInstallOnBootstrap(test.ctx, test.bootstrapCluster, test.clusterSpec)
-	test.clusterManager.EXPECT().InstallCAPI(test.ctx, test.clusterSpec, test.bootstrapCluster, test.provider)
+	test.clusterManager.EXPECT().InstallCAPI(test.ctx, test.managementComponents, test.clusterSpec, test.bootstrapCluster, test.provider)
 	test.clusterManager.EXPECT().CreateAwsIamAuthCaSecret(test.ctx, test.bootstrapCluster, test.clusterSpec.Cluster.Name).Return(wantError)
 	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
 	test.writer.EXPECT().Write(fmt.Sprintf("%s-checkpoint.yaml", test.clusterSpec.Cluster.Name), gomock.Any())

--- a/pkg/workflows/delete.go
+++ b/pkg/workflows/delete.go
@@ -139,7 +139,8 @@ func (s *createManagementCluster) Checkpoint() *task.CompletedTask {
 
 func (s *installCAPI) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Installing cluster-api providers on management cluster")
-	err := commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider)
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+	err := commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &deleteManagementCluster{}

--- a/pkg/workflows/delete_test.go
+++ b/pkg/workflows/delete_test.go
@@ -72,7 +72,7 @@ func (c *deleteTestSetup) expectCreateBootstrap() {
 		).Return(c.bootstrapCluster, nil),
 
 		c.provider.EXPECT().PreCAPIInstallOnBootstrap(c.ctx, c.bootstrapCluster, c.clusterSpec),
-		c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider),
+		c.clusterManager.EXPECT().InstallCAPI(c.ctx, cluster.ManagementComponentsFromBundles(c.clusterSpec.Bundles), gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider),
 	)
 }
 
@@ -86,7 +86,7 @@ func (c *deleteTestSetup) expectNotToCreateBootstrap() {
 		c.ctx, gomock.Not(gomock.Nil()), gomock.Not(gomock.Nil()),
 	).Return(c.bootstrapCluster, nil).Times(0)
 
-	c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider).Times(0)
+	c.clusterManager.EXPECT().InstallCAPI(c.ctx, cluster.ManagementComponentsFromBundles(c.clusterSpec.Bundles), gomock.Not(gomock.Nil()), c.bootstrapCluster, c.provider).Times(0)
 }
 
 func (c *deleteTestSetup) expectDeletePackageResources() {

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -35,7 +35,7 @@ type ClusterManager interface {
 	RunPostCreateWorkloadCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
 	UpgradeCluster(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	DeleteCluster(ctx context.Context, managementCluster, clusterToDelete *types.Cluster, provider providers.Provider, clusterSpec *cluster.Spec) error
-	InstallCAPI(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
+	InstallCAPI(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	InstallNetworking(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	UpgradeNetworking(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec, provider providers.Provider) (*types.ChangeDiff, error)
 	SaveLogsManagementCluster(ctx context.Context, spec *cluster.Spec, cluster *types.Cluster) error
@@ -74,8 +74,8 @@ type Validator interface {
 }
 
 type CAPIManager interface {
-	Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currentSpec, newSpec *cluster.Spec) (*types.ChangeDiff, error)
-	EnsureEtcdProvidersInstallation(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currSpec *cluster.Spec) error
+	Upgrade(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, currentManagementComponents, newManagementComponents *cluster.ManagementComponents, newSpec *cluster.Spec) (*types.ChangeDiff, error)
+	EnsureEtcdProvidersInstallation(ctx context.Context, managementCluster *types.Cluster, provider providers.Provider, managementComponents *cluster.ManagementComponents, currSpec *cluster.Spec) error
 }
 
 type EksdInstaller interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -285,17 +285,17 @@ func (mr *MockClusterManagerMockRecorder) InstallAwsIamAuth(arg0, arg1, arg2, ar
 }
 
 // InstallCAPI mocks base method.
-func (m *MockClusterManager) InstallCAPI(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster, arg3 providers.Provider) error {
+func (m *MockClusterManager) InstallCAPI(arg0 context.Context, arg1 *cluster.ManagementComponents, arg2 *cluster.Spec, arg3 *types.Cluster, arg4 providers.Provider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallCAPI", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InstallCAPI", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallCAPI indicates an expected call of InstallCAPI.
-func (mr *MockClusterManagerMockRecorder) InstallCAPI(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterManagerMockRecorder) InstallCAPI(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallCAPI", reflect.TypeOf((*MockClusterManager)(nil).InstallCAPI), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallCAPI", reflect.TypeOf((*MockClusterManager)(nil).InstallCAPI), arg0, arg1, arg2, arg3, arg4)
 }
 
 // InstallCustomComponents mocks base method.
@@ -726,32 +726,32 @@ func (m *MockCAPIManager) EXPECT() *MockCAPIManagerMockRecorder {
 }
 
 // EnsureEtcdProvidersInstallation mocks base method.
-func (m *MockCAPIManager) EnsureEtcdProvidersInstallation(arg0 context.Context, arg1 *types.Cluster, arg2 providers.Provider, arg3 *cluster.Spec) error {
+func (m *MockCAPIManager) EnsureEtcdProvidersInstallation(arg0 context.Context, arg1 *types.Cluster, arg2 providers.Provider, arg3 *cluster.ManagementComponents, arg4 *cluster.Spec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureEtcdProvidersInstallation", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "EnsureEtcdProvidersInstallation", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureEtcdProvidersInstallation indicates an expected call of EnsureEtcdProvidersInstallation.
-func (mr *MockCAPIManagerMockRecorder) EnsureEtcdProvidersInstallation(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCAPIManagerMockRecorder) EnsureEtcdProvidersInstallation(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureEtcdProvidersInstallation", reflect.TypeOf((*MockCAPIManager)(nil).EnsureEtcdProvidersInstallation), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureEtcdProvidersInstallation", reflect.TypeOf((*MockCAPIManager)(nil).EnsureEtcdProvidersInstallation), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Upgrade mocks base method.
-func (m *MockCAPIManager) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2 providers.Provider, arg3, arg4 *cluster.Spec) (*types.ChangeDiff, error) {
+func (m *MockCAPIManager) Upgrade(arg0 context.Context, arg1 *types.Cluster, arg2 providers.Provider, arg3, arg4 *cluster.ManagementComponents, arg5 *cluster.Spec) (*types.ChangeDiff, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Upgrade", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*types.ChangeDiff)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upgrade indicates an expected call of Upgrade.
-func (mr *MockCAPIManagerMockRecorder) Upgrade(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockCAPIManagerMockRecorder) Upgrade(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockCAPIManager)(nil).Upgrade), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockCAPIManager)(nil).Upgrade), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // MockEksdInstaller is a mock of EksdInstaller interface.

--- a/pkg/workflows/management/core_components.go
+++ b/pkg/workflows/management/core_components.go
@@ -18,7 +18,8 @@ type ensureEtcdCAPIComponentsExist struct{}
 // Run ensureEtcdCAPIComponentsExist ensures ETCD CAPI providers on the management cluster.
 func (s *ensureEtcdCAPIComponentsExist) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Ensuring etcd CAPI providers exist on management cluster before upgrade")
-	if err := commandContext.CAPIManager.EnsureEtcdProvidersInstallation(ctx, commandContext.ManagementCluster, commandContext.Provider, commandContext.CurrentClusterSpec); err != nil {
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.CurrentClusterSpec.Bundles)
+	if err := commandContext.CAPIManager.EnsureEtcdProvidersInstallation(ctx, commandContext.ManagementCluster, commandContext.Provider, managementComponents, commandContext.CurrentClusterSpec); err != nil {
 		commandContext.SetError(err)
 		return &workflows.CollectMgmtClusterDiagnosticsTask{}
 	}
@@ -70,7 +71,7 @@ func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandC
 
 	newManagementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
 
-	changeDiff, err := commandContext.CAPIManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.Provider, commandContext.CurrentClusterSpec, commandContext.ClusterSpec)
+	changeDiff, err := commandContext.CAPIManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.Provider, currentManagementComponents, newManagementComponents, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)
 		return err

--- a/pkg/workflows/management/create_install_capi.go
+++ b/pkg/workflows/management/create_install_capi.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -18,7 +19,8 @@ func (s *installCAPIComponentsTask) Run(ctx context.Context, commandContext *tas
 	}
 
 	logger.Info("Installing cluster-api providers on bootstrap cluster")
-	if err := commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider); err != nil {
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+	if err := commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider); err != nil {
 		commandContext.SetError(err)
 		return &workflows.CollectMgmtClusterDiagnosticsTask{}
 	}

--- a/pkg/workflows/management/create_test.go
+++ b/pkg/workflows/management/create_test.go
@@ -148,7 +148,7 @@ func (c *createTestSetup) expectCAPIInstall(err1, err2, err3 error) {
 			c.ctx, c.bootstrapCluster, c.clusterSpec).Return(err1),
 
 		c.clusterManager.EXPECT().InstallCAPI(
-			c.ctx, c.clusterSpec, c.bootstrapCluster, c.provider).Return(err2),
+			c.ctx, c.managementComponents, c.clusterSpec, c.bootstrapCluster, c.provider).Return(err2),
 
 		c.provider.EXPECT().PostBootstrapSetup(
 			c.ctx, c.clusterSpec.Cluster, c.bootstrapCluster).Return(err3),
@@ -185,7 +185,7 @@ func (c *createTestSetup) expectCreateWorkload(err1, err2, err3, err4 error) {
 			c.ctx, c.workloadCluster).Return(err2),
 
 		c.clusterManager.EXPECT().InstallCAPI(
-			c.ctx, c.clusterSpec, c.workloadCluster, c.provider).Return(err3),
+			c.ctx, c.managementComponents, c.clusterSpec, c.workloadCluster, c.provider).Return(err3),
 
 		c.provider.EXPECT().UpdateSecrets(
 			c.ctx, c.workloadCluster, c.clusterSpec).Return(err4),
@@ -363,7 +363,7 @@ func TestCreateInstallCAPIFailure(t *testing.T) {
 			c.ctx, c.bootstrapCluster, c.clusterSpec),
 
 		c.clusterManager.EXPECT().InstallCAPI(
-			c.ctx, c.clusterSpec, c.bootstrapCluster, c.provider).Return(errors.New("test")),
+			c.ctx, c.managementComponents, c.clusterSpec, c.bootstrapCluster, c.provider).Return(errors.New("test")),
 	)
 
 	c.clusterManager.EXPECT().SaveLogsManagementCluster(c.ctx, c.clusterSpec, c.bootstrapCluster)
@@ -607,7 +607,7 @@ func TestCreateInstallCAPIWorkloadFailure(t *testing.T) {
 		test.ctx, test.workloadCluster)
 
 	test.clusterManager.EXPECT().InstallCAPI(
-		test.ctx, test.clusterSpec, test.workloadCluster, test.provider).Return(errors.New("test"))
+		test.ctx, test.managementComponents, test.clusterSpec, test.workloadCluster, test.provider).Return(errors.New("test"))
 
 	test.clusterManager.EXPECT().SaveLogsManagementCluster(test.ctx, test.clusterSpec, test.bootstrapCluster)
 	test.clusterManager.EXPECT().SaveLogsWorkloadCluster(test.ctx, test.provider, test.clusterSpec, test.workloadCluster)

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -29,7 +30,8 @@ func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	}
 
 	logger.Info("Installing cluster-api providers on workload cluster")
-	err = commandContext.ClusterManager.InstallCAPI(ctx, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+	err = commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
 	if err != nil {
 		commandContext.SetError(err)
 		return &workflows.CollectDiagnosticsTask{}

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -111,7 +111,7 @@ func TestRunnerHappyPath(t *testing.T) {
 		mocks.provider.EXPECT().SetupAndValidateUpgradeCluster(ctx, gomock.Any(), newSpec, curSpec),
 		mocks.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any()),
 		mocks.clientFactory.EXPECT().BuildClientFromKubeconfig(managementCluster.KubeconfigFile).Return(client, nil),
-		mocks.capiManager.EXPECT().Upgrade(ctx, managementCluster, mocks.provider, curSpec, newSpec).Return(capiChangeDiff, nil),
+		mocks.capiManager.EXPECT().Upgrade(ctx, managementCluster, mocks.provider, currentManagementComponents, newManagementComponents, newSpec).Return(capiChangeDiff, nil),
 		mocks.gitOpsManager.EXPECT().Install(ctx, managementCluster, newManagementComponents, curSpec, newSpec).Return(nil),
 		mocks.gitOpsManager.EXPECT().Upgrade(ctx, managementCluster, currentManagementComponents, newManagementComponents, curSpec, newSpec).Return(fluxChangeDiff, nil),
 		mocks.clusterManager.EXPECT().Upgrade(ctx, managementCluster, currentManagementComponents, newManagementComponents, newSpec).Return(eksaChangeDiff, nil),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes here are split out from https://github.com/aws/eks-anywhere/pull/7353 with some changes to use ManagementComponents. It also addresses https://github.com/aws/eks-anywhere/pull/7353#discussion_r1465492542 by passing the ManagementComponents down to where it's need.

Updates the CAPI upgrader to use management components:
- CAPIChangeDiff -> ChangeDiff which takes and compares *cluster.ManagementComponents to get the plan change diff
- CAPI InitInfrastructure updated to use `cluster.ManagementComponents` to initialize infrastructure for the cluster.
- CAPI InstallEtcdadmProviders updated to use `cluster.ManagementComponents` to install etcdadm providers.
- CAPI Upgrade updated to use `cluster.ManagementComponents` for the upgrade

*Testing (if applicable):*
- Created a management and workload cluster with v0.18.3, checked upgrade plans before upgrading management components.
- Ran the `upgrade management-components` subcommand, checked upgrade plans after.

**Before running upgrade management components**

*Management cluster*
```
./bin/eksctl-anywhere upgrade plan cluster -f mgmt/mgmt-eks-a-cluster.yaml
...
NAME                 CURRENT VERSION       NEXT VERSION
EKS-A Management     v0.18.3+cc70180       v0.0.0-dev+build.8203+c1a3710
cert-manager         v1.13.0+68bec33       v1.13.2+a34c207
cluster-api          v1.5.2+b14378d        v1.6.0+04c07bc
kubeadm              v1.5.2+5762149        v1.6.0+5bf0931
vsphere              v1.7.4+6ecf386        v1.8.5+650acfa
kubeadm              v1.5.2+b8987c8        v1.6.0+7a4ce68
etcdadm-bootstrap    v1.0.10+c9a5a8a       v1.0.10+1ceb898
etcdadm-controller   v1.0.16+0ed68e6       v1.0.17+5e33062
cilium               v1.12.15-eksa.1       v1.13.9-eksa.1
kubernetes           v1.27.8-eks-1-27-17   v1.27.8-eks-1-27-20
```

*Workload Cluster*
```
./bin/eksctl-anywhere upgrade plan cluster -f w01/w01-eks-a-cluster.yaml 
...
NAME         CURRENT VERSION       NEXT VERSION
cilium       v1.12.15-eksa.1       v1.13.9-eksa.1
kubernetes   v1.27.8-eks-1-27-17   v1.27.8-eks-1-27-20
```

**After running upgrade management components**

*Management cluster*
```
./bin/eksctl-anywhere upgrade plan cluster -f mgmt/mgmt-eks-a-cluster.yaml
...
NAME         CURRENT VERSION       NEXT VERSION
cilium       v1.12.15-eksa.1       v1.13.9-eksa.1
kubernetes   v1.27.8-eks-1-27-17   v1.27.8-eks-1-27-20
```

*Workload Cluster*
```
./bin/eksctl-anywhere upgrade plan cluster -f w01/w01-eks-a-cluster.yaml 
...
NAME         CURRENT VERSION       NEXT VERSION
cilium       v1.12.15-eksa.1       v1.13.9-eksa.1
kubernetes   v1.27.8-eks-1-27-17   v1.27.8-eks-1-27-20
```


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

