### PR TITLE
Skip iteration for current branch in eksa version script

### DIFF
--- a/scripts/eksa_version.sh
+++ b/scripts/eksa_version.sh
@@ -24,7 +24,7 @@ function eksa-version::get_closest_ancestor_branch() {
     local closest_date=""
 
     # List all branches except the current one, and iterate through them
-    for branch in $(git branch --all | grep upstream | sed 's/\*//g' | sed 's/remotes\/upstream\///g' | sed 's/^[ \t]*//' | grep -e '^main$' -e '^release-' | sort -u); do
+    for branch in $(git branch --all | grep upstream | grep -ve "^$current_branch$" | sed 's/\*//g' | sed 's/remotes\/upstream\///g' | sed 's/^[ \t]*//' | grep -e '^main$' -e '^release-' | sort -u); do
         # Avoid comparing with HEAD or detached states
         if [[ "$branch" == "HEAD" ]]; then
             continue


### PR DESCRIPTION
Skipping current branch because it could mask the possibility of main being the closest ancestor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

