### PR TITLE
Move aws kubeconfig secret to workload cluster

### DIFF
--- a/pkg/awsiamauth/reconciler/reconciler.go
+++ b/pkg/awsiamauth/reconciler/reconciler.go
@@ -172,10 +172,13 @@ func (r *Reconciler) createKubeconfigSecret(ctx context.Context, clusterSpec *an
 		return errors.Wrap(err, "generating aws-iam-authenticator kubeconfig")
 	}
 
+	clusterctlMoveLabel := make(map[string]string)
+	clusterctlMoveLabel[constants.ClusterctlMoveLabelName] = "true"
 	kubeconfigSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      awsiamauth.KubeconfigSecretName(cluster.Name),
 			Namespace: constants.EksaSystemNamespace,
+			Labels:    clusterctlMoveLabel,
 		},
 		StringData: map[string]string{
 			"value": string(yaml),

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,6 +53,9 @@ const (
 
 	FailureDomainLabelName = "cluster.x-k8s.io/failure-domain"
 
+	// ClusterctlMoveLabelName adds the clusterctl move label.
+	ClusterctlMoveLabelName = "clusterctl.cluster.x-k8s.io/move"
+
 	// CloudstackFailureDomainPlaceholder Provider specific keywork placeholder.
 	CloudstackFailureDomainPlaceholder = "ds.meta_data.failuredomain"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move aws kubeconfig secret to workload cluster
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

