### PR TITLE
Add validation for 1.29 k8s version for BR family

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_types.go
@@ -18,7 +18,7 @@ type TinkerbellDatacenterConfigSpec struct {
 	// It must include the Kubernetes version(s). For example, a URL used for Kubernetes 1.27 could
 	// be http://localhost:8080/ubuntu-2204-1.27.tgz
 	//+optional
-	OSImageURL string `json:"osImageURL,omitempty"`
+	OSImageURL string `json:"osImageURL"`
 	// HookImagesURLPath can be used to override the default Hook images path to pull from a local server.
 	HookImagesURLPath string `json:"hookImagesURLPath,omitempty"`
 	// SkipLoadBalancerDeployment when set to "true" can be used to skip deploying a load balancer to expose Tinkerbell stack.

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -26,7 +26,7 @@ func NewTinkerbellMachineConfigGenerate(name string, opts ...TinkerbellMachineCo
 		},
 		Spec: TinkerbellMachineConfigSpec{
 			HardwareSelector: HardwareSelector{},
-			OSFamily:         Bottlerocket,
+			OSFamily:         Ubuntu,
 			Users: []UserConfiguration{
 				{
 					Name:              "ec2-user",

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -121,6 +121,40 @@ func TestAssertMachineConfigNamespaceMatchesDatacenterConfig_Different(t *testin
 	g.Expect(err).ToNot(gomega.Succeed())
 }
 
+func TestAssertMachineConfigK8sVersionBRCP_Error(t *testing.T) {
+	g := gomega.NewWithT(t)
+	builder := NewDefaultValidClusterSpecBuilder()
+	clusterSpec := builder.Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	clusterSpec.Spec.Cluster.Spec.KubernetesVersion = eksav1alpha1.Kube129
+	clusterSpec.MachineConfigs[builder.ControlPlaneMachineName].Spec.OSFamily = "bottlerocket"
+	err := tinkerbell.AssertOsFamilyValid(clusterSpec)
+	g.Expect(err).ToNot(gomega.Succeed())
+}
+
+func TestAssertMachineConfigK8sVersionBRWorker_Error(t *testing.T) {
+	g := gomega.NewWithT(t)
+	builder := NewDefaultValidClusterSpecBuilder()
+	clusterSpec := builder.Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	clusterSpec.Spec.Cluster.Spec.KubernetesVersion = eksav1alpha1.Kube129
+	clusterSpec.MachineConfigs[builder.WorkerNodeGroupMachineName].Spec.OSFamily = "bottlerocket"
+	err := tinkerbell.AssertOsFamilyValid(clusterSpec)
+	g.Expect(err).ToNot(gomega.Succeed())
+}
+
+func TestAssertMachineConfigK8sVersionBR_Success(t *testing.T) {
+	g := gomega.NewWithT(t)
+	builder := NewDefaultValidClusterSpecBuilder()
+	clusterSpec := builder.Build()
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	clusterSpec.Spec.Cluster.Spec.KubernetesVersion = eksav1alpha1.Kube128
+	clusterSpec.MachineConfigs[builder.ControlPlaneMachineName].Spec.OSFamily = "bottlerocket"
+	clusterSpec.MachineConfigs[builder.WorkerNodeGroupMachineName].Spec.OSFamily = "bottlerocket"
+	err := tinkerbell.AssertOsFamilyValid(clusterSpec)
+	g.Expect(err).To(gomega.Succeed())
+}
+
 func TestAssertMachineConfigOSImageURL_Error(t *testing.T) {
 	g := gomega.NewWithT(t)
 	builder := NewDefaultValidClusterSpecBuilder()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Make Ubuntu a default OS for Tinkerbell provider since we are deprecating support for BR for 1.29 k8s version.
- Add validation around osFamily field for controlplane and worker machine kubernetes version.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

