### PR TITLE
Add quick e2e tests for vSphere

### DIFF
--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -2,9 +2,12 @@ quick_tests:
 # Docker
 - TestDocker.*128
 # vSphere
+- ^TestVSphereKubernetes127To128RedHatUpgrade$
+- TestVSphereKubernetes127To128StackedEtcdRedHatUpgrade
 - ^TestVSphereKubernetes127UbuntuTo128Upgrade$
 - TestVSphereKubernetes127UbuntuTo128StackedEtcdUpgrade
 - TestVSphereKubernetes127To128Ubuntu2204Upgrade
+- TestVSphereKubernetes127To128Ubuntu2204StackedEtcdUpgrade
 - TestVSphereKubernetes128Ubuntu2004To2204Upgrade
 - TestVSphereKubernetes127BottlerocketTo128Upgrade
 - TestVSphereKubernetes127BottlerocketTo128StackedEtcdUpgrade

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -1549,6 +1549,37 @@ func TestVSphereKubernetes128RedHatSimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
+func TestVSphereKubernetes127To128RedHatUpgrade(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithRedHat127VSphere())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube128,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		provider.WithProviderUpgrade(provider.Redhat128Template()),
+	)
+}
+
+func TestVSphereKubernetes127To128StackedEtcdRedHatUpgrade(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithRedHat127VSphere())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube127)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube128,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		provider.WithProviderUpgrade(provider.Redhat128Template()),
+	)
+}
+
 func TestVSphereKubernetes128ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -1871,6 +1902,25 @@ func TestVSphereKubernetes127To128Ubuntu2204Upgrade(t *testing.T) {
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube127, framework.Ubuntu2204, nil),
+	)
+	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+		test,
+		v1alpha1.Kube128,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes128Template()),
+	)
+}
+
+func TestVSphereKubernetes127To128Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+	provider := framework.NewVSphere(t)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+	).WithClusterConfig(
+		provider.WithKubeVersionAndOS(v1alpha1.Kube127, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithStackedEtcdTopology(),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the remaining new vSphere e2e tests to the quick test suite.

*Testing (if applicable):*
Manually invoked tests runs

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

