### PR TITLE
Fix e2e workload cluster 1.27 taints tests on docker + vSphere

### DIFF
--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -24,7 +24,7 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 }
 
 func runWorkloadClusterExistingConfigFlow(test *framework.MulticlusterE2ETest) {
-	test.CreateManagementCluster()
+	test.ManagementCluster.CreateCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.CreateCluster()
 		w.DeleteCluster()


### PR DESCRIPTION
*Description of changes:*
`runWorkloadClusterExistingConfigFlow ` used in both Docker and vSphere 1.27 workload cluster taints tests, regenerates management cluster configuration before creating the cluster thereby setting cluster config to defaults. This results with tests running 1.28 k8s management cluster which fails both tests. This change, doesn't regenerate the cluster configuration and uses the config fillers used to define the clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

