### PR TITLE
Use new dev versions in local and E2E test builds

### DIFF
--- a/pkg/manifests/releases/read_test.go
+++ b/pkg/manifests/releases/read_test.go
@@ -120,6 +120,21 @@ func TestReleaseForVersionSuccess(t *testing.T) {
 			version: "v0.0.2-alpha",
 			want:    nil,
 		},
+		{
+			name: "want latest prerelease",
+			releases: &releasev1.Release{
+				Spec: releasev1.ReleaseSpec{
+					Releases: []releasev1.EksARelease{
+						{Version: "v0.0.1-alpha+build.3", Number: 1},
+						{Version: "v0.0.1-alpha+build.1", Number: 2},
+						{Version: "v0.0.1-alpha+build.10", Number: 3},
+						{Version: "v0.0.1-alpha+build.9", Number: 4},
+					},
+				},
+			},
+			version: "v0.0.1-alpha+latest",
+			want:    &releasev1.EksARelease{Version: "v0.0.1-alpha+build.10", Number: 3},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -464,13 +464,13 @@ func (c *CloudStack) WithRedhatVersion(version anywherev1.KubernetesVersion) api
 }
 
 func (c *CloudStack) getDevRelease() *releasev1.EksARelease {
-	c.t.Helper()
 	if c.devRelease == nil {
-		latestRelease, err := getLatestDevRelease()
+		localDevRelease, err := localEksaCLIDevVersionRelease()
 		if err != nil {
 			c.t.Fatal(err)
 		}
-		c.devRelease = latestRelease
+		c.t.Log("Using local eksa dev release:", localDevRelease.Version)
+		c.devRelease = localDevRelease
 	}
 
 	return c.devRelease

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -977,23 +977,13 @@ func (e *ClusterE2ETest) GenerateSupportBundleOnCleanupIfTestFailed(opts ...Comm
 }
 
 func (e *ClusterE2ETest) Run(name string, args ...string) {
-	command := strings.Join(append([]string{name}, args...), " ")
-	shArgs := []string{"-c", command}
-
-	e.T.Log("Running shell command", "[", command, "]")
-	cmd := exec.CommandContext(context.Background(), "sh", shArgs...)
-
-	envPath := os.Getenv("PATH")
-
-	binDir, err := DefaultLocalEKSABinDir()
+	cmd, err := prepareCommand(name, args...)
 	if err != nil {
-		e.T.Fatalf("Error finding current directory: %v", err)
+		e.T.Fatalf("Error preparing command: %v", err)
 	}
+	e.T.Log("Running shell command", "[", cmd.String(), "]")
 
 	var stdoutAndErr bytes.Buffer
-
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s:%s", binDir, envPath))
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stdoutAndErr)
 	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutAndErr)
 

--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -1,7 +1,10 @@
 package framework
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -126,4 +129,23 @@ func DefaultLocalEKSABinDir() (string, error) {
 	}
 
 	return filepath.Join(workDir, "bin"), nil
+}
+
+func prepareCommand(name string, args ...string) (*exec.Cmd, error) {
+	command := strings.Join(append([]string{name}, args...), " ")
+	shArgs := []string{"-c", command}
+
+	cmd := exec.CommandContext(context.Background(), "sh", shArgs...)
+
+	envPath := os.Getenv("PATH")
+
+	binDir, err := DefaultLocalEKSABinDir()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s:%s", binDir, envPath))
+
+	return cmd, nil
 }

--- a/test/framework/eksa_versions.go
+++ b/test/framework/eksa_versions.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"encoding/json"
 	"log"
 
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -12,4 +13,39 @@ func newVersion(version string) *semver.Version {
 		log.Fatalf("error creating semver for EKS-A version %s: %v", version, err)
 	}
 	return v
+}
+
+// versionCommandOutput is the output of the eks-anywhere version command.
+type versionCommandOutput struct {
+	Version           string `json:"version"`
+	BundleManifestURL string `json:"bundleManifestURL"`
+}
+
+// localEKSAVersion returns the version of eks-anywhere installed locally.
+func localEKSAVersion() (string, error) {
+	v, err := localEKSAVersionCommand()
+	if err != nil {
+		return "", err
+	}
+	return v.Version, nil
+}
+
+// localEKSAVersionCommand returns the output of the eks-anywhere version command.
+func localEKSAVersionCommand() (versionCommandOutput, error) {
+	cmd, err := prepareCommand("eksctl", "anywhere", "version", "--output", "json")
+	if err != nil {
+		return versionCommandOutput{}, err
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return versionCommandOutput{}, err
+	}
+
+	versionOut := &versionCommandOutput{}
+	err = json.Unmarshal(out, versionOut)
+	if err != nil {
+		return versionCommandOutput{}, err
+	}
+
+	return *versionOut, nil
 }

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -501,11 +501,12 @@ func (n *Nutanix) ClusterStateValidations() []clusterf.StateValidation {
 func (n *Nutanix) getDevRelease() *releasev1.EksARelease {
 	n.t.Helper()
 	if n.devRelease == nil {
-		latestRelease, err := getLatestDevRelease()
+		localDevRelease, err := localEksaCLIDevVersionRelease()
 		if err != nil {
 			n.t.Fatal(err)
 		}
-		n.devRelease = latestRelease
+		n.t.Log("Using local eksa dev release:", localDevRelease.Version)
+		n.devRelease = localDevRelease
 	}
 
 	return n.devRelease

--- a/test/framework/release_versions.go
+++ b/test/framework/release_versions.go
@@ -183,6 +183,23 @@ func latestRelease(releases *releasev1alpha1.Release) (*releasev1alpha1.EksARele
 	return latestRelease, nil
 }
 
+// localEksaCLIDevVersionRelease returns the EKS-A release for the local eks-a CLI version.
+// It reads the version from the local eks-a CLI by running `eksctl anywhere version` command
+// and follows the same logic as the CLI to extract the release.
+func localEksaCLIDevVersionRelease() (*releasev1alpha1.EksARelease, error) {
+	version, err := localEKSAVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := devReleases()
+	if err != nil {
+		return nil, err
+	}
+
+	return releases.ReleaseForVersion(r, version)
+}
+
 // GetPreviousMinorReleaseFromVersion calculates the previous minor release by decrementing the
 // version minor number, then retrieves the latest <major>.<minor>.<patch>  for the calculated
 // version.

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -504,11 +504,12 @@ func (v *VSphere) Redhat127Template() api.VSphereFiller {
 func (v *VSphere) getDevRelease() *releasev1.EksARelease {
 	v.t.Helper()
 	if v.devRelease == nil {
-		latestRelease, err := getLatestDevRelease()
+		localDevRelease, err := localEksaCLIDevVersionRelease()
 		if err != nil {
 			v.t.Fatal(err)
 		}
-		v.devRelease = latestRelease
+		v.t.Log("Using local eksa dev release:", localDevRelease.Version)
+		v.devRelease = localDevRelease
 	}
 
 	return v.devRelease


### PR DESCRIPTION
## Description of changes
Builds on top of #7463 

This changes the build process for local dev builds and for E2E test builds to use the new versioning schema.

Copy paste of the logic followed from the original PR:

### E2E tests
When a CLI is built for dev E2E tests, it's given the latest available EKS-A dev version. This pins that particular binary to one EKS-A version and hence one Bundles manifest. This is important in order to guarantee that the same Bundles is used for the whole execution of the test pipelines and avoids a race condition where a new EKS-A dev release and Bundles are published during an E2E test run.

### Locally building the CLI
When writing and testing code for the CLI/Controller, most of the time we don't care about particular releases and we just want to use the latest available Bundles that contains the latest available set of components. This verifies that our changes are compatible with the current state of EKS-A dependencies.

To avoid having to rebuild the CLI every time we want to refresh the pulled Bundles or even having to care about fetching the latest version, this PR introduces a special build metadata identifier: `+latest`. This instructs the CLI to not look for an exact match with an EKS-A version, but select the newest one that matches our pre-release. For example: if the release manifest has two releases [`v0.19.0-dev+build.1234`, `v0.19.0-dev+build.1233`], then if the CLI has version `v0.19.0-dev+latest`, then the release `v0.19.0-dev+build.1234` will be selected.

This is the default behavior when building a CLI locally: the Makefile will calculate the appropriate major.minor.patch based on the current HEAD and its closest branch ancestor (either `main` or a `release-*` branch). If you wish to pin your local CLI to a particular version, pass the `DEV_GIT_VERSION` to the make target.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

