### PR TITLE
Add inplace upgrade E2E tests for scaling nodes in vsphere

### DIFF
--- a/internal/pkg/api/vsphere.go
+++ b/internal/pkg/api/vsphere.go
@@ -246,3 +246,14 @@ func WithVSphereMachineConfig(name string, fillers ...VSphereMachineConfigFiller
 		FillVSphereMachineConfig(m, fillers...)
 	}
 }
+
+// RemoveEtcdVsphereMachineConfig removes the etcd VSphereMachineConfig from the cluster spec.
+func RemoveEtcdVsphereMachineConfig() VSphereFiller {
+	return func(config VSphereConfig) {
+		for k, m := range config.machineConfigs {
+			if strings.HasSuffix(m.Name, "-etcd") {
+				delete(config.machineConfigs, k)
+			}
+		}
+	}
+}

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -61,7 +61,7 @@ func runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(test *framework.ClusterE2
 }
 
 func runInPlaceUpgradeFlow(test *framework.ClusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
-	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.CreateCluster()
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateClusterState()
 	test.StopIfFailed()

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -60,6 +60,14 @@ func runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(test *framework.ClusterE2
 	test.ValidateHardwareDecommissioned()
 }
 
+func runInPlaceUpgradeFlow(test *framework.ClusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
+	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+	test.UpgradeClusterWithNewConfig(clusterOpts)
+	test.ValidateClusterState()
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
 func runInPlaceUpgradeFlowForBareMetal(test *framework.ClusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateHardwareConfig()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2475,6 +2475,114 @@ func TestVSphereKubernetes127to128UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 	)
 }
 
+func TestVSphereKubernetes128UbuntuControlPlaneScaleUp1To3(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithStackedEtcdTopology(),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		api.VSphereToConfigFiller(
+			api.RemoveEtcdVsphereMachineConfig(),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+	)
+	runInPlaceUpgradeFlow(
+		test,
+		framework.WithClusterUpgrade(
+			api.WithControlPlaneCount(3),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+	)
+}
+
+func TestVSphereKubernetes128UbuntuControlPlaneScaleDown3To1(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(3),
+			api.WithWorkerNodeCount(1),
+			api.WithStackedEtcdTopology(),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		api.VSphereToConfigFiller(
+			api.RemoveEtcdVsphereMachineConfig(),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+	)
+	runInPlaceUpgradeFlow(
+		test,
+		framework.WithClusterUpgrade(
+			api.WithControlPlaneCount(1),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+	)
+}
+
+func TestVSphereKubernetes128UbuntuWorkerNodeScaleUp1To2(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+			api.WithStackedEtcdTopology(),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		api.VSphereToConfigFiller(
+			api.RemoveEtcdVsphereMachineConfig(),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+	)
+	runInPlaceUpgradeFlow(
+		test,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeCount(2),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+	)
+}
+
+func TestVSphereKubernetes128UbuntuWorkerNodeScaleDown2To1(t *testing.T) {
+	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(2),
+			api.WithStackedEtcdTopology(),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		api.VSphereToConfigFiller(
+			api.RemoveEtcdVsphereMachineConfig(),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+	)
+	runInPlaceUpgradeFlow(
+		test,
+		framework.WithClusterUpgrade(
+			api.WithWorkerNodeCount(1),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+	)
+}
+
 // Workload API
 func TestVSphereMulticlusterWorkloadClusterAPI(t *testing.T) {
 	vsphere := framework.NewVSphere(t)

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2475,11 +2475,12 @@ func TestVSphereKubernetes127to128UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 	)
 }
 
-func TestVSphereKubernetes128UbuntuControlPlaneScaleUp1To3(t *testing.T) {
+func TestVSphereKubernetes128UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
+		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube128),
@@ -2502,11 +2503,12 @@ func TestVSphereKubernetes128UbuntuControlPlaneScaleUp1To3(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes128UbuntuControlPlaneScaleDown3To1(t *testing.T) {
+func TestVSphereKubernetes128UbuntuInPlaceCPScaleDown3To1(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
+		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube128),
@@ -2529,11 +2531,12 @@ func TestVSphereKubernetes128UbuntuControlPlaneScaleDown3To1(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes128UbuntuWorkerNodeScaleUp1To2(t *testing.T) {
+func TestVSphereKubernetes128UbuntuInPlaceWorkerScaleUp1To2(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
+		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube128),
@@ -2556,11 +2559,12 @@ func TestVSphereKubernetes128UbuntuWorkerNodeScaleUp1To2(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes128UbuntuWorkerNodeScaleDown2To1(t *testing.T) {
+func TestVSphereKubernetes128UbuntuInPlaceWorkerScaleDown2To1(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
+		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube128),


### PR DESCRIPTION
*Issue #, if available:*
[#2008](https://github.com/aws/eks-anywhere-internal/issues/2008)

*Description of changes:*
Added four inplace upgrades E2E tests for scaling control plane and worker nodes
- Scale up control plane nodes from 1 to 3
- Scale down control plane nodes from 3 to 1
- Scale up worker nodes from 1 to 2
- Scale down worker nodes from 2 to 1

*Testing (if applicable):*
Tested locally in vsphere dev env

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

