### PR TITLE
Generate snow provider environment variable map using management components

### DIFF
--- a/pkg/executables/clusterctl.go
+++ b/pkg/executables/clusterctl.go
@@ -234,7 +234,7 @@ func (c *Clusterctl) InitInfrastructure(ctx context.Context, managementComponent
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	envMap, err := provider.EnvMap(clusterSpec)
+	envMap, err := provider.EnvMap(managementComponents, clusterSpec)
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (c *Clusterctl) Upgrade(ctx context.Context, managementCluster *types.Clust
 		upgradeCommand = append(upgradeCommand, "--bootstrap", newBootstrapProvider)
 	}
 
-	providerEnvMap, err := provider.EnvMap(newSpec)
+	providerEnvMap, err := provider.EnvMap(managementComponents, newSpec)
 	if err != nil {
 		return fmt.Errorf("failed generating provider env map for clusterctl upgrade: %v", err)
 	}
@@ -419,7 +419,7 @@ func (c *Clusterctl) InstallEtcdadmProviders(ctx context.Context, managementComp
 		params = append(params, "--kubeconfig", cluster.KubeconfigFile)
 	}
 
-	envMap, err := infraProvider.EnvMap(clusterSpec)
+	envMap, err := infraProvider.EnvMap(managementComponents, clusterSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/executables/clusterctl_test.go
+++ b/pkg/executables/clusterctl_test.go
@@ -66,7 +66,7 @@ func (ct *clusterctlTest) expectBuildOverrideLayer() {
 }
 
 func (ct *clusterctlTest) expectGetProviderEnvMap() {
-	ct.provider.EXPECT().EnvMap(clusterSpec).Return(ct.providerEnvMap, nil)
+	ct.provider.EXPECT().EnvMap(ct.managementComponents, clusterSpec).Return(ct.providerEnvMap, nil)
 }
 
 func TestClusterctlInitInfrastructure(t *testing.T) {
@@ -134,7 +134,7 @@ func TestClusterctlInitInfrastructure(t *testing.T) {
 
 			tc.provider.EXPECT().Name().Return(tt.providerName)
 			tc.provider.EXPECT().Version(tc.managementComponents).Return(tt.providerVersion)
-			tc.provider.EXPECT().EnvMap(clusterSpec).Return(tt.env, nil)
+			tc.provider.EXPECT().EnvMap(tc.managementComponents, clusterSpec).Return(tt.env, nil)
 			tc.provider.EXPECT().GetInfrastructureBundle(tc.managementComponents).Return(&types.InfrastructureBundle{})
 
 			tc.e.EXPECT().ExecuteWithEnv(tc.ctx, tt.env, tt.wantExecArgs...).Return(bytes.Buffer{}, nil).Times(1).Do(
@@ -182,7 +182,7 @@ func TestClusterctlInitInfrastructureEnvMapError(t *testing.T) {
 
 	tt.provider.EXPECT().Name()
 	tt.provider.EXPECT().Version(tt.managementComponents)
-	tt.provider.EXPECT().EnvMap(clusterSpec).Return(nil, errors.New("error with env map"))
+	tt.provider.EXPECT().EnvMap(tt.managementComponents, clusterSpec).Return(nil, errors.New("error with env map"))
 	tt.provider.EXPECT().GetInfrastructureBundle(tt.managementComponents).Return(&types.InfrastructureBundle{})
 
 	if err := tt.clusterctl.InitInfrastructure(tt.ctx, tt.managementComponents, clusterSpec, cluster, tt.provider); err == nil {
@@ -201,7 +201,7 @@ func TestClusterctlInitInfrastructureExecutableError(t *testing.T) {
 
 	tt.provider.EXPECT().Name()
 	tt.provider.EXPECT().Version(tt.managementComponents)
-	tt.provider.EXPECT().EnvMap(clusterSpec)
+	tt.provider.EXPECT().EnvMap(tt.managementComponents, clusterSpec)
 	tt.provider.EXPECT().GetInfrastructureBundle(tt.managementComponents).Return(&types.InfrastructureBundle{})
 
 	tt.e.EXPECT().ExecuteWithEnv(tt.ctx, nil, gomock.Any()).Return(bytes.Buffer{}, errors.New("error from execute with env"))

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -815,7 +815,8 @@ func (p *cloudstackProvider) Version(componnets *cluster.ManagementComponents) s
 	return componnets.CloudStack.Version
 }
 
-func (p *cloudstackProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
+// EnvMap returns a map of environment variables required for the cloudstack provider.
+func (p *cloudstackProvider) EnvMap(_ *cluster.ManagementComponents, _ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {
 		if env, ok := os.LookupEnv(key); ok && len(env) > 0 {

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -632,7 +632,7 @@ func (p *Provider) Version(components *cluster.ManagementComponents) string {
 }
 
 // EnvMap returns a map of environment variables to be set when running the docker clusterctl command.
-func (p *Provider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
+func (p *Provider) EnvMap(_ *cluster.ManagementComponents, _ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	if env, ok := os.LookupEnv(githubTokenEnvVar); ok && len(env) > 0 {
 		envMap[githubTokenEnvVar] = env

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -111,18 +111,18 @@ func (mr *MockProviderMockRecorder) DeleteResources(arg0, arg1 interface{}) *gom
 }
 
 // EnvMap mocks base method.
-func (m *MockProvider) EnvMap(arg0 *cluster.Spec) (map[string]string, error) {
+func (m *MockProvider) EnvMap(arg0 *cluster.ManagementComponents, arg1 *cluster.Spec) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnvMap", arg0)
+	ret := m.ctrl.Call(m, "EnvMap", arg0, arg1)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnvMap indicates an expected call of EnvMap.
-func (mr *MockProviderMockRecorder) EnvMap(arg0 interface{}) *gomock.Call {
+func (mr *MockProviderMockRecorder) EnvMap(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvMap", reflect.TypeOf((*MockProvider)(nil).EnvMap), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvMap", reflect.TypeOf((*MockProvider)(nil).EnvMap), arg0, arg1)
 }
 
 // GenerateCAPISpecForCreate mocks base method.

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -530,7 +530,8 @@ func (p *Provider) Version(components *cluster.ManagementComponents) string {
 	return components.Nutanix.Version
 }
 
-func (p *Provider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
+// EnvMap returns the environment variables for the provider.
+func (p *Provider) EnvMap(_ *cluster.ManagementComponents, _ *cluster.Spec) (map[string]string, error) {
 	// TODO(nutanix): determine if any env vars are needed and add them to requiredEnvs
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -902,10 +902,11 @@ func TestNutanixProviderVersion(t *testing.T) {
 func TestNutanixProviderEnvMap(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")
+	managementComponents := givenManagementComponents()
 
 	t.Run("required envs not set", func(t *testing.T) {
 		os.Clearenv()
-		envMap, err := provider.EnvMap(clusterSpec)
+		envMap, err := provider.EnvMap(managementComponents, clusterSpec)
 		assert.Error(t, err)
 		assert.Nil(t, envMap)
 	})
@@ -916,7 +917,7 @@ func TestNutanixProviderEnvMap(t *testing.T) {
 		t.Setenv(nutanixEndpointKey, "prism.nutanix.com")
 		t.Setenv(expClusterResourceSetKey, "true")
 
-		envMap, err := provider.EnvMap(clusterSpec)
+		envMap, err := provider.EnvMap(managementComponents, clusterSpec)
 		assert.NoError(t, err)
 		assert.NotNil(t, envMap)
 	})

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -27,7 +27,7 @@ type Provider interface {
 	BootstrapClusterOpts(clusterSpec *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error)
 	UpdateKubeConfig(content *[]byte, clusterName string) error
 	Version(components *cluster.ManagementComponents) string
-	EnvMap(clusterSpec *cluster.Spec) (map[string]string, error)
+	EnvMap(managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec) (map[string]string, error)
 	GetDeployments() map[string][]string
 	GetInfrastructureBundle(components *cluster.ManagementComponents) *types.InfrastructureBundle
 	DatacenterConfig(clusterSpec *cluster.Spec) DatacenterConfig

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -185,14 +185,13 @@ func (p *SnowProvider) Version(components *cluster.ManagementComponents) string 
 	return components.Snow.Version
 }
 
-func (p *SnowProvider) EnvMap(clusterSpec *cluster.Spec) (map[string]string, error) {
+// EnvMap returns the environment variables for the snow provider.
+func (p *SnowProvider) EnvMap(managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	envMap[snowCredentialsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCredentialsKey])
 	envMap[snowCertsKey] = string(clusterSpec.SnowCredentialsSecret.Data[v1alpha1.SnowCertificatesKey])
 
-	versionsBundle := clusterSpec.RootVersionsBundle()
-
-	envMap["SNOW_CONTROLLER_IMAGE"] = versionsBundle.Snow.Manager.VersionedImage()
+	envMap["SNOW_CONTROLLER_IMAGE"] = managementComponents.Snow.Manager.VersionedImage()
 
 	return envMap, nil
 }

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -221,7 +221,8 @@ func (p *Provider) Version(components *cluster.ManagementComponents) string {
 	return components.Tinkerbell.Version
 }
 
-func (p *Provider) EnvMap(spec *cluster.Spec) (map[string]string, error) {
+// EnvMap returns a map of environment variables for the tinkerbell provider.
+func (p *Provider) EnvMap(_ *cluster.ManagementComponents, _ *cluster.Spec) (map[string]string, error) {
 	return map[string]string{
 		// The TINKERBELL_IP is input for the CAPT deployment and used as part of default template
 		// generation. However, we use custom templates and leverage the template override

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -977,7 +977,8 @@ func (p *vsphereProvider) PostWorkloadInit(ctx context.Context, cluster *types.C
 	return nil
 }
 
-func (p *vsphereProvider) EnvMap(_ *cluster.Spec) (map[string]string, error) {
+// EnvMap returns a map of environment variables required for the vsphere provider.
+func (p *vsphereProvider) EnvMap(_ *cluster.ManagementComponents, _ *cluster.Spec) (map[string]string, error) {
 	envMap := make(map[string]string)
 	for _, key := range requiredEnvs {
 		if env, ok := os.LookupEnv(key); ok && len(env) > 0 {


### PR DESCRIPTION
*Issue #, if available:*

*Context:*

The newly introduced upgrade `management-components` commands is currently building a new cluster spec and running validations against it. We do not want to do this because the users cluster spec updates are not applied while upgrading management components. Specifically, one problem  that arises is that  if your cluster is currently running a deprecated version of Kubernetes in EKS Anywhere (right now Kubernetes 1.24), the CLI will fail upgrading the management components  when [building the new cluster spec](https://github.com/aws/eks-anywhere/blob/4de7cda5ac1e6b571d769df82de2391634b750b8/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go#L37). 

```
Error: failed to upgrade cluster: unable to get cluster config from file: kubernetes version 1.24 is not supported by bundles 
```

This is because Kubernetes 1.24 is not supported now and does not exist in the new bundles .

 As a solution to this, we want to remove the need to build the new full `cluster.Spec` in the upgrade management-components workflow. For this to be possible, we need to remove the need for the `cluster.Spec` when accessing  management component information during the upgrade.

*Description of changes:*
This PR changes the snow provider to generate the environment variable map information using management components. It still uses the *cluster.Spec (presumably the current cluster spec) for any addition information, for snow the  credentials secret

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

