### PR TITLE
Add tests to quick e2e suite from existing tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -8,7 +8,14 @@ env:
     EKSA_GIT_PRIVATE_KEY: "/tmp/private-key"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
     # vsphere variables
+    T_VSPHERE_TEMPLATE_UBUNTU_1_27: "/SDDC-Datacenter/vm/Templates/ubuntu-kube-v1-27"
+    T_VSPHERE_TEMPLATE_UBUNTU_1_28: "/SDDC-Datacenter/vm/Templates/ubuntu-kube-v1-28"
+    T_VSPHERE_TEMPLATE_UBUNTU_2204_1_27: "/SDDC-Datacenter/vm/Templates/ubuntu-2204-kube-v1-27"
     T_VSPHERE_TEMPLATE_UBUNTU_2204_1_28: "/SDDC-Datacenter/vm/Templates/ubuntu-2204-kube-v1-28"
+    T_VSPHERE_TEMPLATE_BR_1_27: "/SDDC-Datacenter/vm/Templates/bottlerocket-kube-v1-27"
+    T_VSPHERE_TEMPLATE_BR_1_28: "/SDDC-Datacenter/vm/Templates/bottlerocket-kube-v1-28"
+    T_VSPHERE_TEMPLATE_REDHAT_1_27: "/SDDC-Datacenter/vm/Templates/redhat-kube-v1-27"
+    T_VSPHERE_TEMPLATE_REDHAT_1_28: "/SDDC-Datacenter/vm/Templates/redhat-kube-v1-28"
     # cloudstack variables
     CLOUDSTACK_PROVIDER: true
     T_CLOUDSTACK_CIDR: "10.80.214.0/23"
@@ -106,14 +113,17 @@ env:
     T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_26: "nutanix_ci:nutanix_template_ubuntu_1_26"
     T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_27: "nutanix_ci:nutanix_template_ubuntu_1_27"
     T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_28: "nutanix_ci:nutanix_template_ubuntu_1_28"
+    T_NUTANIX_TEMPLATE_NAME_UBUNTU_1_29: "nutanix_ci:nutanix_template_ubuntu_1_29"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_1_25: "nutanix_ci:nutanix_template_rhel_8_1_25"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_1_26: "nutanix_ci:nutanix_template_rhel_8_1_26"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_1_27: "nutanix_ci:nutanix_template_rhel_8_1_27"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_1_28: "nutanix_ci:nutanix_template_rhel_8_1_28"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_1_29: "nutanix_ci:nutanix_template_rhel_8_1_29"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_25: "nutanix_ci:nutanix_template_rhel_9_1_25"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_26: "nutanix_ci:nutanix_template_rhel_9_1_26"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_27: "nutanix_ci:nutanix_template_rhel_9_1_27"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_28: "nutanix_ci:nutanix_template_rhel_9_1_28"
+    T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_29: "nutanix_ci:nutanix_template_rhel_9_1_29"
     # Snow secrets
     T_SNOW_DEVICES: "snow_ci:snow_devices"
     T_SNOW_CREDENTIALS_S3_PATH: "snow_ci:snow_credentials_s3_path"

--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -2,12 +2,21 @@ quick_tests:
 # Docker
 - TestDocker.*128
 # vSphere
-- TestVSphereKubernetes128Ubuntu2204SimpleFlow
+- ^TestVSphereKubernetes127UbuntuTo128Upgrade$
+- TestVSphereKubernetes127UbuntuTo128StackedEtcdUpgrade
+- TestVSphereKubernetes127To128Ubuntu2204Upgrade
+- TestVSphereKubernetes128Ubuntu2004To2204Upgrade
+- TestVSphereKubernetes127BottlerocketTo128Upgrade
+- TestVSphereKubernetes127BottlerocketTo128StackedEtcdUpgrade
 # CloudStack
 - TestCloudStackKubernetes127To128RedhatMultipleFieldsUpgrade
 # Nutanix
-- TestNutanixKubernetes127to128RedHat9Upgrade
+- TestNutanixKubernetes128to129RedHat9Upgrade
+- TestNutanixKubernetes128to129RedHat8Upgrade
+- TestNutanixKubernetes128To129UbuntuUpgrade
 # Snow
 - TestSnowKubernetes128SimpleFlow
 # Tinkerbell
 # - ^TestTinkerbellKubernetes127UbuntuTo128Upgrade$
+# - TestTinkerbellKubernetes128Ubuntu2004To2204Upgrade
+# - TestTinkerbellKubernetes127To128Ubuntu2204Upgrade


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add existing tests from the e2e test suite to quick tests suite.
- Add new vSphere test variables

*Testing (if applicable):*
Manually invoke CI to run tests

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

