### PR TITLE
Generate and write AWS IAM auth kubeconfig to disk

### DIFF
--- a/pkg/awsiamauth/installer.go
+++ b/pkg/awsiamauth/installer.go
@@ -76,7 +76,7 @@ func (i *Installer) InstallAWSIAMAuth(
 		return fmt.Errorf("applying aws-iam-authenticator manifest: %v", err)
 	}
 
-	if err = i.generateKubeconfig(ctx, management, workload, spec); err != nil {
+	if err = i.GenerateKubeconfig(ctx, management, workload, spec); err != nil {
 		return err
 	}
 	return nil
@@ -113,7 +113,8 @@ func (i *Installer) generateInstallerKubeconfig(clusterSpec *cluster.Spec, serve
 	return i.templateBuilder.GenerateKubeconfig(clusterSpec, i.clusterID, serverURL, tlsCert)
 }
 
-func (i *Installer) generateKubeconfig(
+// GenerateKubeconfig generates the AWS IAM auth kubeconfig.
+func (i *Installer) GenerateKubeconfig(
 	ctx context.Context,
 	management, workload *types.Cluster,
 	spec *cluster.Spec,

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -122,6 +122,7 @@ type AwsIamAuth interface {
 	CreateAndInstallAWSIAMAuthCASecret(ctx context.Context, managementCluster *types.Cluster, workloadClusterName string) error
 	InstallAWSIAMAuth(ctx context.Context, management, workload *types.Cluster, spec *cluster.Spec) error
 	UpgradeAWSIAMAuth(ctx context.Context, cluster *types.Cluster, spec *cluster.Spec) error
+	GenerateKubeconfig(ctx context.Context, management, workload *types.Cluster, spec *cluster.Spec) error
 }
 
 // EKSAComponents allows to manage the eks-a components installation in a cluster.
@@ -837,6 +838,11 @@ func (c *ClusterManager) InstallMachineHealthChecks(ctx context.Context, cluster
 // Generates a kubeconfig for interacting with the cluster with aws-iam-authenticator client.
 func (c *ClusterManager) InstallAwsIamAuth(ctx context.Context, management, workload *types.Cluster, spec *cluster.Spec) error {
 	return c.awsIamAuth.InstallAWSIAMAuth(ctx, management, workload, spec)
+}
+
+// GenerateIamAuthKubeconfig generates a kubeconfig for interacting with the cluster with aws-iam-authenticator client.
+func (c *ClusterManager) GenerateIamAuthKubeconfig(ctx context.Context, management, workload *types.Cluster, spec *cluster.Spec) error {
+	return c.awsIamAuth.GenerateKubeconfig(ctx, management, workload, spec)
 }
 
 func (c *ClusterManager) CreateAwsIamAuthCaSecret(ctx context.Context, managementCluster *types.Cluster, workloadClusterName string) error {

--- a/pkg/clustermanager/mocks/client_and_networking.go
+++ b/pkg/clustermanager/mocks/client_and_networking.go
@@ -920,6 +920,20 @@ func (mr *MockAwsIamAuthMockRecorder) CreateAndInstallAWSIAMAuthCASecret(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndInstallAWSIAMAuthCASecret", reflect.TypeOf((*MockAwsIamAuth)(nil).CreateAndInstallAWSIAMAuthCASecret), arg0, arg1, arg2)
 }
 
+// GenerateKubeconfig mocks base method.
+func (m *MockAwsIamAuth) GenerateKubeconfig(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 *cluster.Spec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateKubeconfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GenerateKubeconfig indicates an expected call of GenerateKubeconfig.
+func (mr *MockAwsIamAuthMockRecorder) GenerateKubeconfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateKubeconfig", reflect.TypeOf((*MockAwsIamAuth)(nil).GenerateKubeconfig), arg0, arg1, arg2, arg3)
+}
+
 // InstallAWSIAMAuth mocks base method.
 func (m *MockAwsIamAuth) InstallAWSIAMAuth(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 *cluster.Spec) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -54,6 +54,7 @@ type ClusterManager interface {
 	Upgrade(ctx context.Context, cluster *types.Cluster, currentManagementComponents, newManagementComponents *cluster.ManagementComponents, newSpec *cluster.Spec) (*types.ChangeDiff, error)
 	InstallAwsIamAuth(ctx context.Context, managementCluster, workloadCluster *types.Cluster, clusterSpec *cluster.Spec) error
 	CreateAwsIamAuthCaSecret(ctx context.Context, bootstrapCluster *types.Cluster, workloadClusterName string) error
+	GenerateIamAuthKubeconfig(ctx context.Context, management, workload *types.Cluster, spec *cluster.Spec) error
 	DeletePackageResources(ctx context.Context, managementCluster *types.Cluster, clusterName string) error
 	CreateRegistryCredSecret(ctx context.Context, mgmt *types.Cluster) error
 }

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -269,6 +269,20 @@ func (mr *MockClusterManagerMockRecorder) EKSAClusterSpecChanged(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EKSAClusterSpecChanged", reflect.TypeOf((*MockClusterManager)(nil).EKSAClusterSpecChanged), arg0, arg1, arg2)
 }
 
+// GenerateIamAuthKubeconfig mocks base method.
+func (m *MockClusterManager) GenerateIamAuthKubeconfig(arg0 context.Context, arg1, arg2 *types.Cluster, arg3 *cluster.Spec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateIamAuthKubeconfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GenerateIamAuthKubeconfig indicates an expected call of GenerateIamAuthKubeconfig.
+func (mr *MockClusterManagerMockRecorder) GenerateIamAuthKubeconfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateIamAuthKubeconfig", reflect.TypeOf((*MockClusterManager)(nil).GenerateIamAuthKubeconfig), arg0, arg1, arg2, arg3)
+}
+
 // GetCurrentClusterSpec mocks base method.
 func (m *MockClusterManager) GetCurrentClusterSpec(arg0 context.Context, arg1 *types.Cluster, arg2 string) (*cluster.Spec, error) {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -25,6 +25,15 @@ func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	}
 	commandContext.WorkloadCluster = workloadCluster
 
+	if commandContext.ClusterSpec.AWSIamConfig != nil {
+		logger.Info("Generating the aws iam kubeconfig file")
+		err = commandContext.ClusterManager.GenerateIamAuthKubeconfig(ctx, commandContext.BootstrapCluster, workloadCluster, commandContext.ClusterSpec)
+		if err != nil {
+			commandContext.SetError(err)
+			return &workflows.CollectDiagnosticsTask{}
+		}
+	}
+
 	logger.Info("Creating EKS-A namespace")
 	err = commandContext.ClusterManager.CreateEKSANamespace(ctx, commandContext.WorkloadCluster)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Generate and write AWS IAM auth kubeconfig to disk
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

