### PR TITLE
Add version command output to error in e2e tests

### DIFF
--- a/test/framework/eksa_versions.go
+++ b/test/framework/eksa_versions.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log"
 
+	"github.com/pkg/errors"
+
 	"github.com/aws/eks-anywhere/pkg/semver"
 )
 
@@ -38,7 +40,7 @@ func localEKSAVersionCommand() (versionCommandOutput, error) {
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return versionCommandOutput{}, err
+		return versionCommandOutput{}, errors.Errorf("failed to run eksctl anywhere version: %v, output: %s", err, out)
 	}
 
 	versionOut := &versionCommandOutput{}


### PR DESCRIPTION
*Description of changes:*
Without this, the command output is swallowed and it only returns "exit status 255".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

