### PR TITLE
Fix upgrade plan output when all components are up-to-date and for workload clusters.

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplancluster.go
@@ -121,8 +121,8 @@ func serialize(componentChangeDiffs *types.ChangeDiff, outputFormat string) (str
 }
 
 func serializeToText(componentChangeDiffs *types.ChangeDiff) (string, error) {
-	if componentChangeDiffs == nil {
-		return "All the components are up to date with the latest versions\n", nil
+	if componentChangeDiffs == nil || (componentChangeDiffs != nil && len(componentChangeDiffs.ComponentReports) == 0) {
+		return "All the components are up to date with the latest versions", nil
 	}
 
 	buffer := bytes.Buffer{}

--- a/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
@@ -80,7 +80,7 @@ func (uc *upgradeClusterOptions) upgradePlanManagementComponents(ctx context.Con
 	}
 
 	if !newClusterSpec.Cluster.IsSelfManaged() {
-		logger.V(0).Info("No management components to plan. Cluster %s is not a self-managed cluster.\n", newClusterSpec.Cluster.Name)
+		logger.V(0).Info(fmt.Sprintf("No management components to plan. Cluster %s is not a self-managed cluster.", newClusterSpec.Cluster.Name))
 		return nil
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes some issues introduced to the upgrade plan <resource> output.
- Removes the newline added for the output when there is nothing to update. This was needed when using fmt.Print, but not when using the `logger.Info` to write the output.
- Show "All the components are up to date with the latest versions" instead of empty table when there is nothing to update
- Fix output when using `upgrade plan management-components` on a workload cluster. It was showing %s instead of the cluster name, after a change to use the logger to print the output instead of `fmt.Printf`

*Testing (if applicable):*
**upgrade plan cluster/management-components** when there is nothing to update
Before
```
./bin/eksctl-anywhere upgrade plan management-components -f mgmt-2/mgmt-2-eks-a-cluster.yaml 
Warning: The recommended number of control plane nodes is 3 or 5
Warning: The recommended number of control plane nodes is 3 or 5
Checking new release availability...
NAME      CURRENT VERSION   NEXT VERSION

```
After
```
./bin/eksctl-anywhere upgrade plan management-components -f mgmt-2/mgmt-2-eks-a-cluster.yaml 
Warning: The recommended number of control plane nodes is 3 or 5
Warning: The recommended number of control plane nodes is 3 or 5
Checking new release availability...
All the components are up to date with the latest versions
``` 

**upgrade plan management-components output on workload cluster**
Before
```
./bin/eksctl-anywhere upgrade plan management-components -f eksa-w02-cluster.yaml 
Warning: The recommended number of control plane nodes is 3 or 5
Warning: The recommended number of control plane nodes is 3 or 5
Checking new release availability...
No management components to plan. Cluster %s is not a self-managed cluster.
```


After
```
./bin/eksctl-anywhere upgrade plan management-components -f eksa-w02-cluster.yaml 
Warning: The recommended number of control plane nodes is 3 or 5
Warning: The recommended number of control plane nodes is 3 or 5
Checking new release availability...
No management components to plan. Cluster w02 is not a self-managed cluster.
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

