### PR TITLE
Add util to compare semvers build metadata

### DIFF
--- a/pkg/semver/identifiers.go
+++ b/pkg/semver/identifiers.go
@@ -1,0 +1,91 @@
+package semver
+
+import "strconv"
+
+// identifier represents a single identifier in a semver version.
+// identifiers are dot separated strings or numbers in the pre release
+// and build metadata.
+type identifier struct {
+	intValue uint64
+	strValue string
+	isNum    bool
+}
+
+func newIdentifier(s string) identifier {
+	bi := identifier{}
+	if num, err := strconv.ParseUint(s, 10, 64); err == nil {
+		bi.intValue = num
+		bi.isNum = true
+	} else {
+		bi.strValue = s
+		bi.isNum = false
+	}
+	return bi
+}
+
+// compare compares v and o.
+// -1 == v is less than o.
+// 0 == v is equal to o.
+// 1 == v is greater than o.
+// 2 == v is different than o (it is not possible to identify if lower or greater).
+// Number is considered lower than string.
+func (v identifier) compare(o identifier) int {
+	if v.isNum && !o.isNum {
+		return -1
+	}
+	if !v.isNum && o.isNum {
+		return 1
+	}
+	if v.isNum && o.isNum { // both are numbers
+		switch {
+		case v.intValue < o.intValue:
+			return -1
+		case v.intValue == o.intValue:
+			return 0
+		default:
+			return 1
+		}
+	} else { // both are strings
+		if v.strValue == o.strValue {
+			return 0
+		}
+		// In order to support random identifiers, like commit hashes,
+		// we return 2 when the strings are different to signal the
+		// identifiers are different but we can't determine the precedence
+		return 2
+	}
+}
+
+type identifiers []identifier
+
+func newIdentifiers(ids []string) identifiers {
+	bis := make(identifiers, 0, len(ids))
+	for _, id := range ids {
+		bis = append(bis, newIdentifier(id))
+	}
+	return bis
+}
+
+// compare compares 2 identifiers v and o.
+// -1 == v is less than o.
+// 0 == v is equal to o.
+// 1 == v is greater than o.
+// If everything else is equal the longer identifier is greater.
+func (v identifiers) compare(o identifiers) int {
+	i := 0
+	for ; i < len(v) && i < len(o); i++ {
+		comp := v[i].compare(o[i])
+		if comp != 0 {
+			return comp
+		}
+	}
+
+	// if everything is equal until now the longer is greater
+	if i == len(v) && i == len(o) {
+		return 0
+	} else if i == len(v) && i < len(o) {
+		return -1
+	}
+
+	return 1
+}

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 const semverRegex = `^v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
@@ -87,6 +88,22 @@ func (v *Version) Compare(v2 *Version) int {
 		return c
 	}
 	return 0
+}
+
+// CompareBuildMetadata compares the build metadata of v and v2.
+// The metadata is split in its identifiers and these compared one by one.
+// Number identifiers are considered lower than strings.
+// If one build metadata is a prefix of the other, the longer one is considered greater.
+// -1 == v is less than v2.
+// 0 == v is equal to v2.
+// 1 == v is greater than v2.
+// 2 == v is different than v2 (it is not possible to identify if lower or greater).
+func (v *Version) CompareBuildMetadata(v2 *Version) int {
+	return v.buildIdentifiers().compare(v2.buildIdentifiers())
+}
+
+func (v *Version) buildIdentifiers() identifiers {
+	return newIdentifiers(strings.Split(v.Buildmetadata, "."))
 }
 
 func (v *Version) String() string {

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -198,3 +198,112 @@ func TestCompareSuccess(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareBuildMetadata(t *testing.T) {
+	testCases := []struct {
+		testName string
+		v1       *semver.Version
+		v2       *semver.Version
+		want     int
+	}{
+		{
+			testName: "equal build metadata only strings",
+			v1: &semver.Version{
+				Buildmetadata: "f234f.werwe",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "f234f.werwe",
+			},
+			want: 0,
+		},
+		{
+			testName: "equal build metadata strings and numbers",
+			v1: &semver.Version{
+				Buildmetadata: "build.1234",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.1234",
+			},
+			want: 0,
+		},
+		{
+			testName: "different build metadata only strings",
+			v1: &semver.Version{
+				Buildmetadata: "f4fe.f234f",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "f4fe.werwe",
+			},
+			want: 2,
+		},
+		{
+			testName: "lower with build metadata strings and numbers",
+			v1: &semver.Version{
+				Buildmetadata: "build.1234",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.1235",
+			},
+			want: -1,
+		},
+		{
+			testName: "lower as a subset with v2 longer",
+			v1: &semver.Version{
+				Buildmetadata: "build.1235",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.1235.custom",
+			},
+			want: -1,
+		},
+		{
+			testName: "lower because v2 is string and v1 is number",
+			v1: &semver.Version{
+				Buildmetadata: "build.1235",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.custom",
+			},
+			want: -1,
+		},
+		{
+			testName: "greater with build metadata strings and numbers",
+			v1: &semver.Version{
+				Buildmetadata: "build.2340",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.423",
+			},
+			want: 1,
+		},
+		{
+			testName: "greater as a subset with v1 longer",
+			v1: &semver.Version{
+				Buildmetadata: "build.1235.custom.v2",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.1235.custom",
+			},
+			want: 1,
+		},
+		{
+			testName: "greater because v1 is string and v2 is number",
+			v1: &semver.Version{
+				Buildmetadata: "build.v1235",
+			},
+			v2: &semver.Version{
+				Buildmetadata: "build.222",
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			got := tt.v1.CompareBuildMetadata(tt.v2)
+			if got != tt.want {
+				t.Fatalf("Version.CompareBuildMetadata() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
This will be used to retrieve the latest dev build for a particular pre-release: v0.1.0-dev+build.2 > v0.1.0-dev+build.1

I wrote this when working on https://github.com/aws/eks-anywhere/pull/7463. Splitting it since although required, this code can live by itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

