### PR TITLE
Fix management component upgrades and upgrade plan with Cluster using unsupported Kubernetes versions

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
@@ -34,7 +34,7 @@ var upgradeManagementComponentsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		clusterSpec, err := newClusterSpec(umco.clusterOptions)
+		clusterSpec, err := newBasicClusterSpec(umco.clusterOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgradeplanmanagementcomponents.go
@@ -49,7 +49,7 @@ func (uc *upgradeClusterOptions) upgradePlanManagementComponents(ctx context.Con
 		return fmt.Errorf("common validations failed due to: %v", err)
 	}
 
-	newClusterSpec, err := newClusterSpec(uc.clusterOptions)
+	newClusterSpec, err := newBasicClusterSpec(uc.clusterOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -139,14 +139,14 @@ func (d *Dependencies) Close(ctx context.Context) error {
 
 // ForSpec constructs a Factory using the bundle referenced by clusterSpec.
 func ForSpec(clusterSpec *cluster.Spec) *Factory {
-	versionsBundle := clusterSpec.RootVersionsBundle()
-	eksaToolsImage := versionsBundle.Eksa.CliTools
+	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpec.Bundles)
+	eksaToolsImage := managementComponents.Eksa.CliTools
 	return NewFactory().
 		UseExecutableImage(eksaToolsImage.VersionedImage()).
 		WithRegistryMirror(registrymirror.FromCluster(clusterSpec.Cluster)).
 		UseProxyConfiguration(clusterSpec.Cluster.ProxyConfiguration()).
 		WithWriterFolder(clusterSpec.Cluster.Name).
-		WithDiagnosticCollectorImage(versionsBundle.Eksa.DiagnosticCollector.VersionedImage())
+		WithDiagnosticCollectorImage(managementComponents.Eksa.DiagnosticCollector.VersionedImage())
 }
 
 // Factory helps initialization.

--- a/pkg/eksd/upgrader.go
+++ b/pkg/eksd/upgrader.go
@@ -27,12 +27,6 @@ func NewUpgrader(client EksdInstallerClient, reader Reader, opts ...UpgraderOpt)
 
 // Upgrade checks for EKS-D updates, and if there are updates the EKS-D CRDs in the cluster.
 func (u *Upgrader) Upgrade(ctx context.Context, cluster *types.Cluster, currentSpec, newSpec *cluster.Spec) error {
-	logger.V(1).Info("Checking for EKS-D CRD updates")
-	changeDiff := ChangeDiff(currentSpec, newSpec)
-	if changeDiff == nil {
-		logger.V(1).Info("Nothing to update for EKS-D.")
-		return nil
-	}
 	logger.V(1).Info("Updating EKS-D CRDs")
 	if err := u.InstallEksdCRDs(ctx, newSpec, cluster); err != nil {
 		return fmt.Errorf("updating EKS-D crds from bundles %d to bundles %d: %v", currentSpec.Bundles.Spec.Number, newSpec.Bundles.Spec.Number, err)

--- a/pkg/eksd/upgrader_test.go
+++ b/pkg/eksd/upgrader_test.go
@@ -54,19 +54,6 @@ func newUpgraderTest(t *testing.T) *upgraderTest {
 	}
 }
 
-func TestEksdUpgradeNoSelfManaged(t *testing.T) {
-	tt := newUpgraderTest(t)
-	tt.newSpec.Cluster.SetManagedBy("management-cluster")
-
-	tt.Expect(tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil())
-}
-
-func TestEksdUpgradeNoChanges(t *testing.T) {
-	tt := newUpgraderTest(t)
-
-	tt.Expect(tt.eksdUpgrader.Upgrade(tt.ctx, tt.cluster, tt.currentSpec, tt.newSpec)).To(BeNil())
-}
-
 func TestEksdUpgradeSuccess(t *testing.T) {
 	tt := newUpgraderTest(t)
 


### PR DESCRIPTION
*Issue #, if available:*

*Context:*
The newly introduced sub command upgrade management-components currently has an issue where:

If you have an EKS Anywhere 1.24. You cannot update the management components if the cluster is using Kubernetes version 1.24, because the CLI runs into the following error: while [building the new cluster spec](https://github.com/aws/eks-anywhere/blob/4de7cda5ac1e6b571d769df82de2391634b750b8/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go#L37)

```
Error: failed to upgrade cluster: unable to get cluster config from file: kubernetes version 1.24 is not supported by bundles
It occurs while building the new cluster spec, when trying to [pick the correct versions bundle](https://github.com/aws/eks-anywhere/blob/4de7cda5ac1e6b571d769df82de2391634b750b8/pkg/cluster/fetch.go#L117) for the cluster’s kubernetes version because Kubernetes 1.24 is not supported v0.19.0, and therefore, does not have an entry in the bundles.Spec.VersionsBundles where it’s selecting from.
```

*Description of changes:*
This PR addresses the issue adding a short term building the new cluster spec for the management component upgrades flow without the `VersionsBundles` field. When building the full cluster.Spec definition, we fetch the eksdReleases for the KubernetesVersions for all unique k8s versions specified in the Cluster for both CP and workers.
If the Cluster object is using an unsupported version of Kubernetes, an error thrown
because it does not exist in the Bundles file. This method allows to build a `cluster.Spec` without
encountering this problem when performing only a management component upgrade.

*Testing (if applicable):*
- Manually created a vSphere cluster on Kubernetes version 1.24 with EKS-A v0.18.6
   - Upgrade management-components
   - Checked upgrade plan management-components
```
   [ec2-user@ip-172-31-61-197 vsphere-cluster]$ eksctl-anywhere upgrade management-components -f mgmt04/mgmt04-eks-a-cluster.yaml 
Performing setup and validations
✅ Vsphere provider setup and validation
✅ Control plane ready
✅ Cluster CRDs ready
Upgrading core components
🎉 Management components upgraded!
```

```
[ec2-user@ip-172-31-61-197 vsphere-cluster]$ eksctl-anywhere upgrade plan management-components -f mgmt04/mgmt04-eks-a-cluster.yaml
mgmt04/mgmt04-eks-a-cluster.yaml
Checking new release availability...
All the components are up to date with the latest versions
```
 
- Ran the following E2E tests:
```
--- PASS: TestVSphereKubernetes128UpgradeManagementComponents (753.53s)
PASS
```

```
--- PASS: TestVSphereKubernetes128UbuntuTo129Upgrade (2140.91s)
PASS
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

