### PR TITLE
Build binaries for E2E tests in parallel

### DIFF
--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -3,12 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-    - make build-eks-a-for-e2e build-integration-test-binary
-    - |
-      for provider_test_file in test/e2e/*_test.go; do
-        provider=$(echo $(basename $provider_test_file) | cut -d_ -f1)
-        make e2e-tests-binary E2E_TAGS="e2e $provider" E2E_OUTPUT_FILE=bin/$provider/e2e.test
-      done
+    - make -j $(nproc) build-eks-a-for-e2e build-integration-test-binary e2e-test-provider-binaries
     - echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" >> bin/githash
     - >
       ./cmd/integration_test/build/script/upload_artifacts.sh


### PR DESCRIPTION
We require a number of binaries to be built for running the E2E tests for EKS-A. These include the EKS-A CLI itself, the E2E test binary compiled using `go test` and the test runner binary that is an entrypoint and wrapper to the E2E test process. We build these in sequence and sometimes also for multiple GOOS/GOARCH combinations, which takes up several minutes in CI. This PR aims to optimize the time taken by building the binaries in parallel since they are not dependent on each other.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

