### PR TITLE
Upgrade all the way from 1.25 to 1.28

### DIFF
--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -60,6 +60,16 @@ func runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(test *framework.ClusterE2
 	test.ValidateHardwareDecommissioned()
 }
 
+func runInPlaceMultipleUpgradesFlow(test *framework.ClusterE2ETest, clusterOpts ...[]framework.ClusterE2ETestOpt) {
+	test.CreateCluster()
+	for _, opts := range clusterOpts {
+		test.UpgradeClusterWithNewConfig(opts)
+		test.ValidateClusterState()
+		test.StopIfFailed()
+	}
+	test.DeleteCluster()
+}
+
 // runInPlaceUpgradeFlow makes use of the new ValidateClusterState method instead of ValidateCluster, but we should incorporate this
 // in runSimpleUpgradeFlow itself.
 func runInPlaceUpgradeFlow(test *framework.ClusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3599,6 +3599,58 @@ func TestVSphereKubernetes128UbuntuTo129InPlaceUpgrade_3CP_3Worker(t *testing.T)
 	)
 }
 
+func TestVSphereKubernetes125UbuntuTo128InPlaceUpgrade(t *testing.T) {
+	var kube126clusterOpts []framework.ClusterE2ETestOpt
+	var kube127clusterOpts []framework.ClusterE2ETestOpt
+	var kube128clusterOpts []framework.ClusterE2ETestOpt
+	provider := framework.NewVSphere(t, framework.WithUbuntu125())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+	).WithClusterConfig(
+		api.ClusterToConfigFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube125),
+			api.WithStackedEtcdTopology(),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		api.VSphereToConfigFiller(
+			api.RemoveEtcdVsphereMachineConfig(),
+		),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube125, framework.Ubuntu2004, nil),
+	)
+	kube126clusterOpts = append(
+		kube126clusterOpts,
+		framework.WithClusterUpgrade(
+			api.WithKubernetesVersion(v1alpha1.Kube126),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		provider.WithProviderUpgrade(provider.Ubuntu126Template()),
+	)
+	kube127clusterOpts = append(
+		kube127clusterOpts,
+		framework.WithClusterUpgrade(
+			api.WithKubernetesVersion(v1alpha1.Kube127),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		provider.WithProviderUpgrade(provider.Ubuntu127Template()),
+	)
+	kube128clusterOpts = append(
+		kube128clusterOpts,
+		framework.WithClusterUpgrade(
+			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithInPlaceUpgradeStrategy(),
+		),
+		provider.WithProviderUpgrade(provider.Ubuntu128Template()),
+	)
+	runInPlaceMultipleUpgradesFlow(
+		test,
+		kube126clusterOpts,
+		kube127clusterOpts,
+		kube128clusterOpts,
+	)
+}
+
 func TestVSphereKubernetes128UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 	test := framework.NewClusterE2ETest(


### PR DESCRIPTION
*Issue #, if available:*
[#2008](https://github.com/aws/eks-anywhere-internal/issues/2008)

*Description of changes:*
Added E2E test for inplace upgrade from k8s 1.25 all the way to 1.28

*Testing (if applicable):*
Tested locally in vsphere dev env

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

