### PR TITLE
Resolve TestVSphereKubernetes127UbuntuWorkloadClusterTaintsFlow e2e test error

### DIFF
--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -24,7 +24,7 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 }
 
 func runWorkloadClusterExistingConfigFlow(test *framework.MulticlusterE2ETest) {
-	test.CreateManagementClusterWithConfig()
+	test.CreateManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.CreateCluster()
 		w.DeleteCluster()


### PR DESCRIPTION
*Description of changes:*
TestVSphereKubernetes127UbuntuWorkloadClusterTaintsFlow fails with template tag validation error. 

`Error: validations failed: template /SDDC-Datacenter/vm/Templates/kubernetes-1-27-eks-21-ubuntu is missing tag eksdRelease:kubernetes-1-28-eks-14`

Fixing the above error with this PR.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

