### PR TITLE
Add validation for stacked etcd with in place on vsphere

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -848,11 +848,13 @@ func validateCPUpgradeRolloutStrategy(clusterConfig *Cluster) error {
 			return fmt.Errorf("ControlPlaneConfiguration: RollingUpdate field must be empty for 'InPlace' upgrade rollout strategy type")
 		}
 		if clusterConfig.Spec.DatacenterRef.Kind == VSphereDatacenterKind {
-			if features.IsActive(features.VSphereInPlaceUpgradeEnabled()) {
-				return nil
+			if !features.IsActive(features.VSphereInPlaceUpgradeEnabled()) {
+				return errors.New("in place upgrades are not supported on vSphere")
 			}
-			return errors.New("in place upgrades are not supported on vSphere")
-
+			if clusterConfig.Spec.ExternalEtcdConfiguration != nil {
+				return errors.New("stacked etcd must be configured when performing in place upgrades")
+			}
+			return nil
 		}
 		if clusterConfig.Spec.DatacenterRef.Kind != TinkerbellDatacenterKind {
 			return fmt.Errorf("ControlPlaneConfiguration: 'InPlace' upgrade rollout strategy type is only supported on Bare Metal")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We must use local etcd with in place upgrades. Bare metal currently only supports local etcd, but for dev testing with vsphere, I'm adding this validation. Without this, the error would happen later in the flow & it would be hidden in the controller logs. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

