### PR TITLE
Skip E2E tests that are broken

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -20,6 +20,21 @@ skipped_tests:
 # Side effects
 - TestCloudStackKubernetes129WithOIDCManagementClusterUpgradeFromLatestSideEffects
 
+# Temporary disables to stabilize tests. Owners should work on fixes and enable these test along with their fix's PR
+- TestVSphereKubernetes128BottlerocketTo129StackedEtcdUpgrade
+- TestVSphereKubernetes127To128UbuntuManagementCPUpgradeAPI
+- TestCloudStackKubernetes126CiliumAlwaysPolicyEnforcementModeSimpleFlow
+- TestCloudStackKubernetes125CiliumAlwaysPolicyEnforcementModeSimpleFlow
+- TestCloudStackKubernetes127CiliumAlwaysPolicyEnforcementModeSimpleFlow
+- TestCloudStackKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow
+- TestVSphereKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow
+- TestCloudStackKubernetes127RedhatProxyConfig
+- TestCloudStackKubernetes125RedhatProxyConfig
+- TestCloudStackKubernetes126RedhatProxyConfig
+- TestCloudStackKubernetes129RedhatProxyConfig
+- TestCloudStackKubernetes128RedhatProxyConfig
+- TestTinkerbellAirgappedKubernetes129UbuntuProxyConfigFlow
+
 # Nutanix
 
 # Snow


### PR DESCRIPTION
*Description of changes:*
Temporarily skipping tests that are either broken due to feature changes introduced or test environment issues. Owners working on fixing these tests will enable these tests along with their fix's PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

