### PR TITLE
Remove unnecessary args from tink annotations

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -327,11 +327,11 @@ func (c *Cluster) ClearTinkerbellIPAnnotation() {
 }
 
 // HasTinkerbellIPAnnotation returns the tinkerbell IP value if the annotation exists.
-func (c *Cluster) HasTinkerbellIPAnnotation() (string, bool) {
+func (c *Cluster) HasTinkerbellIPAnnotation() string {
 	if tinkerbellIP, ok := c.Annotations[tinkerbellIPAnnotation]; ok {
-		return tinkerbellIP, true
+		return tinkerbellIP
 	}
-	return "", false
+	return ""
 }
 
 // RegistryAuth returns whether registry requires authentication or not.

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -1624,14 +1624,13 @@ func TestClusterClearTinkerbellIPAnnotation(t *testing.T) {
 		},
 	}
 	c.AddTinkerbellIPAnnotation("1.1.1.1")
-	val, ok := c.HasTinkerbellIPAnnotation()
+	val := c.HasTinkerbellIPAnnotation()
 
-	g.Expect(ok).To(BeTrue())
 	g.Expect(val).To(ContainSubstring("1.1.1.1"))
 
 	c.ClearTinkerbellIPAnnotation()
-	_, ok = c.Annotations[tinkerbellIPAnnotation]
-	g.Expect(ok).To(BeFalse())
+	val = c.Annotations[tinkerbellIPAnnotation]
+	g.Expect(val).To(BeEmpty())
 }
 
 func TestGitOpsEquals(t *testing.T) {

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -28,6 +28,7 @@ func (p *Provider) BootstrapClusterOpts(_ *cluster.Spec) ([]bootstrapper.Bootstr
 func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	logger.V(4).Info("Installing Tinkerbell stack on bootstrap cluster")
 
+	// We add this annotation to pass the admin machine URL to the controller for cluster creation.
 	logger.V(4).Info("Adding annotation for tinkerbell ip on bootstrap cluster")
 	clusterSpec.Cluster.AddTinkerbellIPAnnotation(p.tinkerbellIP)
 	versionsBundle := clusterSpec.RootVersionsBundle()

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -71,7 +71,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 	}
 	var OSImageURL string
 
-	if tinkerbellIP, ok := clusterSpec.Cluster.HasTinkerbellIPAnnotation(); ok {
+	if tinkerbellIP := clusterSpec.Cluster.HasTinkerbellIPAnnotation(); tinkerbellIP != "" {
 		tb.tinkerbellIP = tinkerbellIP
 	}
 
@@ -127,7 +127,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 	bundle := clusterSpec.RootVersionsBundle()
 	OSImageURL := clusterSpec.TinkerbellDatacenter.Spec.OSImageURL
 
-	if tinkerbellIP, ok := clusterSpec.Cluster.HasTinkerbellIPAnnotation(); ok {
+	if tinkerbellIP := clusterSpec.Cluster.HasTinkerbellIPAnnotation(); tinkerbellIP != "" {
 		tb.tinkerbellIP = tinkerbellIP
 	}
 

--- a/pkg/workflows/management/create_install_eksa.go
+++ b/pkg/workflows/management/create_install_eksa.go
@@ -39,6 +39,8 @@ func (s *installEksaComponentsOnBootstrapTask) Checkpoint() *task.CompletedTask 
 type installEksaComponentsOnWorkloadTask struct{}
 
 func (s *installEksaComponentsOnWorkloadTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	// Removes the tinkerbell IP annotation added to the spec for controller based cluster creation. This
+	// helps use the right admin machine URL for hegel URLS.
 	if commandContext.ClusterSpec.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind {
 		logger.Info("Removing Tinkerbell IP annotation")
 		commandContext.ClusterSpec.Cluster.ClearTinkerbellIPAnnotation()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove unnecessary args from tink annotations
*Testing (if applicable):*
- unit test

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

