### PR TITLE
Use Kubeconfig Writer for IamAuth

### DIFF
--- a/pkg/awsiamauth/installer_test.go
+++ b/pkg/awsiamauth/installer_test.go
@@ -2,14 +2,12 @@ package awsiamauth_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/internal/test"

--- a/pkg/awsiamauth/installer_test.go
+++ b/pkg/awsiamauth/installer_test.go
@@ -2,12 +2,14 @@ package awsiamauth_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/internal/test"

--- a/pkg/awsiamauth/installer_test.go
+++ b/pkg/awsiamauth/installer_test.go
@@ -3,12 +3,15 @@ package awsiamauth_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -17,6 +20,7 @@ import (
 	cryptomocks "github.com/aws/eks-anywhere/pkg/crypto/mocks"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	filewritermock "github.com/aws/eks-anywhere/pkg/filewriter/mocks"
+	kubeconfigmocks "github.com/aws/eks-anywhere/pkg/kubeconfig/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
 )
 
@@ -38,6 +42,7 @@ func TestInstallAWSIAMAuth(t *testing.T) {
 
 	var kubeconfig []byte
 	writer := filewritermock.NewMockFileWriter(ctrl)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
 	writer.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(fileName string, content []byte, f ...filewriter.FileOptionsFunc) (string, error) {
 			kubeconfig = content
@@ -80,7 +85,7 @@ func TestInstallAWSIAMAuth(t *testing.T) {
 		},
 	}
 
-	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
 
 	err := installer.InstallAWSIAMAuth(context.Background(), &types.Cluster{}, &types.Cluster{}, spec)
 	if err != nil {
@@ -172,8 +177,8 @@ func TestInstallAWSIAMAuthErrors(t *testing.T) {
 					},
 				},
 			}
-
-			installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+			kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+			installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
 
 			err := installer.InstallAWSIAMAuth(context.Background(), &types.Cluster{}, &types.Cluster{}, spec)
 			if err == nil {
@@ -205,7 +210,8 @@ func TestCreateAndInstallAWSIAMAuthCASecret(t *testing.T) {
 	certs := cryptomocks.NewMockCertificateGenerator(ctrl)
 	certs.EXPECT().GenerateIamAuthSelfSignCertKeyPair().Return([]byte("ca-cert"), []byte("ca-key"), nil)
 
-	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
 
 	err := installer.CreateAndInstallAWSIAMAuthCASecret(context.Background(), &types.Cluster{}, "test-cluster")
 	if err != nil {
@@ -248,7 +254,8 @@ func TestCreateAndInstallAWSIAMAuthCASecretErrors(t *testing.T) {
 			certs := cryptomocks.NewMockCertificateGenerator(ctrl)
 			certs.EXPECT().GenerateIamAuthSelfSignCertKeyPair().Return([]byte("ca-cert"), []byte("ca-key"), nil)
 
-			installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+			kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+			installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
 
 			err := installer.CreateAndInstallAWSIAMAuthCASecret(context.Background(), &types.Cluster{}, "test-cluster")
 
@@ -280,7 +287,8 @@ func TestUpgradeAWSIAMAuth(t *testing.T) {
 		},
 	)
 
-	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
 
 	spec := &cluster.Spec{
 		Config: &cluster.Config{
@@ -328,16 +336,26 @@ func TestGenerateManagementAWSIAMKubeconfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	certs := cryptomocks.NewMockCertificateGenerator(ctrl)
 	clusterID := uuid.MustParse("36db102f-9e1e-4ca4-8300-271d30b14161")
+	ctx := context.Background()
 
 	k8s := NewMockKubernetesClient(ctrl)
-	k8s.EXPECT().GetAWSIAMKubeconfigSecretValue(gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("kubeconfig"), nil)
+	secretValue := []byte("kubeconfig")
+	k8s.EXPECT().GetAWSIAMKubeconfigSecretValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(secretValue, nil)
 
+	cluster := &types.Cluster{
+		Name: "cluster-name",
+	}
 	writer := filewritermock.NewMockFileWriter(ctrl)
-	writer.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).Return("kubeconfig", nil)
+	fileName := fmt.Sprintf("%s-aws.kubeconfig", cluster.Name)
+	path := "testpath"
+	fileWriter := os.NewFile(uintptr(*pointer.Uint(0)), "test")
 
-	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+	writer.EXPECT().Create(fileName, gomock.AssignableToTypeOf([]filewriter.FileOptionsFunc{})).Return(fileWriter, path, nil)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
+	kwriter.EXPECT().WriteKubeconfigContent(ctx, cluster.Name, secretValue, fileWriter)
 
-	err := installer.GenerateManagementAWSIAMKubeconfig(context.Background(), &types.Cluster{})
+	err := installer.GenerateManagementAWSIAMKubeconfig(context.Background(), cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,13 +367,50 @@ func TestGenerateManagementAWSIAMKubeconfigError(t *testing.T) {
 	clusterID := uuid.MustParse("36db102f-9e1e-4ca4-8300-271d30b14161")
 
 	k8s := NewMockKubernetesClient(ctrl)
-	k8s.EXPECT().GetAWSIAMKubeconfigSecretValue(gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte{}, errors.New("test"))
+	k8s.EXPECT().GetAWSIAMKubeconfigSecretValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("test"))
 
+	cluster := &types.Cluster{
+		Name: "cluster-name",
+	}
 	writer := filewritermock.NewMockFileWriter(ctrl)
+	fileName := fmt.Sprintf("%s-aws.kubeconfig", cluster.Name)
+	path := "testpath"
+	fileWriter := os.NewFile(uintptr(*pointer.Uint(0)), "test")
 
-	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer)
+	writer.EXPECT().Create(fileName, gomock.AssignableToTypeOf([]filewriter.FileOptionsFunc{})).Return(fileWriter, path, nil)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
 
-	err := installer.GenerateManagementAWSIAMKubeconfig(context.Background(), &types.Cluster{})
+	err := installer.GenerateManagementAWSIAMKubeconfig(context.Background(), cluster)
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateAWSIAMKubeconfigError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	certs := cryptomocks.NewMockCertificateGenerator(ctrl)
+	clusterID := uuid.MustParse("36db102f-9e1e-4ca4-8300-271d30b14161")
+	ctx := context.Background()
+
+	k8s := NewMockKubernetesClient(ctrl)
+	secretValue := []byte("kubeconfig")
+	k8s.EXPECT().GetAWSIAMKubeconfigSecretValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(secretValue, nil)
+
+	cluster := &types.Cluster{
+		Name: "cluster-name",
+	}
+	writer := filewritermock.NewMockFileWriter(ctrl)
+	fileName := fmt.Sprintf("%s-aws.kubeconfig", cluster.Name)
+	path := "testpath"
+	fileWriter := os.NewFile(uintptr(*pointer.Uint(0)), "test")
+
+	writer.EXPECT().Create(fileName, gomock.AssignableToTypeOf([]filewriter.FileOptionsFunc{})).Return(fileWriter, path, nil)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+	installer := awsiamauth.NewInstaller(certs, clusterID, k8s, writer, kwriter)
+	kwriter.EXPECT().WriteKubeconfigContent(ctx, cluster.Name, secretValue, fileWriter).Return(errors.New("test"))
+
+	err := installer.GenerateManagementAWSIAMKubeconfig(context.Background(), cluster)
 	if err == nil {
 		t.Fatal(err)
 	}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -951,8 +951,9 @@ func (f *Factory) WithCiliumTemplater() *Factory {
 	return f
 }
 
-func (f *Factory) WithAwsIamAuth() *Factory {
-	f.WithKubectl().WithWriter()
+// WithAwsIamAuth builds dependencies for AWS IAM Auth.
+func (f *Factory) WithAwsIamAuth(clusterConfig *v1alpha1.Cluster) *Factory {
+	f.WithKubectl().WithWriter().WithKubeconfigWriter(clusterConfig)
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.dependencies.AwsIamAuth != nil {
@@ -971,6 +972,7 @@ func (f *Factory) WithAwsIamAuth() *Factory {
 			clusterId,
 			awsiamauth.NewRetrierClient(f.dependencies.Kubectl, opts...),
 			f.dependencies.Writer,
+			f.dependencies.KubeconfigWriter,
 		)
 		return nil
 	})
@@ -1067,7 +1069,7 @@ func (f *Factory) clusterManagerOpts(timeoutOpts *ClusterManagerTimeoutOptions) 
 
 // WithClusterManager builds a cluster manager based on the cluster config and timeout options.
 func (f *Factory) WithClusterManager(clusterConfig *v1alpha1.Cluster, timeoutOpts *ClusterManagerTimeoutOptions) *Factory {
-	f.WithClusterctl().WithNetworking(clusterConfig).WithWriter().WithDiagnosticBundleFactory().WithAwsIamAuth().WithFileReader().WithUnAuthKubeClient().WithKubernetesRetrierClient().WithEKSAInstaller()
+	f.WithClusterctl().WithNetworking(clusterConfig).WithWriter().WithDiagnosticBundleFactory().WithAwsIamAuth(clusterConfig).WithFileReader().WithUnAuthKubeClient().WithKubernetesRetrierClient().WithEKSAInstaller()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.dependencies.ClusterManager != nil {

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -691,7 +691,7 @@ func TestFactoryBuildWithAwsIamAuthNoTimeout(t *testing.T) {
 	deps, err := dependencies.NewFactory().
 		WithLocalExecutables().
 		WithNoTimeouts().
-		WithAwsIamAuth().
+		WithAwsIamAuth(tt.clusterSpec.Cluster).
 		Build(context.Background())
 
 	tt.Expect(err).To(BeNil())

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -17,6 +17,7 @@ import (
 // Writer reads the kubeconfig secret on a cluster and copies the contents to a writer.
 type Writer interface {
 	WriteKubeconfig(ctx context.Context, clusterName, kubeconfig string, w io.Writer) error
+	WriteKubeconfigContent(ctx context.Context, clusterName string, content []byte, w io.Writer) error
 }
 
 // FromClusterFormat defines the format of the kubeconfig of the.

--- a/pkg/kubeconfig/kubeconfig_writer.go
+++ b/pkg/kubeconfig/kubeconfig_writer.go
@@ -66,7 +66,16 @@ func (kr ClusterAPIKubeconfigSecretWriter) WriteKubeconfig(ctx context.Context, 
 		return err
 	}
 
-	if _, err := io.Copy(w, bytes.NewReader(rawKubeconfig)); err != nil {
+	if err := kr.WriteKubeconfigContent(ctx, clusterName, rawKubeconfig, w); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteKubeconfigContent copies a raw kubeconfig to an io.Writer.
+func (kr ClusterAPIKubeconfigSecretWriter) WriteKubeconfigContent(ctx context.Context, clusterName string, content []byte, w io.Writer) error {
+	if _, err := io.Copy(w, bytes.NewReader(content)); err != nil {
 		return err
 	}
 

--- a/pkg/kubeconfig/mocks/writer.go
+++ b/pkg/kubeconfig/mocks/writer.go
@@ -48,3 +48,17 @@ func (mr *MockWriterMockRecorder) WriteKubeconfig(ctx, clusterName, kubeconfig, 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteKubeconfig", reflect.TypeOf((*MockWriter)(nil).WriteKubeconfig), ctx, clusterName, kubeconfig, w)
 }
+
+// WriteKubeconfigContent mocks base method.
+func (m *MockWriter) WriteKubeconfigContent(ctx context.Context, clusterName string, content []byte, w io.Writer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteKubeconfigContent", ctx, clusterName, content, w)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteKubeconfigContent indicates an expected call of WriteKubeconfigContent.
+func (mr *MockWriterMockRecorder) WriteKubeconfigContent(ctx, clusterName, content, w interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteKubeconfigContent", reflect.TypeOf((*MockWriter)(nil).WriteKubeconfigContent), ctx, clusterName, content, w)
+}

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -607,14 +607,23 @@ func (kr KubeconfigWriter) WriteKubeconfig(ctx context.Context, clusterName, kub
 		return err
 	}
 
+	if err := kr.WriteKubeconfigContent(ctx, clusterName, rawkubeconfig, w); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteKubeconfigContent retrieves the contents of the specified cluster's kubeconfig from a secret and copies it to an io.Writer.
+func (kr KubeconfigWriter) WriteKubeconfigContent(ctx context.Context, clusterName string, content []byte, w io.Writer) error {
 	port, err := kr.docker.GetDockerLBPort(ctx, clusterName)
 	if err != nil {
 		return err
 	}
 
-	updateKubeconfig(&rawkubeconfig, port)
+	updateKubeconfig(&content, port)
 
-	if _, err := io.Copy(w, bytes.NewReader(rawkubeconfig)); err != nil {
+	if _, err := io.Copy(w, bytes.NewReader(content)); err != nil {
 		return err
 	}
 

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -32,15 +32,6 @@ func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	}
 	commandContext.WorkloadCluster = workloadCluster
 
-	// if commandContext.ClusterSpec.AWSIamConfig != nil {
-	// 	logger.Info("Generating the aws iam kubeconfig file")
-	// 	err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.WorkloadCluster)
-	// 	if err != nil {
-	// 		commandContext.SetError(err)
-	// 		return &workflows.CollectDiagnosticsTask{}
-	// 	}
-	// }
-
 	logger.Info("Creating EKS-A namespace")
 	err = commandContext.ClusterManager.CreateEKSANamespace(ctx, commandContext.WorkloadCluster)
 	if err != nil {

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -32,14 +32,14 @@ func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 	}
 	commandContext.WorkloadCluster = workloadCluster
 
-	if commandContext.ClusterSpec.AWSIamConfig != nil {
-		logger.Info("Generating the aws iam kubeconfig file")
-		err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.WorkloadCluster)
-		if err != nil {
-			commandContext.SetError(err)
-			return &workflows.CollectDiagnosticsTask{}
-		}
-	}
+	// if commandContext.ClusterSpec.AWSIamConfig != nil {
+	// 	logger.Info("Generating the aws iam kubeconfig file")
+	// 	err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.WorkloadCluster)
+	// 	if err != nil {
+	// 		commandContext.SetError(err)
+	// 		return &workflows.CollectDiagnosticsTask{}
+	// 	}
+	// }
 
 	logger.Info("Creating EKS-A namespace")
 	err = commandContext.ClusterManager.CreateEKSANamespace(ctx, commandContext.WorkloadCluster)

--- a/pkg/workflows/management/write_cluster_config.go
+++ b/pkg/workflows/management/write_cluster_config.go
@@ -49,6 +49,16 @@ func (s *writeCreateClusterConfig) Run(ctx context.Context, commandContext *task
 		commandContext.SetError(err)
 		return &workflows.CollectDiagnosticsTask{}
 	}
+
+	if commandContext.ClusterSpec.AWSIamConfig != nil {
+		logger.Info("Generating the aws iam kubeconfig file")
+		err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.WorkloadCluster)
+		if err != nil {
+			commandContext.SetError(err)
+			return &workflows.CollectDiagnosticsTask{}
+		}
+	}
+
 	return &deleteBootstrapClusterTask{}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Docker's kubeconfig requires getting the load balancer's port and rewriting the kubeconfig to use that port. 

*Description of changes:*
Use the existing Kubeconfig Writer interface for writing IamAuth's kubeconfig. Docker has its own implementation and the implementation of kubeconfig writer chosen when creating a cluster is determined by factory based on provider.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

