### PR TITLE
Remove Kubernetes v1.29 feature flag and make it the default cluster version

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -223,7 +223,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster.
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube128
+	return Kube129
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3829,7 +3829,7 @@ func TestValidateEksaVersion(t *testing.T) {
 
 func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
-	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube128))
+	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube129))
 }
 
 func TestClusterWorkerNodeConfigCount(t *testing.T) {

--- a/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
@@ -17,7 +17,7 @@ spec:
     upgradeRolloutStrategy:
       type: InPlace
   datacenterRef: {}
-  kubernetesVersion: "1.28"
+  kubernetesVersion: "1.29"
   managementCluster:
     name: test-cluster
   workerNodeGroupConfigurations:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -6,7 +6,6 @@ const (
 	CheckpointEnabledEnvVar         = "CHECKPOINT_ENABLED"
 	UseNewWorkflowsEnvVar           = "USE_NEW_WORKFLOWS"
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
-	K8s129SupportEnvVar             = "K8S_1_29_SUPPORT"
 	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 )
 
@@ -54,14 +53,6 @@ func UseControllerViaCLIWorkflow() Feature {
 	return Feature{
 		Name:     "Use new workflow logic for cluster operations leveraging controller via CLI",
 		IsActive: globalFeatures.isActiveForEnvVar(UseControllerForCli),
-	}
-}
-
-// K8s129Support is the feature flag for Kubernetes 1.29 support.
-func K8s129Support() Feature {
-	return Feature{
-		Name:     "Kubernetes version 1.29 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s129SupportEnvVar),
 	}
 }
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -86,14 +86,6 @@ func TestUseControllerForCliTrue(t *testing.T) {
 	g.Expect(UseControllerViaCLIWorkflow().IsActive()).To(BeTrue())
 }
 
-func TestWithK8s129FeatureFlag(t *testing.T) {
-	g := NewWithT(t)
-	setupContext(t)
-
-	g.Expect(os.Setenv(K8s129SupportEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(K8s129Support())).To(BeTrue())
-}
-
 func TestVSphereInPlaceUpgradeEnabledFeatureFlag(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -222,16 +221,6 @@ func parseClusterEksaVersion(mgmtCluster, cluster *v1alpha1.Cluster) (*semver.Ve
 	}
 
 	return mVersion, wVersion, nil
-}
-
-// ValidateK8s129Support checks if the 1.29 feature flag is set when using k8s 1.29.
-func ValidateK8s129Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s129Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube129 {
-			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube129, features.K8s129SupportEnvVar)
-		}
-	}
-	return nil
 }
 
 // ValidateEksaReleaseExistOnManagement checks if there is a corresponding eksareleases CR for workload's eksaVersion on the mgmt cluster.

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -571,21 +570,6 @@ func TestValidateManagementClusterEksaVersion(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateK8s129Support(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube129
-	tt.Expect(validations.ValidateK8s129Support(tt.clusterSpec)).To(
-		MatchError(ContainSubstring("kubernetes version 1.29 is not enabled. Please set the env variable K8S_1_29_SUPPORT")))
-}
-
-func TestValidateK8s129SupportActive(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube129
-	features.ClearCache()
-	os.Setenv(features.K8s129SupportEnvVar, "true")
-	tt.Expect(validations.ValidateK8s129Support(tt.clusterSpec)).To(Succeed())
 }
 
 func TestValidateEksaReleaseExistOnManagement(t *testing.T) {

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -7,7 +7,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -48,14 +47,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate cluster's eksaVersion matches EKS-A version",
 				Remediation: "ensure EksaVersion matches the EKS-A release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, v.Opts.CliVersion, v.Opts.Spec),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.29 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s129SupportEnvVar),
-				Err:         validations.ValidateK8s129Support(v.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,7 +9,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -114,14 +113,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate cluster's eksaVersion matches EKS-Anywhere Version",
 				Remediation: "ensure eksaVersion matches the EKS-Anywhere release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, u.Opts.CliVersion, u.Opts.Spec),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.29 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s129SupportEnvVar),
-				Err:         validations.ValidateK8s129Support(u.Opts.Spec),
-				Silent:      true,
 			}
 		},
 		func() *validations.ValidationResult {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -2180,12 +2179,11 @@ func dumpFile(description, path string, t T) {
 func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
 	// Update this variable to equal the feature flagged k8s version when applicable.
 	// For example, if k8s 1.26 is under a feature flag, we would set this to v1alpha1.Kube126
-	unreleasedK8sVersion := v1alpha1.Kube129
+	var unreleasedK8sVersion v1alpha1.KubernetesVersion
 
 	if version == unreleasedK8sVersion {
 		// Set feature flag for the unreleased k8s version when applicable
 		e.T.Logf("Setting k8s version support feature flag...")
-		os.Setenv(features.K8s129SupportEnvVar, "true")
 	}
 }
 


### PR DESCRIPTION
This PR removes the feature flag for Kubernetes v1.29 support and make it the default cluster version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

