### PR TITLE
Update PreCoreComponentsUpgrade to use management components

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -980,6 +980,7 @@ func machineDeploymentName(clusterName, nodeGroupName string) string {
 func (p *cloudstackProvider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
+	managementComponents *cluster.ManagementComponents,
 	clusterSpec *cluster.Spec,
 ) error {
 	return nil

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -727,6 +727,7 @@ func getHAProxyImageRepo(haProxyImage releasev1alpha1.Image) string {
 func (p *Provider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
+	managementComponents *cluster.ManagementComponents,
 	clusterSpec *cluster.Spec,
 ) error {
 	return nil

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -340,17 +340,17 @@ func (mr *MockProviderMockRecorder) PreCAPIInstallOnBootstrap(arg0, arg1, arg2 i
 }
 
 // PreCoreComponentsUpgrade mocks base method.
-func (m *MockProvider) PreCoreComponentsUpgrade(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.Spec) error {
+func (m *MockProvider) PreCoreComponentsUpgrade(arg0 context.Context, arg1 *types.Cluster, arg2 *cluster.ManagementComponents, arg3 *cluster.Spec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreCoreComponentsUpgrade", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PreCoreComponentsUpgrade", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PreCoreComponentsUpgrade indicates an expected call of PreCoreComponentsUpgrade.
-func (mr *MockProviderMockRecorder) PreCoreComponentsUpgrade(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockProviderMockRecorder) PreCoreComponentsUpgrade(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreCoreComponentsUpgrade", reflect.TypeOf((*MockProvider)(nil).PreCoreComponentsUpgrade), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreCoreComponentsUpgrade", reflect.TypeOf((*MockProvider)(nil).PreCoreComponentsUpgrade), arg0, arg1, arg2, arg3)
 }
 
 // RunPostControlPlaneUpgrade mocks base method.

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -709,6 +709,7 @@ func (p *Provider) PostMoveManagementToBootstrap(ctx context.Context, bootstrapC
 func (p *Provider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
+	managementComponents *cluster.ManagementComponents,
 	clusterSpec *cluster.Spec,
 ) error {
 	return nil

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -43,7 +43,7 @@ type Provider interface {
 	PostClusterDeleteValidate(ctx context.Context, managementCluster *types.Cluster) error
 	// PostMoveManagementToBootstrap is called after the CAPI management is moved back to the bootstrap cluster.
 	PostMoveManagementToBootstrap(ctx context.Context, bootstrapCluster *types.Cluster) error
-	PreCoreComponentsUpgrade(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
+	PreCoreComponentsUpgrade(ctx context.Context, cluster *types.Cluster, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec) error
 }
 
 type DatacenterConfig interface {

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -365,6 +365,7 @@ func (p *SnowProvider) InstallCustomProviderComponents(ctx context.Context, kube
 func (p *SnowProvider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
+	managementComponents *cluster.ManagementComponents,
 	clusterSpec *cluster.Spec,
 ) error {
 	return nil

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -434,6 +434,7 @@ func (p *Provider) validateMachineCfg(ctx context.Context, cluster *types.Cluste
 func (p *Provider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
+	managementComponents *cluster.ManagementComponents,
 	clusterSpec *cluster.Spec,
 ) error {
 	// When a workload cluster the cluster object could be nil. Noop if it is.
@@ -451,13 +452,11 @@ func (p *Provider) PreCoreComponentsUpgrade(
 		return nil
 	}
 
-	versionsBundle := clusterSpec.RootVersionsBundle()
-
 	// Attempt the upgrade. This should upgrade the stack in the mangement cluster by updating
 	// images, installing new CRDs and possibly removing old ones.
 	err := p.stackInstaller.Upgrade(
 		ctx,
-		versionsBundle.Tinkerbell,
+		managementComponents.Tinkerbell,
 		p.datacenterConfig.Spec.TinkerbellIP,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1259,6 +1259,7 @@ func (p *vsphereProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, clu
 func (p *vsphereProvider) PreCoreComponentsUpgrade(
 	ctx context.Context,
 	cluster *types.Cluster,
+	managementComponents *cluster.ManagementComponents,
 	clusterSpec *cluster.Spec,
 ) error {
 	return nil

--- a/pkg/workflows/management/core_components.go
+++ b/pkg/workflows/management/core_components.go
@@ -47,9 +47,12 @@ type upgradeCoreComponents struct {
 func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandContext) error {
 	logger.Info("Upgrading core components")
 
+	newManagementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
+
 	err := commandContext.Provider.PreCoreComponentsUpgrade(
 		ctx,
 		commandContext.ManagementCluster,
+		newManagementComponents,
 		commandContext.ClusterSpec,
 	)
 	if err != nil {
@@ -68,8 +71,6 @@ func runUpgradeCoreComponents(ctx context.Context, commandContext *task.CommandC
 		commandContext.SetError(err)
 		return err
 	}
-
-	newManagementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
 
 	changeDiff, err := commandContext.CAPIManager.Upgrade(ctx, commandContext.ManagementCluster, commandContext.Provider, currentManagementComponents, newManagementComponents, commandContext.ClusterSpec)
 	if err != nil {

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -109,7 +109,7 @@ func TestRunnerHappyPath(t *testing.T) {
 		mocks.validator.EXPECT().PreflightValidations(ctx).Return(nil),
 		mocks.provider.EXPECT().Name(),
 		mocks.provider.EXPECT().SetupAndValidateUpgradeCluster(ctx, gomock.Any(), newSpec, curSpec),
-		mocks.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any()),
+		mocks.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), newManagementComponents, gomock.Any()),
 		mocks.clientFactory.EXPECT().BuildClientFromKubeconfig(managementCluster.KubeconfigFile).Return(client, nil),
 		mocks.capiManager.EXPECT().Upgrade(ctx, managementCluster, mocks.provider, currentManagementComponents, newManagementComponents, newSpec).Return(capiChangeDiff, nil),
 		mocks.gitOpsManager.EXPECT().Install(ctx, managementCluster, newManagementComponents, curSpec, newSpec).Return(nil),

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -156,7 +156,7 @@ func (c *upgradeManagementTestSetup) expectPauseGitOpsReconcile(err error) {
 }
 
 func (c *upgradeManagementTestSetup) expectPreCoreComponentsUpgrade() {
-	c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any())
+	c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), c.newManagementComponents, gomock.Any())
 }
 
 func (c *upgradeManagementTestSetup) expectUpgradeCoreComponents() {
@@ -178,7 +178,7 @@ func (c *upgradeManagementTestSetup) expectUpgradeCoreComponents() {
 	})
 
 	gomock.InOrder(
-		c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any()),
+		c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), c.newManagementComponents, gomock.Any()),
 		c.clientFactory.EXPECT().BuildClientFromKubeconfig(c.managementCluster.KubeconfigFile).Return(c.client, nil),
 		c.capiManager.EXPECT().Upgrade(c.ctx, c.managementCluster, c.provider, c.currentManagementComponents, c.newManagementComponents, c.newClusterSpec).Return(capiChangeDiff, nil),
 		c.gitOpsManager.EXPECT().Install(c.ctx, c.managementCluster, c.newManagementComponents, currentSpec, c.newClusterSpec).Return(nil),

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -228,6 +228,7 @@ func (s *upgradeCoreComponents) Run(ctx context.Context, commandContext *task.Co
 	err := commandContext.Provider.PreCoreComponentsUpgrade(
 		ctx,
 		commandContext.ManagementCluster,
+		cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles),
 		commandContext.ClusterSpec,
 	)
 	if err != nil {

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -401,7 +401,7 @@ func (c *upgradeTestSetup) expectWriteCheckpointFile() {
 }
 
 func (c *upgradeTestSetup) expectPreCoreComponentsUpgrade() {
-	c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any())
+	c.provider.EXPECT().PreCoreComponentsUpgrade(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 }
 
 func (c *upgradeTestSetup) run() error {


### PR DESCRIPTION
*Issue #, if available:*
*Context:*

The newly introduced upgrade `management-components` commands is currently building a new cluster spec and running validations against it. We do not want to do this because the users cluster spec updates are not applied while upgrading management components. Specifically, one problem  that arises is that  if your cluster is currently running a deprecated version of Kubernetes in EKS Anywhere (right now Kubernetes 1.24), the CLI will fail upgrading the management components  when [building the new cluster spec](https://github.com/aws/eks-anywhere/blob/4de7cda5ac1e6b571d769df82de2391634b750b8/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go#L37). 

```
Error: failed to upgrade cluster: unable to get cluster config from file: kubernetes version 1.24 is not supported by bundles 
```

This is because Kubernetes 1.24 is not supported now and does not exist in the new bundles .

 As a solution to this, we want to remove the need to build the new full `cluster.Spec` in the upgrade management-components workflow. For this to be possible, we need to remove the need for the `cluster.Spec` when accessing  management component information during the upgrade.

*Description of changes:*
This PR updates the preCoreComponentsUpgrade for the providers to use a provided `cluster.Management` to perform the step. It still uses the *cluster.Spec (presumably the current cluster spec) for any addition information. For example, the the `Tinkerbell` provider needs it to run the[ stack installer upgrade](https://github.com/aws/eks-anywhere/blob/91339efb6dc85bf296c2289dbe2eb4849cd25ef7/pkg/providers/tinkerbell/upgrade.go#L464) check `workerNodeConfigurations` and the `TinkerbellDatacenter` to decide whether or not to enable the load balancer.

*Testing (if applicable):*
- Unit tests
- Upgraded management components from v0.18.6

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

