### PR TITLE
Handle release not found from version command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/version.go
+++ b/cmd/eksctl-anywhere/cmd/version.go
@@ -36,7 +36,7 @@ func (vo *versionOptions) printVersion() error {
 	case "":
 		fmt.Printf("Version: %s\n", versionInfo.GitVersion)
 		if bundlesErr != nil {
-			return fmt.Errorf("error getting bundle manifest URL for version %s: %v", versionInfo, bundlesErr)
+			return fmt.Errorf("error getting bundle manifest URL for version %s: %v", versionInfo.GitVersion, bundlesErr)
 		}
 		fmt.Printf("Bundle Manifest URL: %s\n", versionInfo.BundleManifestURL)
 	case "json":

--- a/pkg/manifests/releases/read.go
+++ b/pkg/manifests/releases/read.go
@@ -49,9 +49,19 @@ func GetBundleManifestURL(reader Reader, version string) (string, error) {
 		return "", fmt.Errorf("failed to read releases: %v", err)
 	}
 
-	eksAReleaseForVersion, err := ReleaseForVersion(eksAReleases, version)
+	return BundleManifestURL(eksAReleases, version)
+}
+
+// BundleManifestURL returns the  Bundles manifest URL for the release matched by the provided
+// version. If no release is found for the version, an error is returned.
+func BundleManifestURL(releases *releasev1.Release, version string) (string, error) {
+	eksAReleaseForVersion, err := ReleaseForVersion(releases, version)
 	if err != nil {
 		return "", fmt.Errorf("failed to get EKS-A release for version %s: %v", version, err)
+	}
+
+	if eksAReleaseForVersion == nil {
+		return "", fmt.Errorf("no matching release found for version %s to get Bundles URL", version)
 	}
 
 	return eksAReleaseForVersion.BundleManifestUrl, nil


### PR DESCRIPTION
*Description of changes:*
The code was panicking with a nil pointer when a release wasn't found for the current version.

Discovered when working on #7463. Splitting it since it's not part of the original intent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

