### PR TITLE
Fix InPlace upgrade objects cleanup race conditions

### DIFF
--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -114,9 +114,6 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, log logr.Lo
 		return ctrl.Result{}, fmt.Errorf("unable to retrieve kubernetes version from MachineDeployment \"%s\"", md.Name)
 	}
 
-	mdUpgrade := &anywherev1.MachineDeploymentUpgrade{}
-	mduGetErr := r.client.Get(ctx, GetNamespacedNameType(mdUpgradeName(md.Name), constants.EksaSystemNamespace), mdUpgrade)
-
 	mhc := &clusterv1.MachineHealthCheck{}
 	if err := r.client.Get(ctx, GetNamespacedNameType(mdMachineHealthCheckName(md.Name), constants.EksaSystemNamespace), mhc); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -129,8 +126,23 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, log logr.Lo
 		return ctrl.Result{}, err
 	}
 
-	if md.Spec.Replicas != nil && (*md.Spec.Replicas == md.Status.UpdatedReplicas) {
-		if mduGetErr == nil && mdUpgrade.Status.Ready {
+	machineList, machineRefList, err := r.machinesToUpgrade(ctx, md)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("retrieving list of control plane machines: %v", err)
+	}
+
+	mdUpgrade := &anywherev1.MachineDeploymentUpgrade{}
+	mduGetErr := r.client.Get(ctx, GetNamespacedNameType(mdUpgradeName(md.Name), constants.EksaSystemNamespace), mdUpgrade)
+	if mduGetErr == nil {
+		machinesUpgraded := true
+		for i := range machineList {
+			m := machineList[i]
+			if m.Spec.Version == nil || *m.Spec.Version != mdUpgrade.Spec.KubernetesVersion {
+				machinesUpgraded = false
+				break
+			}
+		}
+		if machinesUpgraded && mdUpgrade.Status.Ready {
 			log.Info("Machine deployment upgrade complete, deleting object", "MachineDeploymentUpgrade", mdUpgrade.Name)
 			if err := r.client.Delete(ctx, mdUpgrade); err != nil {
 				return ctrl.Result{}, fmt.Errorf("deleting MachineDeploymentUpgrade object: %v", err)
@@ -139,67 +151,48 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, log logr.Lo
 			if err := resumeMachineHealthCheck(ctx, mhc, mhcPatchHelper); err != nil {
 				return ctrl.Result{}, fmt.Errorf("updating annotations for machine health check: %v", err)
 			}
-		} else if !apierrors.IsNotFound(mduGetErr) {
-			return ctrl.Result{}, fmt.Errorf("getting MachineDeploymentUpgrade for MachineDeployment %s: %v", md.Name, mduGetErr)
-		}
-		log.Info("MachineDeployment is ready, removing the \"in-place-upgrade-needed\" annotation")
-		// Remove the in-place-upgrade-needed annotation only after the MachineDeploymentUpgrade object is deleted
-		delete(md.Annotations, mdInPlaceUpgradeNeededAnnotation)
-		return ctrl.Result{}, nil
-	}
-
-	if mduGetErr != nil {
-		if apierrors.IsNotFound(mduGetErr) {
-			log.Info("Creating MachineDeploymentUpgrade object")
-			machines, err := r.machinesToUpgrade(ctx, md)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("retrieving list of control plane machines: %v", err)
-			}
-			mdUpgrade, err := machineDeploymentUpgrade(md, machines)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("generating MachineDeploymentUpgrade: %v", err)
-			}
-
-			log.Info("Pausing machine deployment machine health check", "MachineHealthCheck", mdMachineHealthCheckName(md.Name))
-			if err := pauseMachineHealthCheck(ctx, mhc, mhcPatchHelper); err != nil {
-				return ctrl.Result{}, fmt.Errorf("updating annotations for machine health check: %v", err)
-			}
-
-			if err := r.client.Create(ctx, mdUpgrade); client.IgnoreAlreadyExists(err) != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to create MachineDeploymentUpgrade for MachineDeployment %s:  %v", md.Name, err)
-			}
+			log.Info("MachineDeployment is ready, removing the \"in-place-upgrade-needed\" annotation")
+			// Remove the in-place-upgrade-needed annotation only after the MachineDeploymentUpgrade object is deleted
+			delete(md.Annotations, mdInPlaceUpgradeNeededAnnotation)
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("getting MachineDeploymentUpgrade for MachineDeployment %s: %v", md.Name, mduGetErr)
-	}
-	if !mdUpgrade.Status.Ready {
 		return ctrl.Result{}, nil
 	}
-	log.Info("Machine deployment upgrade complete, deleting object", "MachineDeploymentUpgrade", mdUpgrade.Name)
-	if err := r.client.Delete(ctx, mdUpgrade); err != nil {
-		return ctrl.Result{}, fmt.Errorf("deleting MachineDeploymentUpgrade object: %v", err)
+
+	if apierrors.IsNotFound(mduGetErr) {
+		log.Info("Creating MachineDeploymentUpgrade object")
+		mdUpgrade, err := machineDeploymentUpgrade(md, machineRefList)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("generating MachineDeploymentUpgrade: %v", err)
+		}
+
+		log.Info("Pausing machine deployment machine health check", "MachineHealthCheck", mdMachineHealthCheckName(md.Name))
+		if err := pauseMachineHealthCheck(ctx, mhc, mhcPatchHelper); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating annotations for machine health check: %v", err)
+		}
+
+		if err := r.client.Create(ctx, mdUpgrade); client.IgnoreAlreadyExists(err) != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create MachineDeploymentUpgrade for MachineDeployment %s:  %v", md.Name, err)
+		}
+		return ctrl.Result{}, nil
 	}
 
-	log.Info("Resuming machine deployment machine health check", "MachineHealthCheck", mdMachineHealthCheckName(md.Name))
-	if err := resumeMachineHealthCheck(ctx, mhc, mhcPatchHelper); err != nil {
-		return ctrl.Result{}, fmt.Errorf("updating annotations for machine health check: %v", err)
-	}
+	return ctrl.Result{}, fmt.Errorf("getting MachineDeploymentUpgrade for MachineDeployment %s: %v", md.Name, err)
 
-	return ctrl.Result{}, nil
 }
 
 func (r *MachineDeploymentReconciler) inPlaceUpgradeNeeded(md *clusterv1.MachineDeployment) bool {
 	return strings.ToLower(md.Annotations[mdInPlaceUpgradeNeededAnnotation]) == "true"
 }
 
-func (r *MachineDeploymentReconciler) machinesToUpgrade(ctx context.Context, md *clusterv1.MachineDeployment) ([]corev1.ObjectReference, error) {
+func (r *MachineDeploymentReconciler) machinesToUpgrade(ctx context.Context, md *clusterv1.MachineDeployment) ([]*clusterv1.Machine, []corev1.ObjectReference, error) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{workerMachineLabel: md.Name}})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	machineList := &clusterv1.MachineList{}
 	if err := r.client.List(ctx, machineList, &client.ListOptions{LabelSelector: selector, Namespace: md.Namespace}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	machines := collections.FromMachineList(machineList).SortedByCreationTimestamp()
 	machineObjects := make([]corev1.ObjectReference, 0, len(machines))
@@ -212,7 +205,7 @@ func (r *MachineDeploymentReconciler) machinesToUpgrade(ctx context.Context, md 
 			},
 		)
 	}
-	return machineObjects, nil
+	return machines, machineObjects, nil
 }
 
 func machineDeploymentUpgrade(md *clusterv1.MachineDeployment, machines []corev1.ObjectReference) (*anywherev1.MachineDeploymentUpgrade, error) {


### PR DESCRIPTION
*Description of changes:*
We noticed that after the `ControlPlaneUpgrade` (CPU) was complete and the corresponding CPU object was deleted, there was a race condition where if the KCP object statuses weren't updated on time, our KCP controller would create another CPU object and try to perform the upgrade again. 

This PR fixes this race condition issue by only deleting the CPU after the KCP object has reached the expected state.
The same fix is applied for in the MachineDeployment controller for cleaning up `MachineDeploymentUpgrade` objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

