### PR TITLE
Refactoring installing of new components in workflows to decouple from full cluster.Spec

### DIFF
--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/version"
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const defaultTinkerbellNodeStartupTimeout = 20 * time.Minute
@@ -153,6 +154,38 @@ func newClusterSpec(options clusterOptions) (*cluster.Spec, error) {
 	}
 
 	return clusterSpec, nil
+}
+
+func newEKSARelease(bundles *releasev1.Bundles, options clusterOptions) (*releasev1.EKSARelease, error) {
+	var opts []cluster.FileSpecBuilderOpt
+	if options.bundlesOverride != "" {
+		opts = append(opts, cluster.WithOverrideBundlesManifest(options.bundlesOverride))
+	}
+
+	cliVersion := version.Get()
+	b := cluster.NewFileSpecBuilder(
+		files.NewReader(files.WithEKSAUserAgent("cli", cliVersion.GitVersion)),
+		cliVersion,
+		opts...,
+	)
+
+	return cluster.BuildEKSARelease(b, bundles)
+}
+
+func newBundles(options clusterOptions) (*releasev1.Bundles, error) {
+	var opts []cluster.FileSpecBuilderOpt
+	if options.bundlesOverride != "" {
+		opts = append(opts, cluster.WithOverrideBundlesManifest(options.bundlesOverride))
+	}
+
+	cliVersion := version.Get()
+	b := cluster.NewFileSpecBuilder(
+		files.NewReader(files.WithEKSAUserAgent("cli", cliVersion.GitVersion)),
+		cliVersion,
+		opts...,
+	)
+
+	return cluster.GetBundlesManifest(b)
 }
 
 func markFlagHidden(flagSet *pflag.FlagSet, flagName string) {

--- a/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
@@ -38,6 +38,17 @@ var upgradeManagementComponentsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		bundles, err := newBundles(umco.clusterOptions)
+		if err != nil {
+			return err
+		}
+
+		eksaRelease, err := newEKSARelease(bundles, umco.clusterOptions)
+		if err != nil {
+			return err
+		}
+
 		if !clusterSpec.Cluster.IsSelfManaged() {
 			return fmt.Errorf("cluster %s doesn't contain management components to be upgraded", clusterSpec.Cluster.Name)
 		}
@@ -85,7 +96,7 @@ var upgradeManagementComponentsCmd = &cobra.Command{
 		}
 
 		validator := management.NewUMCValidator(managementCluster, deps.Kubectl)
-		return runner.Run(ctx, clusterSpec, managementCluster, validator)
+		return runner.Run(ctx, bundles, eksaRelease, clusterSpec, managementCluster, validator)
 	},
 }
 

--- a/pkg/cluster/builder.go
+++ b/pkg/cluster/builder.go
@@ -201,6 +201,7 @@ func (b FileSpecBuilder) getEksaRelease(mReader *manifests.Reader) (*releasev1.E
 	}, nil
 }
 
+// buildEKSARelease builds an EKSARelease from a Release and a Bundles.
 func buildEKSARelease(release *releasev1.EksARelease, bundle *releasev1.Bundles) *releasev1.EKSARelease {
 	eksaRelease := &releasev1.EKSARelease{
 		TypeMeta: v1.TypeMeta{
@@ -224,4 +225,28 @@ func buildEKSARelease(release *releasev1.EksARelease, bundle *releasev1.Bundles)
 		},
 	}
 	return eksaRelease
+}
+
+// GetBundlesManifest builds a Bundles from a FileSpecBuilder.
+func GetBundlesManifest(b FileSpecBuilder) (*releasev1.Bundles, error) {
+	mReader := b.createManifestReader()
+
+	bundlesManifest, err := b.getBundles(mReader)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting Bundles manifest")
+	}
+
+	return bundlesManifest, nil
+}
+
+// BuildEKSARelease builds an EKSARelease from a FileSpecBuilder and bundles.
+func BuildEKSARelease(b FileSpecBuilder, bundles *releasev1.Bundles) (*releasev1.EKSARelease, error) {
+	mReader := b.createManifestReader()
+	release, err := b.getEksaRelease(mReader)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting EksaRelease manifest")
+	}
+
+	eksaRelease := buildEKSARelease(release, bundles)
+	return eksaRelease, nil
 }

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -1163,7 +1163,7 @@ func (c *ClusterManager) CreateEKSAResources(ctx context.Context, cluster *types
 	if err = c.ApplyBundles(ctx, clusterSpec.Bundles, cluster); err != nil {
 		return err
 	}
-	return c.ApplyReleases(ctx, clusterSpec, cluster)
+	return c.ApplyReleases(ctx, clusterSpec.EKSARelease, cluster)
 }
 
 // ApplyBundles applies the Bundles manifest to the cluster.
@@ -1191,8 +1191,8 @@ func (c *ClusterManager) ApplyBundles(ctx context.Context, bundles *releasev1alp
 }
 
 // ApplyReleases applies the EKSARelease manifest.
-func (c *ClusterManager) ApplyReleases(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
-	releaseObj, err := yaml.Marshal(clusterSpec.EKSARelease)
+func (c *ClusterManager) ApplyReleases(ctx context.Context, eksaRelease *releasev1alpha1.EKSARelease, cluster *types.Cluster) error {
+	releaseObj, err := yaml.Marshal(eksaRelease)
 	if err != nil {
 		return fmt.Errorf("outputting release yaml: %v", err)
 	}

--- a/pkg/eksd/installer.go
+++ b/pkg/eksd/installer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/retrier"
 	"github.com/aws/eks-anywhere/pkg/types"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const (
@@ -92,9 +93,10 @@ func (i *Installer) SetRetrier(retrier *retrier.Retrier) {
 	i.retrier = retrier
 }
 
-func (i *Installer) InstallEksdManifest(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error {
+// InstallEksdManifest installs the eksd manifest to the cluster.
+func (i *Installer) InstallEksdManifest(ctx context.Context, bundles *releasev1alpha1.Bundles, cluster *types.Cluster) error {
 	var eksdReleaseManifest []byte
-	for _, vb := range clusterSpec.Bundles.Spec.VersionsBundles {
+	for _, vb := range bundles.Spec.VersionsBundles {
 		if err := i.retrier.Retry(
 			func() error {
 				var readerErr error

--- a/pkg/eksd/installer_test.go
+++ b/pkg/eksd/installer_test.go
@@ -73,7 +73,7 @@ func TestInstallEksdManifestSuccess(t *testing.T) {
 	tt.reader.EXPECT().ReadFile(testdataFile).Return([]byte("test data"), nil).Times(2)
 	tt.client.EXPECT().ApplyKubeSpecFromBytesWithNamespace(tt.ctx, tt.cluster, []byte("test data"), constants.EksaSystemNamespace).Return(errors.New("error apply")).Times(2)
 	tt.client.EXPECT().ApplyKubeSpecFromBytesWithNamespace(tt.ctx, tt.cluster, []byte("test data"), constants.EksaSystemNamespace).Return(nil).Times(2)
-	if err := tt.eksdInstaller.InstallEksdManifest(tt.ctx, tt.clusterSpec, tt.cluster); err != nil {
+	if err := tt.eksdInstaller.InstallEksdManifest(tt.ctx, tt.clusterSpec.Bundles, tt.cluster); err != nil {
 		t.Errorf("Eksd.InstallEksdManifest() error = %v, wantErr nil", err)
 	}
 }
@@ -85,7 +85,7 @@ func TestInstallEksdManifestErrorReadingManifest(t *testing.T) {
 	tt.clusterSpec.Bundles.Spec.VersionsBundles[0].EksD.EksDReleaseUrl = "fake.yaml"
 
 	tt.reader.EXPECT().ReadFile(tt.clusterSpec.Bundles.Spec.VersionsBundles[0].EksD.EksDReleaseUrl).Return([]byte(""), fmt.Errorf("error"))
-	if err := tt.eksdInstaller.InstallEksdManifest(tt.ctx, tt.clusterSpec, tt.cluster); err == nil {
+	if err := tt.eksdInstaller.InstallEksdManifest(tt.ctx, tt.clusterSpec.Bundles, tt.cluster); err == nil {
 		t.Error("Eksd.InstallEksdManifest() error = nil, wantErr not nil")
 	}
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 // Task is a logical unit of work - meant to be implemented by each Task.
@@ -42,6 +43,8 @@ type CommandContext struct {
 	ClusterCreator        interfaces.ClusterCreator
 	ClusterDeleter        interfaces.ClusterDeleter
 	CAPIManager           interfaces.CAPIManager
+	Bundles               *releasev1alpha1.Bundles
+	EKSARelease           *releasev1alpha1.EKSARelease
 	ClusterSpec           *cluster.Spec
 	CurrentClusterSpec    *cluster.Spec
 	UpgradeChangeDiff     *types.ChangeDiff

--- a/pkg/workflows/create.go
+++ b/pkg/workflows/create.go
@@ -375,7 +375,7 @@ func (s *InstallEksaComponentsTask) Run(ctx context.Context, commandContext *tas
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
-	err = commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec, targetCluster)
+	err = commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec.Bundles, targetCluster)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/create_test.go
+++ b/pkg/workflows/create_test.go
@@ -213,7 +213,7 @@ func (c *createTestSetup) expectInstallEksaComponents() {
 		),
 
 		c.eksd.EXPECT().InstallEksdManifest(
-			c.ctx, c.clusterSpec, c.workloadCluster),
+			c.ctx, c.clusterSpec.Bundles, c.workloadCluster),
 
 		c.clientFactory.EXPECT().BuildClientFromKubeconfig(c.workloadCluster.KubeconfigFile).Return(c.client, nil),
 
@@ -245,7 +245,7 @@ func (c *createTestSetup) skipInstallEksaComponents() {
 		),
 
 		c.eksd.EXPECT().InstallEksdManifest(
-			c.ctx, c.clusterSpec, c.bootstrapCluster),
+			c.ctx, c.clusterSpec.Bundles, c.bootstrapCluster),
 
 		c.clientFactory.EXPECT().BuildClientFromKubeconfig(c.bootstrapCluster.KubeconfigFile).Return(c.client, nil),
 
@@ -351,7 +351,7 @@ func TestCreateRunInstallEksaComponentsBuildClientFailure(t *testing.T) {
 		),
 
 		test.eksd.EXPECT().InstallEksdManifest(
-			test.ctx, test.clusterSpec, test.workloadCluster),
+			test.ctx, test.clusterSpec.Bundles, test.workloadCluster),
 
 		test.clientFactory.EXPECT().BuildClientFromKubeconfig(test.workloadCluster.KubeconfigFile).Return(nil, wantError),
 	)
@@ -390,7 +390,7 @@ func TestCreateRunInstallEksaComponentsApplyServerSideFailure(t *testing.T) {
 		),
 
 		test.eksd.EXPECT().InstallEksdManifest(
-			test.ctx, test.clusterSpec, test.workloadCluster),
+			test.ctx, test.clusterSpec.Bundles, test.workloadCluster),
 
 		test.clientFactory.EXPECT().BuildClientFromKubeconfig(test.workloadCluster.KubeconfigFile).Return(test.client, nil),
 

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 // ClientFactory builds Kubernetes clients.
@@ -43,7 +44,7 @@ type ClusterManager interface {
 	InstallCustomComponents(ctx context.Context, managementComponents *cluster.ManagementComponents, clusterSpec *cluster.Spec, cluster *types.Cluster, provider providers.Provider) error
 	CreateEKSANamespace(ctx context.Context, cluster *types.Cluster) error
 	CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) error
-	ApplyBundles(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
+	ApplyBundles(ctx context.Context, bundles *releasev1alpha1.Bundles, cluster *types.Cluster) error
 	ApplyReleases(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
 	PauseEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	ResumeEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -84,7 +84,7 @@ type CAPIManager interface {
 
 type EksdInstaller interface {
 	InstallEksdCRDs(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
-	InstallEksdManifest(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
+	InstallEksdManifest(ctx context.Context, bundles *releasev1alpha1.Bundles, cluster *types.Cluster) error
 }
 
 type EksdUpgrader interface {

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -45,7 +45,7 @@ type ClusterManager interface {
 	CreateEKSANamespace(ctx context.Context, cluster *types.Cluster) error
 	CreateEKSAResources(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, datacenterConfig providers.DatacenterConfig, machineConfigs []providers.MachineConfig) error
 	ApplyBundles(ctx context.Context, bundles *releasev1alpha1.Bundles, cluster *types.Cluster) error
-	ApplyReleases(ctx context.Context, clusterSpec *cluster.Spec, cluster *types.Cluster) error
+	ApplyReleases(ctx context.Context, eksaRelease *releasev1alpha1.EKSARelease, cluster *types.Cluster) error
 	PauseEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	ResumeEKSAControllerReconcile(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error
 	RemoveManagedByCLIAnnotationForCluster(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec, provider providers.Provider) error

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -15,6 +15,7 @@ import (
 	providers "github.com/aws/eks-anywhere/pkg/providers"
 	types "github.com/aws/eks-anywhere/pkg/types"
 	validations "github.com/aws/eks-anywhere/pkg/validations"
+	v1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -100,7 +101,7 @@ func (m *MockClusterManager) EXPECT() *MockClusterManagerMockRecorder {
 }
 
 // ApplyBundles mocks base method.
-func (m *MockClusterManager) ApplyBundles(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster) error {
+func (m *MockClusterManager) ApplyBundles(arg0 context.Context, arg1 *v1alpha1.Bundles, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyBundles", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -835,7 +835,7 @@ func (mr *MockEksdInstallerMockRecorder) InstallEksdCRDs(arg0, arg1, arg2 interf
 }
 
 // InstallEksdManifest mocks base method.
-func (m *MockEksdInstaller) InstallEksdManifest(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster) error {
+func (m *MockEksdInstaller) InstallEksdManifest(arg0 context.Context, arg1 *v1alpha1.Bundles, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstallEksdManifest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -115,7 +115,7 @@ func (mr *MockClusterManagerMockRecorder) ApplyBundles(arg0, arg1, arg2 interfac
 }
 
 // ApplyReleases mocks base method.
-func (m *MockClusterManager) ApplyReleases(arg0 context.Context, arg1 *cluster.Spec, arg2 *types.Cluster) error {
+func (m *MockClusterManager) ApplyReleases(arg0 context.Context, arg1 *v1alpha1.EKSARelease, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyReleases", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/workflows/management/create_install_eksa.go
+++ b/pkg/workflows/management/create_install_eksa.go
@@ -96,7 +96,7 @@ func installEKSAComponents(ctx context.Context, commandContext *task.CommandCont
 		return err
 	}
 
-	if err := commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec, targetCluster); err != nil {
+	if err := commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec.Bundles, targetCluster); err != nil {
 		commandContext.SetError(err)
 		return err
 	}

--- a/pkg/workflows/management/create_test.go
+++ b/pkg/workflows/management/create_test.go
@@ -170,7 +170,7 @@ func (c *createTestSetup) expectInstallEksaComponentsBootstrap(err1, err2, err3,
 			c.ctx, c.bootstrapCluster.KubeconfigFile).Return(err3),
 
 		c.eksdInstaller.EXPECT().InstallEksdManifest(
-			c.ctx, c.clusterSpec, c.bootstrapCluster).Return(err4),
+			c.ctx, c.clusterSpec.Bundles, c.bootstrapCluster).Return(err4),
 	)
 }
 
@@ -221,7 +221,7 @@ func (c *createTestSetup) expectInstallEksaComponentsWorkload(err1, err2, err3 e
 			c.ctx, c.workloadCluster.KubeconfigFile),
 
 		c.eksdInstaller.EXPECT().InstallEksdManifest(
-			c.ctx, c.clusterSpec, c.workloadCluster),
+			c.ctx, c.clusterSpec.Bundles, c.workloadCluster),
 
 		c.clusterManager.EXPECT().CreateNamespace(c.ctx, c.workloadCluster, c.clusterSpec.Cluster.Namespace).Return(err3),
 
@@ -500,7 +500,7 @@ func TestCreateInstallEksdManifestFailure(t *testing.T) {
 		c.ctx, c.bootstrapCluster.KubeconfigFile)
 
 	c.eksdInstaller.EXPECT().InstallEksdManifest(
-		c.ctx, c.clusterSpec, c.bootstrapCluster).Return(err)
+		c.ctx, c.clusterSpec.Bundles, c.bootstrapCluster).Return(err)
 
 	c.clusterManager.EXPECT().SaveLogsManagementCluster(c.ctx, c.clusterSpec, c.bootstrapCluster)
 	c.clusterManager.EXPECT().SaveLogsWorkloadCluster(c.ctx, c.provider, c.clusterSpec, nil)
@@ -763,7 +763,7 @@ func TestCreateEKSAWorkloadNamespaceFailure(t *testing.T) {
 			test.ctx, test.workloadCluster.KubeconfigFile),
 
 		test.eksdInstaller.EXPECT().InstallEksdManifest(
-			test.ctx, test.clusterSpec, test.workloadCluster),
+			test.ctx, test.clusterSpec.Bundles, test.workloadCluster),
 
 		test.clusterManager.EXPECT().CreateNamespace(test.ctx, test.workloadCluster, test.clusterSpec.Cluster.Namespace).Return(fmt.Errorf("")),
 	)

--- a/pkg/workflows/management/install_new_components.go
+++ b/pkg/workflows/management/install_new_components.go
@@ -20,7 +20,7 @@ func runInstallNewComponents(ctx context.Context, commandContext *task.CommandCo
 		return err
 	}
 
-	err := commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec, commandContext.ManagementCluster)
+	err := commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.Bundles, commandContext.ManagementCluster)
 	if err != nil {
 		commandContext.SetError(err)
 		return err

--- a/pkg/workflows/management/install_new_components.go
+++ b/pkg/workflows/management/install_new_components.go
@@ -15,7 +15,7 @@ func runInstallNewComponents(ctx context.Context, commandContext *task.CommandCo
 		return err
 	}
 
-	if err := commandContext.ClusterManager.ApplyReleases(ctx, commandContext.ClusterSpec, commandContext.ManagementCluster); err != nil {
+	if err := commandContext.ClusterManager.ApplyReleases(ctx, commandContext.EKSARelease, commandContext.ManagementCluster); err != nil {
 		commandContext.SetError(err)
 		return err
 	}

--- a/pkg/workflows/management/install_new_components.go
+++ b/pkg/workflows/management/install_new_components.go
@@ -10,7 +10,7 @@ import (
 type installNewComponents struct{}
 
 func runInstallNewComponents(ctx context.Context, commandContext *task.CommandContext) error {
-	if err := commandContext.ClusterManager.ApplyBundles(ctx, commandContext.ClusterSpec, commandContext.ManagementCluster); err != nil {
+	if err := commandContext.ClusterManager.ApplyBundles(ctx, commandContext.Bundles, commandContext.ManagementCluster); err != nil {
 		commandContext.SetError(err)
 		return err
 	}

--- a/pkg/workflows/management/upgrade.go
+++ b/pkg/workflows/management/upgrade.go
@@ -59,6 +59,8 @@ func (c *Upgrade) Run(ctx context.Context, clusterSpec *cluster.Spec, management
 		ClusterManager:    c.clusterManager,
 		GitOpsManager:     c.gitOpsManager,
 		ManagementCluster: managementCluster,
+		Bundles:           clusterSpec.Bundles,
+		EKSARelease:       clusterSpec.EKSARelease,
 		ClusterSpec:       clusterSpec,
 		Validations:       validator,
 		Writer:            c.writer,

--- a/pkg/workflows/management/upgrade_management_components.go
+++ b/pkg/workflows/management/upgrade_management_components.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/workflows"
 	"github.com/aws/eks-anywhere/pkg/workflows/interfaces"
+	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 // UpgradeManagementComponentsWorkflow is a schema for upgrade management components.
@@ -88,12 +89,14 @@ func (u *UMCValidator) PreflightValidations(ctx context.Context) []validations.V
 }
 
 // Run Upgrade implements upgrade functionality for management cluster's upgrade operation.
-func (umc *UpgradeManagementComponentsWorkflow) Run(ctx context.Context, clusterSpec *cluster.Spec, managementCluster *types.Cluster, validator interfaces.Validator) error {
+func (umc *UpgradeManagementComponentsWorkflow) Run(ctx context.Context, bundles *releasev1alpha1.Bundles, eksaRelease *releasev1alpha1.EKSARelease, clusterSpec *cluster.Spec, managementCluster *types.Cluster, validator interfaces.Validator) error {
 	commandContext := &task.CommandContext{
 		ClientFactory:     umc.clientFactory,
 		Provider:          umc.provider,
 		ClusterManager:    umc.clusterManager,
 		ManagementCluster: managementCluster,
+		Bundles:           bundles,
+		EKSARelease:       eksaRelease,
 		ClusterSpec:       clusterSpec,
 		Validations:       validator,
 		Writer:            umc.writer,

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -124,7 +124,7 @@ func TestRunnerHappyPath(t *testing.T) {
 			ctx, eksaRelease, managementCluster,
 		).Return(nil),
 		mocks.eksdInstaller.EXPECT().InstallEksdManifest(
-			ctx, newSpec, managementCluster,
+			ctx, bundles, managementCluster,
 		).Return(nil),
 	)
 

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -121,7 +121,7 @@ func TestRunnerHappyPath(t *testing.T) {
 			ctx, bundles, managementCluster,
 		).Return(nil),
 		mocks.clusterManager.EXPECT().ApplyReleases(
-			ctx, newSpec, managementCluster,
+			ctx, eksaRelease, managementCluster,
 		).Return(nil),
 		mocks.eksdInstaller.EXPECT().InstallEksdManifest(
 			ctx, newSpec, managementCluster,

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -233,7 +233,7 @@ func (c *upgradeManagementTestSetup) expectInstallEksdManifest(err error) {
 func (c *upgradeManagementTestSetup) expectApplyBundles(err error) {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().ApplyBundles(
-			c.ctx, c.newClusterSpec, c.managementCluster,
+			c.ctx, c.newClusterSpec.Bundles, c.managementCluster,
 		).Return(err),
 	)
 }

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -225,7 +225,7 @@ func (c *upgradeManagementTestSetup) expectMachineConfigs() {
 func (c *upgradeManagementTestSetup) expectInstallEksdManifest(err error) {
 	gomock.InOrder(
 		c.eksdInstaller.EXPECT().InstallEksdManifest(
-			c.ctx, c.newClusterSpec, c.managementCluster,
+			c.ctx, c.newClusterSpec.Bundles, c.managementCluster,
 		).Return(err),
 	)
 }

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -241,7 +241,7 @@ func (c *upgradeManagementTestSetup) expectApplyBundles(err error) {
 func (c *upgradeManagementTestSetup) expectApplyReleases(err error) {
 	gomock.InOrder(
 		c.clusterManager.EXPECT().ApplyReleases(
-			c.ctx, c.newClusterSpec, c.managementCluster,
+			c.ctx, c.newClusterSpec.EKSARelease, c.managementCluster,
 		).Return(err),
 	)
 }

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -510,7 +510,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 		return &CollectDiagnosticsTask{}
 	}
 
-	if err = commandContext.ClusterManager.ApplyReleases(ctx, commandContext.ClusterSpec, eksaManagementCluster); err != nil {
+	if err = commandContext.ClusterManager.ApplyReleases(ctx, commandContext.ClusterSpec.EKSARelease, eksaManagementCluster); err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -580,7 +580,7 @@ func (s *reconcileClusterDefinitions) Run(ctx context.Context, commandContext *t
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}
-	err = commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec, commandContext.ManagementCluster)
+	err = commandContext.EksdInstaller.InstallEksdManifest(ctx, commandContext.ClusterSpec.Bundles, commandContext.ManagementCluster)
 	if err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}

--- a/pkg/workflows/upgrade.go
+++ b/pkg/workflows/upgrade.go
@@ -505,7 +505,7 @@ func (s *upgradeWorkloadClusterTask) Run(ctx context.Context, commandContext *ta
 		return &CollectDiagnosticsTask{}
 	}
 
-	if err = commandContext.ClusterManager.ApplyBundles(ctx, commandContext.ClusterSpec, eksaManagementCluster); err != nil {
+	if err = commandContext.ClusterManager.ApplyBundles(ctx, commandContext.ClusterSpec.Bundles, eksaManagementCluster); err != nil {
 		commandContext.SetError(err)
 		return &CollectDiagnosticsTask{}
 	}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -231,12 +231,12 @@ func (c *upgradeTestSetup) expectUpgradeWorkload(managementCluster *types.Cluste
 
 	if c.newClusterSpec.Cluster.IsManaged() {
 		calls = append(calls,
-			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec, managementCluster),
+			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec.Bundles, managementCluster),
 			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec, managementCluster),
 		)
 	} else {
 		calls = append(calls,
-			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec, workloadCluster),
+			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec.Bundles, workloadCluster),
 			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec, workloadCluster),
 		)
 	}

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -346,7 +346,7 @@ func (c *upgradeTestSetup) expectCreateEKSAResources(expectedCluster *types.Clus
 func (c *upgradeTestSetup) expectInstallEksdManifest(expectedCLuster *types.Cluster) {
 	gomock.InOrder(
 		c.eksdInstaller.EXPECT().InstallEksdManifest(
-			c.ctx, c.newClusterSpec, expectedCLuster,
+			c.ctx, c.newClusterSpec.Bundles, expectedCLuster,
 		),
 	)
 }

--- a/pkg/workflows/upgrade_test.go
+++ b/pkg/workflows/upgrade_test.go
@@ -232,12 +232,12 @@ func (c *upgradeTestSetup) expectUpgradeWorkload(managementCluster *types.Cluste
 	if c.newClusterSpec.Cluster.IsManaged() {
 		calls = append(calls,
 			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec.Bundles, managementCluster),
-			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec, managementCluster),
+			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec.EKSARelease, managementCluster),
 		)
 	} else {
 		calls = append(calls,
 			c.clusterManager.EXPECT().ApplyBundles(c.ctx, c.newClusterSpec.Bundles, workloadCluster),
-			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec, workloadCluster),
+			c.clusterManager.EXPECT().ApplyReleases(c.ctx, c.newClusterSpec.EKSARelease, workloadCluster),
 		)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Context:*
The newly introduced sub command upgrade management-components currently has an issue where:

If you have an EKS Anywhere 1.24. You cannot update the management components if the cluster is using Kubernetes version 1.24, because the CLI runs into the following error: while [building the new cluster spec](https://github.com/aws/eks-anywhere/blob/4de7cda5ac1e6b571d769df82de2391634b750b8/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go#L37) 

```
Error: failed to upgrade cluster: unable to get cluster config from file: kubernetes version 1.24 is not supported by bundles
```
It occurs while building the new cluster spec, when trying to [pick the correct versions bundle](https://github.com/aws/eks-anywhere/blob/4de7cda5ac1e6b571d769df82de2391634b750b8/pkg/cluster/fetch.go#L117) for the cluster’s kubernetes version because Kubernetes 1.24 is not supported v0.19.0, and therefore, does not have an entry in the bundles.Spec.VersionsBundles where it’s selecting from.
 
To address this, we do not need to use the full cluster.Spec in the upgrade management components workflow.

*Description of changes:*
This PR refactors `ClusterManager.ApplyBundles` and `ClusterManager.ApplyReleases` used in the workflow to not need the full `cluster.Spec`

*Testing (if applicable):*
```
--- PASS: TestVSphereKubernetes128UpgradeManagementComponents (753.53s)
PASS
```

```
--- PASS: TestVSphereKubernetes128UbuntuTo129Upgrade (2140.91s)
PASS
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

