### PR TITLE
Add KMS v1 feature gate for Kubernetes v1.29

### DIFF
--- a/internal/test/testdata/bundles.yaml
+++ b/internal/test/testdata/bundles.yaml
@@ -1006,4 +1006,800 @@ spec:
       metadata:
         uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.0.0-dev-build.8341/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.2.4/metadata.yaml
       version: v1.2.4+4b53cc4
+  - bootstrap:
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/bootstrap-kubeadm/v1.6.1/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-bootstrap-controller image
+        imageDigest: sha256:0023b8bc34f6eb7e8596f553716127271d8a97a62ca99f15d0ed43a094054758
+        name: kubeadm-bootstrap-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.6.1-eks-a-v0.19.0-dev-build.158
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/bootstrap-kubeadm/v1.6.1/metadata.yaml
+      version: v1.6.1+53890b3
+    bottlerocketHostContainers:
+      admin:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-admin image
+        imageDigest: sha256:789cb7d120ac7633bda792660266214a486c182db67d89ee6508216fe2bc7f93
+        name: bottlerocket-admin
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-admin:v0.11.4
+      control:
+        arch:
+        - amd64
+        description: Container image for bottlerocket-control image
+        imageDigest: sha256:29deada0d540dfe6ecb8238e0eb04ed4a9e6b8cf0d5cab232890ef9404643c30
+        name: bottlerocket-control
+        os: linux
+        uri: public.ecr.aws/bottlerocket/bottlerocket-control:v0.7.8
+      kubeadmBootstrap:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap image
+        imageDigest: sha256:831bca8b626f2af0201d2dc9f36473b5fc7496dd19667f47ec173679a79c068e
+        name: bottlerocket-bootstrap
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap:v1-29-4-eks-a-v0.19.0-dev-build.158
+    certManager:
+      acmesolver:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-acmesolver image
+        imageDigest: sha256:4224d02f0045051f3b6fe85a9d18db982c2bf299bd235d198b8f2d273909ef83
+        name: cert-manager-acmesolver
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-acmesolver:v1.13.2-eks-a-v0.19.0-dev-build.158
+      cainjector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-cainjector image
+        imageDigest: sha256:d930a7a331352fc05db704972220f5e80e2b31fd6e1a6bad14de80a03466268c
+        name: cert-manager-cainjector
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.13.2-eks-a-v0.19.0-dev-build.158
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-controller image
+        imageDigest: sha256:55b039291a62fa9d2d3057e0e33caca1cc0010f1f2d1c7db48f1d6b4ea49263e
+        name: cert-manager-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.13.2-eks-a-v0.19.0-dev-build.158
+      ctl:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-ctl image
+        imageDigest: sha256:a66ccf7bea427be01061474d392b20e4bc5248b0c79b9e4b3b2c1813e67a6969
+        name: cert-manager-ctl
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-ctl:v1.13.2-eks-a-v0.19.0-dev-build.158
+      manifest:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cert-manager/manifests/v1.13.2/cert-manager.yaml
+      version: v1.13.2+a34c207
+      webhook:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cert-manager-webhook image
+        imageDigest: sha256:75c2a3d6c0331a4c4032b6ba719fa4e8b8acc557b60854c539734465cdd8a9c0
+        name: cert-manager-webhook
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.13.2-eks-a-v0.19.0-dev-build.158
+    cilium:
+      cilium:
+        arch:
+        - amd64
+        description: Container image for cilium image
+        imageDigest: sha256:3999832c1d339148ea367a587b88e3c29cd745c5d659237ca3ab85f42a9dd845
+        name: cilium
+        os: linux
+        uri: public.ecr.aws/isovalent/cilium:v1.13.9-eksa.1
+      helmChart:
+        description: Helm chart for cilium-chart
+        imageDigest: sha256:3efe51316cca07ee9344870bda8a5564a23c238603737a1c3ce89f2721648fc8
+        name: cilium-chart
+        uri: public.ecr.aws/isovalent/cilium:1.13.9-eksa.1
+      manifest:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cilium/manifests/cilium/v1.13.9-eksa.1/cilium.yaml
+      operator:
+        arch:
+        - amd64
+        description: Container image for operator-generic image
+        imageDigest: sha256:777299bcf6829048d5a5f4db8ca71c472a8adf8bb21d79d272a264f4857d8c60
+        name: operator-generic
+        os: linux
+        uri: public.ecr.aws/isovalent/operator-generic:v1.13.9-eksa.1
+      version: v1.13.9-eksa.1
+    cloudStack:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-cloudstack image
+        imageDigest: sha256:d6f2a79ce9a71f6c6407fe8ece71b4fddf9d8c8b707c590dace946573cc71020
+        name: cluster-api-provider-cloudstack
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.4.9-rc8-eks-a-v0.19.0-dev-build.158
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc8/infrastructure-components.yaml
+      kubeRbacProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:af4ced2d214c3b440bf00cc04f352052796cbc384efba7dbdfb82b15315a12b8
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.9-rc8/metadata.yaml
+      version: v0.4.9-rc8+570e6a9
+    clusterAPI:
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/cluster-api/v1.6.1/core-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-controller image
+        imageDigest: sha256:2de8ad556510c931c9a63b28f88da51eeaba94025726b585b6e3009fd1c60ba4
+        name: cluster-api-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/cluster-api-controller:v1.6.1-eks-a-v0.19.0-dev-build.158
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/cluster-api/v1.6.1/metadata.yaml
+      version: v1.6.1+996a9a2
+    controlPlane:
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/control-plane-kubeadm/v1.6.1/control-plane-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kubeadm-control-plane-controller image
+        imageDigest: sha256:ff147b0a99a3ff99411dbf1f411fde35091f070b7b352c79846ff31b744d35cf
+        name: kubeadm-control-plane-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.6.1-eks-a-v0.19.0-dev-build.158
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/control-plane-kubeadm/v1.6.1/metadata.yaml
+      version: v1.6.1+b32aa1a
+    docker:
+      clusterTemplate:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/infrastructure-docker/v1.6.1/cluster-template-development.yaml
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/infrastructure-docker/v1.6.1/infrastructure-components-development.yaml
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-docker image
+        imageDigest: sha256:5f0a726897f42a8809597239f98fa6e59f7b243b8991d452463a9cd1a18bbe64
+        name: cluster-api-provider-docker
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/capd-manager:v1.6.1-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api/manifests/infrastructure-docker/v1.6.1/metadata.yaml
+      version: v1.6.1+515d2a9
+    eksD:
+      ami:
+        bottlerocket:
+          arch:
+          - amd64
+          description: Bottlerocket Ami image for EKS-D 1-29-4 release
+          name: bottlerocket-v1.29.0-eks-d-1-29-4-eks-a-v0.19.0-dev-build.158-amd64.img.gz
+          os: linux
+          osName: bottlerocket
+          sha256: 1d52163ed6e040b47689dfd85d428437803e6a903d6720af31b75be710b2c3ad
+          sha512: f979a54b7f07d642c4861a224d02f8b6454fce1a71903d314cc2fa30c70ea5fab4ccc639df1cf08a149ab442e7c25d25e83eb29cf8054e1b562cd64382100de6
+          uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/eks-distro/ami/1-29/1-29-4/bottlerocket-v1.29.0-eks-d-1-29-4-eks-a-v0.19.0-dev-build.158-amd64.img.gz
+      channel: 1-29
+      components: https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+      containerd:
+        arch:
+        - amd64
+        description: containerd tarball for linux/amd64
+        name: containerd-v0.19.0-dev-build.158-linux-amd64.tar.gz
+        os: linux
+        sha256: 15d4431d1644ab7b12583770254de5cbe2e2ca3ea4c4543c9294a5c17d6ee4ed
+        sha512: 6fc8495eae3814c88cd08b0f46e7a834812c1468211d8661406d480a74a05d9e4c684a68c8eba83a853905099010c898ad4471f4de2612e50eb922eca7dca36f
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/containerd/v1.7.13/containerd-v0.19.0-dev-build.158-linux-amd64.tar.gz
+      crictl:
+        arch:
+        - amd64
+        description: cri-tools tarball for linux/amd64
+        name: cri-tools-v0.19.0-dev-build.158-linux-amd64.tar.gz
+        os: linux
+        sha256: f181d0937e42d2282df6f19b76d0f67a87d18b6e24b06ceded7763cc64d773e1
+        sha512: f18c3cd57293e62555502454ae5c69abb29866f64d5f8f377cde914d15e4969d74371e557b961d9c6d290dd5918e6a74c3bf5e884390ac816185127e1a384686
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cri-tools/v1.29.0/cri-tools-v0.19.0-dev-build.158-linux-amd64.tar.gz
+      etcdadm:
+        arch:
+        - amd64
+        description: etcdadm tarball for linux/amd64
+        name: etcdadm-v0.19.0-dev-build.158-linux-amd64.tar.gz
+        os: linux
+        sha256: 29166473fcbc7650c8d1b7783c9a6844789fbc393e9836c838774b292e501f40
+        sha512: e88e1ba55f9ade7e5e1d16a5a2c1f61b41407eeab1928136e27691f54241c2a2b71a29ee5b5bded83440f6f46b5954c8433cc50ffd5df7027ba4caafd1703652
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/etcdadm/f089d308442c18f487a52d09fd067ae9ac7cd8f2/etcdadm-v0.19.0-dev-build.158-linux-amd64.tar.gz
+      gitCommit: 685f7b3f1546d64a8fed97ffb41f3aa574598ab4
+      imagebuilder:
+        arch:
+        - amd64
+        description: image-builder tarball for linux/amd64
+        name: image-builder-v0.19.0-dev-build.158-linux-amd64.tar.gz
+        os: linux
+        sha256: 27b790602ae435f893aa9c547797d96074678db2d07d9309b0b1d5531d1144d6
+        sha512: d2da83ebf66383c1f493268da3a2f7040c3ed497d3bde075ced7232f76d01c3387724fef82e6e5be406baac7d6e56738e884b1801747ca3024da2fbef266d6d2
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/image-builder/v0.4.0/image-builder-v0.19.0-dev-build.158-linux-amd64.tar.gz
+      kindNode:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kind-node image
+        imageDigest: sha256:a3f958ac0cd91f1d8460d0da07f748cb013328dc8bbe6b05a5e43148a06cd5aa
+        name: kind-node
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node:v1.29.0-eks-d-1-29-4-eks-a-v0.19.0-dev-build.158
+      kubeVersion: v1.29.0
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-29/kubernetes-1-29-eks-4.yaml
+      name: kubernetes-1-29-eks-4
+      ova:
+        bottlerocket:
+          arch:
+          - amd64
+          description: Bottlerocket Ova image for EKS-D 1-29-4 release
+          name: bottlerocket-v1.29.0-eks-d-1-29-4-eks-a-v0.19.0-dev-build.158-amd64.ova
+          os: linux
+          osName: bottlerocket
+          sha256: 57b326f54e294b7442cb306a8600711feb78b5c06ba4bdaec716d8c030f04cd1
+          sha512: f5d8ccf960da1c0ee0be0022ea81cb10809310163ed71201a1f27478fdab1b042f1f0a8f41d685aa82660d165c8de6e619b42d63251190ace4d7438878688a57
+          uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/eks-distro/ova/1-29/1-29-4/bottlerocket-v1.29.0-eks-d-1-29-4-eks-a-v0.19.0-dev-build.158-amd64.ova
+      raw:
+        bottlerocket: {}
+    eksa:
+      cliTools:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cli-tools image
+        imageDigest: sha256:0bc18b955fa36d6c9d0f142038887bf19adc8b84a2d48a61af2fe3de7422c67d
+        name: eks-anywhere-cli-tools
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.19.0-dev-build.158
+      clusterController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-cluster-controller image
+        imageDigest: sha256:ce5f48a4572bc76f037ac0bd68f2507b372f569b69a3d3a3821c5d2a7da70b6a
+        name: eks-anywhere-cluster-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/eks-anywhere-cluster-controller:v0.18.6-eks-a-v0.19.0-dev-build.158
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/eks-anywhere/manifests/cluster-controller/v0.18.6/eksa-components.yaml
+      diagnosticCollector:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-diagnostic-collector image
+        imageDigest: sha256:f2ed41f30e7a3085c7c262b84a32d4c7f60f2063b62bc0b27d7ff3d45783dc43
+        name: eks-anywhere-diagnostic-collector
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/eks-anywhere-diagnostic-collector:v0.18.6-eks-a-v0.19.0-dev-build.158
+      version: v0.19.0-dev+build.158+b749e4f
+    etcdadmBootstrap:
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.10/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-bootstrap-provider image
+        imageDigest: sha256:3817df19381adf4b0379f1895660dc815ef635afc81e4b5fc82cf26f2df580df
+        name: etcdadm-bootstrap-provider
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/aws/etcdadm-bootstrap-provider:v1.0.10-eks-a-v0.19.0-dev-build.158
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.10/metadata.yaml
+      version: v1.0.10+16165a3
+    etcdadmController:
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.17/bootstrap-components.yaml
+      controller:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for etcdadm-controller image
+        imageDigest: sha256:dc028bd99b3c0e789204e04fe98e16cedd708f279812afe614a770e639f4a8f3
+        name: etcdadm-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/aws/etcdadm-controller:v1.0.17-eks-a-v0.19.0-dev-build.158
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.17/metadata.yaml
+      version: v1.0.17+aa67988
+    flux:
+      helmController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for helm-controller image
+        imageDigest: sha256:4956b2aaa19c51efcd8e208b2f69294b39d623dca8497823dea59d79e1303948
+        name: helm-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/helm-controller:v0.37.4-eks-a-v0.19.0-dev-build.158
+      kustomizeController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kustomize-controller image
+        imageDigest: sha256:597c947d1eef33a09cab0ee1d1cb26cda7217119732d884da17e830fd6df7935
+        name: kustomize-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/kustomize-controller:v1.2.2-eks-a-v0.19.0-dev-build.158
+      notificationController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for notification-controller image
+        imageDigest: sha256:5d84bc08fe32bbc4d202c72546c962a4ae1f63f74ba90d7881bf99ef87bd3cb4
+        name: notification-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/notification-controller:v1.2.4-eks-a-v0.19.0-dev-build.158
+      sourceController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for source-controller image
+        imageDigest: sha256:b08765659445ee09de743c58bd0aa2d0252df7a2f21d8b293b26a9aea64a1517
+        name: source-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/fluxcd/source-controller:v1.2.4-eks-a-v0.19.0-dev-build.158
+      version: v2.2.3+4713e2d
+    haproxy:
+      image:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for haproxy image
+        imageDigest: sha256:d15dfa6956436110d7d3b00cbf555be0a53edc3790d555bd1c9db9d0994be5cf
+        name: haproxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/haproxy:v0.22.0-eks-a-v0.19.0-dev-build.158
+    kindnetd:
+      manifest:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/kind/manifests/kindnetd/v0.22.0/kindnetd.yaml
+      version: v0.22.0+cd372fb
+    kubeVersion: "1.29"
+    nutanix:
+      cloudProvider:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cloud-provider-nutanix image
+        imageDigest: sha256:11b00e5434961ca5bde7dd90d41d5a9f695b60673f6691ced33116f40b971035
+        name: cloud-provider-nutanix
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.19.0-dev-build.158
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-nutanix image
+        imageDigest: sha256:fece31d3573f3f03bfc5ff205f57b4ab8097b539ced2427c9ce74fbd4c05da63
+        name: cluster-api-provider-nutanix
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/nutanix-cloud-native/cluster-api-provider-nutanix:v1.3.1-eks-a-v0.19.0-dev-build.158
+      clusterTemplate:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.1/cluster-template.yaml
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.1/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:af4ced2d214c3b440bf00cc04f352052796cbc384efba7dbdfb82b15315a12b8
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.1/metadata.yaml
+      version: v1.3.1+093a77d
+    packageController:
+      credentialProviderPackage:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for credential-provider-package image
+        imageDigest: sha256:850887eb850d0571033f7045551e40d0b27fbfd6f1175398143fe2ae279c65c5
+        name: credential-provider-package
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/credential-provider-package:v0.3.13-eks-a-v0.19.0-dev-build.158
+      helmChart:
+        description: Helm chart for eks-anywhere-packages
+        imageDigest: sha256:69a10a0fdfa9f918daa5b3f0deb65eeb415783f42aa305b6435edff7cf8daf17
+        name: eks-anywhere-packages
+        uri: public.ecr.aws/l0g8r8j6/eks-anywhere-packages:0.0.0-473d9fb892b31c8fc444dec44adb84a16d74c6c5-release-0.18-helm
+      packageController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for eks-anywhere-packages image
+        imageDigest: sha256:f42d955852c76f16b52ce3ef9c004582e1b872ef772f4a1e8744a98363dbccce
+        name: eks-anywhere-packages
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/eks-anywhere-packages:v0.0.0-473d9fb892b31c8fc444dec44adb84a16d74c6c5
+      tokenRefresher:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for ecr-token-refresher image
+        imageDigest: sha256:57a102594f12618a91458506d004c34134bcdf54d96bba6b3e03ba8000b45020
+        name: ecr-token-refresher
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/ecr-token-refresher:v0.0.0-473d9fb892b31c8fc444dec44adb84a16d74c6c5
+      version: v0.3.13+bcb5fd2
+    snow:
+      bottlerocketBootstrapSnow:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for bottlerocket-bootstrap-snow image
+        imageDigest: sha256:28f2f1b85d46ac3cab7812fd4550db578ca20ee86d96d7d6a6251a2750005977
+        name: bottlerocket-bootstrap-snow
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap-snow:v1-29-4-eks-a-v0.19.0-dev-build.158
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.27/infrastructure-components.yaml
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:af4ced2d214c3b440bf00cc04f352052796cbc384efba7dbdfb82b15315a12b8
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-snow-controller image
+        imageDigest: sha256:1feaa3497c0794104dcc766319e0c9297d0b885ec0c8001544d5810c2cc04b9e
+        name: cluster-api-snow-controller
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/aws/cluster-api-provider-aws-snow/manager:v0.1.27-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.1.27/metadata.yaml
+      version: v0.1.27+291b537
+    tinkerbell:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-tinkerbell image
+        imageDigest: sha256:9c8a3aa0bb12eb60e0bfc870d0aafd9680daee9ac29a2035d8c1f37ab07c94f9
+        name: cluster-api-provider-tinkerbell
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/tinkerbell/cluster-api-provider-tinkerbell:v0.4.0-eks-a-v0.19.0-dev-build.158
+      clusterTemplate:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/cluster-template.yaml
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/infrastructure-components.yaml
+      envoy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for envoy image
+        imageDigest: sha256:f671bfb50239c918e4953e1792c1b8251b90a577c8c6ab090b99f08d1d15bc5d
+        name: envoy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/envoyproxy/envoy:v1.22.2.0-prod-eks-a-v0.19.0-dev-build.158
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:af4ced2d214c3b440bf00cc04f352052796cbc384efba7dbdfb82b15315a12b8
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.4.0/metadata.yaml
+      tinkerbellStack:
+        actions:
+          cexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for cexec image
+            imageDigest: sha256:d5346a5259fd51d29be1e446f9f23887ff9f35ac6b09c58377c6a4c225d60c4d
+            name: cexec
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hub/cexec:404dab73a8a7f33e973c6e71782f07e82b125da9-eks-a-v0.19.0-dev-build.158
+          imageToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for image2disk image
+            imageDigest: sha256:acac9f14bce9206b058ce9d6a115d68c5237c3c586571dfc28b6e897d18b7297
+            name: image2disk
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hub/image2disk:404dab73a8a7f33e973c6e71782f07e82b125da9-eks-a-v0.19.0-dev-build.158
+          kexec:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for kexec image
+            imageDigest: sha256:14957b20ad0fce168106ca757c572533e83fd26d126131e5fd581f1d7923a7d1
+            name: kexec
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hub/kexec:404dab73a8a7f33e973c6e71782f07e82b125da9-eks-a-v0.19.0-dev-build.158
+          ociToDisk:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for oci2disk image
+            imageDigest: sha256:9097353fbb9826bd4ecbe2ec69e2f3b2f6ccd7cbc11bfd41a5604f9c175a39fa
+            name: oci2disk
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hub/oci2disk:404dab73a8a7f33e973c6e71782f07e82b125da9-eks-a-v0.19.0-dev-build.158
+          reboot:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for reboot image
+            imageDigest: sha256:e260ff9749f0cc03f213f712aec843f743edde0f7246d92c615bbe16e0a92e06
+            name: reboot
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hub/reboot:404dab73a8a7f33e973c6e71782f07e82b125da9-eks-a-v0.19.0-dev-build.158
+          writeFile:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for writefile image
+            imageDigest: sha256:9d70ca5310db0761462941553c324ee182645731c91e78a2dca337954c8bf3fd
+            name: writefile
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hub/writefile:404dab73a8a7f33e973c6e71782f07e82b125da9-eks-a-v0.19.0-dev-build.158
+        boots:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for boots image
+          imageDigest: sha256:8b78e6a76b32298ad9ab019be9b31c550df2cb799cf386cc99f26b40e58b5744
+          name: boots
+          os: linux
+          uri: public.ecr.aws/l0g8r8j6/tinkerbell/boots:v0.8.1-eks-a-v0.19.0-dev-build.158
+        hegel:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for hegel image
+          imageDigest: sha256:e4978e9229d8e24702ce417fcaaf6a8c6a275e91a398cd4525f72a7e3ddcd406
+          name: hegel
+          os: linux
+          uri: public.ecr.aws/l0g8r8j6/tinkerbell/hegel:v0.10.1-eks-a-v0.19.0-dev-build.158
+        hook:
+          bootkit:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-bootkit image
+            imageDigest: sha256:28c4172d916122bffbd12cd0f99b1c5da1f4b630a8a35fe8670a533e951c2248
+            name: hook-bootkit
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hook-bootkit:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.19.0-dev-build.158
+          docker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-docker image
+            imageDigest: sha256:149a8cd44614ed4c5d88c8bb78dd972d0f14ec158c04c36f42ed3e93b55724e2
+            name: hook-docker
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hook-docker:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.19.0-dev-build.158
+          initramfs:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-x86_64
+              uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: initramfs-aarch64
+              uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/hook/9d54933a03f2f4c06322969b06caa18702d17f66/initramfs-aarch64
+          kernel:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for hook-kernel image
+            imageDigest: sha256:e7e4fca78f575be76724a656898d1cb9499f1583a4ac89a3ceb7439de64d4870
+            name: hook-kernel
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/hook-kernel:9d54933a03f2f4c06322969b06caa18702d17f66-eks-a-v0.19.0-dev-build.158
+          vmlinuz:
+            amd:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-x86_64
+              uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-x86_64
+            arm:
+              description: Tinkerbell operating system installation environment (osie)
+                component
+              name: vmlinuz-aarch64
+              uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/hook/9d54933a03f2f4c06322969b06caa18702d17f66/vmlinuz-aarch64
+        rufio:
+          arch:
+          - amd64
+          - arm64
+          description: Container image for rufio image
+          imageDigest: sha256:eee50aca79394ece312d42e74475a2b21e9daa90664f0714a381fa30d7bd2d76
+          name: rufio
+          os: linux
+          uri: public.ecr.aws/l0g8r8j6/tinkerbell/rufio:afd7cd82fa08dae8f9f3ffac96eb030176f3abbd-eks-a-v0.19.0-dev-build.158
+        tink:
+          tinkController:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-controller image
+            imageDigest: sha256:f2c165597ad2ff1af3ed225b3e97bc56937a30499ec58f63fcd06ffa653ee181
+            name: tink-controller
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/tink/tink-controller:v0.8.0-eks-a-v0.19.0-dev-build.158
+          tinkServer:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-server image
+            imageDigest: sha256:70d9cf51a1ca4e4d9c9f457a4c63390de498b1874b7f9fc564aa393997cc09ce
+            name: tink-server
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/tink/tink-server:v0.8.0-eks-a-v0.19.0-dev-build.158
+          tinkWorker:
+            arch:
+            - amd64
+            - arm64
+            description: Container image for tink-worker image
+            imageDigest: sha256:43f814a673a0a54c82b6e004e7e10c0c3f8e2655202dd4de77adbd6d6a584e0f
+            name: tink-worker
+            os: linux
+            uri: public.ecr.aws/l0g8r8j6/tinkerbell/tink/tink-worker:v0.8.0-eks-a-v0.19.0-dev-build.158
+        tinkerbellChart:
+          description: Helm chart for tinkerbell-chart
+          imageDigest: sha256:901a9dbebc777710e9d358c45c93edd415739ba467512ebc38ee177db6d98066
+          name: tinkerbell-chart
+          uri: public.ecr.aws/l0g8r8j6/tinkerbell/tinkerbell-chart:0.2.4-eks-a-v0.19.0-dev-build.158
+      version: v0.4.0+a92cb2a
+    upgrader:
+      upgrader:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for upgrader image
+        imageDigest: sha256:1cea869e48b81e81e0ec934ca362dd5fd8717d9116f9a18c4d7e99959a4473e3
+        name: upgrader
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/aws/upgrader:v1-29-4-eks-a-v0.19.0-dev-build.158
+    vSphere:
+      clusterAPIController:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cluster-api-provider-vsphere image
+        imageDigest: sha256:1e6ad1de2efb7dd49073385b1e8eb686a7edc89bb6c4b9408f557100cbac34cb
+        name: cluster-api-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-vsphere/release/manager:v1.8.5-eks-a-v0.19.0-dev-build.158
+      clusterTemplate:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.8.5/cluster-template.yaml
+      components:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.8.5/infrastructure-components.yaml
+      kubeProxy:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-rbac-proxy image
+        imageDigest: sha256:5bf6ef9dc8dccd3e90b89803db69e7d065dfe80a4aaf1d82c8778c99f86d4fb5
+        name: kube-rbac-proxy
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy:v0.16.0-eks-a-v0.19.0-dev-build.158
+      kubeVip:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for kube-vip image
+        imageDigest: sha256:af4ced2d214c3b440bf00cc04f352052796cbc384efba7dbdfb82b15315a12b8
+        name: kube-vip
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+      manager:
+        arch:
+        - amd64
+        - arm64
+        description: Container image for cloud-provider-vsphere image
+        imageDigest: sha256:3a878cfe82bf605921a3972759cf9026dd456a5b64526766f42f8f54f6917d8a
+        name: cloud-provider-vsphere
+        os: linux
+        uri: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.29.0-eks-d-1-29-eks-a-v0.19.0-dev-build.158
+      metadata:
+        uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cluster-api-provider-vsphere/manifests/infrastructure-vsphere/v1.8.5/metadata.yaml
+      version: v1.8.5+06b35ec
 status: {}

--- a/pkg/providers/cloudstack/cloudstack_test.go
+++ b/pkg/providers/cloudstack/cloudstack_test.go
@@ -2577,6 +2577,12 @@ func TestProviderGenerateCAPISpecForUpgradeEtcdEncryption(t *testing.T) {
 			wantCPFile:        "testdata/expected_results_encryption_config_cp.yaml",
 			wantMDFile:        "testdata/expected_results_minimal_md.yaml",
 		},
+		{
+			testName:          "etcd-encryption 1.29",
+			clusterconfigFile: "cluster_etcd_encryption_1_29.yaml",
+			wantCPFile:        "testdata/expected_results_encryption_config_cp_1_29.yaml",
+			wantMDFile:        "testdata/expected_results_minimal_md_1_29.yaml",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -1,3 +1,4 @@
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) -}}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -99,6 +100,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
+{{- if and .encryptionProviderConfig (ge (atoi $kube_minor_version) 29) }}
+          feature-gates: "KMSv1=true"
+{{- end }}
 {{- if .apiserverExtraArgs }}
 {{ .apiserverExtraArgs.ToYaml | indent 10 }}
 {{- end }}
@@ -352,7 +356,6 @@ spec:
         else echo "{{$dir}} already symlnk";
       fi
 {{- end}}
-{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
 {{- if (ge (atoi $kube_minor_version) 29) }}
     - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
 {{- end }}

--- a/pkg/providers/cloudstack/testdata/cluster_etcd_encryption_1_29.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_etcd_encryption_1_29.yaml
@@ -1,0 +1,81 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  clusterNetwork:
+    cni: cilium
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test
+  datacenterRef:
+    kind: CloudStackDatacenterConfig
+    name: test
+  kubernetesVersion: "1.29"
+  etcdEncryption:
+  - providers:
+    - kms:
+        name: config1
+        socketListenAddress: unix:///var/run/kmsplugin/socket1-new.sock
+    - kms:
+        name: config2
+        socketListenAddress: unix:///var/run/kmsplugin/socket1-old.sock
+    resources:
+    - secrets
+    - resource1.anywhere.eks.amazonsaws.com
+  - providers:
+    - kms:
+        name: config3
+        socketListenAddress: unix:///var/run/kmsplugin/socket2-new.sock
+    - kms:
+        name: config4
+        socketListenAddress: unix:///var/run/kmsplugin/socket2-old.sock
+    resources:
+    - configmaps
+    - resource2.anywhere.eks.amazonsaws.com
+  workerNodeGroupConfigurations:
+  - count: 3
+    machineGroupRef:
+      kind: CloudStackMachineConfig
+      name: test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  account: "admin"
+  domain: "domain1"
+  zones:
+  - name: "zone1"
+    network:
+      name: "net1"
+  managementApiEndpoint: "http://127.16.0.1:8080/client/api"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: CloudStackMachineConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  computeOffering:
+    name: "m4-large"
+  users:
+  - name: "mySshUsername"
+    sshAuthorizedKeys:
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+  template:
+    name: "centos7-k8s-118"
+---

--- a/pkg/providers/cloudstack/testdata/expected_results_encryption_config_cp_1_29.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_encryption_config_cp_1_29.yaml
@@ -1,0 +1,451 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    services:
+      cidrBlocks: [10.96.0.0/12]
+  controlPlaneEndpoint:
+    host: 1.2.3.4
+    port: 6443
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: test
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+    kind: CloudStackCluster
+    name: test
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+kind: CloudStackCluster
+metadata:
+  name: test
+  namespace: eksa-system
+spec:
+  controlPlaneEndpoint:
+    host: 1.2.3.4
+    port: 6443
+  failureDomains:
+  - name: default-az-0
+    zone:
+      id: 
+      name: zone1
+      network:
+        id: 
+        name: net1
+    domain: domain1
+    account: admin
+    acsEndpoint:
+      name: global
+      namespace: eksa-system
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: test
+  namespace: eksa-system
+spec:
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+      kind: CloudStackMachineTemplate
+      name: test-control-plane-template-1234567890000
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
+      etcd:
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.5.10-eks-1-29-4
+          extraArgs:
+            cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      dns:
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.11.1-eks-1-29-4
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          profiling: "false"
+          feature-gates: "KMSv1=true"
+          encryption-provider-config: /etc/kubernetes/enc/encryption-config.yaml
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        extraVolumes:
+        - hostPath: /etc/kubernetes/audit-policy.yaml
+          mountPath: /etc/kubernetes/audit-policy.yaml
+          name: audit-policy
+          pathType: File
+          readOnly: true
+        - hostPath: /var/log/kubernetes
+          mountPath: /var/log/kubernetes
+          name: audit-log-dir
+          pathType: DirectoryOrCreate
+          readOnly: false
+        - hostPath: /var/lib/kubeadm/encryption-config.yaml
+          mountPath: /etc/kubernetes/enc/encryption-config.yaml
+          name: encryption-config
+          pathType: File
+          readOnly: true
+        - hostPath: /var/run/kmsplugin/
+          mountPath: /var/run/kmsplugin/
+          name: kms-plugin
+          readOnly: false
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          profiling: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      scheduler:
+        extraArgs:
+          profiling: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    files:
+    - content: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: EncryptionConfiguration
+        resources:
+        - providers:
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket1-new.sock
+              name: config1
+              timeout: 3s
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket1-old.sock
+              name: config2
+              timeout: 3s
+          - identity: {}
+          resources:
+          - secrets
+          - resource1.anywhere.eks.amazonsaws.com
+        - providers:
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket2-new.sock
+              name: config3
+              timeout: 3s
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket2-old.sock
+              name: config4
+              timeout: 3s
+          - identity: {}
+          resources:
+          - configmaps
+          - resource2.anywhere.eks.amazonsaws.com
+      owner: root:root
+      path: /var/lib/kubeadm/encryption-config.yaml
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: vip_ddns
+              value: "false"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            - name: address
+              value: 1.2.3.4
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    - content: |
+        apiVersion: audit.k8s.io/v1
+        kind: Policy
+        metadata:
+          creationTimestamp: null
+        rules:
+        - level: RequestResponse
+          namespaces:
+          - kube-system
+          omitStages:
+          - RequestReceived
+          resources:
+          - resourceNames:
+            - aws-auth
+            resources:
+            - configmaps
+          verbs:
+          - update
+          - patch
+          - delete
+        - level: None
+          resources:
+          - resources:
+            - endpoints
+            - services
+            - services/status
+          users:
+          - system:kube-proxy
+          verbs:
+          - watch
+        - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          users:
+          - kubelet
+          verbs:
+          - get
+        - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          verbs:
+          - get
+        - level: None
+          namespaces:
+          - kube-system
+          resources:
+          - resources:
+            - endpoints
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs:
+          - get
+          - update
+        - level: None
+          resources:
+          - resources:
+            - namespaces
+            - namespaces/status
+            - namespaces/finalize
+          users:
+          - system:apiserver
+          verbs:
+          - get
+        - level: None
+          resources:
+          - group: metrics.k8s.io
+          users:
+          - system:kube-controller-manager
+          verbs:
+          - get
+          - list
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        - level: None
+          resources:
+          - resources:
+            - events
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - nodes/status
+            - pods/status
+          users:
+          - kubelet
+          - system:node-problem-detector
+          - system:serviceaccount:kube-system:node-problem-detector
+          verbs:
+          - update
+          - patch
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - nodes/status
+            - pods/status
+          userGroups:
+          - system:nodes
+          verbs:
+          - update
+          - patch
+        - level: Request
+          omitStages:
+          - RequestReceived
+          users:
+          - system:serviceaccount:kube-system:namespace-controller
+          verbs:
+          - deletecollection
+        - level: Metadata
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - secrets
+            - configmaps
+          - group: authentication.k8s.io
+            resources:
+            - tokenreviews
+        - level: Request
+          resources:
+          - resources:
+            - serviceaccounts/token
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+          verbs:
+          - get
+          - list
+          - watch
+        - level: RequestResponse
+          omitStages:
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+        - level: Metadata
+          omitStages:
+          - RequestReceived
+      owner: root:root
+      path: /etc/kubernetes/audit-policy.yaml
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
+    preKubeadmCommands:
+    - swapoff -a
+    - hostname "{{ ds.meta_data.hostname }}"
+    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+    - echo "127.0.0.1   localhost" >>/etc/hosts
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+    useExperimentalRetryJoin: true
+    users:
+    - name: mySshUsername
+      sshAuthorizedKeys:
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+      sudo: ALL=(ALL) NOPASSWD:ALL
+    format: cloud-config
+  replicas: 3
+  version: v1.29.0-eks-1-29-4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+kind: CloudStackMachineTemplate
+metadata:
+  creationTimestamp: null
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      diskOffering:
+        customSizeInGB: 0
+        device: ""
+        filesystem: ""
+        label: ""
+        mountPath: ""
+      offering:
+        name: m4-large
+      sshKey: ""
+      template:
+        name: centos7-k8s-118
+
+---

--- a/pkg/providers/cloudstack/testdata/expected_results_minimal_md_1_29.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_minimal_md_1_29.yaml
@@ -1,0 +1,86 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-0-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+            read-only-port: "0"
+            anonymous-auth: "false"
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: "{{ ds.meta_data.hostname }}"
+      preKubeadmCommands:
+      - swapoff -a
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+      - name: mySshUsername
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 3
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-0-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+        kind: CloudStackMachineTemplate
+        name: test-md-0-1234567890000
+      version: v1.29.0-eks-1-29-4
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
+kind: CloudStackMachineTemplate
+metadata:
+  creationTimestamp: null
+  name: test-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      diskOffering:
+        customSizeInGB: 0
+        device: ""
+        filesystem: ""
+        label: ""
+        mountPath: ""
+      offering:
+        name: m4-large
+      sshKey: ""
+      template:
+        name: centos7-k8s-118
+
+---
+
+---

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -1,3 +1,4 @@
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) -}}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: NutanixCluster
 metadata:
@@ -88,6 +89,9 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
+{{- if and .encryptionProviderConfig (ge (atoi $kube_minor_version) 29) }}
+          feature-gates: "KMSv1=true"
+{{- end }}
 {{- if .apiServerExtraArgs }}
 {{ .apiServerExtraArgs.ToYaml | indent 10 }}
 {{- end }}
@@ -351,7 +355,6 @@ spec:
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >> /etc/hosts
-{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
 {{- if (ge (atoi $kube_minor_version) 29) }}
       - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
 {{- end }}

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -611,6 +611,31 @@ func TestTemplateBuilderEtcdEncryption(t *testing.T) {
 	}
 }
 
+func TestTemplateBuilderEtcdEncryptionKubernetes129(t *testing.T) {
+	for _, tc := range []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "testdata/cluster_nutanix_etcd_encryption_1_29.yaml",
+			Output: "testdata/expected_results_etcd_encryption_1_29.yaml",
+		},
+	} {
+		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
+
+		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+		creds := GetCredsFromEnv()
+
+		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
+			map[string]anywherev1.NutanixMachineConfigSpec{}, creds, time.Now)
+
+		data, err := bldr.GenerateCAPISpecControlPlane(clusterSpec)
+		assert.NoError(t, err)
+
+		test.AssertContentToFile(t, string(data), tc.Output)
+	}
+}
+
 func minimalNutanixConfigSpec(t *testing.T) (*anywherev1.NutanixDatacenterConfig, *anywherev1.NutanixMachineConfig, map[string]anywherev1.NutanixMachineConfigSpec) {
 	dcConf := &anywherev1.NutanixDatacenterConfig{}
 	err := yaml.Unmarshal([]byte(nutanixDatacenterConfigSpec), dcConf)

--- a/pkg/providers/nutanix/testdata/cluster_nutanix_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/cluster_nutanix_etcd_encryption_1_29.yaml
@@ -1,0 +1,89 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: default
+spec:
+  kubernetesVersion: "1.29"
+  controlPlaneConfiguration:
+    name: test
+    count: 1
+    endpoint:
+      host: test
+    machineGroupRef:
+      name: test
+      kind: NutanixMachineConfig
+  datacenterRef:
+    kind: NutanixDatacenterConfig
+    name: test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  etcdEncryption:
+  - providers:
+    - kms:
+        name: config1
+        socketListenAddress: unix:///var/run/kmsplugin/socket1-new.sock
+    - kms:
+        name: config2
+        socketListenAddress: unix:///var/run/kmsplugin/socket1-old.sock
+    resources:
+    - secrets
+    - resource1.anywhere.eks.amazonsaws.com
+  - providers:
+    - kms:
+        name: config3
+        socketListenAddress: unix:///var/run/kmsplugin/socket2-new.sock
+    - kms:
+        name: config4
+        socketListenAddress: unix:///var/run/kmsplugin/socket2-old.sock
+    resources:
+    - configmaps
+    - resource2.anywhere.eks.amazonsaws.com
+  workerNodeGroupConfigurations:
+  - count: 3
+    machineGroupRef:
+      kind: NutanixMachineConfig
+      name: test
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixDatacenterConfig
+metadata:
+  name: test
+  namespace: default
+spec:
+  endpoint: "prism.nutanix.com"
+  port: 9440
+  credentialRef:
+    kind: Secret
+    name: "nutanix-credentials"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: NutanixMachineConfig
+metadata:
+  name: test
+  namespace: default
+spec:
+  vcpusPerSocket: 1
+  vcpuSockets: 4
+  memorySize: 8Gi
+  image:
+    type: "name"
+    name: "prism-image-1-19"
+  cluster:
+    type: "name"
+    name: "prism-cluster"
+  subnet:
+    type: "name"
+    name: "prism-subnet"
+  systemDiskSize: 40Gi
+  osFamily: "ubuntu"
+  users:
+    - name: "mySshUsername"
+      sshAuthorizedKeys:
+        - "mySshAuthorizedKey"

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
@@ -1,0 +1,663 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixCluster
+metadata:
+  name: "test"
+  namespace: "eksa-system"
+spec:
+  failureDomains: []
+  prismCentral:
+    address: "prism.nutanix.com"
+    port: 9440
+    insecure: false
+    credentialRef:
+      name: "capx-test"
+      kind: Secret
+  controlPlaneEndpoint:
+    host: "test"
+    port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: "test"
+  name: "test"
+  namespace: "eksa-system"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: [10.96.0.0/12]
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    serviceDomain: "cluster.local"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: "test"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: NutanixCluster
+    name: "test"
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: "test"
+  namespace: "eksa-system"
+spec:
+  replicas: 1
+  version: "v1.29.0-eks-1-29-4"
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: NutanixMachineTemplate
+      name: "<no value>"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: "public.ecr.aws/eks-distro/kubernetes"
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
+        extraArgs:
+          cloud-provider: external
+          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          feature-gates: "KMSv1=true"
+          encryption-provider-config: /etc/kubernetes/enc/encryption-config.yaml
+        extraVolumes:
+        - hostPath: /etc/kubernetes/audit-policy.yaml
+          mountPath: /etc/kubernetes/audit-policy.yaml
+          name: audit-policy
+          pathType: File
+          readOnly: true
+        - hostPath: /var/log/kubernetes
+          mountPath: /var/log/kubernetes
+          name: audit-log-dir
+          pathType: DirectoryOrCreate
+          readOnly: false
+        - hostPath: /etc/kubernetes/enc/encryption-config.yaml
+          mountPath: /etc/kubernetes/enc/encryption-config.yaml
+          name: encryption-config
+          pathType: File
+          readOnly: false
+        - hostPath: /var/run/kmsplugin/
+          mountPath: /var/run/kmsplugin/
+          name: kms-plugin
+          readOnly: false
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          enable-hostpath-provisioner: "true"
+      dns:
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.11.1-eks-1-29-4
+      etcd:
+        local:
+          imageRepository: public.ecr.aws/eks-distro/etcd-io
+          imageTag: v3.5.10-eks-1-29-4
+    files:
+    - content: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: EncryptionConfiguration
+        resources:
+        - providers:
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket1-new.sock
+              name: config1
+              timeout: 3s
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket1-old.sock
+              name: config2
+              timeout: 3s
+          - identity: {}
+          resources:
+          - secrets
+          - resource1.anywhere.eks.amazonsaws.com
+        - providers:
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket2-new.sock
+              name: config3
+              timeout: 3s
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket2-old.sock
+              name: config4
+              timeout: 3s
+          - identity: {}
+          resources:
+          - configmaps
+          - resource2.anywhere.eks.amazonsaws.com
+      owner: root:root
+      path: /etc/kubernetes/enc/encryption-config.yaml
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+            - name: kube-vip
+              image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+              imagePullPolicy: IfNotPresent
+              args:
+                - manager
+              env:
+                - name: vip_arp
+                  value: "true"
+                - name: address
+                  value: "test"
+                - name: port
+                  value: "6443"
+                - name: vip_cidr
+                  value: "32"
+                - name: cp_enable
+                  value: "true"
+                - name: cp_namespace
+                  value: kube-system
+                - name: vip_ddns
+                  value: "false"
+                - name: vip_leaderelection
+                  value: "true"
+                - name: vip_leaseduration
+                  value: "15"
+                - name: vip_renewdeadline
+                  value: "10"
+                - name: vip_retryperiod
+                  value: "2"
+                - name: svc_enable
+                  value: "false"
+                - name: lb_enable
+                  value: "false"
+              securityContext:
+                capabilities:
+                  add:
+                    - NET_ADMIN
+                    - SYS_TIME
+                    - NET_RAW
+              volumeMounts:
+                - mountPath: /etc/kubernetes/admin.conf
+                  name: kubeconfig
+              resources: {}
+          hostNetwork: true
+          volumes:
+            - name: kubeconfig
+              hostPath:
+                type: FileOrCreate
+                path: /etc/kubernetes/admin.conf
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    - content: |
+        apiVersion: audit.k8s.io/v1
+        kind: Policy
+        metadata:
+          creationTimestamp: null
+        rules:
+        - level: RequestResponse
+          namespaces:
+          - kube-system
+          omitStages:
+          - RequestReceived
+          resources:
+          - resourceNames:
+            - aws-auth
+            resources:
+            - configmaps
+          verbs:
+          - update
+          - patch
+          - delete
+        - level: None
+          resources:
+          - resources:
+            - endpoints
+            - services
+            - services/status
+          users:
+          - system:kube-proxy
+          verbs:
+          - watch
+        - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          users:
+          - kubelet
+          verbs:
+          - get
+        - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          verbs:
+          - get
+        - level: None
+          namespaces:
+          - kube-system
+          resources:
+          - resources:
+            - endpoints
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs:
+          - get
+          - update
+        - level: None
+          resources:
+          - resources:
+            - namespaces
+            - namespaces/status
+            - namespaces/finalize
+          users:
+          - system:apiserver
+          verbs:
+          - get
+        - level: None
+          resources:
+          - group: metrics.k8s.io
+          users:
+          - system:kube-controller-manager
+          verbs:
+          - get
+          - list
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        - level: None
+          resources:
+          - resources:
+            - events
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - nodes/status
+            - pods/status
+          users:
+          - kubelet
+          - system:node-problem-detector
+          - system:serviceaccount:kube-system:node-problem-detector
+          verbs:
+          - update
+          - patch
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - nodes/status
+            - pods/status
+          userGroups:
+          - system:nodes
+          verbs:
+          - update
+          - patch
+        - level: Request
+          omitStages:
+          - RequestReceived
+          users:
+          - system:serviceaccount:kube-system:namespace-controller
+          verbs:
+          - deletecollection
+        - level: Metadata
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - secrets
+            - configmaps
+          - group: authentication.k8s.io
+            resources:
+            - tokenreviews
+        - level: Request
+          resources:
+          - resources:
+            - serviceaccounts/token
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+          verbs:
+          - get
+          - list
+          - watch
+        - level: RequestResponse
+          omitStages:
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+        - level: Metadata
+          omitStages:
+          - RequestReceived
+      owner: root:root
+      path: /etc/kubernetes/audit-policy.yaml
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+          #cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: "{{ ds.meta_data.hostname }}"
+    users:
+      - name: "mySshUsername"
+        lockPassword: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        sshAuthorizedKeys:
+          - "mySshAuthorizedKey"
+    preKubeadmCommands:
+      - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
+      - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+    postKubeadmCommands:
+      - echo export KUBECONFIG=/etc/kubernetes/admin.conf >> /root/.bashrc
+    useExperimentalRetryJoin: true
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixMachineTemplate
+metadata:
+  name: "<no value>"
+  namespace: "eksa-system"
+spec:
+  template:
+    spec:
+      providerID: "nutanix://test-m1"
+      vcpusPerSocket: 1
+      vcpuSockets: 4
+      memorySize: 8Gi
+      systemDiskSize: 40Gi
+      image:
+        type: name
+        name: "prism-image-1-19"
+
+      cluster:
+        type: name
+        name: "prism-cluster"
+      subnet:
+        - type: name
+          name: "prism-subnet"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-nutanix-ccm
+  namespace: "eksa-system"
+data:
+  nutanix-ccm.yaml: |
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      namespace: kube-system
+    ---
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: nutanix-config
+      namespace: kube-system
+    data:
+      nutanix_config.json: |-
+        {
+          "prismCentral": {
+            "address": "prism.nutanix.com",
+            "port": 9440,
+            "insecure": false,
+            "credentialRef": {
+              "kind": "secret",
+              "name": "nutanix-creds",
+              "namespace": "kube-system"
+            }
+          },
+          "enableCustomLabeling": false,
+          "topologyDiscovery": {
+            "type": "Prism"
+          }
+        }
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+      name: system:cloud-controller-manager
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - "*"
+      - apiGroups:
+          - ""
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: system:cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-controller-manager
+    subjects:
+      - kind: ServiceAccount
+        name: cloud-controller-manager
+        namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: nutanix-cloud-controller-manager
+      name: nutanix-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: nutanix-cloud-controller-manager
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            k8s-app: nutanix-cloud-controller-manager
+        spec:
+          hostNetwork: true
+          priorityClassName: system-cluster-critical
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          serviceAccountName: cloud-controller-manager
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    k8s-app: nutanix-cloud-controller-manager
+                topologyKey: kubernetes.io/hostname
+          dnsPolicy: Default
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - effect: NoExecute
+              key: node.kubernetes.io/unreachable
+              operator: Exists
+              tolerationSeconds: 120
+            - effect: NoExecute
+              key: node.kubernetes.io/not-ready
+              operator: Exists
+              tolerationSeconds: 120
+            - effect: NoSchedule
+              key: node.cloudprovider.kubernetes.io/uninitialized
+              operator: Exists
+            - effect: NoSchedule
+              key: node.kubernetes.io/not-ready
+              operator: Exists
+          containers:
+            - image: "public.ecr.aws/l0g8r8j6/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.19.0-dev-build.158"
+              imagePullPolicy: IfNotPresent
+              name: nutanix-cloud-controller-manager
+              env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              args:
+                - "--leader-elect=true"
+                - "--cloud-config=/etc/cloud/nutanix_config.json"
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 50Mi
+              volumeMounts:
+                - mountPath: /etc/cloud
+                  name: nutanix-config-volume
+                  readOnly: true
+          volumes:
+            - name: nutanix-config-volume
+              configMap:
+                name: nutanix-config
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: test-nutanix-ccm-crs
+  namespace: "eksa-system"
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: "test"
+  resources:
+  - kind: ConfigMap
+    name: test-nutanix-ccm
+  - kind: Secret
+    name: test-nutanix-ccm-secret
+  strategy: Reconcile

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -1,3 +1,4 @@
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) -}}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -158,6 +159,9 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           profiling: "false"
+{{- if and .encryptionProviderConfig (ge (atoi $kube_minor_version) 29) }}
+          feature-gates: "KMSv1=true"
+{{- end }}
 {{- if .apiserverExtraArgs }}
 {{ .apiserverExtraArgs.ToYaml | indent 10 }}
 {{- end }}
@@ -472,7 +476,6 @@ spec:
     - echo "127.0.0.1   localhost" >>/etc/hosts
     - echo "127.0.0.1   {{`{{ ds.meta_data.hostname }}`}}" >>/etc/hosts
     - echo "{{`{{ ds.meta_data.hostname }}`}}" >/etc/hostname
-{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
 {{- if and (ge (atoi $kube_minor_version) 29) (ne .format "bottlerocket") }}
     - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
 {{- end }}

--- a/pkg/providers/vsphere/testdata/cluster_ubuntu_etcd_encryption_1_29.yaml
+++ b/pkg/providers/vsphere/testdata/cluster_ubuntu_etcd_encryption_1_29.yaml
@@ -1,0 +1,132 @@
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  controlPlaneConfiguration:
+    count: 3
+    endpoint:
+      host: 1.2.3.4
+    machineGroupRef:
+      name: test-cp
+      kind: VSphereMachineConfig
+  kubernetesVersion: "1.29"
+  etcdEncryption:
+  - providers:
+    - kms:
+        name: config1
+        socketListenAddress: unix:///var/run/kmsplugin/socket1-new.sock
+    - kms:
+        name: config2
+        socketListenAddress: unix:///var/run/kmsplugin/socket1-old.sock
+    resources:
+    - secrets
+    - resource1.anywhere.eks.amazonsaws.com
+  - providers:
+    - kms:
+        name: config3
+        socketListenAddress: unix:///var/run/kmsplugin/socket2-new.sock
+    - kms:
+        name: config4
+        socketListenAddress: unix:///var/run/kmsplugin/socket2-old.sock
+    resources:
+    - configmaps
+    - resource2.anywhere.eks.amazonsaws.com
+  workerNodeGroupConfigurations:
+    - count: 3
+      machineGroupRef:
+        name: test-wn
+        kind: VSphereMachineConfig
+      name: md-0
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      name: test-etcd
+      kind: VSphereMachineConfig
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: test
+  clusterNetwork:
+    cni: "cilium"
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-cp
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-wn
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: test-etcd
+  namespace: test-namespace
+spec:
+  diskGiB: 25
+  cloneMode: linkedClone
+  datastore: "/SDDC-Datacenter/datastore/WorkloadDatastore"
+  folder: "/SDDC-Datacenter/vm"
+  memoryMiB: 4096
+  numCPUs: 3
+  osFamily: ubuntu
+  resourcePool: "*/Resources"
+  storagePolicyName: "vSAN Default Storage Policy"
+  template: "/SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2"
+  users:
+    - name: capv
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ== testemail@test.com"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: test
+  namespace: test-namespace
+spec:
+  datacenter: "SDDC-Datacenter"
+  network: "/SDDC-Datacenter/network/sddc-cgw-network-1"
+  server: "vsphere_server"
+  thumbprint: "ABCDEFG"
+  insecure: false

--- a/pkg/providers/vsphere/testdata/expected_results_main_129_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_129_md.yaml
@@ -1,0 +1,86 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: test-md-0-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          taints: []
+          kubeletExtraArgs:
+            cloud-provider: external
+            read-only-port: "0"
+            anonymous-auth: "false"
+            tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          name: '{{ ds.meta_data.hostname }}'
+      preKubeadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      users:
+      - name: capv
+        sshAuthorizedKeys:
+        - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+      format: cloud-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-md-0
+  namespace: eksa-system
+spec:
+  clusterName: test
+  replicas: 3
+  selector:
+    matchLabels: {}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: test
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: test-md-0-template-1234567890000
+      clusterName: test
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        name: test-md-0-1234567890000
+      version: v1.29.0-eks-1-29-4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-md-0-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'SDDC-Datacenter'
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 4096
+      network:
+        devices:
+        - dhcp4: true
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
+      thumbprint: 'ABCDEFG'
+
+---

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
@@ -1,0 +1,773 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test
+  namespace: eksa-system
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: [192.168.0.0/16]
+    services:
+      cidrBlocks: [10.96.0.0/12]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: test
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: VSphereCluster
+    name: test
+  managedExternalEtcdRef:
+    apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+    kind: EtcdadmCluster
+    name: test-etcd
+    namespace: eksa-system
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  name: test
+  namespace: eksa-system
+spec:
+  controlPlaneEndpoint:
+    host: 1.2.3.4
+    port: 6443
+  identityRef:
+    kind: Secret
+    name: test-vsphere-credentials
+  server: vsphere_server
+  thumbprint: 'ABCDEFG'
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-control-plane-template-1234567890000
+  namespace: eksa-system
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'SDDC-Datacenter'
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
+      network:
+        devices:
+        - dhcp4: true
+          networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 2
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
+      thumbprint: 'ABCDEFG'
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: test
+  namespace: eksa-system
+spec:
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: test-control-plane-template-1234567890000
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: public.ecr.aws/eks-distro/kubernetes
+      etcd:
+        external:
+          endpoints: []
+          caFile: "/etc/kubernetes/pki/etcd/ca.crt"
+          certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
+          keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
+      dns:
+        imageRepository: public.ecr.aws/eks-distro/coredns
+        imageTag: v1.11.1-eks-1-29-4
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          profiling: "false"
+          feature-gates: "KMSv1=true"
+          encryption-provider-config: /etc/kubernetes/enc/encryption-config.yaml
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        extraVolumes:
+        - hostPath: /etc/kubernetes/audit-policy.yaml
+          mountPath: /etc/kubernetes/audit-policy.yaml
+          name: audit-policy
+          pathType: File
+          readOnly: true
+        - hostPath: /var/log/kubernetes
+          mountPath: /var/log/kubernetes
+          name: audit-log-dir
+          pathType: DirectoryOrCreate
+          readOnly: false
+        - hostPath: /var/lib/kubeadm/encryption-config.yaml
+          mountPath: /etc/kubernetes/enc/encryption-config.yaml
+          name: encryption-config
+          pathType: File
+          readOnly: true
+        - hostPath: /var/run/kmsplugin/
+          mountPath: /var/run/kmsplugin/
+          name: kms-plugin
+          readOnly: false
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          profiling: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      scheduler:
+        extraArgs:
+          profiling: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    files:
+    - content: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: EncryptionConfiguration
+        resources:
+        - providers:
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket1-new.sock
+              name: config1
+              timeout: 3s
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket1-old.sock
+              name: config2
+              timeout: 3s
+          - identity: {}
+          resources:
+          - secrets
+          - resource1.anywhere.eks.amazonsaws.com
+        - providers:
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket2-new.sock
+              name: config3
+              timeout: 3s
+          - kms:
+              apiVersion: v1
+              cachesize: 1000
+              endpoint: unix:///var/run/kmsplugin/socket2-old.sock
+              name: config4
+              timeout: 3s
+          - identity: {}
+          resources:
+          - configmaps
+          - resource2.anywhere.eks.amazonsaws.com
+      owner: root:root
+      path: /var/lib/kubeadm/encryption-config.yaml
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: kube-system
+            - name: vip_ddns
+              value: "false"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            - name: address
+              value: 1.2.3.4
+            image: public.ecr.aws/l0g8r8j6/kube-vip/kube-vip:v0.6.4-eks-a-v0.19.0-dev-build.158
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    - content: |
+        apiVersion: audit.k8s.io/v1
+        kind: Policy
+        metadata:
+          creationTimestamp: null
+        rules:
+        - level: RequestResponse
+          namespaces:
+          - kube-system
+          omitStages:
+          - RequestReceived
+          resources:
+          - resourceNames:
+            - aws-auth
+            resources:
+            - configmaps
+          verbs:
+          - update
+          - patch
+          - delete
+        - level: None
+          resources:
+          - resources:
+            - endpoints
+            - services
+            - services/status
+          users:
+          - system:kube-proxy
+          verbs:
+          - watch
+        - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          users:
+          - kubelet
+          verbs:
+          - get
+        - level: None
+          resources:
+          - resources:
+            - nodes
+            - nodes/status
+          verbs:
+          - get
+        - level: None
+          namespaces:
+          - kube-system
+          resources:
+          - resources:
+            - endpoints
+          users:
+          - system:kube-controller-manager
+          - system:kube-scheduler
+          - system:serviceaccount:kube-system:endpoint-controller
+          verbs:
+          - get
+          - update
+        - level: None
+          resources:
+          - resources:
+            - namespaces
+            - namespaces/status
+            - namespaces/finalize
+          users:
+          - system:apiserver
+          verbs:
+          - get
+        - level: None
+          resources:
+          - group: metrics.k8s.io
+          users:
+          - system:kube-controller-manager
+          verbs:
+          - get
+          - list
+        - level: None
+          nonResourceURLs:
+          - /healthz*
+          - /version
+          - /swagger*
+        - level: None
+          resources:
+          - resources:
+            - events
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - nodes/status
+            - pods/status
+          users:
+          - kubelet
+          - system:node-problem-detector
+          - system:serviceaccount:kube-system:node-problem-detector
+          verbs:
+          - update
+          - patch
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - nodes/status
+            - pods/status
+          userGroups:
+          - system:nodes
+          verbs:
+          - update
+          - patch
+        - level: Request
+          omitStages:
+          - RequestReceived
+          users:
+          - system:serviceaccount:kube-system:namespace-controller
+          verbs:
+          - deletecollection
+        - level: Metadata
+          omitStages:
+          - RequestReceived
+          resources:
+          - resources:
+            - secrets
+            - configmaps
+          - group: authentication.k8s.io
+            resources:
+            - tokenreviews
+        - level: Request
+          resources:
+          - resources:
+            - serviceaccounts/token
+        - level: Request
+          omitStages:
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+          verbs:
+          - get
+          - list
+          - watch
+        - level: RequestResponse
+          omitStages:
+          - RequestReceived
+          resources:
+          - {}
+          - group: admissionregistration.k8s.io
+          - group: apiextensions.k8s.io
+          - group: apiregistration.k8s.io
+          - group: apps
+          - group: authentication.k8s.io
+          - group: authorization.k8s.io
+          - group: autoscaling
+          - group: batch
+          - group: certificates.k8s.io
+          - group: extensions
+          - group: metrics.k8s.io
+          - group: networking.k8s.io
+          - group: policy
+          - group: rbac.authorization.k8s.io
+          - group: scheduling.k8s.io
+          - group: settings.k8s.io
+          - group: storage.k8s.io
+        - level: Metadata
+          omitStages:
+          - RequestReceived
+      owner: root:root
+      path: /etc/kubernetes/audit-policy.yaml
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cloud-provider: external
+          read-only-port: "0"
+          anonymous-auth: "false"
+          tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        name: '{{ ds.meta_data.hostname }}'
+    preKubeadmCommands:
+    - hostname "{{ ds.meta_data.hostname }}"
+    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+    - echo "127.0.0.1   localhost" >>/etc/hosts
+    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    - "if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi"
+    useExperimentalRetryJoin: true
+    users:
+    - name: capv
+      sshAuthorizedKeys:
+      - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+      sudo: ALL=(ALL) NOPASSWD:ALL
+    format: cloud-config
+  replicas: 3
+  version: v1.29.0-eks-1-29-4
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test
+  name: test-cpi
+  namespace: eksa-system
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: test
+  resources:
+  - kind: Secret
+    name: test-cloud-controller-manager
+  - kind: Secret
+    name: test-cloud-provider-vsphere-credentials
+  - kind: ConfigMap
+    name: test-cpi-manifests
+---
+kind: EtcdadmCluster
+apiVersion: etcdcluster.cluster.x-k8s.io/v1beta1
+metadata:
+  name: test-etcd
+  namespace: eksa-system
+spec:
+  replicas: 3
+  etcdadmConfigSpec:
+    etcdadmBuiltin: true
+    format: cloud-config
+    cloudInitConfig:
+      version: 3.5.10
+      installDir: "/usr/bin"
+      etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/4/artifacts/etcd/v3.5.10/etcd-linux-amd64-v3.5.10.tar.gz
+    preEtcdadmCommands:
+      - hostname "{{ ds.meta_data.hostname }}"
+      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
+      - echo "127.0.0.1   localhost" >>/etc/hosts
+      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+    cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    users:
+      - name: capv
+        sshAuthorizedKeys:
+          - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: VSphereMachineTemplate
+    name: test-etcd-template-1234567890000
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: test-etcd-template-1234567890000
+  namespace: 'eksa-system'
+spec:
+  template:
+    spec:
+      cloneMode: linkedClone
+      datacenter: 'SDDC-Datacenter'
+      datastore: /SDDC-Datacenter/datastore/WorkloadDatastore
+      diskGiB: 25
+      folder: '/SDDC-Datacenter/vm'
+      memoryMiB: 8192
+      network:
+        devices:
+          - dhcp4: true
+            networkName: /SDDC-Datacenter/network/sddc-cgw-network-1
+      numCPUs: 3
+      resourcePool: '*/Resources'
+      server: vsphere_server
+      storagePolicyName: "vSAN Default Storage Policy"
+      template: /SDDC-Datacenter/vm/Templates/ubuntu-2004-kube-v1.21.2
+      thumbprint: 'ABCDEFG'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-vsphere-credentials
+  namespace: eksa-system
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+stringData:
+  username: "vsphere_username"
+  password: "vsphere_password"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-cloud-controller-manager
+  namespace: eksa-system
+stringData:
+  data: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      namespace: kube-system
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-cloud-provider-vsphere-credentials
+  namespace: eksa-system
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cloud-provider-vsphere-credentials
+      namespace: kube-system
+    stringData:
+      vsphere_server.password: "vsphere_password"
+      vsphere_server.username: "vsphere_username"
+    type: Opaque
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+data:
+  data: |
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:cloud-controller-manager
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - serviceaccounts
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: system:cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-controller-manager
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: v1
+    data:
+      vsphere.conf: |
+        global:
+          secretName: cloud-provider-vsphere-credentials
+          secretNamespace: kube-system
+          thumbprint: "ABCDEFG"
+          insecureFlag: false
+        vcenter:
+          vsphere_server:
+            datacenters:
+            - 'SDDC-Datacenter'
+            secretName: cloud-provider-vsphere-credentials
+            secretNamespace: kube-system
+            server: 'vsphere_server'
+            thumbprint: 'ABCDEFG'
+    kind: ConfigMap
+    metadata:
+      name: vsphere-cloud-config
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: servicecatalog.k8s.io:apiserver-authentication-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+    - kind: User
+      name: cloud-controller-manager
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        component: cloud-controller-manager
+      name: cloud-controller-manager
+      namespace: kube-system
+    spec:
+      ports:
+      - port: 443
+        protocol: TCP
+        targetPort: 43001
+      selector:
+        component: cloud-controller-manager
+      type: NodePort
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: vsphere-cloud-controller-manager
+      name: vsphere-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: vsphere-cloud-controller-manager
+      template:
+        metadata:
+          labels:
+            k8s-app: vsphere-cloud-controller-manager
+        spec:
+          containers:
+          - args:
+            - --v=2
+            - --cloud-provider=vsphere
+            - --cloud-config=/etc/cloud/vsphere.conf
+            image: public.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager:v1.29.0-eks-d-1-29-eks-a-v0.19.0-dev-build.158
+            name: vsphere-cloud-controller-manager
+            resources:
+              requests:
+                cpu: 200m
+            volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          hostNetwork: true
+          serviceAccountName: cloud-controller-manager
+          tolerations:
+          - effect: NoSchedule
+            key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          - effect: NoSchedule
+            key: node.kubernetes.io/not-ready
+          volumes:
+          - configMap:
+              name: vsphere-cloud-config
+            name: vsphere-config-volume
+      updateStrategy:
+        type: RollingUpdate
+kind: ConfigMap
+metadata:
+  name: test-cpi-manifests
+  namespace: eksa-system

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -56,6 +56,7 @@ const (
 	eksd119Release                         = "kubernetes-1-19-eks-4"
 	eksd119ReleaseTag                      = "eksdRelease:kubernetes-1-19-eks-4"
 	eksd121ReleaseTag                      = "eksdRelease:kubernetes-1-21-eks-4"
+	eksd129ReleaseTag                      = "eksdRelease:kubernetes-1-29-eks-4"
 	ubuntuOSTag                            = "os:ubuntu"
 	bottlerocketOSTag                      = "os:bottlerocket"
 	testTemplate                           = "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6"
@@ -158,7 +159,7 @@ func (pc *DummyProviderGovcClient) GetResourcePoolInfo(ctx context.Context, data
 }
 
 func (pc *DummyProviderGovcClient) GetTags(ctx context.Context, path string) (tags []string, err error) {
-	return []string{eksd119ReleaseTag, eksd121ReleaseTag, pc.osTag}, nil
+	return []string{eksd119ReleaseTag, eksd121ReleaseTag, eksd129ReleaseTag, pc.osTag}, nil
 }
 
 func (pc *DummyProviderGovcClient) ListTags(ctx context.Context) ([]executables.Tag, error) {
@@ -3912,6 +3913,12 @@ func TestProviderGenerateCAPISpecForUpgradeEtcdEncryption(t *testing.T) {
 			clusterconfigFile: "cluster_ubuntu_etcd_encryption.yaml",
 			wantCPFile:        "testdata/expected_results_ubuntu_etcd_encryption_cp.yaml",
 			wantMDFile:        "testdata/expected_results_main_121_md.yaml",
+		},
+		{
+			testName:          "etcd-encryption 1.29",
+			clusterconfigFile: "cluster_ubuntu_etcd_encryption_1_29.yaml",
+			wantCPFile:        "testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml",
+			wantMDFile:        "testdata/expected_results_main_129_md.yaml",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The KMS v1 provider was deprecated in Kubernetes v1.28 and [disabled by default](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/#kms-v1) in Kubernetes v1.29, in favor of the KMS V2 provider . To use KMS v1 in Kubernetes v1.29, we need to set the API server feature gate `KMSv1=true`. This PR adds the feature flag to our cluster templates, along with unit tests verifying the feature gate gets added for Kubernetes v1.29.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

