### PR TITLE
Add env var to controller when in place upgrades on VSphere env var is set

### DIFF
--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -240,6 +241,11 @@ func setManagerEnvVars(d *appsv1.Deployment, spec *cluster.Spec) {
 		for _, name := range proxyEnvVarNames {
 			envVars = append(envVars, v1.EnvVar{Name: name, Value: proxy[name]})
 		}
+	}
+
+	// TODO: remove this feature flag if we decide to support in-place upgrades for vSphere provider.
+	if features.IsActive(features.VSphereInPlaceUpgradeEnabled()) {
+		envVars = append(envVars, v1.EnvVar{Name: features.VSphereInPlaceEnvVar, Value: "true"})
 	}
 
 	d.Spec.Template.Spec.Containers[0].Env = envVars

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -400,6 +400,26 @@ func TestSetManagerEnvVars(t *testing.T) {
 	}
 }
 
+func TestSetManagerEnvVarsVSphereInPlaceUpgrade(t *testing.T) {
+	g := NewWithT(t)
+	features.ClearCache()
+	t.Setenv(features.VSphereInPlaceEnvVar, "true")
+
+	deploy := deployment()
+	spec := test.NewClusterSpec()
+	want := deployment(func(d *appsv1.Deployment) {
+		d.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+			{
+				Name:  "VSPHERE_IN_PLACE_UPGRADE",
+				Value: "true",
+			},
+		}
+	})
+
+	clustermanager.SetManagerEnvVars(deploy, spec)
+	g.Expect(deploy).To(Equal(want))
+}
+
 func TestEKSAInstallerNewUpgraderConfigMap(t *testing.T) {
 	tt := newInstallerTest(t)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to set the env var in the controller deployment for in place upgrades to work in the unified controller.CLI flow on vSphere

*Testing (if applicable):*
created cluster

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

