### PR TITLE
Bump up Nutanix CAPX to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v35 v35.3.0
 	github.com/google/uuid v1.4.0
-	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.0
+	github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.1
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.29.0
 	github.com/opencontainers/image-spec v1.1.0-rc5

--- a/go.sum
+++ b/go.sum
@@ -1442,8 +1442,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.0 h1:EZqexf4PyZzfUw+skmpYzP7pdjcxfNIhzbiTOP3TAbo=
-github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.0/go.mod h1:wphe4ijJBkkMdg2ZScO/l7K/5RBAjhBGm3RsMbVjkow=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.1 h1:ugJfylfF06dnL/yi7GF1tC3S2CJrkQFDPjv5qYrrQGM=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.3.1/go.mod h1:wphe4ijJBkkMdg2ZScO/l7K/5RBAjhBGm3RsMbVjkow=
 github.com/nutanix-cloud-native/prism-go-client v0.3.4 h1:bHY3VPrHHYnbRtkpGaKK+2ZmvUjNVRC55CYZbXIfnOk=
 github.com/nutanix-cloud-native/prism-go-client v0.3.4/go.mod h1:tTIH02E6o6AWSShr98QChoxuZl+jBhkXFixom9+fd1Y=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
*Description of changes:*
Bump up Nutanix CAPX to v1.3.1.
Changes in CAPX are trivial (get rid of CAPX manager pod limits), but fix customer issue.

Related PR: https://github.com/aws/eks-anywhere-build-tooling/pull/2920

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

