### PR TITLE
Add upgrader image to import images

### DIFF
--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -193,6 +193,7 @@ func (vb *VersionsBundle) SharedImages() []Image {
 		vb.Haproxy.Image,
 		vb.PackageController.Controller,
 		vb.PackageController.TokenRefresher,
+		vb.Upgrader.Upgrader,
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*
Add upgrader image to import images so it can be imported and used with registry mirror

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

