### PR TITLE
Add one nutanix test to quick e2e suite

### DIFF
--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -12,6 +12,12 @@ env:
     # cloudstack variables
     CLOUDSTACK_PROVIDER: true
     T_CLOUDSTACK_CIDR: "10.80.214.0/23"
+    # nutanix variables
+    T_NUTANIX_MACHINE_VCPU_PER_SOCKET: 1
+    T_NUTANIX_MACHINE_VCPU_SOCKET: 2
+    T_NUTANIX_MACHINE_MEMORY_SIZE: "4Gi"
+    T_NUTANIX_SYSTEMDISK_SIZE: "40Gi"
+    T_NUTANIX_INSECURE: true
   secrets-manager:
     EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
     EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
@@ -77,6 +83,36 @@ env:
     T_CLOUDSTACK_POD_CIDR: "cloudstack_ci_beta_connection:pod_cidr"
     T_CLOUDSTACK_SERVICE_CIDR: "cloudstack_ci_beta_connection:service_cidr"
     T_CLOUDSTACK_SSH_AUTHORIZED_KEY: "vsphere_ci_beta_connection:ssh_authorized_key"
+    # nutanix secrets
+    EKSA_NUTANIX_USERNAME: "nutanix_ci:nutanix_user"
+    EKSA_NUTANIX_PASSWORD: "nutanix_ci:nutanix_password"
+    T_NUTANIX_ENDPOINT: "nutanix_ci:nutanix_pc_endpoint"
+    T_NUTANIX_PORT: "nutanix_ci:nutanix_port"
+    T_NUTANIX_MACHINE_BOOT_TYPE: "nutanix_ci:nutanix_machine_boot_type"
+    T_NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: "nutanix_ci:nutanix_prism_element_cluster_name"
+    T_NUTANIX_SSH_AUTHORIZED_KEY: "nutanix_ci:nutanix_ssh_authorized_key"
+    T_NUTANIX_SUBNET_NAME: "nutanix_ci:nutanix_subnet_name"
+    T_NUTANIX_CONTROL_PLANE_CIDR: "nutanix_ci:nutanix_control_plane_cidr"
+    T_NUTANIX_POD_CIDR: "nutanix_ci:nutanix_pod_cidr"
+    T_NUTANIX_SERVICE_CIDR: "nutanix_ci:nutanix_service_cidr"
+    T_NUTANIX_ADDITIONAL_TRUST_BUNDLE: "nutanix_ci:nutanix_additional_trust_bundle"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_22: "nutanix_ci:nutanix_template_ubuntu_1_22"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_23: "nutanix_ci:nutanix_template_ubuntu_1_23"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_24: "nutanix_ci:nutanix_template_ubuntu_1_24"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_25: "nutanix_ci:nutanix_template_ubuntu_1_25"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_26: "nutanix_ci:nutanix_template_ubuntu_1_26"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_27: "nutanix_ci:nutanix_template_ubuntu_1_27"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_28: "nutanix_ci:nutanix_template_ubuntu_1_28"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_1_24: "nutanix_ci:nutanix_template_rhel_8_1_24"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_1_25: "nutanix_ci:nutanix_template_rhel_8_1_25"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_1_26: "nutanix_ci:nutanix_template_rhel_8_1_26"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_1_27: "nutanix_ci:nutanix_template_rhel_8_1_27"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_1_28: "nutanix_ci:nutanix_template_rhel_8_1_28"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_24: "nutanix_ci:nutanix_template_rhel_9_1_24"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_25: "nutanix_ci:nutanix_template_rhel_9_1_25"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_26: "nutanix_ci:nutanix_template_rhel_9_1_26"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_27: "nutanix_ci:nutanix_template_rhel_9_1_27"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_28: "nutanix_ci:nutanix_template_rhel_9_1_28"
 
 phases:
   pre_build:

--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -5,3 +5,5 @@ quick_tests:
 - TestVSphereKubernetes128Ubuntu2204SimpleFlow
 # CloudStack
 - TestCloudStackKubernetes127To128RedhatMultipleFieldsUpgrade
+# Nutanix
+- TestNutanixKubernetes127to128RedHat9Upgrade


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding one Nutanix test to the e2e suite.
- Add all the required environment variables to the quick e2e code build spec yaml
   - Had to include templates for kubernetes versions that won't be in the suite due to it being required to run the tests. Moving forward, we might need to look into scoping these more appropriately for the tests.
 - Added `TestNutanixKubernetes127to128RedHat9Upgrade` to the `QUICK_TESTS.yaml`

*Testing (if applicable):*
- Manually invoked code build run

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

