### PR TITLE
Add e2e test for inplace upgrade from latest release

### DIFF
--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -58,6 +58,14 @@ func runUpgradeWithFluxFromReleaseFlow(test *framework.ClusterE2ETest, latestRel
 	test.DeleteCluster()
 }
 
+func runInPlaceUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *releasev1.EksARelease, clusterOpts ...framework.ClusterE2ETestOpt) {
+	test.CreateCluster(framework.ExecuteWithEksaRelease(latestRelease))
+	test.UpgradeClusterWithNewConfig(clusterOpts)
+	test.ValidateClusterState()
+	test.StopIfFailed()
+	test.DeleteCluster()
+}
+
 func runMulticlusterUpgradeFromReleaseFlowAPI(test *framework.MulticlusterE2ETest, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion, os framework.OS) {
 	provider := test.ManagementCluster.Provider
 	test.CreateManagementCluster(framework.ExecuteWithEksaRelease(release))


### PR DESCRIPTION
*Issue #, if available:*
[#2008](https://github.com/aws/eks-anywhere-internal/issues/2008)

*Description of changes:*
Added E2E test for inplace upgrade from latest minor release with k8s version upgrade from 1.28 to 1.29

*Testing (if applicable):*
Tested locally in vsphere dev env

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

