### PR TITLE
Add remaining quick e2e tests for cloudstack, nutanix and snow

### DIFF
--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -13,12 +13,17 @@ quick_tests:
 - TestVSphereKubernetes128BottlerocketTo129StackedEtcdUpgrade
 # CloudStack
 - TestCloudStackKubernetes128To129RedhatMultipleFieldsUpgrade
+- TestCloudStackKubernetes128To129StackedEtcdRedhatMultipleFieldsUpgrade
 # Nutanix
 - TestNutanixKubernetes128to129RedHat9Upgrade
+- TestNutanixKubernetes128to129StackedEtcdRedHat9Upgrade
 - TestNutanixKubernetes128to129RedHat8Upgrade
+- TestNutanixKubernetes128to129StackedEtcdRedHat8Upgrade
 - TestNutanixKubernetes128To129UbuntuUpgrade
+- TestNutanixKubernetes128To129StackedEtcdUbuntuUpgrade
 # Snow
 # - TestSnowKubernetes128SimpleFlow
+# - TestSnowKubernetes128StackedEtcdSimpleFlow
 # Tinkerbell
 # - ^TestTinkerbellKubernetes127UbuntuTo128Upgrade$
 # - TestTinkerbellKubernetes128Ubuntu2004To2204Upgrade

--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -27,6 +27,7 @@ skipped_tests:
 - TestSnowKubernetes126SimpleFlow
 - TestSnowKubernetes127SimpleFlow
 - TestSnowKubernetes128SimpleFlow
+- TestSnowKubernetes128StackedEtcdSimpleFlow
 - TestSnowKubernetes127To128UbuntuManagementCPUpgradeAPI
 - TestSnowKubernetes128UbuntuAWSIamAuth
 - TestSnowKubernetes127To128AWSIamAuthUpgrade

--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -3500,6 +3500,26 @@ func TestCloudStackKubernetes128To129RedhatMultipleFieldsUpgrade(t *testing.T) {
 	)
 }
 
+func TestCloudStackKubernetes128To129StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
+	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube129,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		provider.WithProviderUpgrade(
+			provider.Redhat9Kubernetes129Template(),
+			framework.UpdateLargerCloudStackComputeOffering(),
+		),
+	)
+}
+
 // This test is skipped as registry mirror was not configured for CloudStack
 func TestCloudStackKubernetes125RedhatAirgappedRegistryMirror(t *testing.T) {
 	test := framework.NewClusterE2ETest(

--- a/test/e2e/nutanix_test.go
+++ b/test/e2e/nutanix_test.go
@@ -649,12 +649,29 @@ func TestNutanixKubernetes127To128UbuntuUpgrade(t *testing.T) {
 	)
 }
 
+func TestNutanixKubernetes128To129StackedEtcdUbuntuUpgrade(t *testing.T) {
+	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube129,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+	)
+}
+
 func TestNutanixKubernetes128To129UbuntuUpgrade(t *testing.T) {
 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 	)
 	runSimpleUpgradeFlow(
 		test,
@@ -723,6 +740,25 @@ func TestNutanixKubernetes128to129RedHat8Upgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube129,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+		provider.WithProviderUpgrade(provider.RedHat129Template()),
+	)
+}
+
+func TestNutanixKubernetes128to129StackedEtcdRedHat8Upgrade(t *testing.T) {
+	provider := framework.NewNutanix(t, framework.WithRedHat128Nutanix())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
 	)
 	runSimpleUpgradeFlow(
 		test,
@@ -774,6 +810,25 @@ func TestNutanixKubernetes128to129RedHat9Upgrade(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+	)
+	runSimpleUpgradeFlow(
+		test,
+		v1alpha1.Kube129,
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+		provider.WithProviderUpgrade(provider.RedHat9Kubernetes129Template()),
+	)
+}
+
+func TestNutanixKubernetes128to129StackedEtcdRedHat9Upgrade(t *testing.T) {
+	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes128Nutanix())
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
 	)
 	runSimpleUpgradeFlow(
 		test,

--- a/test/e2e/snow_test.go
+++ b/test/e2e/snow_test.go
@@ -160,6 +160,16 @@ func TestSnowKubernetes128SimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
+func TestSnowKubernetes128StackedEtcdSimpleFlow(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewSnow(t, framework.WithSnowUbuntu128()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+	)
+	runSimpleFlow(test)
+}
+
 // Taints
 func TestSnowKubernetes128UbuntuTaintsUpgradeFlow(t *testing.T) {
 	provider := framework.NewSnow(t,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR creates the remaining e2e tests for Cloudstack, Nutanix and Snow that we want to include in the quick e2e suite.

*Testing (if applicable):*
- Manually invoking code build to run tests

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

