### PR TITLE
Validate immutable Tinkerbell Datacenter fields in web-hook when managing with the Full Lifecycle Controller API

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -216,6 +216,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command, args []strin
 
 	} else {
 		upgradeWorkloadCluster := workload.NewUpgrade(
+			deps.UnAuthKubeClient,
 			deps.Provider,
 			deps.ClusterManager,
 			deps.GitOpsFlux,

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -108,6 +109,20 @@ func validateImmutableFieldsTinkerbellDatacenterConfig(new, old *TinkerbellDatac
 		allErrs = append(
 			allErrs,
 			field.Forbidden(specPath.Child("tinkerbellIP"), "field is immutable"),
+		)
+	}
+
+	if new.Spec.HookImagesURLPath != old.Spec.HookImagesURLPath && !metav1.HasAnnotation(new.ObjectMeta, ManagedByCLIAnnotation) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(specPath.Child("hookImagesURLPath"), "field is immutable"),
+		)
+	}
+
+	if new.Spec.SkipLoadBalancerDeployment != old.Spec.SkipLoadBalancerDeployment && !metav1.HasAnnotation(new.ObjectMeta, ManagedByCLIAnnotation) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(specPath.Child("skipLoadBalancerDeployment"), "field is immutable"),
 		)
 	}
 

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 )
 
 func TestTinkerbellDatacenterValidateCreate(t *testing.T) {
@@ -51,14 +52,80 @@ func TestTinkerbellDatacenterValidateUpdateFailBadReq(t *testing.T) {
 	g.Expect(c.ValidateUpdate(cOld)).To(MatchError(ContainSubstring("expected a TinkerbellDatacenterConfig but got a *v1alpha1.Cluster")))
 }
 
-func TestTinkerbellDatacenterValidateUpdateImmutableTinkIP(t *testing.T) {
-	tOld := tinkerbellDatacenterConfig()
-	tOld.Spec.TinkerbellIP = "1.1.1.1"
-	tNew := tOld.DeepCopy()
+func TestTinkerbellDatacenterValidateUpdateImmutable(t *testing.T) {
+	tests := []struct {
+		name    string
+		old     v1alpha1.TinkerbellDatacenterConfig
+		new     v1alpha1.TinkerbellDatacenterConfig
+		wantErr string
+	}{
+		{
+			name: "updated tinkerbellIP",
+			old: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.TinkerbellIP = "1.1.1.1"
+			}),
+			new: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.TinkerbellIP = "1.1.1.2"
+			}),
+			wantErr: "spec.tinkerbellIP: Forbidden: field is immutable",
+		},
+		{
+			name: "updated hookImagesURLPath",
+			old: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.HookImagesURLPath = "https://oldpath"
+			}),
+			new: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.HookImagesURLPath = "https://newpath"
+			}),
+			wantErr: "spec.hookImagesURLPath: Forbidden: field is immutable",
+		},
+		{
+			name: "updated hookImagesURLPath, managed by cli",
+			old: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.HookImagesURLPath = "https://oldpath"
+			}),
+			new: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.HookImagesURLPath = "https://newpath"
+				clientutil.AddAnnotation(d, v1alpha1.ManagedByCLIAnnotation, "true")
+			}),
+			wantErr: "",
+		},
+		{
+			name: "updated skipLoadBalancerDeployment",
+			old: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.SkipLoadBalancerDeployment = false
+			}),
+			new: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.SkipLoadBalancerDeployment = true
+			}),
+			wantErr: "spec.skipLoadBalancerDeployment: Forbidden: field is immutable",
+		},
+		{
+			name: "updated skipLoadBalancerDeployment, managed by cli",
+			old: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.SkipLoadBalancerDeployment = false
+			}),
+			new: tinkerbellDatacenterConfig(func(d *v1alpha1.TinkerbellDatacenterConfig) {
+				d.Spec.SkipLoadBalancerDeployment = true
+				clientutil.AddAnnotation(d, v1alpha1.ManagedByCLIAnnotation, "true")
+			}),
+			wantErr: "",
+		},
+	}
 
-	tNew.Spec.TinkerbellIP = "1.1.1.2"
-	g := NewWithT(t)
-	g.Expect(tNew.ValidateUpdate(&tOld)).To(MatchError(ContainSubstring("spec.tinkerbellIP: Forbidden: field is immutable")))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := tt.new.ValidateUpdate(&tt.old)
+			if tt.wantErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErr)))
+			}
+		})
+	}
+
 }
 
 func TestTinkerbellDatacenterValidateDelete(t *testing.T) {
@@ -68,8 +135,10 @@ func TestTinkerbellDatacenterValidateDelete(t *testing.T) {
 	g.Expect(tOld.ValidateDelete()).To(Succeed())
 }
 
-func tinkerbellDatacenterConfig() v1alpha1.TinkerbellDatacenterConfig {
-	return v1alpha1.TinkerbellDatacenterConfig{
+type tinkerbellDatacenterConfigOpt func(*v1alpha1.TinkerbellDatacenterConfig)
+
+func tinkerbellDatacenterConfig(opts ...tinkerbellDatacenterConfigOpt) v1alpha1.TinkerbellDatacenterConfig {
+	d := v1alpha1.TinkerbellDatacenterConfig{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: make(map[string]string, 1),
@@ -80,4 +149,10 @@ func tinkerbellDatacenterConfig() v1alpha1.TinkerbellDatacenterConfig {
 		},
 		Status: v1alpha1.TinkerbellDatacenterConfigStatus{},
 	}
+
+	for _, opt := range opts {
+		opt(&d)
+	}
+
+	return d
 }

--- a/pkg/controller/clientutil/annotations.go
+++ b/pkg/controller/clientutil/annotations.go
@@ -23,3 +23,12 @@ func AddLabel(o client.Object, key, value string) {
 	l[key] = value
 	o.SetLabels(l)
 }
+
+// RemoveAnnotation removes an annotation from the given object.
+func RemoveAnnotation(o client.Object, key string) {
+	a := o.GetAnnotations()
+	if a != nil {
+		delete(a, key)
+		o.SetAnnotations(a)
+	}
+}

--- a/pkg/controller/clientutil/annotations_test.go
+++ b/pkg/controller/clientutil/annotations_test.go
@@ -126,3 +126,46 @@ func TestAddLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		key  string
+	}{
+		{
+			name: "empty annotations",
+			obj:  &corev1.ConfigMap{},
+			key:  "my-annotation",
+		},
+		{
+			name: "annotations key present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"my-annotation": "b",
+					},
+				},
+			},
+			key: "my-annotation",
+		},
+		{
+			name: "annotation key not present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"a": "b",
+					},
+				},
+			},
+			key: "my-annotation",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			clientutil.RemoveAnnotation(tt.obj, tt.key)
+			g.Expect(tt.obj.GetAnnotations()).ToNot(HaveKey(tt.key))
+		})
+	}
+}

--- a/pkg/workflows/management/upgrade_cluster.go
+++ b/pkg/workflows/management/upgrade_cluster.go
@@ -3,6 +3,10 @@ package management
 import (
 	"context"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -13,11 +17,31 @@ type upgradeCluster struct{}
 // Run upgradeCluster performs actions needed to upgrade the management cluster.
 func (s *upgradeCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Upgrading management cluster")
+	if commandContext.ClusterSpec.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
+		clientutil.AddAnnotation(commandContext.ClusterSpec.TinkerbellDatacenter, v1alpha1.ManagedByCLIAnnotation, "true")
+	}
 	if err := commandContext.ClusterUpgrader.Run(ctx, commandContext.ClusterSpec, *commandContext.ManagementCluster); err != nil {
 		commandContext.SetError(err)
 		return &workflows.CollectMgmtClusterDiagnosticsTask{}
 	}
 
+	client, err := commandContext.ClientFactory.BuildClientFromKubeconfig(commandContext.ManagementCluster.KubeconfigFile)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	if commandContext.ClusterSpec.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
+		clientutil.RemoveAnnotation(commandContext.ClusterSpec.TinkerbellDatacenter, v1alpha1.ManagedByCLIAnnotation)
+		if err := client.ApplyServerSide(ctx,
+			constants.EKSACLIFieldManager,
+			commandContext.ClusterSpec.TinkerbellDatacenter,
+			kubernetes.ApplyServerSideOptions{ForceOwnership: true},
+		); err != nil {
+			commandContext.SetError(err)
+			return &workflows.CollectMgmtClusterDiagnosticsTask{}
+		}
+	}
 	return &reconcileGitOps{}
 }
 

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -246,8 +248,11 @@ func (c *upgradeManagementTestSetup) expectApplyReleases(err error) {
 	)
 }
 
-func (c *upgradeManagementTestSetup) expectUpgradeManagementCluster(err error) {
-	c.clusterUpgrader.EXPECT().Run(c.ctx, c.newClusterSpec, *c.managementCluster).Return(err)
+func (c *upgradeManagementTestSetup) expectUpgradeManagementCluster() {
+	gomock.InOrder(
+		c.clusterUpgrader.EXPECT().Run(c.ctx, c.newClusterSpec, *c.managementCluster).Return(nil),
+		c.clientFactory.EXPECT().BuildClientFromKubeconfig(c.managementCluster.KubeconfigFile).Return(c.client, nil),
+	)
 }
 
 func (c *upgradeManagementTestSetup) expectResumeCAPIWorkloadClustersAPI(err error) {
@@ -569,7 +574,34 @@ func TestUpgradeManagementRunFailedUpgrade(t *testing.T) {
 	test.expectInstallEksdManifest(nil)
 	test.expectApplyBundles(nil)
 	test.expectApplyReleases(nil)
-	test.expectUpgradeManagementCluster(errors.New("failed upgrading"))
+	test.clusterUpgrader.EXPECT().Run(test.ctx, test.newClusterSpec, *test.managementCluster).Return(errors.New("failed upgrading"))
+	test.expectSaveLogs()
+	test.expectWriteCheckpointFile()
+
+	err := test.run()
+	if err == nil {
+		t.Fatal("UpgradeManagement.Run() err = nil, want err not nil")
+	}
+}
+
+func TestUpgradeManagementRunFailedUpgradeClusterBuildClientFromKubeconfig(t *testing.T) {
+	os.Unsetenv(features.CheckpointEnabledEnvVar)
+	features.ClearCache()
+	test := newUpgradeManagementClusterTest(t)
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectUpdateSecrets(nil)
+	test.expectEnsureManagementEtcdCAPIComponentsExist(nil)
+	test.expectPauseGitOpsReconcile(nil)
+	test.expectUpgradeCoreComponents()
+	test.expectBackupManagementFromCluster(nil)
+	test.expectPauseCAPIWorkloadClusters(nil)
+	test.expectDatacenterConfig()
+	test.expectMachineConfigs()
+	test.expectInstallEksdManifest(nil)
+	test.expectApplyBundles(nil)
+	test.expectApplyReleases(nil)
+	test.clusterUpgrader.EXPECT().Run(test.ctx, test.newClusterSpec, *test.managementCluster).Return(errors.New("failed upgrading"))
 	test.expectSaveLogs()
 	test.expectWriteCheckpointFile()
 
@@ -596,7 +628,7 @@ func TestUpgradeManagementRunResumeCAPIWorkloadFailed(t *testing.T) {
 	test.expectInstallEksdManifest(nil)
 	test.expectApplyBundles(nil)
 	test.expectApplyReleases(nil)
-	test.expectUpgradeManagementCluster(nil)
+	test.expectUpgradeManagementCluster()
 	test.expectUpdateGitEksaSpec(nil)
 	test.expectForceReconcileGitRepo(nil)
 	test.expectResumeGitOpsReconcile(nil)
@@ -628,7 +660,7 @@ func TestUpgradeManagementRunUpdateGitEksaSpecFailed(t *testing.T) {
 	test.expectInstallEksdManifest(nil)
 	test.expectApplyBundles(nil)
 	test.expectApplyReleases(nil)
-	test.expectUpgradeManagementCluster(nil)
+	test.expectUpgradeManagementCluster()
 	test.expectUpdateGitEksaSpec(errors.New(""))
 	test.expectSaveLogs()
 	test.expectWriteCheckpointFile()
@@ -656,7 +688,7 @@ func TestUpgradeManagementRunForceReconcileGitRepoFailed(t *testing.T) {
 	test.expectInstallEksdManifest(nil)
 	test.expectApplyBundles(nil)
 	test.expectApplyReleases(nil)
-	test.expectUpgradeManagementCluster(nil)
+	test.expectUpgradeManagementCluster()
 	test.expectUpdateGitEksaSpec(nil)
 	test.expectForceReconcileGitRepo(errors.New(""))
 	test.expectSaveLogs()
@@ -685,7 +717,7 @@ func TestUpgradeManagementRunResumeClusterResourcesReconcileFailed(t *testing.T)
 	test.expectInstallEksdManifest(nil)
 	test.expectApplyBundles(nil)
 	test.expectApplyReleases(nil)
-	test.expectUpgradeManagementCluster(nil)
+	test.expectUpgradeManagementCluster()
 	test.expectUpdateGitEksaSpec(nil)
 	test.expectForceReconcileGitRepo(nil)
 	test.expectResumeGitOpsReconcile(errors.New(""))
@@ -716,7 +748,44 @@ func TestUpgradeManagementRunSuccess(t *testing.T) {
 	test.expectInstallEksdManifest(nil)
 	test.expectApplyBundles(nil)
 	test.expectApplyReleases(nil)
-	test.expectUpgradeManagementCluster(nil)
+	test.expectUpgradeManagementCluster()
+	test.expectResumeCAPIWorkloadClustersAPI(nil)
+	test.expectUpdateGitEksaSpec(nil)
+	test.expectForceReconcileGitRepo(nil)
+	test.expectResumeGitOpsReconcile(nil)
+	test.expectWriteManagementClusterConfig(nil)
+
+	err := test.run()
+	if err != nil {
+		t.Fatalf("UpgradeManagement.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestTinkerbellUpgradeManagementRunSuccess(t *testing.T) {
+	os.Unsetenv(features.CheckpointEnabledEnvVar)
+	features.ClearCache()
+	test := newUpgradeManagementClusterTest(t)
+	test.newClusterSpec.Cluster.Spec.DatacenterRef.Kind = v1alpha1.TinkerbellDatacenterKind
+	test.newClusterSpec.TinkerbellDatacenter = &v1alpha1.TinkerbellDatacenterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-datacenter",
+			Namespace: "default",
+		},
+	}
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectUpdateSecrets(nil)
+	test.expectEnsureManagementEtcdCAPIComponentsExist(nil)
+	test.expectUpgradeCoreComponents()
+	test.expectPauseGitOpsReconcile(nil)
+	test.expectBackupManagementFromCluster(nil)
+	test.expectPauseCAPIWorkloadClusters(nil)
+	test.expectDatacenterConfig()
+	test.expectMachineConfigs()
+	test.expectInstallEksdManifest(nil)
+	test.expectApplyBundles(nil)
+	test.expectApplyReleases(nil)
+	test.expectUpgradeManagementCluster()
 	test.expectResumeCAPIWorkloadClustersAPI(nil)
 	test.expectUpdateGitEksaSpec(nil)
 	test.expectForceReconcileGitRepo(nil)

--- a/pkg/workflows/workload/upgrade.go
+++ b/pkg/workflows/workload/upgrade.go
@@ -13,6 +13,7 @@ import (
 
 // Upgrade is a schema for upgrade cluster.
 type Upgrade struct {
+	clientFactory    interfaces.ClientFactory
 	provider         providers.Provider
 	clusterManager   interfaces.ClusterManager
 	gitOpsManager    interfaces.GitOpsManager
@@ -23,7 +24,8 @@ type Upgrade struct {
 }
 
 // NewUpgrade builds a new upgrade construct.
-func NewUpgrade(provider providers.Provider,
+func NewUpgrade(clientFactory interfaces.ClientFactory,
+	provider providers.Provider,
 	clusterManager interfaces.ClusterManager, gitOpsManager interfaces.GitOpsManager,
 	writer filewriter.FileWriter,
 	clusterUpgrader interfaces.ClusterUpgrader,
@@ -31,6 +33,7 @@ func NewUpgrade(provider providers.Provider,
 	packageInstaller interfaces.PackageInstaller,
 ) *Upgrade {
 	return &Upgrade{
+		clientFactory:    clientFactory,
 		provider:         provider,
 		clusterManager:   clusterManager,
 		gitOpsManager:    gitOpsManager,
@@ -44,6 +47,7 @@ func NewUpgrade(provider providers.Provider,
 // Run Upgrade implements upgrade functionality for workload cluster's upgrade operation.
 func (c *Upgrade) Run(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, validator interfaces.Validator) error {
 	commandContext := &task.CommandContext{
+		ClientFactory:     c.clientFactory,
 		Provider:          c.provider,
 		ClusterManager:    c.clusterManager,
 		GitOpsManager:     c.gitOpsManager,

--- a/pkg/workflows/workload/upgradecluster.go
+++ b/pkg/workflows/workload/upgradecluster.go
@@ -3,6 +3,10 @@ package workload
 import (
 	"context"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
 	"github.com/aws/eks-anywhere/pkg/workflows"
@@ -13,9 +17,31 @@ type upgradeCluster struct{}
 // Run upgradeCluster performs actions needed to upgrade the workload cluster.
 func (s *upgradeCluster) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	logger.Info("Upgrading workload cluster components")
+	if commandContext.ClusterSpec.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
+		clientutil.AddAnnotation(commandContext.ClusterSpec.TinkerbellDatacenter, v1alpha1.ManagedByCLIAnnotation, "true")
+	}
+
 	if err := commandContext.ClusterUpgrader.Run(ctx, commandContext.ClusterSpec, *commandContext.ManagementCluster); err != nil {
 		commandContext.SetError(err)
 		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	client, err := commandContext.ClientFactory.BuildClientFromKubeconfig(commandContext.ManagementCluster.KubeconfigFile)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
+	}
+
+	if commandContext.ClusterSpec.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
+		clientutil.RemoveAnnotation(commandContext.ClusterSpec.TinkerbellDatacenter, v1alpha1.ManagedByCLIAnnotation)
+		if err := client.ApplyServerSide(ctx,
+			constants.EKSACLIFieldManager,
+			commandContext.ClusterSpec.TinkerbellDatacenter,
+			kubernetes.ApplyServerSideOptions{ForceOwnership: true},
+		); err != nil {
+			commandContext.SetError(err)
+			return &workflows.CollectMgmtClusterDiagnosticsTask{}
+		}
 	}
 
 	return &writeClusterConfig{}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After `upgrade management-components` operation, EKSA allows the user to upgrade the cluster one of two ways: through the CLI and through the API. Today, the `upgrade cluster` command will upgrade the Tinkerbell stack, but upgrading the cluster through the API does not. So, any fields changed in the spec after upgrading management components would not be respected if upgrade through the API, as there is no logic in the controller that upgrades the Tinkerbell stack. Overall, there is a discrepancy between the behavior of the CLI `upgrade cluster` command and `kubectl apply -f <cluster.yaml>` when there should not be.

This PR adds some immutability validation in the tinkerbelldatacenterconfig webhook on fields that should be reconciled with trigger a Tinkerbell stack upgrade to address this in short term. ([reference to a stackInstaller.Upgrade in the code](https://github.com/aws/eks-anywhere/blob/899930ea28be6d709e96f2f113913f87861578f2/pkg/providers/tinkerbell/upgrade.go#L462))

- The `TinkerbellDatacenterConfig` fields are now immutable when managed through the API
  - `SkipLoadBalancerDeployment`
  - `HookImagesURLPath`

*Testing (if applicable):*
- Unit tests
- Manual testing, creating cluster and seeing the managed by cli annotation added and removed during upgrade.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

