### PR TITLE
Update kube-vip for InPlace upgrades.

### DIFF
--- a/controllers/controlplaneupgrade_controller.go
+++ b/controllers/controlplaneupgrade_controller.go
@@ -49,6 +49,7 @@ const (
 	controlPlaneUpgradeFinalizerName      = "controlplaneupgrades.anywhere.eks.amazonaws.com/finalizer"
 	kubeadmClusterConfigurationAnnotation = "controlplane.cluster.x-k8s.io/kubeadm-cluster-configuration"
 	cloneFromNameAnnotationInfraMachine   = "cluster.x-k8s.io/cloned-from-name"
+	kubeVipStaticPodPath                  = "/etc/kubernetes/manifests/kube-vip.yaml"
 )
 
 // ControlPlaneUpgradeReconciler reconciles a ControlPlaneUpgradeReconciler object.
@@ -141,9 +142,16 @@ func (r *ControlPlaneUpgradeReconciler) reconcile(ctx context.Context, log logr.
 	// return early if controlplane upgrade is already complete
 	if cpUpgrade.Status.Ready {
 		log.Info("All Control Plane nodes are upgraded")
+		// check if kube-vip config map exists and clean it up
+		if err := cleanupKubeVipCM(ctx, log, r.client); err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
+	if err := createKubeVipCMIfNotExist(ctx, r.client, cpUpgrade); err != nil {
+		return ctrl.Result{}, err
+	}
 	log.Info("Upgrading all Control Plane nodes")
 
 	for idx, machineRef := range cpUpgrade.Spec.MachinesRequireUpgrade {
@@ -362,4 +370,72 @@ func getCapiMachine(ctx context.Context, client client.Client, nodeUpgrade *anyw
 		return nil, fmt.Errorf("getting machine %s: %v", nodeUpgrade.Spec.Machine.Name, err)
 	}
 	return machine, nil
+}
+
+func cleanupKubeVipCM(ctx context.Context, log logr.Logger, client client.Client) error {
+	cm := &corev1.ConfigMap{}
+	if err := client.Get(ctx, GetNamespacedNameType(constants.KubeVipConfigMapName, constants.EksaSystemNamespace), cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("config map %s  not found, skipping deletion", "ConfigMap", constants.KubeVipConfigMapName, "Namespace", constants.EksaSystemNamespace)
+		} else {
+			return fmt.Errorf("getting %s config map: %v", constants.KubeVipConfigMapName, err)
+		}
+	} else {
+		log.Info("Deleting kube-vip config map", "ConfigMap", constants.KubeVipConfigMapName, "Namespace", constants.EksaSystemNamespace)
+		if err := client.Delete(ctx, cm); err != nil {
+			return fmt.Errorf("deleting %s config map: %v", constants.KubeVipConfigMapName, err)
+		}
+	}
+	return nil
+}
+
+func createKubeVipCMIfNotExist(ctx context.Context, client client.Client, cpUpgrade *anywherev1.ControlPlaneUpgrade) error {
+	kubeVipCM := &corev1.ConfigMap{}
+	if err := client.Get(ctx, GetNamespacedNameType(constants.KubeVipConfigMapName, constants.EksaSystemNamespace), kubeVipCM); err != nil {
+		if apierrors.IsNotFound(err) {
+			kubeVipCM, err = kubeVipConfigMap(cpUpgrade)
+			if err != nil {
+				return err
+			}
+			if err := client.Create(ctx, kubeVipCM); err != nil {
+				return fmt.Errorf("failed to create %s config map: %v", constants.KubeVipConfigMapName, err)
+			}
+		} else {
+			return fmt.Errorf("getting %s configmap: %v", constants.KubeVipConfigMapName, err)
+		}
+	}
+	return nil
+}
+
+func kubeVipConfigMap(cpUpgrade *anywherev1.ControlPlaneUpgrade) (*corev1.ConfigMap, error) {
+	kcpSpec, err := decodeAndUnmarshalKcpSpecData(cpUpgrade.Spec.ControlPlaneSpecData)
+	if err != nil {
+		return nil, err
+	}
+	var kubeVipConfig string
+	for _, file := range kcpSpec.KubeadmConfigSpec.Files {
+		if file.Path == kubeVipStaticPodPath {
+			kubeVipConfig = file.Content
+			break
+		}
+	}
+	blockOwnerDeletionFlag := true
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.KubeVipConfigMapName,
+			Namespace: constants.EksaSystemNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         cpUpgrade.APIVersion,
+				Kind:               cpUpgrade.Kind,
+				Name:               cpUpgrade.Name,
+				UID:                cpUpgrade.UID,
+				BlockOwnerDeletion: &blockOwnerDeletionFlag,
+			}},
+		},
+		Data: map[string]string{constants.KubeVipManifestName: kubeVipConfig},
+	}, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -48,6 +48,9 @@ const (
 	EksaPackagesName       = "eksa-packages"
 	// UpgraderConfigMapName is the name of config map that stores the upgrader images.
 	UpgraderConfigMapName = "in-place-upgrade"
+	// KubeVipConfigMapName is the name of config map that stores the kube-vip config.
+	KubeVipConfigMapName = "kube-vip-in-place-upgrade"
+	KubeVipManifestName  = "kube-vip.yaml"
 
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -50,7 +50,8 @@ const (
 	UpgraderConfigMapName = "in-place-upgrade"
 	// KubeVipConfigMapName is the name of config map that stores the kube-vip config.
 	KubeVipConfigMapName = "kube-vip-in-place-upgrade"
-	KubeVipManifestName  = "kube-vip.yaml"
+	// KubeVipManifestName is the name of kube-vip spec file.
+	KubeVipManifestName = "kube-vip.yaml"
 
 	CloudstackAnnotationSuffix = "cloudstack.anywhere.eks.amazonaws.com/v1alpha1"
 

--- a/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
@@ -36,6 +36,9 @@ spec:
     volumeMounts:
     - mountPath: /usr/host
       name: host-components
+    - mountPath: /eksa-upgrades/kube-vip.yaml
+      name: kube-vip
+      subPath: kube-vip.yaml
   - args:
     - --target
     - "1"
@@ -109,4 +112,10 @@ spec:
       path: /foo
       type: DirectoryOrCreate
     name: host-components
+  - configMap:
+      items:
+      - key: kube-vip.yaml
+        path: kube-vip.yaml
+      name: kube-vip-in-place-upgrade
+    name: kube-vip
 status: {}

--- a/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
@@ -36,6 +36,9 @@ spec:
     volumeMounts:
     - mountPath: /usr/host
       name: host-components
+    - mountPath: /eksa-upgrades/kube-vip.yaml
+      name: kube-vip
+      subPath: kube-vip.yaml
   - args:
     - --target
     - "1"
@@ -107,4 +110,10 @@ spec:
       path: /foo
       type: DirectoryOrCreate
     name: host-components
+  - configMap:
+      items:
+      - key: kube-vip.yaml
+        path: kube-vip.yaml
+      name: kube-vip-in-place-upgrade
+    name: kube-vip
 status: {}

--- a/pkg/nodeupgrader/upgrader.go
+++ b/pkg/nodeupgrader/upgrader.go
@@ -39,27 +39,30 @@ func PodName(nodeName string) string {
 
 // UpgradeFirstControlPlanePod returns an upgrader pod that should be deployed on the first control plane node.
 func UpgradeFirstControlPlanePod(nodeName, image, kubernetesVersion, etcdVersion string) *corev1.Pod {
-	p := upgraderPod(nodeName, image)
-	p.Spec.InitContainers = containersForUpgrade(image, nodeName, "kubeadm_in_first_cp", kubernetesVersion, etcdVersion)
+	p := upgraderPod(nodeName, image, true)
+	p.Spec.InitContainers = containersForUpgrade(true, image, nodeName, "kubeadm_in_first_cp", kubernetesVersion, etcdVersion)
 	return p
 }
 
 // UpgradeSecondaryControlPlanePod returns an upgrader pod that can be deployed on the remaining control plane nodes.
 func UpgradeSecondaryControlPlanePod(nodeName, image string) *corev1.Pod {
-	p := upgraderPod(nodeName, image)
-	p.Spec.InitContainers = containersForUpgrade(image, nodeName, "kubeadm_in_rest_cp")
+	p := upgraderPod(nodeName, image, true)
+	p.Spec.InitContainers = containersForUpgrade(true, image, nodeName, "kubeadm_in_rest_cp")
 	return p
 }
 
 // UpgradeWorkerPod returns an upgrader pod that can be deployed on worker nodes.
 func UpgradeWorkerPod(nodeName, image string) *corev1.Pod {
-	p := upgraderPod(nodeName, image)
-	p.Spec.InitContainers = containersForUpgrade(image, nodeName, "kubeadm_in_worker")
+	p := upgraderPod(nodeName, image, false)
+	p.Spec.InitContainers = containersForUpgrade(false, image, nodeName, "kubeadm_in_worker")
 	return p
 }
 
-func upgraderPod(nodeName, image string) *corev1.Pod {
-	dirOrCreate := corev1.HostPathDirectoryOrCreate
+func upgraderPod(nodeName, image string, isCP bool) *corev1.Pod {
+	volumes := []corev1.Volume{hostComponentsVolume()}
+	if isCP {
+		volumes = append(volumes, kubeVipVolume())
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PodName(nodeName),
@@ -71,17 +74,7 @@ func upgraderPod(nodeName, image string) *corev1.Pod {
 		Spec: corev1.PodSpec{
 			NodeName: nodeName,
 			HostPID:  true,
-			Volumes: []corev1.Volume{
-				{
-					Name: "host-components",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/foo",
-							Type: &dirOrCreate,
-						},
-					},
-				},
-			},
+			Volumes:  volumes,
 			Containers: []corev1.Container{
 				nsenterContainer(image, PostUpgradeContainerName, upgradeScript, "print_status_and_cleanup"),
 			},
@@ -90,9 +83,9 @@ func upgraderPod(nodeName, image string) *corev1.Pod {
 	}
 }
 
-func containersForUpgrade(image, nodeName string, kubeadmUpgradeCommand ...string) []corev1.Container {
+func containersForUpgrade(isCP bool, image, nodeName string, kubeadmUpgradeCommand ...string) []corev1.Container {
 	return []corev1.Container{
-		copierContainer(image),
+		copierContainer(image, isCP),
 		nsenterContainer(image, ContainerdUpgraderContainerName, upgradeScript, "upgrade_containerd"),
 		nsenterContainer(image, CNIPluginsUpgraderContainerName, upgradeScript, "cni_plugins"),
 		nsenterContainer(image, KubeadmUpgraderContainerName, append([]string{upgradeScript}, kubeadmUpgradeCommand...)...),
@@ -100,18 +93,27 @@ func containersForUpgrade(image, nodeName string, kubeadmUpgradeCommand ...strin
 	}
 }
 
-func copierContainer(image string) corev1.Container {
-	return corev1.Container{
-		Name:    CopierContainerName,
-		Image:   image,
-		Command: []string{"cp"},
-		Args:    []string{"-r", "/eksa-upgrades", "/usr/host"},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "host-components",
-				MountPath: "/usr/host",
-			},
+func copierContainer(image string, isCP bool) corev1.Container {
+	volumeMount := []corev1.VolumeMount{
+		{
+			Name:      "host-components",
+			MountPath: "/usr/host",
 		},
+	}
+	if isCP {
+		kubeVipVolMount := corev1.VolumeMount{
+			Name:      "kube-vip",
+			MountPath: fmt.Sprintf("/eksa-upgrades/%s", constants.KubeVipManifestName),
+			SubPath:   constants.KubeVipManifestName,
+		}
+		volumeMount = append(volumeMount, kubeVipVolMount)
+	}
+	return corev1.Container{
+		Name:         CopierContainerName,
+		Image:        image,
+		Command:      []string{"cp"},
+		Args:         []string{"-r", "/eksa-upgrades", "/usr/host"},
+		VolumeMounts: volumeMount,
 	}
 }
 
@@ -132,6 +134,38 @@ func nsenterContainer(image, name string, extraArgs ...string) corev1.Container 
 		Args:    append(args, extraArgs...),
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: ptr.Bool(true),
+		},
+	}
+}
+
+func hostComponentsVolume() corev1.Volume {
+	dirOrCreate := corev1.HostPathDirectoryOrCreate
+	return corev1.Volume{
+		Name: "host-components",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/foo",
+				Type: &dirOrCreate,
+			},
+		},
+	}
+}
+
+func kubeVipVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: "kube-vip",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: constants.KubeVipConfigMapName,
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  constants.KubeVipManifestName,
+						Path: constants.KubeVipManifestName,
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
Kube-vip is deployed as static pod which means during any eksd/k8s version upgrade InPlace, we need to also update the kube-vip manifest with the new image for InPlace upgrades. This change parses the udpated Kube-vip manifest from `KubeadmControlPlaneSpec.KubeadmConfigSpec` and uses a config map mounted to the upgrader pod to facilitate kube-vip update for InPlace.  The upgrader [script](https://github.com/aws/eks-anywhere-build-tooling/pull/2926) then uses the volume mount to update the kube-vip manifest onto the host. 
 
*Description of changes:*

*Testing (if applicable):*
Tested the changes locally. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

