### PR TITLE
Pause eksa cluster before moving capi for delete

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1288,7 +1288,7 @@ func (f *Factory) WithClusterDeleter() *Factory {
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		var opts []clustermanager.DeleterOpt
 		if f.config.noTimeouts {
-			opts = append(opts, clustermanager.WithDeleterNoTimeouts())
+			opts = append(opts, clustermanager.WithDeleterApplyClusterTimeout(time.Hour))
 		}
 
 		f.dependencies.ClusterDeleter = clustermanager.NewDeleter(

--- a/pkg/workflows/management/delete_move_capi.go
+++ b/pkg/workflows/management/delete_move_capi.go
@@ -12,8 +12,14 @@ import (
 type moveClusterManagementForDeleteTask struct{}
 
 func (s *moveClusterManagementForDeleteTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
+	err := commandContext.ClusterManager.PauseEKSAControllerReconcile(ctx, commandContext.WorkloadCluster, commandContext.ClusterSpec, commandContext.Provider)
+	if err != nil {
+		commandContext.SetError(err)
+		return &workflows.CollectDiagnosticsTask{}
+	}
+
 	logger.Info("Moving cluster management from workload cluster to bootstrap")
-	err := commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef())
+	err = commandContext.ClusterManager.MoveCAPI(ctx, commandContext.WorkloadCluster, commandContext.BootstrapCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef())
 	if err != nil {
 		commandContext.SetError(err)
 		return &workflows.CollectDiagnosticsTask{}

--- a/pkg/workflows/management/delete_test.go
+++ b/pkg/workflows/management/delete_test.go
@@ -159,6 +159,7 @@ func (c *deleteTestSetup) expectInstallCAPI(err error) {
 }
 
 func (c *deleteTestSetup) expectMoveCAPI(err error) {
+	c.clusterManager.EXPECT().PauseEKSAControllerReconcile(c.ctx, c.workloadCluster, c.clusterSpec, c.provider)
 	c.clusterManager.EXPECT().MoveCAPI(c.ctx, c.workloadCluster, c.bootstrapCluster, c.workloadCluster.Name, c.clusterSpec, gomock.Any()).Return(err)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pauses the mgmt cluster before moving CAPI for delete task. 
Also adds a 1 hour timeout for delete.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

