### PR TITLE
Update status message to show upgrade type

### DIFF
--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -49,6 +49,10 @@ const (
 	// a new desired machine spec.
 	RollingUpgradeInProgress = "RollingUpgradeInProgress"
 
+	// InPlaceUpgradeInProgress reports the Cluster is executing a in place upgrade to align the nodes to
+	// a new desired machine specs.
+	InPlaceUpgradeInProgress = "InPlaceUpgradeInProgress"
+
 	// ExternalEtcdNotAvailable reports the Cluster status is waiting for Etcd to be available.
 	ExternalEtcdNotAvailable = "ExternalEtcdNotAvailable"
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update cluster status to show `RollingUpgradeInProgress` when the upgrade type is `rollingUpgrade` and `InPlaceUpgradeInProgress` when the upgrade type is `inPlace`. 

For worker nodes, it will show `RollingUpgradeInProgress` if all nodes have upgrade type `rollingUpgrade`, `InPlaceUpgradeInProgress` when the upgrade type is `inPlace`, and `UpgradeInProgress` if there is a combination of both upgrade types.

*Testing (if applicable):*
```
Status:
  Children Reconciled Generation:  5
  Conditions:
    Last Transition Time:  2024-02-12T20:20:23Z
    Message:               Control plane nodes not up-to-date yet, 3 upgrading (0 up to date)
    Reason:                InPlaceUpgradeInProgress
    Severity:              Info
    Status:                False
    Type:                  Ready
    Last Transition Time:  2024-02-12T19:53:16Z
    Status:                True
    Type:                  ControlPlaneInitialized
    Last Transition Time:  2024-02-12T20:20:23Z
    Message:               Control plane nodes not up-to-date yet, 3 upgrading (0 up to date)
    Reason:                InPlaceUpgradeInProgress
    Severity:              Info
    Status:                False
    Type:                  ControlPlaneReady
    Last Transition Time:  2024-02-12T19:53:30Z
    Status:                True
    Type:                  DefaultCNIConfigured
    Last Transition Time:  2024-02-12T20:13:10Z
    Status:                True
    Type:                  WorkersReady
  Observed Generation:     4
  Reconciled Generation:   3
Events:                    <none>
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


