### PR TITLE
Fix workload cluster kube-vip update

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -585,7 +585,7 @@ spec:
                           type: string
                       type: object
                     machineHealthCheck:
-                      description: MachineHealthCheck is a control-plane level override
+                      description: MachineHealthCheck is a worker node level override
                         for the timeouts and maxUnhealthy specified in the top-level
                         MHC configuration. If not configured, the defaults in the
                         top-level MHC configuration are used.

--- a/controllers/controlplaneupgrade_controller_test.go
+++ b/controllers/controlplaneupgrade_controller_test.go
@@ -95,6 +95,7 @@ func TestCPUpgradeReconcileEarly(t *testing.T) {
 		testObjs.nodeUpgrades[0], testObjs.nodeUpgrades[1], testObjs.kubeadmConfigs[0], testObjs.kubeadmConfigs[1], testObjs.infraMachines[0], testObjs.infraMachines[1],
 	}
 	client := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	clientRegistry.EXPECT().GetClient(ctx, types.NamespacedName{Name: "my-cp", Namespace: "eksa-system"}).Return(client, nil)
 
 	r := controllers.NewControlPlaneUpgradeReconciler(client, clientRegistry)
 	req := cpUpgradeRequest(testObjs.cpUpgrade)

--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -629,6 +629,7 @@ func (f *Factory) WithMachineDeploymentReconciler() *Factory {
 
 // WithControlPlaneUpgradeReconciler builds the ControlPlaneUpgrade reconciler.
 func (f *Factory) WithControlPlaneUpgradeReconciler() *Factory {
+	f.withTracker()
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.reconcilers.ControlPlaneUpgradeReconciler != nil {
 			return nil
@@ -636,6 +637,7 @@ func (f *Factory) WithControlPlaneUpgradeReconciler() *Factory {
 
 		f.reconcilers.ControlPlaneUpgradeReconciler = NewControlPlaneUpgradeReconciler(
 			f.manager.GetClient(),
+			f.tracker,
 		)
 
 		return nil

--- a/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
@@ -106,7 +106,7 @@ spec:
     securityContext:
       privileged: true
   nodeName: my-node
-  restartPolicy: Never
+  restartPolicy: OnFailure
   volumes:
   - hostPath:
       path: /foo

--- a/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
@@ -104,7 +104,7 @@ spec:
     securityContext:
       privileged: true
   nodeName: my-node
-  restartPolicy: Never
+  restartPolicy: OnFailure
   volumes:
   - hostPath:
       path: /foo

--- a/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
@@ -101,7 +101,7 @@ spec:
     securityContext:
       privileged: true
   nodeName: my-node
-  restartPolicy: Never
+  restartPolicy: OnFailure
   volumes:
   - hostPath:
       path: /foo

--- a/pkg/nodeupgrader/upgrader.go
+++ b/pkg/nodeupgrader/upgrader.go
@@ -78,7 +78,7 @@ func upgraderPod(nodeName, image string, isCP bool) *corev1.Pod {
 			Containers: []corev1.Container{
 				nsenterContainer(image, PostUpgradeContainerName, upgradeScript, "print_status_and_cleanup"),
 			},
-			RestartPolicy: corev1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyOnFailure,
 		},
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
When updating kube-vip manifest for workload cluster, we need the remote client to be able to create the config map with kube-vip manifest data. This change uses remote client instead of management client to create the kube-vip config map for InPlace upgrades. Additionally the upgrader pod is also set to restart on failure as a retry mechanism. 

*Description of changes:*

*Testing (if applicable):*
Tested locally for workload cluster upgrade using InPlace strategy

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

