### PR TITLE
Fix check for getting etcd url

### DIFF
--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -27,7 +27,7 @@ var configFS embed.FS
 
 // DevEksaVersion can be used in tests.
 func DevEksaVersion() v1alpha1.EksaVersion {
-	return v1alpha1.EksaVersion("v0.0.0-dev")
+	return v1alpha1.EksaVersion("v0.19.0-dev+latest")
 }
 
 func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
@@ -82,7 +82,7 @@ func NewClusterSpec(opts ...ClusterSpecOpt) *cluster.Spec {
 func NewFullClusterSpec(t *testing.T, clusterConfigFile string) *cluster.Spec {
 	b := cluster.NewFileSpecBuilder(
 		files.NewReader(files.WithEmbedFS(configFS)),
-		version.Info{GitVersion: "v0.0.0-dev"},
+		version.Info{GitVersion: "v0.19.0-dev+latest"},
 		cluster.WithReleasesManifest("embed:///testdata/releases.yaml"),
 	)
 	s, err := b.Build(clusterConfigFile)

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -37,12 +37,12 @@ func EKSARelease() *releasev1.EKSARelease {
 			APIVersion: releasev1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "eksa-v0-0-0-dev",
+			Name:      "eksa-v0-19-0-dev-plus-latest",
 			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: releasev1.EKSAReleaseSpec{
 			ReleaseDate:       "",
-			Version:           "v0.0.0-dev",
+			Version:           "v0.19.0-dev+latest",
 			GitCommit:         "",
 			BundleManifestURL: "",
 			BundlesRef: releasev1.BundlesRef{

--- a/internal/test/testdata/releases.yaml
+++ b/internal/test/testdata/releases.yaml
@@ -11,5 +11,5 @@ spec:
       gitCommit: ""
       gitTag: ""
       number: 0
-      version: v0.0.0-dev
+      version: v0.19.0-dev+latest
 status: {}

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -88,7 +88,7 @@ type EksaVersion string
 
 const (
 	// DevBuildVersion is the version string for the dev build of EKS-A.
-	DevBuildVersion = "v0.0.0-dev"
+	DevBuildVersion = "v0.19.0-dev+latest"
 
 	// MinEksAVersionWithEtcdURL is the version from which the etcd url will be set
 	// for etcdadm to pull the etcd tarball if that binary isnt cached.

--- a/pkg/cluster/fetch_test.go
+++ b/pkg/cluster/fetch_test.go
@@ -75,7 +75,7 @@ func newBuildSpecTest(t *testing.T) *buildSpecTest {
 
 	eksaRelease := &releasev1.EKSARelease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "eksa-v0-0-0-dev",
+			Name: "eksa-v0-19-0-dev-plus-latest",
 		},
 		Spec: releasev1.EKSAReleaseSpec{
 			BundlesRef: releasev1.BundlesRef{
@@ -99,7 +99,7 @@ func newBuildSpecTest(t *testing.T) *buildSpecTest {
 }
 
 func (tt *buildSpecTest) expectGetEKSARelease() {
-	tt.client.EXPECT().Get(tt.ctx, "eksa-v0-0-0-dev", "eksa-system", &releasev1.EKSARelease{}).DoAndReturn(
+	tt.client.EXPECT().Get(tt.ctx, "eksa-v0-19-0-dev-plus-latest", "eksa-system", &releasev1.EKSARelease{}).DoAndReturn(
 		func(ctx context.Context, name, namespace string, obj runtime.Object) error {
 			o := obj.(*releasev1.EKSARelease)
 			o.ObjectMeta = tt.eksaRelease.ObjectMeta
@@ -183,7 +183,7 @@ func TestBuildSpec(t *testing.T) {
 func TestBuildSpecGetEKSAReleaseError(t *testing.T) {
 	tt := newBuildSpecTest(t)
 	tt.cluster.Spec.BundlesRef = nil
-	tt.client.EXPECT().Get(tt.ctx, "eksa-v0-0-0-dev", "eksa-system", &releasev1.EKSARelease{}).Return(errors.New("client error"))
+	tt.client.EXPECT().Get(tt.ctx, "eksa-v0-19-0-dev-plus-latest", "eksa-system", &releasev1.EKSARelease{}).Return(errors.New("client error"))
 
 	_, err := cluster.BuildSpec(tt.ctx, tt.client, tt.cluster)
 	tt.Expect(err).To(MatchError(ContainSubstring("error getting EKSARelease")))
@@ -464,7 +464,7 @@ func TestGetManagementComponents(t *testing.T) {
 						VersionsBundles: []releasev1.VersionsBundle{
 							{
 								Eksa: releasev1.EksaBundle{
-									Version: "v0.0.0-dev",
+									Version: "v0.19.0-dev+latest",
 								},
 							},
 						},
@@ -472,7 +472,7 @@ func TestGetManagementComponents(t *testing.T) {
 				}
 				s.EKSARelease = &releasev1.EKSARelease{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "eksa-v0-0-0-dev",
+						Name:      "eksa-v0-19-0-dev-plus-latest",
 						Namespace: constants.EksaSystemNamespace,
 					},
 					Spec: releasev1.EKSAReleaseSpec{
@@ -485,7 +485,7 @@ func TestGetManagementComponents(t *testing.T) {
 			}),
 			want: &cluster.ManagementComponents{
 				Eksa: releasev1.EksaBundle{
-					Version: "v0.0.0-dev",
+					Version: "v0.19.0-dev+latest",
 				},
 			},
 			wantErr: "",

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -9,7 +9,7 @@ spec:
     services: {}
   controlPlaneConfiguration: {}
   datacenterRef: {}
-  eksaVersion: v0.0.0-dev
+  eksaVersion: v0.19.0-dev+latest
   externalEtcdConfiguration:
     count: 3
   gitOpsRef:

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
@@ -9,7 +9,7 @@ spec:
     services: {}
   controlPlaneConfiguration: {}
   datacenterRef: {}
-  eksaVersion: v0.0.0-dev
+  eksaVersion: v0.19.0-dev+latest
   externalEtcdConfiguration:
     count: 3
   gitOpsRef:

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
@@ -9,7 +9,7 @@ spec:
     services: {}
   controlPlaneConfiguration: {}
   datacenterRef: {}
-  eksaVersion: v0.0.0-dev
+  eksaVersion: v0.19.0-dev+latest
   externalEtcdConfiguration:
     count: 3
   gitOpsRef:

--- a/pkg/curatedpackages/packagecontrollerclient_test.go
+++ b/pkg/curatedpackages/packagecontrollerclient_test.go
@@ -1247,7 +1247,6 @@ func TestGetCuratedPackagesRegistries(s *testing.T) {
 			Name: "test_controller",
 			URI:  "test_registry/eks-anywhere/eks-anywhere-packages:v1",
 		}
-		// eksaRegion := "test-region"
 		clusterName := "billy"
 		writer, _ := filewriter.NewWriter(clusterName)
 		client := curatedpackages.NewPackageControllerClient(
@@ -1449,7 +1448,7 @@ func createBundle(cluster *anywherev1.Cluster) *artifactsv1.Bundles {
 func createEKSARelease(cluster *anywherev1.Cluster, bundle *artifactsv1.Bundles) *artifactsv1.EKSARelease {
 	return &artifactsv1.EKSARelease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "eksa-v0-0-0-dev",
+			Name:      "eksa-v0-19-0-dev-plus-latest",
 			Namespace: constants.EksaSystemNamespace,
 		},
 		Spec: artifactsv1.EKSAReleaseSpec{

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -161,12 +161,10 @@ func GetExternalEtcdReleaseURL(clusterVersion string, versionBundle *cluster.Ver
 	if err != nil {
 		return "", fmt.Errorf("invalid semver for etcd url enabled clusterVersion: %v", err)
 	}
-	devEksaVersion, err := semver.New(v1alpha1.DevBuildVersion)
 	if err != nil {
 		return "", fmt.Errorf("invalid semver for dev eksa version: %v", err)
 	}
-	if clusterVersionSemVer.Equal(minEksAVersionWithEtcdURL) || clusterVersionSemVer.GreaterThan(minEksAVersionWithEtcdURL) ||
-		clusterVersionSemVer.Equal(devEksaVersion) {
+	if !(clusterVersionSemVer.LessThan(minEksAVersionWithEtcdURL)) {
 		return versionBundle.KubeDistro.EtcdURL, nil
 	}
 	logger.V(4).Info(fmt.Sprintf("Eks-a cluster version is less than version %s. Skip setting etcd url", v1alpha1.MinEksAVersionWithEtcdURL))

--- a/pkg/providers/common/common_test.go
+++ b/pkg/providers/common/common_test.go
@@ -158,6 +158,11 @@ func TestGetExternalEtcdReleaseURL(t *testing.T) {
 			etcdURL:        test.VersionBundle().KubeDistro.EtcdURL,
 		},
 		{
+			name:           "Etcd url enabled version = 0.19.0 with dev build",
+			clusterVersion: "v0.19.0-dev+latest",
+			etcdURL:        test.VersionBundle().KubeDistro.EtcdURL,
+		},
+		{
 			name:           "Post etcd url enabled version > 0.19.0",
 			clusterVersion: "v0.21.0",
 			etcdURL:        test.VersionBundle().KubeDistro.EtcdURL,

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -38,7 +38,7 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 			Name: "gitops",
 		}
 	})
-	version := "v0.0.0-dev"
+	version := "v0.19.0-dev+latest"
 	objects := []client.Object{test.EKSARelease()}
 	opts := &validations.Opts{
 		Kubectl:           k,

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -361,7 +361,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 				ManagementCluster: workloadCluster,
 				Provider:          provider,
 				TLSValidator:      tlsValidator,
-				CliVersion:        "v0.0.0-dev",
+				CliVersion:        "v0.19.0-dev+latest",
 			}
 
 			clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.KubernetesVersion(tc.upgradeVersion)
@@ -1095,7 +1095,7 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 				ManagementCluster: workloadCluster,
 				Provider:          provider,
 				TLSValidator:      tlsValidator,
-				CliVersion:        "v0.0.0-dev",
+				CliVersion:        "v0.19.0-dev+latest",
 				KubeClient:        test.NewFakeKubeClient(objects...),
 			}
 
@@ -1335,7 +1335,7 @@ func TestPreFlightValidationsGit(t *testing.T) {
 				Provider:          provider,
 				TLSValidator:      tlsValidator,
 				CliConfig:         cliConfig,
-				CliVersion:        "v0.0.0-dev",
+				CliVersion:        "v0.19.0-dev+latest",
 			}
 
 			clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.KubernetesVersion(tc.upgradeVersion)

--- a/pkg/workflows/management/upgrade_management_components_test.go
+++ b/pkg/workflows/management/upgrade_management_components_test.go
@@ -38,7 +38,7 @@ var eksaChangeDiff = types.NewChangeDiff(&types.ComponentChangeDiff{
 })
 
 var managementComponentsVersionAnnotation = map[string]string{
-	"anywhere.eks.amazonaws.com/management-components-version": "v0.0.0-dev",
+	"anywhere.eks.amazonaws.com/management-components-version": "v0.19.0-dev+latest",
 }
 
 type TestMocks struct {

--- a/pkg/workflows/management/upgrade_test.go
+++ b/pkg/workflows/management/upgrade_test.go
@@ -84,7 +84,7 @@ func newUpgradeManagementTest(t *testing.T) *upgradeManagementTestSetup {
 		s.Cluster.Name = "management"
 		s.Cluster.Namespace = "default"
 		s.Cluster.Spec.DatacenterRef.Kind = v1alpha1.VSphereDatacenterKind
-		s.Cluster.SetManagementComponentsVersion("v0.0.0-dev")
+		s.Cluster.SetManagementComponentsVersion("v0.19.0-dev+latest")
 		s.Bundles = test.Bundle()
 		s.EKSARelease = test.EKSARelease()
 	})
@@ -452,7 +452,7 @@ func TestUpgradeManagementRunFailedUpgradeGetManagementComponents(t *testing.T) 
 
 	err := u.run()
 	g := NewWithT(t)
-	g.Expect(err).To(MatchError(ContainSubstring("\"eksa-v0-0-0-dev\" not found")))
+	g.Expect(err).To(MatchError(ContainSubstring("\"eksa-v0-19-0-dev-plus-latest\" not found")))
 }
 
 func TestUpgradeManagementRunFailedUpgradeClientGet(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
`GetExternalEtcdReleaseURL` doesn't work for dev builds currently cuz it only checks if the current cluster version is either equal to or greater than the bundle version. The equality check doesn't work for dev bundles because they are of the form `v0.19.0-dev+latest` which doesn't equal the bundle version `v0.19.0`

This PR updates this check to ensure that the cluster version is not less than bundle version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

