### PR TITLE
Unify delete mgmt

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -464,14 +463,8 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 }
 
 func (r *ClusterReconciler) reconcileDelete(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) (ctrl.Result, error) {
-	if cluster.IsSelfManaged() {
+	if cluster.IsSelfManaged() && !cluster.IsManagedByCLI() {
 		return ctrl.Result{}, errors.New("deleting self-managed clusters is not supported")
-	}
-
-	if metav1.HasAnnotation(cluster.ObjectMeta, anywherev1.ManagedByCLIAnnotation) {
-		log.Info("Clusters is managed by CLI, removing finalizer")
-		controllerutil.RemoveFinalizer(cluster, ClusterFinalizerName)
-		return ctrl.Result{}, nil
 	}
 
 	if cluster.IsReconcilePaused() {

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -1375,6 +1375,19 @@ func (c *ClusterManager) RemoveManagedByCLIAnnotationForCluster(ctx context.Cont
 	return nil
 }
 
+// AddManagedByCLIAnnotationForCluster removes the managed-by-cli annotation from the cluster.
+func (c *ClusterManager) AddManagedByCLIAnnotationForCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error {
+	err := c.clusterClient.UpdateAnnotationInNamespace(ctx, clusterSpec.Cluster.ResourceType(),
+		cluster.Name,
+		map[string]string{v1alpha1.ManagedByCLIAnnotation: "true"},
+		cluster,
+		clusterSpec.Cluster.Namespace)
+	if err != nil {
+		return fmt.Errorf("adding managed by CLI annotation after apply cluster spec: %v", err)
+	}
+	return nil
+}
+
 func (c *ClusterManager) applyResource(ctx context.Context, cluster *types.Cluster, resourcesSpec []byte) error {
 	err := c.clusterClient.ApplyKubeSpecFromBytes(ctx, cluster, resourcesSpec)
 	if err != nil {

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -57,6 +57,7 @@ type ClusterManager interface {
 	GenerateAWSIAMKubeconfig(ctx context.Context, cluster *types.Cluster) error
 	DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error
 	CreateRegistryCredSecret(ctx context.Context, mgmt *types.Cluster) error
+	AddManagedByCLIAnnotationForCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 }
 
 type GitOpsManager interface {

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -99,6 +99,20 @@ func (m *MockClusterManager) EXPECT() *MockClusterManagerMockRecorder {
 	return m.recorder
 }
 
+// AddManagedByCLIAnnotationForCluster mocks base method.
+func (m *MockClusterManager) AddManagedByCLIAnnotationForCluster(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec, arg3 providers.Provider) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddManagedByCLIAnnotationForCluster", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddManagedByCLIAnnotationForCluster indicates an expected call of AddManagedByCLIAnnotationForCluster.
+func (mr *MockClusterManagerMockRecorder) AddManagedByCLIAnnotationForCluster(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddManagedByCLIAnnotationForCluster", reflect.TypeOf((*MockClusterManager)(nil).AddManagedByCLIAnnotationForCluster), arg0, arg1, arg2, arg3)
+}
+
 // ApplyBundles mocks base method.
 func (m *MockClusterManager) ApplyBundles(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/management/delete.go
+++ b/pkg/workflows/management/delete.go
@@ -1,0 +1,68 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/filewriter"
+	"github.com/aws/eks-anywhere/pkg/providers"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
+)
+
+// Delete is the workflow that deletes a workload clusters.
+type Delete struct {
+	bootstrapper   interfaces.Bootstrapper
+	provider       providers.Provider
+	writer         filewriter.FileWriter
+	clusterManager interfaces.ClusterManager
+	gitopsManager  interfaces.GitOpsManager
+	clusterDeleter interfaces.ClusterDeleter
+	eksdInstaller  interfaces.EksdInstaller
+	eksaInstaller  interfaces.EksaInstaller
+	clientFactory  interfaces.ClientFactory
+}
+
+// NewDelete builds a new delete construct.
+func NewDelete(bootstrapper interfaces.Bootstrapper,
+	provider providers.Provider,
+	writer filewriter.FileWriter,
+	clusterManager interfaces.ClusterManager,
+	gitopsManager interfaces.GitOpsManager,
+	clusterDeleter interfaces.ClusterDeleter,
+	eksdInstaller interfaces.EksdInstaller,
+	eksaInstaller interfaces.EksaInstaller,
+	clientFactory interfaces.ClientFactory,
+) *Delete {
+	return &Delete{
+		bootstrapper:   bootstrapper,
+		provider:       provider,
+		writer:         writer,
+		clusterManager: clusterManager,
+		gitopsManager:  gitopsManager,
+		clusterDeleter: clusterDeleter,
+		eksdInstaller:  eksdInstaller,
+		eksaInstaller:  eksaInstaller,
+		clientFactory:  clientFactory,
+	}
+}
+
+// Run executes the tasks to delete a management cluster.
+func (c *Delete) Run(ctx context.Context, workload *types.Cluster, clusterSpec *cluster.Spec) error {
+	commandContext := &task.CommandContext{
+		Bootstrapper:    c.bootstrapper,
+		Provider:        c.provider,
+		Writer:          c.writer,
+		ClusterManager:  c.clusterManager,
+		ClusterSpec:     clusterSpec,
+		WorkloadCluster: workload,
+		GitOpsManager:   c.gitopsManager,
+		ClusterDeleter:  c.clusterDeleter,
+		EksdInstaller:   c.eksdInstaller,
+		EksaInstaller:   c.eksaInstaller,
+		ClientFactory:   c.clientFactory,
+	}
+
+	return task.NewTaskRunner(&setupAndValidateDelete{}, c.writer).RunTask(ctx, commandContext)
+}

--- a/pkg/workflows/management/delete_bootstrap.go
+++ b/pkg/workflows/management/delete_bootstrap.go
@@ -1,0 +1,38 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+)
+
+type deleteBootstrapClusterForDeleteTask struct{}
+
+func (s *deleteBootstrapClusterForDeleteTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Deleting bootstrap cluster")
+	if err := commandContext.Bootstrapper.DeleteBootstrapCluster(ctx, commandContext.BootstrapCluster, constants.Delete, false); err != nil {
+		commandContext.SetError(err)
+	}
+
+	if commandContext.OriginalError != nil {
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	logger.MarkSuccess("Cluster deleted!")
+	return nil
+}
+
+func (s *deleteBootstrapClusterForDeleteTask) Name() string {
+	return "kind-cluster-delete"
+}
+
+func (s *deleteBootstrapClusterForDeleteTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *deleteBootstrapClusterForDeleteTask) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/management/delete_cluster.go
+++ b/pkg/workflows/management/delete_cluster.go
@@ -1,0 +1,78 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+)
+
+type deleteManagementCluster struct{}
+
+func (s *deleteManagementCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Deleting management cluster")
+
+	err := commandContext.ClusterManager.ResumeEKSAControllerReconcile(ctx, commandContext.BootstrapCluster, commandContext.ClusterSpec, commandContext.Provider)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	err = commandContext.ClusterManager.AddManagedByCLIAnnotationForCluster(ctx, commandContext.BootstrapCluster, commandContext.ClusterSpec, commandContext.Provider)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	err = commandContext.ClusterDeleter.Run(ctx, commandContext.ClusterSpec, *commandContext.BootstrapCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	err = commandContext.Provider.PostClusterDeleteValidate(ctx, commandContext.BootstrapCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	return &cleanupGitRepo{}
+}
+
+func (s *deleteManagementCluster) Name() string {
+	return "delete-management-cluster"
+}
+
+func (s *deleteManagementCluster) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *deleteManagementCluster) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+type cleanupGitRepo struct{}
+
+func (s *cleanupGitRepo) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Clean up Git Repo")
+	err := commandContext.GitOpsManager.CleanupGitRepo(ctx, commandContext.ClusterSpec)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	return &deleteBootstrapClusterForDeleteTask{}
+}
+
+func (s *cleanupGitRepo) Name() string {
+	return "clean-up-git-repo"
+}
+
+func (s *cleanupGitRepo) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *cleanupGitRepo) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/management/delete_create_bootstrap.go
+++ b/pkg/workflows/management/delete_create_bootstrap.go
@@ -1,0 +1,41 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+)
+
+type createBootStrapClusterForDeleteTask struct{}
+
+func (s *createBootStrapClusterForDeleteTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Creating new bootstrap cluster")
+
+	bootstrapOptions, err := commandContext.Provider.BootstrapClusterOpts(commandContext.ClusterSpec)
+	if err != nil {
+		commandContext.SetError(err)
+		return nil
+	}
+
+	bootstrapCluster, err := commandContext.Bootstrapper.CreateBootstrapCluster(ctx, commandContext.ClusterSpec, bootstrapOptions...)
+	if err != nil {
+		commandContext.SetError(err)
+		return nil
+	}
+	commandContext.BootstrapCluster = bootstrapCluster
+
+	return &installCAPIComponentsForDeleteTask{}
+}
+
+func (s *createBootStrapClusterForDeleteTask) Name() string {
+	return "bootstrap-cluster-for-delete-init"
+}
+
+func (s *createBootStrapClusterForDeleteTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *createBootStrapClusterForDeleteTask) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/management/delete_install_capi.go
+++ b/pkg/workflows/management/delete_install_capi.go
@@ -1,0 +1,41 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+)
+
+type installCAPIComponentsForDeleteTask struct{}
+
+func (s *installCAPIComponentsForDeleteTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Provider specific pre-capi-install-setup on bootstrap cluster")
+	if err := commandContext.Provider.PreCAPIInstallOnBootstrap(ctx, commandContext.BootstrapCluster, commandContext.ClusterSpec); err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	logger.Info("Installing cluster-api providers on bootstrap cluster")
+	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+	if err := commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.Provider); err != nil {
+		commandContext.SetError(err)
+		return &deleteManagementCluster{}
+	}
+
+	return &moveClusterManagementForDeleteTask{}
+}
+
+func (s *installCAPIComponentsForDeleteTask) Name() string {
+	return "install-capi-components-bootstrap-for-delete"
+}
+
+func (s *installCAPIComponentsForDeleteTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *installCAPIComponentsForDeleteTask) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/management/delete_install_eksa.go
+++ b/pkg/workflows/management/delete_install_eksa.go
@@ -1,0 +1,68 @@
+package management
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
+)
+
+type installEksaComponentsOnBootstrapForDeleteTask struct{}
+
+func (s *installEksaComponentsOnBootstrapForDeleteTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Installing EKS-A custom components on bootstrap cluster")
+	err := installEKSAComponents(ctx, commandContext, commandContext.BootstrapCluster)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	commandContext.ClusterSpec.Cluster.PauseReconcile()
+	commandContext.ClusterSpec.Cluster.SetFinalizers([]string{"clusters.anywhere.eks.amazonaws.com/finalizer"})
+	commandContext.ClusterSpec.Cluster.AddManagedByCLIAnnotation()
+	err = applyClusterSpecOnBootstrapForDeleteTask(ctx, commandContext.ClusterSpec, commandContext.BootstrapCluster, commandContext.ClientFactory)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	return &deleteManagementCluster{}
+}
+
+func (s *installEksaComponentsOnBootstrapForDeleteTask) Name() string {
+	return "eksa-components-bootstrap-install-delete-task"
+}
+
+func (s *installEksaComponentsOnBootstrapForDeleteTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *installEksaComponentsOnBootstrapForDeleteTask) Checkpoint() *task.CompletedTask {
+	return nil
+}
+
+func applyClusterSpecOnBootstrapForDeleteTask(ctx context.Context, spec *cluster.Spec, cluster *types.Cluster, clientFactory interfaces.ClientFactory) error {
+	client, err := clientFactory.BuildClientFromKubeconfig(cluster.KubeconfigFile)
+	if err != nil {
+		return errors.Wrap(err, "building client to apply cluster spec changes")
+	}
+
+	for _, obj := range spec.ClusterAndChildren() {
+		if err := client.ApplyServerSide(ctx,
+			"eks-a-cli",
+			obj,
+			kubernetes.ApplyServerSideOptions{ForceOwnership: true},
+		); err != nil {
+			return errors.Wrapf(err, "applying cluster spec")
+		}
+	}
+
+	return nil
+}

--- a/pkg/workflows/management/delete_move_capi.go
+++ b/pkg/workflows/management/delete_move_capi.go
@@ -1,0 +1,35 @@
+package management
+
+import (
+	"context"
+
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/task"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/workflows"
+)
+
+type moveClusterManagementForDeleteTask struct{}
+
+func (s *moveClusterManagementForDeleteTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Moving cluster management from workload cluster to bootstrap")
+	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef())
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
+	return &installEksaComponentsOnBootstrapForDeleteTask{}
+}
+
+func (s *moveClusterManagementForDeleteTask) Name() string {
+	return "capi-management-move-for-delete"
+}
+
+func (s *moveClusterManagementForDeleteTask) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *moveClusterManagementForDeleteTask) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/management/delete_test.go
+++ b/pkg/workflows/management/delete_test.go
@@ -1,0 +1,476 @@
+package management_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/aws/eks-anywhere/internal/test"
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/bootstrapper"
+	clientmocks "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
+	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
+	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
+	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/providers"
+	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
+	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/workflows/interfaces/mocks"
+	"github.com/aws/eks-anywhere/pkg/workflows/management"
+)
+
+type deleteTestSetup struct {
+	t                    *testing.T
+	provider             *providermocks.MockProvider
+	clusterManager       *mocks.MockClusterManager
+	datacenterConfig     providers.DatacenterConfig
+	machineConfigs       []providers.MachineConfig
+	ctx                  context.Context
+	clusterSpec          *cluster.Spec
+	workloadCluster      *types.Cluster
+	workload             *management.Delete
+	writer               *writermocks.MockFileWriter
+	bootstrapper         *mocks.MockBootstrapper
+	gitopsManager        *mocks.MockGitOpsManager
+	bootstrapCluster     *types.Cluster
+	clusterDeleter       *mocks.MockClusterDeleter
+	eksdInstaller        *mocks.MockEksdInstaller
+	eksaInstaller        *mocks.MockEksaInstaller
+	clientFactory        *mocks.MockClientFactory
+	managementComponents *cluster.ManagementComponents
+	client               *clientmocks.MockClient
+}
+
+func newDeleteTest(t *testing.T) *deleteTestSetup {
+	featureEnvVars := []string{}
+	mockCtrl := gomock.NewController(t)
+	provider := providermocks.NewMockProvider(mockCtrl)
+	writer := writermocks.NewMockFileWriter(mockCtrl)
+	manager := mocks.NewMockClusterManager(mockCtrl)
+	client := clientmocks.NewMockClient(mockCtrl)
+
+	datacenterConfig := &v1alpha1.VSphereDatacenterConfig{}
+	machineConfigs := []providers.MachineConfig{&v1alpha1.VSphereMachineConfig{}}
+	bootstrapper := mocks.NewMockBootstrapper(mockCtrl)
+	gitopsManager := mocks.NewMockGitOpsManager(mockCtrl)
+	clusterDeleter := mocks.NewMockClusterDeleter(mockCtrl)
+	eksdInstaller := mocks.NewMockEksdInstaller(mockCtrl)
+	eksaInstaller := mocks.NewMockEksaInstaller(mockCtrl)
+	clientFactory := mocks.NewMockClientFactory(mockCtrl)
+	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
+		s.Cluster.Name = "workload"
+		s.Cluster.Spec.DatacenterRef.Kind = v1alpha1.VSphereDatacenterKind
+		s.ManagementCluster = &types.Cluster{Name: "management"}
+		s.GitOpsConfig = &v1alpha1.GitOpsConfig{}
+	})
+	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpec.Bundles)
+
+	workload := management.NewDelete(
+		bootstrapper,
+		provider,
+		writer,
+		manager,
+		gitopsManager,
+		clusterDeleter,
+		eksdInstaller,
+		eksaInstaller,
+		clientFactory,
+	)
+
+	for _, e := range featureEnvVars {
+		t.Setenv(e, "true")
+	}
+
+	return &deleteTestSetup{
+		t:                    t,
+		provider:             provider,
+		datacenterConfig:     datacenterConfig,
+		machineConfigs:       machineConfigs,
+		workload:             workload,
+		ctx:                  context.Background(),
+		clusterSpec:          clusterSpec,
+		workloadCluster:      &types.Cluster{Name: "workload"},
+		clusterManager:       manager,
+		writer:               writer,
+		bootstrapper:         bootstrapper,
+		gitopsManager:        gitopsManager,
+		bootstrapCluster:     &types.Cluster{},
+		clusterDeleter:       clusterDeleter,
+		eksdInstaller:        eksdInstaller,
+		eksaInstaller:        eksaInstaller,
+		clientFactory:        clientFactory,
+		managementComponents: managementComponents,
+		client:               client,
+	}
+}
+
+func (c *deleteTestSetup) expectSetup(err error) {
+	c.provider.EXPECT().SetupAndValidateDeleteCluster(c.ctx, c.workloadCluster, c.clusterSpec).Return(err)
+}
+
+func (c *deleteTestSetup) expectCleanupGitRepo(err error) {
+	c.gitopsManager.EXPECT().CleanupGitRepo(c.ctx, c.clusterSpec).Return(err)
+}
+
+func (c *deleteTestSetup) expectBootstrapOpts(err error) {
+	c.provider.EXPECT().BootstrapClusterOpts(c.clusterSpec).Return([]bootstrapper.BootstrapClusterOption{}, err)
+}
+
+func (c *deleteTestSetup) expectCreateBootstrap(err error) {
+	c.bootstrapper.EXPECT().CreateBootstrapCluster(c.ctx, c.clusterSpec, gomock.Any()).Return(&types.Cluster{}, err)
+}
+
+func (c *deleteTestSetup) run() error {
+	return c.workload.Run(c.ctx, c.workloadCluster, c.clusterSpec)
+}
+
+func (c *deleteTestSetup) expectWrite() {
+	c.writer.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+}
+
+func (c *deleteTestSetup) expectSaveLogsWorkload() {
+	c.clusterManager.EXPECT().SaveLogsWorkloadCluster(c.ctx, c.provider, c.clusterSpec, c.workloadCluster)
+}
+
+func (c *deleteTestSetup) expectSaveLogsManagement() {
+	c.clusterManager.EXPECT().SaveLogsManagementCluster(c.ctx, c.clusterSpec, c.bootstrapCluster)
+	c.expectWrite()
+}
+
+func (c *deleteTestSetup) expectDeleteBootstrap(err error) {
+	c.bootstrapper.EXPECT().DeleteBootstrapCluster(c.ctx, c.bootstrapCluster, constants.Delete, false).Return(err)
+}
+
+func (c *deleteTestSetup) expectPreCAPI(err error) {
+	c.provider.EXPECT().PreCAPIInstallOnBootstrap(c.ctx, c.bootstrapCluster, c.clusterSpec).Return(err)
+}
+
+func (c *deleteTestSetup) expectInstallCAPI(err error) {
+	c.clusterManager.EXPECT().InstallCAPI(c.ctx, gomock.Any(), c.clusterSpec, c.bootstrapCluster, c.provider).Return(err)
+}
+
+func (c *deleteTestSetup) expectMoveCAPI(err error) {
+	c.clusterManager.EXPECT().MoveCAPI(c.ctx, c.workloadCluster, c.bootstrapCluster, c.workloadCluster.Name, c.clusterSpec, gomock.Any()).Return(err)
+}
+
+func (c *deleteTestSetup) expectInstallEksaComponentsBootstrap(err1, err2, err3, err4, err5 error) {
+	gomock.InOrder(
+		c.eksdInstaller.EXPECT().InstallEksdCRDs(c.ctx, c.clusterSpec, c.bootstrapCluster).Return(err1).AnyTimes(),
+
+		c.eksaInstaller.EXPECT().Install(
+			c.ctx, logger.Get(), c.bootstrapCluster, c.managementComponents, c.clusterSpec).Return(err2).AnyTimes(),
+
+		c.provider.EXPECT().InstallCustomProviderComponents(
+			c.ctx, c.bootstrapCluster.KubeconfigFile).Return(err3).AnyTimes(),
+
+		c.eksdInstaller.EXPECT().InstallEksdManifest(
+			c.ctx, c.clusterSpec, c.bootstrapCluster).Return(err4).AnyTimes(),
+
+		c.clientFactory.EXPECT().BuildClientFromKubeconfig(c.bootstrapCluster.KubeconfigFile).Return(c.client, err5).AnyTimes(),
+	)
+}
+
+func (c *deleteTestSetup) expectDeleteCluster(err1, err2, err3, err4 error) {
+	gomock.InOrder(
+
+		c.clusterManager.EXPECT().ResumeEKSAControllerReconcile(c.ctx, c.bootstrapCluster, c.clusterSpec, c.provider).Return(err1).AnyTimes(),
+
+		c.clusterManager.EXPECT().AddManagedByCLIAnnotationForCluster(c.ctx, c.bootstrapCluster, c.clusterSpec, c.provider).Return(err2).AnyTimes(),
+
+		c.clusterDeleter.EXPECT().Run(c.ctx, c.clusterSpec, *c.bootstrapCluster).Return(err3).AnyTimes(),
+
+		c.provider.EXPECT().PostClusterDeleteValidate(c.ctx, c.bootstrapCluster).Return(err4).AnyTimes(),
+	)
+}
+
+func (c *deleteTestSetup) expectApplyOnBootstrap(err error) {
+	c.client.EXPECT().ApplyServerSide(c.ctx, "eks-a-cli", gomock.Any(), gomock.Any()).Return(err).AnyTimes()
+}
+
+func TestDeleteRunSuccess(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil)
+	test.expectApplyOnBootstrap(nil)
+	test.expectDeleteCluster(nil, nil, nil, nil)
+	test.expectCleanupGitRepo(nil)
+	test.expectDeleteBootstrap(nil)
+
+	err := test.run()
+	if err != nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailSetup(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(fmt.Errorf("Failure"))
+	test.expectWrite()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailBootstrapOpts(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(fmt.Errorf(""))
+	test.expectWrite()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailCreateBootstrap(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(fmt.Errorf(""))
+	test.expectWrite()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailPreCAPI(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(fmt.Errorf(""))
+	test.expectSaveLogsManagement()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailInstallCAPI(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(fmt.Errorf(""))
+	test.expectDeleteCluster(fmt.Errorf(""), nil, nil, nil)
+	test.expectSaveLogsManagement()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailMoveCAPI(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(fmt.Errorf(""))
+	test.expectSaveLogsWorkload()
+	test.expectSaveLogsManagement()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailResumeReconcile(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(fmt.Errorf(""), nil, nil, nil, nil)
+	test.expectSaveLogsManagement()
+	test.expectSaveLogsWorkload()
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailAddAnnotation(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, fmt.Errorf(""), nil, nil, nil)
+	test.expectSaveLogsManagement()
+	test.expectSaveLogsWorkload()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailProviderInstall(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, fmt.Errorf(""), nil, nil)
+	test.expectSaveLogsManagement()
+	test.expectSaveLogsWorkload()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailEksdInstall(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, fmt.Errorf(""), nil)
+	test.expectSaveLogsManagement()
+	test.expectSaveLogsWorkload()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailBuildClient(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, fmt.Errorf(""))
+	test.expectSaveLogsManagement()
+	test.expectSaveLogsWorkload()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailPostDelete(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil)
+	test.expectApplyOnBootstrap(nil)
+	test.expectDeleteCluster(nil, nil, nil, fmt.Errorf(""))
+	test.expectSaveLogsManagement()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailCleanupGit(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil)
+	test.expectApplyOnBootstrap(nil)
+	test.expectDeleteCluster(nil, nil, nil, nil)
+	test.expectCleanupGitRepo(fmt.Errorf(""))
+	test.expectSaveLogsWorkload()
+	test.expectSaveLogsManagement()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestDeleteRunFailDeleteBootstrap(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newDeleteTest(t)
+	test.expectSetup(nil)
+	test.expectBootstrapOpts(nil)
+	test.expectCreateBootstrap(nil)
+	test.expectPreCAPI(nil)
+	test.expectInstallCAPI(nil)
+	test.expectMoveCAPI(nil)
+	test.expectInstallEksaComponentsBootstrap(nil, nil, nil, nil, nil)
+	test.expectApplyOnBootstrap(nil)
+	test.expectDeleteCluster(nil, nil, nil, nil)
+	test.expectCleanupGitRepo(nil)
+	test.expectDeleteBootstrap(fmt.Errorf(""))
+	test.expectSaveLogsManagement()
+
+	err := test.run()
+	if err == nil {
+		t.Fatalf("Delete.Run() err = %v, want err = nil", err)
+	}
+}

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/internal/test"

--- a/pkg/workflows/management/validate.go
+++ b/pkg/workflows/management/validate.go
@@ -111,3 +111,28 @@ func (s *setupAndValidateUpgrade) Checkpoint() *task.CompletedTask {
 		Checkpoint: nil,
 	}
 }
+
+type setupAndValidateDelete struct{}
+
+func (s *setupAndValidateDelete) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	logger.Info("Performing provider setup and validations")
+	err := commandContext.Provider.SetupAndValidateDeleteCluster(ctx, commandContext.WorkloadCluster, commandContext.ClusterSpec)
+	if err != nil {
+		commandContext.SetError(err)
+		return nil
+	}
+
+	return &createBootStrapClusterForDeleteTask{}
+}
+
+func (s *setupAndValidateDelete) Name() string {
+	return "setup-and-validate-delete"
+}
+
+func (s *setupAndValidateDelete) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
+	return nil, nil
+}
+
+func (s *setupAndValidateDelete) Checkpoint() *task.CompletedTask {
+	return nil
+}

--- a/pkg/workflows/workload/delete_test.go
+++ b/pkg/workflows/workload/delete_test.go
@@ -102,9 +102,6 @@ func (c *deleteTestSetup) expectSaveLogsWorkload() {
 
 func (c *deleteTestSetup) expectCleanup(err error) {
 	c.gitopsManager.EXPECT().CleanupGitRepo(c.ctx, c.clusterSpec).Return(err)
-	if err == nil {
-		c.writer.EXPECT().CleanUp()
-	}
 }
 
 func TestDeleteRunSuccess(t *testing.T) {

--- a/pkg/workflows/workload/deletecluster.go
+++ b/pkg/workflows/workload/deletecluster.go
@@ -18,7 +18,7 @@ func (s *deleteWorkloadCluster) Run(ctx context.Context, commandContext *task.Co
 		return &workflows.CollectWorkloadClusterDiagnosticsTask{}
 	}
 
-	return &cleanupGitRepo{}
+	return &postDeleteWorkload{}
 }
 
 func (s *deleteWorkloadCluster) Name() string {

--- a/pkg/workflows/workload/post_delete.go
+++ b/pkg/workflows/workload/post_delete.go
@@ -14,7 +14,12 @@ type (
 )
 
 func (s *postDeleteWorkload) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	commandContext.Writer.CleanUp()
+	logger.Info("Clean up Git Repo")
+	err := commandContext.GitOpsManager.CleanupGitRepo(ctx, commandContext.ClusterSpec)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
 
 	if commandContext.OriginalError != nil {
 		collector := &workflows.CollectMgmtClusterDiagnosticsTask{}
@@ -35,28 +40,5 @@ func (s *postDeleteWorkload) Restore(ctx context.Context, commandContext *task.C
 }
 
 func (s *postDeleteWorkload) Checkpoint() *task.CompletedTask {
-	return nil
-}
-
-func (s *cleanupGitRepo) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	logger.Info("Clean up Git Repo")
-	err := commandContext.GitOpsManager.CleanupGitRepo(ctx, commandContext.ClusterSpec)
-	if err != nil {
-		commandContext.SetError(err)
-		return &workflows.CollectDiagnosticsTask{}
-	}
-
-	return &postDeleteWorkload{}
-}
-
-func (s *cleanupGitRepo) Name() string {
-	return "clean-up-git-repo"
-}
-
-func (s *cleanupGitRepo) Restore(ctx context.Context, commandContext *task.CommandContext, completedTask *task.CompletedTask) (task.Task, error) {
-	return nil, nil
-}
-
-func (s *cleanupGitRepo) Checkpoint() *task.CompletedTask {
 	return nil
 }

--- a/pkg/workflows/workload/upgrade_test.go
+++ b/pkg/workflows/workload/upgrade_test.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-
-	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/features"
 	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a new delete workflow for mgmt clusters

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

