### PR TITLE
Allow to set tests to run in quick e2e buildspec

### DIFF
--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -130,7 +130,10 @@ phases:
           BUNDLES_OVERRIDE=true
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
-      - QUICK_TESTS="($(yq e '.quick_tests | join("|")' ./test/e2e/QUICK_TESTS.yaml))"
+      - |
+        if [ -z "$TESTS" ] || [ "$TESTS" == "QUICK" ]; then
+          TESTS=$(yq e '.quick_tests | join("|")' ./test/e2e/QUICK_TESTS.yaml)
+        fi
       - >
         ./bin/test e2e run
         -c ${INTEGRATION_TEST_INFRA_CONFIG}
@@ -139,7 +142,7 @@ phases:
         -i ${INTEGRATION_TEST_INSTANCE_PROFILE}
         -m ${INTEGRATION_TEST_MAX_EC2_COUNT}
         -p ${INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT}
-        -r ${QUICK_TESTS}
+        -r ${TESTS}
         -v 4
         --skip ${SKIPPED_TESTS}
         --bundles-override=${BUNDLES_OVERRIDE}


### PR DESCRIPTION
*Description of changes:*
This allows to manually run a pipeline with this buildspec and running only one or a particular subset of tests.

It introduces the value "QUICK" that allows to run all configured tests for the quick pipeline without knowing the tests. This allows a manual pipeline to run all quick tests without passing an empty variable, which is not allowed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

