### PR TITLE
Fix docker nil pointer for endpoint host aws iam auth reconciler

### DIFF
--- a/pkg/awsiamauth/reconciler/reconciler.go
+++ b/pkg/awsiamauth/reconciler/reconciler.go
@@ -155,7 +155,7 @@ func (r *Reconciler) applyIAMAuthManifest(ctx context.Context, client client.Cli
 }
 
 func (r *Reconciler) createKubeconfigSecret(ctx context.Context, clusterSpec *anywhereCluster.Spec, cluster *anywherev1.Cluster, clusterID uuid.UUID) error {
-	endpoint := "127.0.0.1"
+	endpoint := "localhost"
 	if cluster.Spec.DatacenterRef.Kind != v1alpha1.DockerDatacenterKind {
 		endpoint = cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
 	}

--- a/pkg/awsiamauth/reconciler/reconciler.go
+++ b/pkg/awsiamauth/reconciler/reconciler.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/awsiamauth"
 	anywhereCluster "github.com/aws/eks-anywhere/pkg/cluster"
@@ -154,7 +155,11 @@ func (r *Reconciler) applyIAMAuthManifest(ctx context.Context, client client.Cli
 }
 
 func (r *Reconciler) createKubeconfigSecret(ctx context.Context, clusterSpec *anywhereCluster.Spec, cluster *anywherev1.Cluster, clusterID uuid.UUID) error {
-	apiServerEndpoint := fmt.Sprintf("https://%s:6443", cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)
+	endpoint := "127.0.0.1"
+	if cluster.Spec.DatacenterRef.Kind != v1alpha1.DockerDatacenterKind {
+		endpoint = cluster.Spec.ControlPlaneConfiguration.Endpoint.Host
+	}
+	apiServerEndpoint := fmt.Sprintf("https://%s:6443", endpoint)
 
 	clusterCaSecretName := clusterapi.ClusterCASecretName(cluster.Name)
 	clusterCaSecret := &corev1.Secret{}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix docker nil pointer for endpoint host aws iam auth reconciler
*Testing (if applicable):*
- manual e2e

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

