### PR TITLE
Add Nutanix 129 env to required env for e2e

### DIFF
--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -70,14 +70,17 @@ var requiredNutanixEnvVars = []string{
 	nutanixTemplateNameUbuntu126Var,
 	nutanixTemplateNameUbuntu127Var,
 	nutanixTemplateNameUbuntu128Var,
+	nutanixTemplateNameUbuntu129Var,
 	nutanixTemplateNameRedHat125Var,
 	nutanixTemplateNameRedHat126Var,
 	nutanixTemplateNameRedHat127Var,
 	nutanixTemplateNameRedHat128Var,
+	nutanixTemplateNameRedHat129Var,
 	nutanixTemplateNameRedHat9125Var,
 	nutanixTemplateNameRedHat9126Var,
 	nutanixTemplateNameRedHat9127Var,
 	nutanixTemplateNameRedHat9128Var,
+	nutanixTemplateNameRedHat9129Var,
 	nutanixInsecure,
 }
 


### PR DESCRIPTION
*Description of changes:*
Add Nutanix 129 env to required env for e2e so the tests can pick up the right templates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

