### PR TITLE
Add one Snow test to quick e2e test suite

### DIFF
--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -108,6 +108,11 @@ env:
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_26: "nutanix_ci:nutanix_template_rhel_9_1_26"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_27: "nutanix_ci:nutanix_template_rhel_9_1_27"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_28: "nutanix_ci:nutanix_template_rhel_9_1_28"
+    # Snow secrets
+    T_SNOW_DEVICES: "snow_ci:snow_devices"
+    T_SNOW_CREDENTIALS_S3_PATH: "snow_ci:snow_credentials_s3_path"
+    T_SNOW_CERTIFICATES_S3_PATH: "snow_ci:snow_certificates_s3_path"
+    T_SNOW_CONTROL_PLANE_CIDRS: "snow_ci:control_plane_cidrs"
 
 phases:
   pre_build:

--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -7,3 +7,5 @@ quick_tests:
 - TestCloudStackKubernetes127To128RedhatMultipleFieldsUpgrade
 # Nutanix
 - TestNutanixKubernetes127to128RedHat9Upgrade
+# Snow
+# - TestSnowKubernetes128SimpleFlow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding one Snow test to the e2e suite.
- Added all the required environment variables to the quick e2e code build spec yaml
- Added `TestSnowKubernetes128SimpleFlow` to the `QUICK_TESTS.yaml`. It is disabled for now until we move the current tests to nightly, being cognizant of infrastructure limitations.

*Testing (if applicable):*
- Manually invoking the codebuild project and sourcing the changes on this branch

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

