### PR TITLE
Fix script to get next eksa version

### DIFF
--- a/scripts/eksa_version.sh
+++ b/scripts/eksa_version.sh
@@ -68,10 +68,16 @@ function eksa-version::get_next_eksa_version_for_ancestor() {
         
         release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$2++; $3=0; print}')
     else
-        # For release branhc, get the latest tag that matches current commit
-        # and bump the patch version
-        latest_tag=$(git describe --tags --abbrev=0)
-        release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$3++; print}')
+        # For a release branch, get the latest tag for the release minor version and bump the patch version
+        # If there is not tag yet, use latest tag by date but bumping the minor version and using 0 as the patch
+        # Silence stdeer as the command will fail if there are no tags
+        latest_tag=$(git describe --tags --match "v$(echo "$ancestor_branch" | sed 's/release-//').*" "$(git rev-list --tags --max-count=1)" 2>/dev/null)
+        if [[ -z "$latest_tag" ]]; then
+            latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+            release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$2++; $3=0; print}')
+        else
+            release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$3++; print}')
+        fi
     fi
 
     echo "$release_version"


### PR DESCRIPTION
*Description of changes:*
Just before we release a new minor version, we cut a release branch that we use to run tests and stabilize the release. At this point, there isn't yet any tag for the minor release. The old code was assuming there was one at thus picking the wrong tag. This solves the issue by running the same logic as for main where there are no tags that match the release branch minor version.

*Testing (if applicable):*
Tested manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

