### PR TITLE
Add additional version check for cp ready

### DIFF
--- a/pkg/awsiamauth/reconciler/reconciler_test.go
+++ b/pkg/awsiamauth/reconciler/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -235,8 +236,10 @@ func TestReconcileRemoteGetClientError(t *testing.T) {
 			EksaVersion: &version,
 		},
 	}
+	kcpVersion := "test"
 	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
 		kcp.Name = cluster.Name
+		kcp.Spec.Version = kcpVersion
 		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
 			Conditions: clusterv1.Conditions{
 				{
@@ -245,6 +248,7 @@ func TestReconcileRemoteGetClientError(t *testing.T) {
 					LastTransitionTime: metav1.NewTime(time.Now()),
 				},
 			},
+			Version: pointer.String(kcpVersion),
 		}
 	})
 	sec := &corev1.Secret{
@@ -309,8 +313,10 @@ func TestReconcileConfigMapNotFoundApplyError(t *testing.T) {
 			EksaVersion: &version,
 		},
 	}
+	kcpVersion := "test"
 	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
 		kcp.Name = cluster.Name
+		kcp.Spec.Version = kcpVersion
 		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
 			Conditions: clusterv1.Conditions{
 				{
@@ -319,6 +325,7 @@ func TestReconcileConfigMapNotFoundApplyError(t *testing.T) {
 					LastTransitionTime: metav1.NewTime(time.Now()),
 				},
 			},
+			Version: pointer.String(kcpVersion),
 		}
 	})
 	sec := &corev1.Secret{

--- a/pkg/controller/clusters/clusterapi.go
+++ b/pkg/controller/clusters/clusterapi.go
@@ -34,7 +34,9 @@ func CheckControlPlaneReady(ctx context.Context, client client.Client, log logr.
 		return controller.ResultWithRequeue(5 * time.Second), nil
 	}
 
-	if !conditions.IsTrue(kcp, clusterapi.ReadyCondition) {
+	// Checking for version as well to avoid race condition of status not being updated in time at least for Kubernetes version upgrades
+	if !conditions.IsTrue(kcp, clusterapi.ReadyCondition) ||
+		kcp.Status.Version == nil || kcp.Spec.Version != *kcp.Status.Version {
 		log.Info("KCP is not ready yet, requeing")
 		return controller.ResultWithRequeue(30 * time.Second), nil
 	}

--- a/pkg/providers/snow/reconciler/reconciler_test.go
+++ b/pkg/providers/snow/reconciler/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -230,6 +231,8 @@ func TestReconcilerReconcileControlPlane(t *testing.T) {
 
 func TestReconcilerCheckControlPlaneReadyItIsReady(t *testing.T) {
 	tt := newReconcilerTest(t)
+	kcpVersion := "test"
+	tt.kcp.Spec.Version = kcpVersion
 	tt.kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
 		Conditions: clusterv1.Conditions{
 			{
@@ -238,6 +241,7 @@ func TestReconcilerCheckControlPlaneReadyItIsReady(t *testing.T) {
 				LastTransitionTime: metav1.NewTime(time.Now()),
 			},
 		},
+		Version: pointer.String(kcpVersion),
 	}
 	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.kcp)
 	tt.withFakeClient()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There seems to be a race condition where the observed generation gets updated but the status is updated separately, which results in our controller thinking kcp is ready and moving onto applying the md specs. Though we need to figure out a better way to cover more use cases in terms of changes to kcp spec, adding a check for version will at least stop this from happening for version upgrades, ensuring kcp rollout is fully complete before moving onto md.

*Testing (if applicable):*
unit testing and functional testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

