### PR TITLE
Fix validation to enforce same upgrade strategy for cp and workers for in place

### DIFF
--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -1053,6 +1053,9 @@ func TestAssertUpgradeRolloutStrategyValid_UpgradeStrategyNotEqual(t *testing.T)
 	}
 
 	g.Expect(tinkerbell.AssertUpgradeRolloutStrategyValid(clusterSpec)).ToNot(gomega.Succeed())
+
+	clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations[0].UpgradeRolloutStrategy = nil
+	g.Expect(tinkerbell.AssertUpgradeRolloutStrategyValid(clusterSpec)).ToNot(gomega.Succeed())
 }
 
 func TestAssertAutoScalerDisabledForInPlace_Success(t *testing.T) {

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -51,15 +51,17 @@ func validateUpgradeRolloutStrategy(spec *ClusterSpec) error {
 	}
 
 	for _, group := range spec.Cluster.Spec.WorkerNodeGroupConfigurations {
+		wnUpgradeRolloutStrategyType := v1alpha1.RollingUpdateStrategyType
 		groupRef := group.MachineGroupRef
 
 		if group.UpgradeRolloutStrategy != nil {
-			if spec.MachineConfigs[groupRef.Name].OSFamily() != v1alpha1.Ubuntu && group.UpgradeRolloutStrategy.Type == v1alpha1.InPlaceStrategyType {
+			wnUpgradeRolloutStrategyType = group.UpgradeRolloutStrategy.Type
+			if spec.MachineConfigs[groupRef.Name].OSFamily() != v1alpha1.Ubuntu && wnUpgradeRolloutStrategyType == v1alpha1.InPlaceStrategyType {
 				return errors.New("InPlace upgrades are only supported on the Ubuntu OS family")
 			}
-			if group.UpgradeRolloutStrategy.Type != cpUpgradeRolloutStrategyType {
-				return errors.New("cannot specify different upgrade rollout strategy types for control plane and worker node group configurations")
-			}
+		}
+		if wnUpgradeRolloutStrategyType != cpUpgradeRolloutStrategyType {
+			return errors.New("cannot specify different upgrade rollout strategy types for control plane and worker node group configurations")
 		}
 	}
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Validation wasn't catching the case where there is none specified for worker node groups, so fixed it to follow the similar pattern used for cp.

*Testing (if applicable):*
unit testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

