### PR TITLE
Remove cluster config validation from common validations

### DIFF
--- a/cmd/eksctl-anywhere/cmd/validations.go
+++ b/cmd/eksctl-anywhere/cmd/validations.go
@@ -20,7 +20,8 @@ func commonValidation(ctx context.Context, clusterConfigFile string) (*v1alpha1.
 	if !clusterConfigFileExist {
 		return nil, fmt.Errorf("the cluster config file %s does not exist", clusterConfigFile)
 	}
-	clusterConfig, err := v1alpha1.GetAndValidateClusterConfig(clusterConfigFile)
+
+	clusterConfig, err := v1alpha1.GetClusterConfig(clusterConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("the cluster config file provided is invalid: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Common validations is run before a few of our operations:
- [upgrade cluster](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/upgradecluster.go#L107)
- [delete cluster](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/deletecluster.go#L84)
- [generating the support bundle](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/supportbundle.go#L60)
- [generating the upgrade plan for the cluster](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/upgradeplancluster.go#L56)`
- [generating the upgrade plan for management components](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go#L48)

The common validations call [GetAndValidateClusterConfig](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/pkg/api/v1alpha1/cluster.go#L211) to retrieve the cluster config which calls [ValidateClusterConfigContent](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/pkg/api/v1alpha1/cluster.go#L231) to runs the validations. However, the above operations all end up calling the same method to validate the config in some way before executing the rest of the workflows. For example, when generating the support bundles, it calls [readAndValidateClusterSpec](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/options.go#L117) which runs the validations on the cluster config content after reading it. This is called by [newClusterSpec](https://github.com/aws/eks-anywhere/blob/02225e79dddc967349d44b91c12b2b37b8ee25c1/cmd/eksctl-anywhere/cmd/options.go#L129) used in the upgrade flow etc. So, we end up running some duplicate validations and getting extra logs.

*Testing (if applicable):*
- `create cluster` with an invalid cluster name
```
./bin/eksctl-anywhere create cluster -f eksa-mgmt-cluster.yaml -v 6
Error: the cluster config file provided is invalid: failed to validate cluster config name: 3mgmt is not a valid cluster name, cluster names must start with lowercase/uppercase letters and can include numbers and dashes. For instance 'testCluster-123' is a valid name but '123testCluster' is not. 
```
- `upgrade management-components` with an invalid cluster name
```
./bin/eksctl-anywhere upgrade management-components -f mgmt/mgmt-eks-a-cluster.yaml
Error: unable to get cluster config from file: invalid cluster config: failed to validate cluster config name: 3mgmt is not a valid cluster name, cluster names must start with lowercase/uppercase letters and can include numbers and dashes. For instance 'testCluster-123' is a valid name but '123testCluster' is not. 
```
- `upgrade cluster` with an invalid cluster name 
```
./bin/eksctl-anywhere upgrade cluster -f mgmt/m
gmt-eks-a-cluster.yaml
Error: failed to upgrade cluster: the cluster config file provided is invalid: failed to validate cluster config name: 3mgmt is not a valid cluster name, cluster names must start with lowercase/uppercase letters and can include numbers and dashes. For instance 'testCluster-123' is a valid name but '123testCluster' is not
```
- `delete cluster` using config with empty control plane host endpoint
```
./bin/eksctl-anywhere delete cluster -f mgmt/mgmt-eks-a-cluster.yaml
Error: failed to delete cluster: unable to get cluster config from file: unable to get cluster config from file: invalid cluster config: cluster controlPlaneConfiguration.Endpoint.Host is not set or is empty
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

