### PR TITLE
Block autoscaler configuration with Inplace upgrade strategy

### DIFF
--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -95,6 +95,11 @@ func AssertUpgradeRolloutStrategyValid(spec *ClusterSpec) error {
 	return validateUpgradeRolloutStrategy(spec)
 }
 
+// AssertAutoScalerDisabledForInPlace ensures that the autoscaler configuration is not enabled when upgrade rollout strategy is InPlace.
+func AssertAutoScalerDisabledForInPlace(spec *ClusterSpec) error {
+	return validateAutoScalerDisabledForInPlace(spec)
+}
+
 // AssertOSImageURL ensures that the OSImageURL value is either set at the datacenter config level or set for each machine config and not at both levels.
 func AssertOSImageURL(spec *ClusterSpec) error {
 	return validateOSImageURL(spec)

--- a/pkg/providers/tinkerbell/cluster.go
+++ b/pkg/providers/tinkerbell/cluster.go
@@ -112,6 +112,7 @@ func NewClusterSpecValidator(assertions ...ClusterSpecAssertion) *ClusterSpecVal
 		AssertTinkerbellIPAndControlPlaneIPNotSame,
 		AssertHookRetrievableWithoutProxy,
 		AssertUpgradeRolloutStrategyValid,
+		AssertAutoScalerDisabledForInPlace,
 	)
 	v.Register(assertions...)
 	return &v


### PR DESCRIPTION
*Issue #, if available:*
InPlace upgrades do not roll-over the nodes during an upgrade. In most cases customer might not even have a spare hardware for the node to roll-over in case of baremetal. Cluster autoscaler internally uses Machinesets constructs to scale the nodes based on demand. During or after an inplace upgrade is completed, machinesets might not reflect the true source of truth of the capi machine as we only patch the `machineset.Spec.Template.Spec` field on the machineset after inplace upgrade is done.  Moreover if autoscaler decides to scale the node during when an inplace upgrade is in progress, it can lead to undesirable side-effects. This change blocks Autoscaler configuration along with InPlace upgrades.  

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

