### PR TITLE
Remove note that gitops is not supported for BareMetal

### DIFF
--- a/docs/content/en/docs/clustermgmt/cluster-flux.md
+++ b/docs/content/en/docs/clustermgmt/cluster-flux.md
@@ -9,8 +9,6 @@ description: >
   Use Flux to manage clusters with GitOps
 ---
 
-> **_NOTE_**: GitOps support is available for vSphere clusters, but is not yet available for Bare Metal clusters
->
 ## GitOps Support (optional)
 
 EKS Anywhere supports a [GitOps](https://www.weave.works/technologies/gitops/) workflow for the management of your cluster.


### PR DESCRIPTION
*Issue #, if available:*
This PR removes the note that GitOps is not suppported for BareMetal. It is support for all providers.
*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

