### PR TITLE
Preserve CloudStack case sensitivity for e2e tests

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -3548,7 +3548,7 @@ func TestCloudStackWorkloadClusterOIDCAuthGithubFluxAPI(t *testing.T) {
 	test.DeleteManagementCluster()
 }
 
-func TestCloudstackKubernetes127To128RedHatManagementCPUpgradeAPI(t *testing.T) {
+func TestCloudStackKubernetes127To128RedHatManagementCPUpgradeAPI(t *testing.T) {
 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes127())
 	test := framework.NewClusterE2ETest(
 		t, provider,


### PR DESCRIPTION
*Description of changes:*
`TestCloudstackKubernetes127To128RedHatManagementCPUpgradeAPI` fails because we [check](https://github.com/aws/eks-anywhere/blob/main/internal/test/e2e/cloudstack.go#L11) for string `CloudStack` which is case sensitive. Thus required env variables were not getting passed for this test. This PR fixes this issue. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

