### PR TITLE
Skip extra hardware validation for InPlace Upgrades

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -381,8 +381,12 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 		if err != nil {
 			return controller.Result{}, err
 		}
-		// eksa version upgrade cannot be triggered from controller, so set it to false.
-		v.Register(tinkerbell.ExtraHardwareAvailableAssertionForRollingUpgrade(kubeReader.GetCatalogue(), validatableCAPI, false))
+		upgradeStrategy := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy
+		// skip extra hardware validation for InPlace upgrades
+		if upgradeStrategy == nil || upgradeStrategy.Type != anywherev1.InPlaceStrategyType {
+			// eksa version upgrade cannot be triggered from controller, so set it to false.
+			v.Register(tinkerbell.ExtraHardwareAvailableAssertionForRollingUpgrade(kubeReader.GetCatalogue(), validatableCAPI, false))
+		}
 	case NewClusterOperation:
 		v.Register(tinkerbell.MinimumHardwareAvailableAssertionForCreate(kubeReader.GetCatalogue()))
 	case NoChange:

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -113,8 +113,12 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 		return err
 	}
 
-	if err := p.validateAvailableHardwareForUpgrade(ctx, currentClusterSpec, clusterSpec); err != nil {
-		return err
+	upgradeStrategy := currentClusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy
+	// skip extra hardware validation for InPlace upgrades
+	if upgradeStrategy == nil || upgradeStrategy.Type != v1alpha1.InPlaceStrategyType {
+		if err := p.validateAvailableHardwareForUpgrade(ctx, currentClusterSpec, clusterSpec); err != nil {
+			return err
+		}
 	}
 
 	if p.clusterConfig.IsManaged() {


### PR DESCRIPTION
*Issue #, if available:*
As part of our pre-flight assertions currently we check for extra hardware was available during an upgrade for baremetal. With InPlace upgrades we don't need to perform this check when the Upgrade Strategy is configured for InPlace.

*Description of changes:*
This change skips the extra hardware availability validation for upgrades when the rollout strategy is configured to InPlace. 

*Testing (if applicable):*
Tested this manually.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

