### PR TITLE
Improve release handling in version command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/version.go
+++ b/cmd/eksctl-anywhere/cmd/version.go
@@ -38,6 +38,7 @@ func (vo *versionOptions) printVersion() error {
 		if bundlesErr != nil {
 			return fmt.Errorf("error getting bundle manifest URL for version %s: %v", versionInfo.GitVersion, bundlesErr)
 		}
+		fmt.Printf("Release Manifest URL: %s\n", versionInfo.ReleaseManifestURL)
 		fmt.Printf("Bundle Manifest URL: %s\n", versionInfo.BundleManifestURL)
 	case "json":
 		versionInfoJSON, unmarshalErr := json.Marshal(versionInfo)

--- a/pkg/manifests/releases/read.go
+++ b/pkg/manifests/releases/read.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
+	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
 	"github.com/aws/eks-anywhere/pkg/semver"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -28,6 +29,7 @@ func ReadReleases(reader Reader) (*releasev1.Release, error) {
 }
 
 func ReadReleasesFromURL(reader Reader, url string) (*releasev1.Release, error) {
+	logger.V(4).Info("Reading release manifest", "url", url)
 	content, err := reader.ReadFile(url)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading Releases file")
@@ -61,7 +63,7 @@ func BundleManifestURL(releases *releasev1.Release, version string) (string, err
 	}
 
 	if eksAReleaseForVersion == nil {
-		return "", fmt.Errorf("no matching release found for version %s to get Bundles URL", version)
+		return "", fmt.Errorf("no matching release found for version %s to get Bundles URL. Latest available version is %s", version, releases.Spec.LatestVersion)
 	}
 
 	return eksAReleaseForVersion.BundleManifestUrl, nil

--- a/pkg/manifests/releases/read_test.go
+++ b/pkg/manifests/releases/read_test.go
@@ -222,6 +222,7 @@ func TestBundleManifestURL(t *testing.T) {
 			name: "error getting release",
 			releases: &releasev1.Release{
 				Spec: releasev1.ReleaseSpec{
+					LatestVersion: "v0.0.2",
 					Releases: []releasev1.EksARelease{
 						{Version: "v0.0.1", Number: 1, BundleManifestUrl: "https://example.com/bundle-manifest"},
 						{Version: "v0.0.2", Number: 2, BundleManifestUrl: "https://example.com/bundle-manifest"},
@@ -230,7 +231,7 @@ func TestBundleManifestURL(t *testing.T) {
 			},
 			version: "v0.0.3",
 			wantURL: "",
-			wantErr: "no matching release found for version v0.0.3 to get Bundles URL",
+			wantErr: "no matching release found for version v0.0.3 to get Bundles URL. Latest available version is v0.0.2",
 		},
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,8 +8,9 @@ import (
 var gitVersion string
 
 type Info struct {
-	GitVersion        string `json:"version"`
-	BundleManifestURL string `json:"bundleManifestURL,omitempty"`
+	GitVersion         string `json:"version"`
+	BundleManifestURL  string `json:"bundleManifestURL,omitempty"`
+	ReleaseManifestURL string `json:"releaseManifestURL,omitempty"`
 }
 
 func Get() Info {
@@ -29,7 +30,8 @@ func GetFullVersionInfo() (Info, error) {
 	}
 
 	return Info{
-		GitVersion:        gitVersion,
-		BundleManifestURL: bundleManifestURL,
+		GitVersion:         gitVersion,
+		BundleManifestURL:  bundleManifestURL,
+		ReleaseManifestURL: releases.ManifestURL(),
 	}, nil
 }

--- a/test/framework/eksa_versions.go
+++ b/test/framework/eksa_versions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/aws/eks-anywhere/pkg/semver"
+	"github.com/aws/eks-anywhere/pkg/version"
 )
 
 func newVersion(version string) *semver.Version {
@@ -17,36 +18,30 @@ func newVersion(version string) *semver.Version {
 	return v
 }
 
-// versionCommandOutput is the output of the eks-anywhere version command.
-type versionCommandOutput struct {
-	Version           string `json:"version"`
-	BundleManifestURL string `json:"bundleManifestURL"`
-}
-
 // localEKSAVersion returns the version of eks-anywhere installed locally.
 func localEKSAVersion() (string, error) {
 	v, err := localEKSAVersionCommand()
 	if err != nil {
 		return "", err
 	}
-	return v.Version, nil
+	return v.GitVersion, nil
 }
 
 // localEKSAVersionCommand returns the output of the eks-anywhere version command.
-func localEKSAVersionCommand() (versionCommandOutput, error) {
+func localEKSAVersionCommand() (version.Info, error) {
 	cmd, err := prepareCommand("eksctl", "anywhere", "version", "--output", "json")
 	if err != nil {
-		return versionCommandOutput{}, err
+		return version.Info{}, err
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return versionCommandOutput{}, errors.Errorf("failed to run eksctl anywhere version: %v, output: %s", err, out)
+		return version.Info{}, errors.Errorf("failed to run eksctl anywhere version: %v, output: %s", err, out)
 	}
 
-	versionOut := &versionCommandOutput{}
+	versionOut := &version.Info{}
 	err = json.Unmarshal(out, versionOut)
 	if err != nil {
-		return versionCommandOutput{}, err
+		return version.Info{}, err
 	}
 
 	return *versionOut, nil


### PR DESCRIPTION
*Description of changes:*
* Print manifest URL when readin it for debugging
* Print release manifest URL as part of the version output
* When desired version is not found in release manifest, include the latest available version in the error message
* Update E2E tests to reuse version.Info

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

