### PR TITLE
Override pod and service subnet for kind cluster

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: {{ .PodSubnet }}
+  serviceSubnet: {{ .ServiceSubnet }}
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -55,6 +55,8 @@ type kindExecConfig struct {
 	ExtraPortMappings    []int
 	DockerExtraMounts    bool
 	DisableDefaultCNI    bool
+	PodSubnet            string
+	ServiceSubnet        string
 }
 
 func NewKind(executable Executable, writer filewriter.FileWriter) *Kind {
@@ -74,6 +76,17 @@ func (k *Kind) CreateBootstrapCluster(ctx context.Context, clusterSpec *cluster.
 	err = processOpts(opts)
 	if err != nil {
 		return "", err
+	}
+
+	serviceCidrs := clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks
+	podCidrs := clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks
+
+	if len(serviceCidrs) != 0 {
+		k.execConfig.ServiceSubnet = serviceCidrs[0]
+	}
+
+	if len(podCidrs) != 0 {
+		k.execConfig.PodSubnet = podCidrs[0]
 	}
 
 	err = k.buildConfigFile()

--- a/pkg/executables/kind_test.go
+++ b/pkg/executables/kind_test.go
@@ -32,6 +32,14 @@ func TestKindCreateBootstrapClusterSuccess(t *testing.T) {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = clusterName
 		s.VersionsBundles["1.19"] = versionBundle
+		s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+			Pods: v1alpha1.Pods{
+				CidrBlocks: []string{"1.1.1.1"},
+			},
+			Services: v1alpha1.Services{
+				CidrBlocks: []string{"2.2.2.2"},
+			},
+		}
 	})
 	eksClusterName := "test_cluster-eks-a-cluster"
 	kubeConfigFile := "test_cluster.kind.kubeconfig"
@@ -176,6 +184,14 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 						},
 					},
 				}
+				s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+					Pods: v1alpha1.Pods{
+						CidrBlocks: []string{"1.1.1.1"},
+					},
+					Services: v1alpha1.Services{
+						CidrBlocks: []string{"2.2.2.2"},
+					},
+				}
 			}),
 			env:            map[string]string{},
 			wantKindConfig: "testdata/kind_config_registry_mirror_insecure.yaml",
@@ -190,6 +206,14 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 					Endpoint:      registryMirror,
 					Port:          constants.DefaultHttpsPort,
 					CACertContent: "test",
+				}
+				s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+					Pods: v1alpha1.Pods{
+						CidrBlocks: []string{"1.1.1.1"},
+					},
+					Services: v1alpha1.Services{
+						CidrBlocks: []string{"2.2.2.2"},
+					},
 				}
 			}),
 			env:            map[string]string{},
@@ -215,6 +239,14 @@ func TestKindCreateBootstrapClusterSuccessWithRegistryMirror(t *testing.T) {
 						},
 					},
 					Authenticate: true,
+				}
+				s.Cluster.Spec.ClusterNetwork = v1alpha1.ClusterNetwork{
+					Pods: v1alpha1.Pods{
+						CidrBlocks: []string{"1.1.1.1"},
+					},
+					Services: v1alpha1.Services{
+						CidrBlocks: []string{"2.2.2.2"},
+					},
 				}
 			}),
 			env:            map[string]string{},

--- a/pkg/executables/testdata/kind_config.yaml
+++ b/pkg/executables/testdata/kind_config.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: 1.1.1.1
+  serviceSubnet: 2.2.2.2
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/testdata/kind_config_docker_mount_networking.yaml
+++ b/pkg/executables/testdata/kind_config_docker_mount_networking.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: 1.1.1.1
+  serviceSubnet: 2.2.2.2
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
+++ b/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: 1.1.1.1
+  serviceSubnet: 2.2.2.2
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/testdata/kind_config_registry_mirror_insecure.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_insecure.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: 1.1.1.1
+  serviceSubnet: 2.2.2.2
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/testdata/kind_config_registry_mirror_with_auth.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_with_auth.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: 1.1.1.1
+  serviceSubnet: 2.2.2.2
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/pkg/executables/testdata/kind_config_registry_mirror_with_ca.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_with_ca.yaml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  podSubnet: 1.1.1.1
+  serviceSubnet: 2.2.2.2
 kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Override pod and service subnet for kind cluster
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

