### PR TITLE
Add success log to upgrade management components flow

### DIFF
--- a/pkg/workflows/management/upgrade_management_components.go
+++ b/pkg/workflows/management/upgrade_management_components.go
@@ -192,6 +192,11 @@ func (s *installNewComponentsMC) Run(ctx context.Context, commandContext *task.C
 	if err := runInstallNewComponents(ctx, commandContext); err != nil {
 		return &workflows.CollectMgmtClusterDiagnosticsTask{}
 	}
+
+	if commandContext.OriginalError == nil {
+		logger.MarkSuccess("Management components upgraded!")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a success log at the end of the `upgrade management-components` workflow.

*Testing (if applicable):*
- Ran `upgrade management-components`

Output
```
[ec2-user@ip-172-31-61-197 vsphere-cluster]$ eksctl-anywhere upgrade management-components -f mgmt/mgmt-eks-a-cluster.yaml
Warning: The recommended size of an external etcd cluster is 3 or 5
Performing setup and validations
✅ Connected to server
✅ Authenticated to vSphere
✅ Datacenter validated
✅ Network validated
✅ cxbrowne@amazon.com user vSphere privileges validated
✅ Vsphere provider validation
✅ Control plane ready
✅ Cluster CRDs ready
Upgrading core components
🎉 Management components upgraded!
```
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

