### PR TITLE
Ensure the `ControlPlaneUpgrade` and `MachineDeploymentUpgrade` statuses get updated

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_controlplaneupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_controlplaneupgrades.yaml
@@ -204,9 +204,6 @@ spec:
                 description: Upgraded is the number of machines that have been upgraded.
                 format: int64
                 type: integer
-            required:
-            - requireUpgrade
-            - upgraded
             type: object
         type: object
     served: true

--- a/config/crd/bases/anywhere.eks.amazonaws.com_machinedeploymentupgrades.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_machinedeploymentupgrades.yaml
@@ -199,9 +199,6 @@ spec:
                   that have been upgraded.
                 format: int64
                 type: integer
-            required:
-            - requireUpgrade
-            - upgraded
             type: object
         type: object
     served: true

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4615,9 +4615,6 @@ spec:
                 description: Upgraded is the number of machines that have been upgraded.
                 format: int64
                 type: integer
-            required:
-            - requireUpgrade
-            - upgraded
             type: object
         type: object
     served: true
@@ -5158,9 +5155,6 @@ spec:
                   that have been upgraded.
                 format: int64
                 type: integer
-            required:
-            - requireUpgrade
-            - upgraded
             type: object
         type: object
     served: true

--- a/controllers/machinedeploymentupgrade_controller_test.go
+++ b/controllers/machinedeploymentupgrade_controller_test.go
@@ -26,12 +26,8 @@ func TestMDUpgradeReconcile(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms).Build()
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], mdUpgrade, nodeUpgrades[0], nodeUpgrades[1], md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -41,6 +37,8 @@ func TestMDUpgradeReconcile(t *testing.T) {
 	mdu := &anywherev1.MachineDeploymentUpgrade{}
 	err = client.Get(ctx, types.NamespacedName{Name: mdUpgrade.Name, Namespace: constants.EksaSystemNamespace}, mdu)
 	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(mdu.Status.RequireUpgrade).To(BeEquivalentTo(0))
+	g.Expect(mdu.Status.Upgraded).To(BeEquivalentTo(2))
 	g.Expect(mdu.Status.Ready).To(BeTrue())
 }
 
@@ -48,18 +46,22 @@ func TestMDUpgradeReconcileNodesNotReadyYet(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	mdUpgrade.Status = anywherev1.MachineDeploymentUpgradeStatus{
-		Upgraded:       0,
-		RequireUpgrade: 1,
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
+	nodeUpgrades[1].Status = anywherev1.NodeUpgradeStatus{
+		Completed: false,
 	}
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms).Build()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], mdUpgrade, nodeUpgrades[0], nodeUpgrades[1], md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
+
+	mdu := &anywherev1.MachineDeploymentUpgrade{}
+	err = client.Get(ctx, types.NamespacedName{Name: mdUpgrade.Name, Namespace: constants.EksaSystemNamespace}, mdu)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(mdu.Status.RequireUpgrade).To(BeEquivalentTo(1))
+	g.Expect(mdu.Status.Upgraded).To(BeEquivalentTo(1))
 	g.Expect(mdUpgrade.Status.Ready).To(BeFalse())
 }
 
@@ -68,13 +70,9 @@ func TestMDUpgradeReconcileDelete(t *testing.T) {
 	now := metav1.Now()
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
 	mdUpgrade.DeletionTimestamp = &now
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms).Build()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], mdUpgrade, nodeUpgrades[0], nodeUpgrades[1], md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -82,22 +80,21 @@ func TestMDUpgradeReconcileDelete(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	n := &anywherev1.NodeUpgrade{}
-	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrade.Name, Namespace: constants.EksaSystemNamespace}, n)
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrades[0].Name, Namespace: constants.EksaSystemNamespace}, n)
 	g.Expect(err).To(MatchError("nodeupgrades.anywhere.eks.amazonaws.com \"machine01-node-upgrader\" not found"))
+
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrades[1].Name, Namespace: constants.EksaSystemNamespace}, n)
+	g.Expect(err).To(MatchError("nodeupgrades.anywhere.eks.amazonaws.com \"machine02-node-upgrader\" not found"))
 }
 
-func TestMDUpgradeReconcileDeleteNodeUgradeAlreadyDeleted(t *testing.T) {
+func TestMDUpgradeReconcileDeleteNodeUpgradeAlreadyDeleted(t *testing.T) {
 	g := NewWithT(t)
 	now := metav1.Now()
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
 	mdUpgrade.DeletionTimestamp = &now
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms).Build()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], mdUpgrade, nodeUpgrades[0], nodeUpgrades[1], md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -105,8 +102,11 @@ func TestMDUpgradeReconcileDeleteNodeUgradeAlreadyDeleted(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	n := &anywherev1.NodeUpgrade{}
-	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrade.Name, Namespace: constants.EksaSystemNamespace}, n)
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrades[0].Name, Namespace: constants.EksaSystemNamespace}, n)
 	g.Expect(err).To(MatchError("nodeupgrades.anywhere.eks.amazonaws.com \"machine01-node-upgrader\" not found"))
+
+	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgrades[1].Name, Namespace: constants.EksaSystemNamespace}, n)
+	g.Expect(err).To(MatchError("nodeupgrades.anywhere.eks.amazonaws.com \"machine02-node-upgrader\" not found"))
 
 	_, err = r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -115,8 +115,8 @@ func TestMDUpgradeReconcileDeleteNodeUgradeAlreadyDeleted(t *testing.T) {
 func TestMDUpgradeReconcileNodeUpgraderCreate(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	cluster, machine, node, mdUpgrade, _, md, ms := getObjectsForMDUpgradeTest()
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, md, ms).Build()
+	cluster, machines, nodes, mdUpgrade, _, md, ms := getObjectsForMDUpgradeTest()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], mdUpgrade, md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -124,7 +124,7 @@ func TestMDUpgradeReconcileNodeUpgraderCreate(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	n := &anywherev1.NodeUpgrade{}
-	nodeUpgradeName := fmt.Sprintf("%s-node-upgrader", machine.Name)
+	nodeUpgradeName := fmt.Sprintf("%s-node-upgrader", machines[0].Name)
 	err = client.Get(ctx, types.NamespacedName{Name: nodeUpgradeName, Namespace: constants.EksaSystemNamespace}, n)
 	g.Expect(err).ToNot(HaveOccurred())
 }
@@ -132,13 +132,8 @@ func TestMDUpgradeReconcileNodeUpgraderCreate(t *testing.T) {
 func TestMDUpgradeObjectDoesNotExist(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrade", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, md, ms).Build()
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], nodeUpgrades[0], nodeUpgrades[1], md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -150,13 +145,9 @@ func TestMDUpgradeReconcileUpdateMachineSet(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
 	mdUpgrade.Status.Ready = true
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms).Build()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], nodeUpgrades[0], nodeUpgrades[1], mdUpgrade, md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -167,7 +158,7 @@ func TestMDUpgradeReconcileUpdateMachineSet(t *testing.T) {
 	err = client.Get(ctx, types.NamespacedName{Name: "my-md-ms", Namespace: constants.EksaSystemNamespace}, ms)
 	g.Expect(err).ToNot(HaveOccurred())
 	if !strings.Contains(*ms.Spec.Template.Spec.Version, k8s128) {
-		t.Fatalf("unexpected k8s version in capi machine: %s", *machine.Spec.Version)
+		t.Fatalf("unexpected k8s version in capi machine: %s", *machines[0].Spec.Version)
 	}
 }
 
@@ -175,13 +166,9 @@ func TestMDUpgradeReconcileUpdateMachineSetError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrader", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, md, ms := getObjectsForMDUpgradeTest()
 	ms.Annotations[clusterv1.RevisionAnnotation] = "0"
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms).Build()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], nodeUpgrades[0], nodeUpgrades[1], mdUpgrade, md, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -193,12 +180,8 @@ func TestMDObjectDoesNotExistError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	cluster, machine, node, mdUpgrade, nodeUpgrade, _, ms := getObjectsForMDUpgradeTest()
-	nodeUpgrade.Name = fmt.Sprintf("%s-node-upgrade", machine.Name)
-	nodeUpgrade.Status = anywherev1.NodeUpgradeStatus{
-		Completed: true,
-	}
-	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machine, node, nodeUpgrade, mdUpgrade, ms).Build()
+	cluster, machines, nodes, mdUpgrade, nodeUpgrades, _, ms := getObjectsForMDUpgradeTest()
+	client := fake.NewClientBuilder().WithRuntimeObjects(cluster, machines[0], machines[1], nodes[0], nodes[1], nodeUpgrades[0], nodeUpgrades[1], mdUpgrade, ms).Build()
 
 	r := controllers.NewMachineDeploymentUpgradeReconciler(client)
 	req := mdUpgradeRequest(mdUpgrade)
@@ -206,16 +189,30 @@ func TestMDObjectDoesNotExistError(t *testing.T) {
 	g.Expect(err).To(MatchError("getting MachineDeployment my-cluster-md: machinedeployments.cluster.x-k8s.io \"my-cluster-md\" not found"))
 }
 
-func getObjectsForMDUpgradeTest() (*clusterv1.Cluster, *clusterv1.Machine, *corev1.Node, *anywherev1.MachineDeploymentUpgrade, *anywherev1.NodeUpgrade, *clusterv1.MachineDeployment, *clusterv1.MachineSet) {
+func getObjectsForMDUpgradeTest() (*clusterv1.Cluster, []*clusterv1.Machine, []*corev1.Node, *anywherev1.MachineDeploymentUpgrade, []*anywherev1.NodeUpgrade, *clusterv1.MachineDeployment, *clusterv1.MachineSet) {
 	cluster := generateCluster()
-	node := generateNode()
-	kubeadmConfig := generateKubeadmConfig()
-	machine := generateMachine(cluster, node, kubeadmConfig)
-	nodeUpgrade := generateNodeUpgrade(machine)
-	mdUpgrade := generateMDUpgrade(cluster, machine)
+	node1 := generateNode()
+	node2 := node1.DeepCopy()
+	node2.ObjectMeta.Name = "node02"
+	kubeadmConfig1 := generateKubeadmConfig()
+	kubeadmConfig2 := generateKubeadmConfig()
+	machine1 := generateMachine(cluster, node1, kubeadmConfig1)
+	machine2 := generateMachine(cluster, node2, kubeadmConfig2)
+	machine2.ObjectMeta.Name = "machine02"
+	nodeUpgrade1 := generateNodeUpgrade(machine1)
+	nodeUpgrade1.Status = anywherev1.NodeUpgradeStatus{
+		Completed: true,
+	}
+	nodeUpgrade1.Name = fmt.Sprintf("%s-node-upgrader", machine1.Name)
+	nodeUpgrade2 := generateNodeUpgrade(machine2)
+	nodeUpgrade2.Status = anywherev1.NodeUpgradeStatus{
+		Completed: true,
+	}
+	nodeUpgrade2.Name = fmt.Sprintf("%s-node-upgrader", machine2.Name)
+	mdUpgrade := generateMDUpgrade(cluster, machine1, machine2)
 	md := generateMachineDeployment(cluster)
 	ms := generateMachineset(cluster)
-	return cluster, machine, node, mdUpgrade, nodeUpgrade, md, ms
+	return cluster, []*clusterv1.Machine{machine1, machine2}, []*corev1.Node{node1, node2}, mdUpgrade, []*anywherev1.NodeUpgrade{nodeUpgrade1, nodeUpgrade2}, md, ms
 }
 
 func mdUpgradeRequest(mdUpgrade *anywherev1.MachineDeploymentUpgrade) reconcile.Request {
@@ -227,10 +224,20 @@ func mdUpgradeRequest(mdUpgrade *anywherev1.MachineDeploymentUpgrade) reconcile.
 	}
 }
 
-func generateMDUpgrade(cluster *clusterv1.Cluster, machine *clusterv1.Machine) *anywherev1.MachineDeploymentUpgrade {
+func generateMDUpgrade(cluster *clusterv1.Cluster, machines ...*clusterv1.Machine) *anywherev1.MachineDeploymentUpgrade {
 	machineSpec := getMachineSpec(cluster)
 	machineSpecJSON, _ := json.Marshal(machineSpec)
 	machineSpecB64Encoded := base64.StdEncoding.EncodeToString(machineSpecJSON)
+	machinesRequireUpdate := []corev1.ObjectReference{}
+	for i := range machines {
+		machine := machines[i]
+		machinesRequireUpdate = append(machinesRequireUpdate, corev1.ObjectReference{
+			Kind:      "Machine",
+			Name:      machine.Name,
+			Namespace: machine.Namespace,
+		})
+	}
+
 	return &anywherev1.MachineDeploymentUpgrade{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "md-upgrade-request",
@@ -242,15 +249,9 @@ func generateMDUpgrade(cluster *clusterv1.Cluster, machine *clusterv1.Machine) *
 				Kind:      "MachineDeployment",
 				Namespace: constants.EksaSystemNamespace,
 			},
-			MachinesRequireUpgrade: []corev1.ObjectReference{
-				{
-					Kind:      "Machine",
-					Name:      machine.Name,
-					Namespace: machine.Namespace,
-				},
-			},
-			KubernetesVersion: k8s128,
-			MachineSpecData:   machineSpecB64Encoded,
+			MachinesRequireUpgrade: machinesRequireUpdate,
+			KubernetesVersion:      k8s128,
+			MachineSpecData:        machineSpecB64Encoded,
 		},
 	}
 }

--- a/controllers/nodeupgrade_controller.go
+++ b/controllers/nodeupgrade_controller.go
@@ -164,7 +164,7 @@ func (r *NodeUpgradeReconciler) reconcile(ctx context.Context, log logr.Logger, 
 	log.Info("Upgrading node", "Node", node.Name)
 	upgraderPod := &corev1.Pod{}
 	if conditions.IsTrue(nodeUpgrade, anywherev1.UpgraderPodCreated) || upgraderPodExists(ctx, remoteClient, node.Name) {
-		log.Info("Upgrader pod already exists, skipping creation of the pod", "Pod", upgraderPod.Name)
+		log.Info("Upgrader pod already exists, skipping creation of the pod", "Pod", upgrader.PodName(node.Name))
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/api/v1alpha1/controlplaneupgrade_types.go
+++ b/pkg/api/v1alpha1/controlplaneupgrade_types.go
@@ -33,10 +33,10 @@ type ControlPlaneUpgradeSpec struct {
 // ControlPlaneUpgradeStatus defines the observed state of ControlPlaneUpgrade.
 type ControlPlaneUpgradeStatus struct {
 	// RequireUpgrade is the number of machines that still need to be upgraded.
-	RequireUpgrade int64 `json:"requireUpgrade"`
+	RequireUpgrade int64 `json:"requireUpgrade,omitempty"`
 
 	// Upgraded is the number of machines that have been upgraded.
-	Upgraded int64 `json:"upgraded"`
+	Upgraded int64 `json:"upgraded,omitempty"`
 
 	// Ready denotes that the all control planes have finished upgrading and are ready.
 	Ready bool `json:"ready,omitempty"`

--- a/pkg/api/v1alpha1/machinedeploymentupgrade_types.go
+++ b/pkg/api/v1alpha1/machinedeploymentupgrade_types.go
@@ -26,10 +26,10 @@ type MachineDeploymentUpgradeSpec struct {
 // MachineDeploymentUpgradeStatus defines the observed state of MachineDeploymentUpgrade.
 type MachineDeploymentUpgradeStatus struct {
 	// RequireUpgrade is the number of machines in the MachineDeployment that still need to be upgraded.
-	RequireUpgrade int64 `json:"requireUpgrade"`
+	RequireUpgrade int64 `json:"requireUpgrade,omitempty"`
 
 	// Upgraded is the number of machines in the MachineDeployment that have been upgraded.
-	Upgraded int64 `json:"upgraded"`
+	Upgraded int64 `json:"upgraded,omitempty"`
 
 	// Ready denotes that the all machines in the MachineDeployment have finished upgrading and are ready.
 	Ready bool `json:"ready,omitempty"`


### PR DESCRIPTION
*Description of changes:*
This PR ensures that the `ControlPlaneUpgrade` (CPU) and `MachineDeploymentUpgrade` (MDU) CR statuses get updated properly on each reconcile. Currently, in `updateStatus` for CPU and MDU controllers, we are looping through the machine lists and checking the statuses of the corresponding `NodeUpgrade` objects. These objects are only created after the previous one has finished. This leads to a scenario where the status won't get updated until all the `NodeUpgrades` corresponding to a CPU or MDU exist. To prevent this from happening, this PR skips any `NodeUpgrade` objects that are not found and only errors out on other errors.

This PR also adds back the omitempty tags to the CPU and MDU status fields as they are also needed to ensure the status gets updated every time even if one of the status fields are missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

