### PR TITLE
Revert "Remove feature flag for controller via CLI (#7546)"

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
 	newManagement "github.com/aws/eks-anywhere/pkg/workflow/management"
+	"github.com/aws/eks-anywhere/pkg/workflows"
 	"github.com/aws/eks-anywhere/pkg/workflows/management"
 	"github.com/aws/eks-anywhere/pkg/workflows/workload"
 )
@@ -207,6 +208,17 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		return err
 	}
 
+	createCluster := workflows.NewCreate(
+		deps.UnAuthKubeClient,
+		deps.Bootstrapper,
+		deps.Provider,
+		deps.ClusterManager,
+		deps.GitOpsFlux,
+		deps.Writer,
+		deps.EksdInstaller,
+		deps.PackageInstaller,
+	)
+
 	mgmt := getManagementCluster(clusterSpec)
 
 	validationOpts := &validations.Opts{
@@ -261,8 +273,9 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		)
 		err = createWorkloadCluster.Run(ctx, clusterSpec, createValidations)
 
-	} else if clusterSpec.Cluster.IsSelfManaged() {
+	} else if clusterSpec.Cluster.IsSelfManaged() && features.UseControllerViaCLIWorkflow().IsActive() {
 		logger.Info("Using the new workflow using the controller for management cluster create")
+
 		createMgmtCluster := management.NewCreate(
 			deps.Bootstrapper,
 			deps.Provider,
@@ -276,6 +289,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		)
 
 		err = createMgmtCluster.Run(ctx, clusterSpec, createValidations)
+	} else {
+		err = createCluster.Run(ctx, clusterSpec, createValidations, cc.forceClean)
 	}
 
 	cleanup(deps, &err)

--- a/cmd/eksctl-anywhere/cmd/deletecluster.go
+++ b/cmd/eksctl-anywhere/cmd/deletecluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aws/eks-anywhere/pkg/dependencies"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers/tinkerbell/hardware"
@@ -155,7 +156,7 @@ func (dc *deleteClusterOptions) deleteCluster(ctx context.Context) error {
 		}
 	}
 
-	if clusterSpec.Cluster.IsManaged() {
+	if features.UseControllerViaCLIWorkflow().IsActive() && clusterSpec.Cluster.IsManaged() {
 		deleteWorkload := workload.NewDelete(deps.Provider, deps.Writer, deps.ClusterManager, deps.ClusterDeleter, deps.GitOpsFlux)
 		err = deleteWorkload.Run(ctx, cluster, clusterSpec)
 	} else {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -5,6 +5,7 @@ const (
 	CloudStackKubeVipDisabledEnvVar = "CLOUDSTACK_KUBE_VIP_DISABLED"
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
+	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
 	K8s129SupportEnvVar             = "K8S_1_29_SUPPORT"
 	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 )
@@ -45,6 +46,14 @@ func UseNewWorkflows() Feature {
 	return Feature{
 		Name:     "Use new workflow logic for cluster management operations",
 		IsActive: globalFeatures.isActiveForEnvVar(UseNewWorkflowsEnvVar),
+	}
+}
+
+// UseControllerViaCLIWorkflow is used for the controller behind the CLI workflow.
+func UseControllerViaCLIWorkflow() Feature {
+	return Feature{
+		Name:     "Use new workflow logic for cluster operations leveraging controller via CLI",
+		IsActive: globalFeatures.isActiveForEnvVar(UseControllerForCli),
 	}
 }
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -70,6 +70,22 @@ func TestIsActiveWithFeatureGatesTrue(t *testing.T) {
 	g.Expect(IsActive(fakeFeatureWithGate())).To(BeTrue())
 }
 
+func TestUseControllerForCliFalse(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	t.Setenv(UseControllerForCli, "false")
+	g.Expect(UseControllerViaCLIWorkflow().IsActive()).To(BeFalse())
+}
+
+func TestUseControllerForCliTrue(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	t.Setenv(UseControllerForCli, "true")
+	g.Expect(UseControllerViaCLIWorkflow().IsActive()).To(BeTrue())
+}
+
 func TestWithK8s129FeatureFlag(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)

--- a/pkg/workflows/management/create_test.go
+++ b/pkg/workflows/management/create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/bootstrapper"
 	clientmocks "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
 	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -46,6 +47,8 @@ type createTestSetup struct {
 }
 
 func newCreateTest(t *testing.T) *createTestSetup {
+	featureEnvVars := []string{}
+	featureEnvVars = append(featureEnvVars, features.UseControllerForCli)
 	mockCtrl := gomock.NewController(t)
 	bootstrapper := mocks.NewMockBootstrapper(mockCtrl)
 	clusterManager := mocks.NewMockClusterManager(mockCtrl)
@@ -74,6 +77,10 @@ func newCreateTest(t *testing.T) *createTestSetup {
 		clusterCreator,
 		eksaInstaller,
 	)
+
+	for _, e := range featureEnvVars {
+		t.Setenv(e, "true")
+	}
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) { s.Cluster.Name = "test-cluster" })
 	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpec.Bundles)

--- a/pkg/workflows/workload/create_test.go
+++ b/pkg/workflows/workload/create_test.go
@@ -3,6 +3,7 @@ package workload_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
 	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
@@ -147,6 +149,8 @@ func (c *createTestSetup) expectWrite() {
 }
 
 func TestCreateRunSuccess(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newCreateTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -163,6 +167,8 @@ func TestCreateRunSuccess(t *testing.T) {
 }
 
 func TestCreateRunFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newCreateTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -178,6 +184,8 @@ func TestCreateRunFail(t *testing.T) {
 }
 
 func TestCreateRunValidateFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newCreateTest(t)
 	test.provider.EXPECT().Name()
 	test.gitOpsManager.EXPECT().Validations(test.ctx, test.clusterSpec)
@@ -192,6 +200,8 @@ func TestCreateRunValidateFail(t *testing.T) {
 }
 
 func TestCreateRunGitOpsConfigFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newCreateTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -208,6 +218,8 @@ func TestCreateRunGitOpsConfigFail(t *testing.T) {
 }
 
 func TestCreateRunWriteClusterConfigFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newCreateTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()

--- a/pkg/workflows/workload/delete_test.go
+++ b/pkg/workflows/workload/delete_test.go
@@ -3,6 +3,7 @@ package workload_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
 	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
@@ -106,6 +108,8 @@ func (c *deleteTestSetup) expectCleanup(err error) {
 }
 
 func TestDeleteRunSuccess(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newDeleteTest(t)
 	test.expectSetup(nil)
 	test.expectDeleteWorkloadCluster(nil)
@@ -118,6 +122,8 @@ func TestDeleteRunSuccess(t *testing.T) {
 }
 
 func TestDeleteRunFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newDeleteTest(t)
 	test.expectSetup(nil)
 	test.expectDeleteWorkloadCluster(fmt.Errorf("Failure"))
@@ -130,6 +136,8 @@ func TestDeleteRunFail(t *testing.T) {
 }
 
 func TestDeleteRunFailSetup(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newDeleteTest(t)
 	test.expectSetup(fmt.Errorf("Failure"))
 	test.expectWrite()
@@ -141,6 +149,8 @@ func TestDeleteRunFailSetup(t *testing.T) {
 }
 
 func TestDeleteRunFailCleanup(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newDeleteTest(t)
 	test.expectSetup(nil)
 	test.expectDeleteWorkloadCluster(nil)

--- a/pkg/workflows/workload/upgrade_test.go
+++ b/pkg/workflows/workload/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
 	writermocks "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
@@ -155,6 +157,8 @@ func (c *upgradeTestSetup) expectWrite() {
 }
 
 func TestUpgradeRunSuccess(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newUpgradeTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -171,6 +175,8 @@ func TestUpgradeRunSuccess(t *testing.T) {
 }
 
 func TestUpgradeRunUpgradeFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newUpgradeTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -187,6 +193,8 @@ func TestUpgradeRunUpgradeFail(t *testing.T) {
 }
 
 func TestUpgradeRunGetCurrentClusterSpecFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newUpgradeTest(t)
 	test.clusterManager.EXPECT().GetCurrentClusterSpec(test.ctx, test.clusterSpec.ManagementCluster, test.clusterSpec.Cluster.Name).Return(nil, fmt.Errorf("boom"))
 	test.expectWrite()
@@ -198,6 +206,8 @@ func TestUpgradeRunGetCurrentClusterSpecFail(t *testing.T) {
 }
 
 func TestUpgradeRunValidateFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newUpgradeTest(t)
 	test.clusterManager.EXPECT().GetCurrentClusterSpec(test.ctx, test.clusterSpec.ManagementCluster, test.clusterSpec.Cluster.Name).AnyTimes().Return(test.currentClusterSpec, nil)
 	test.provider.EXPECT().Name().AnyTimes()
@@ -213,6 +223,8 @@ func TestUpgradeRunValidateFail(t *testing.T) {
 }
 
 func TestUpgradeWorkloadRunBackupFailed(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newUpgradeTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()
@@ -228,6 +240,8 @@ func TestUpgradeWorkloadRunBackupFailed(t *testing.T) {
 }
 
 func TestUpgradeRunWriteClusterConfigFail(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
 	test := newUpgradeTest(t)
 	test.expectSetup()
 	test.expectPreflightValidationsToPass()


### PR DESCRIPTION
This reverts commit 1034e5170ce84132d53da3d45657e18250cf648a.

*Issue #, if available:*

*Description of changes:*
Revert "Remove feature flag for controller via CLI (#7546)"
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

