### PR TITLE
Fix InPlace e2e validation  to check for actual values in kcp/md.spec.Replicas  

### DIFF
--- a/test/framework/cluster/validations/cluster.go
+++ b/test/framework/cluster/validations/cluster.go
@@ -87,7 +87,7 @@ func validateKCP(ctx context.Context, vc clusterf.StateValidationConfig) error {
 	}
 	if conditions.IsFalse(kcp, v1beta1.ReadyCondition) {
 		return errors.New("kcp ready condition is not true")
-	} else if kcp.Status.UpdatedReplicas != kcp.Status.ReadyReplicas || kcp.Spec.Replicas != &kcp.Status.UpdatedReplicas {
+	} else if kcp.Status.UpdatedReplicas != kcp.Status.ReadyReplicas || *kcp.Spec.Replicas != kcp.Status.UpdatedReplicas {
 		return fmt.Errorf("kcp replicas count %d, updated replicas count %d and ready replicas count %d are not in sync", *kcp.Spec.Replicas, kcp.Status.UpdatedReplicas, kcp.Status.ReadyReplicas)
 	}
 	return nil
@@ -104,7 +104,7 @@ func validateMDs(ctx context.Context, vc clusterf.StateValidationConfig) error {
 	for _, md := range mds {
 		if conditions.IsFalse(&md, v1beta1.ReadyCondition) {
 			return fmt.Errorf("md ready condition is not true for md %s", md.Name)
-		} else if md.Status.UpdatedReplicas != md.Status.ReadyReplicas || md.Spec.Replicas != &md.Status.UpdatedReplicas {
+		} else if md.Status.UpdatedReplicas != md.Status.ReadyReplicas || *md.Spec.Replicas != md.Status.UpdatedReplicas {
 			return fmt.Errorf("md replicas count %d, updated replicas count %d and ready replicas count %d for md %s are not in sync", *md.Spec.Replicas, md.Status.UpdatedReplicas, md.Status.ReadyReplicas, md.Name)
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*
In our e2e validations for InPlace we check for kcp/md.Spec.Replicas to be equal to the updated and ready replicas count. There was a bug in the validation logic wherein we checked for the addresses of these fields instead of dereferencing and checking for the exact value. 

*Description of changes:*
This change dereferences the kcp/md.spec.replicas to check for the actual value instead of the addresses as it is a pointer.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

