### PR TITLE
Disable ETCD Learner Mode

### DIFF
--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -67,6 +67,10 @@ spec:
       name: {{.controlPlaneTemplateName}}
   kubeadmConfigSpec:
     clusterConfiguration:
+{{- if (ge (atoi $kube_minor_version) 29) }}
+      featureGates:
+        EtcdLearnerMode: false
+{{- end }}
       imageRepository: {{.kubernetesRepository}}
       etcd:
 {{- if .externalEtcd }}

--- a/pkg/providers/cloudstack/testdata/expected_results_encryption_config_cp_1_29.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_encryption_config_cp_1_29.yaml
@@ -59,6 +59,8 @@ spec:
       name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
+      featureGates:
+        EtcdLearnerMode: false
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         local:

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -55,11 +55,18 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
 	addStackedEtcdExtraArgsInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration)
-	if versionsBundle.KubeVersion == "1.29" {
-		disableEtcdLearnerMode(kcp)
-	}
 
 	machineConfig := clusterSpec.SnowMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+	kubeVersionSemver, err := semver.New(string(clusterSpec.Cluster.Spec.KubernetesVersion) + ".0")
+	if err != nil {
+		return nil, fmt.Errorf("error converting kubeVersion %v to semver %v", clusterSpec.Cluster.Spec.KubernetesVersion, err)
+	}
+
+	kube129Semver, err := semver.New(string(v1alpha1.Kube129) + ".0")
+	if err != nil {
+		return nil, fmt.Errorf("error converting kubeVersion %v to semver %v", v1alpha1.Kube129, err)
+	}
 
 	osFamily := machineConfig.OSFamily()
 	switch osFamily {
@@ -73,24 +80,20 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 		addBottlerocketBootstrapSnowInKubeadmControlPlane(kcp, versionsBundle.Snow.BottlerocketBootstrapSnow)
 		clusterapi.SetBottlerocketHostConfigInKubeadmControlPlane(kcp, machineConfig.Spec.HostOSConfiguration)
 
+		if kubeVersionSemver.Compare(kube129Semver) != -1 {
+			disableEtcdLearnerMode(kcp)
+		}
+
 	case v1alpha1.Ubuntu:
 		kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands,
 			"/etc/eks/bootstrap.sh",
 		)
-		kubeVersionSemver, err := semver.New(string(clusterSpec.Cluster.Spec.KubernetesVersion) + ".0")
-		if err != nil {
-			return nil, fmt.Errorf("error converting kubeVersion %v to semver %v", clusterSpec.Cluster.Spec.KubernetesVersion, err)
-		}
-
-		kube129Semver, err := semver.New(string(v1alpha1.Kube129) + ".0")
-		if err != nil {
-			return nil, fmt.Errorf("error converting kubeVersion %v to semver %v", v1alpha1.Kube129, err)
-		}
 
 		if kubeVersionSemver.Compare(kube129Semver) != -1 {
 			kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(kcp.Spec.KubeadmConfigSpec.PreKubeadmCommands,
 				"if [ -f /run/kubeadm/kubeadm.yaml ]; then sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml; fi",
 			)
+			disableEtcdLearnerMode(kcp)
 		}
 
 		if err := clusterapi.SetProxyConfigInKubeadmControlPlaneForUbuntu(kcp, clusterSpec.Cluster); err != nil {

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -55,6 +55,9 @@ func KubeadmControlPlane(log logr.Logger, clusterSpec *cluster.Spec, snowMachine
 	joinConfigKubeletExtraArg["provider-id"] = "aws-snow:////'{{ ds.meta_data.instance_id }}'"
 
 	addStackedEtcdExtraArgsInKubeadmControlPlane(kcp, clusterSpec.Cluster.Spec.ExternalEtcdConfiguration)
+	if versionsBundle.KubeVersion == "1.29" {
+		disableEtcdLearnerMode(kcp)
+	}
 
 	machineConfig := clusterSpec.SnowMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
 

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -108,7 +108,7 @@ func wantKubeadmControlPlane(kubeVersion v1alpha1.KubernetesVersion) *controlpla
 	wantReplicas := int32(3)
 	wantMaxSurge := intstr.FromInt(1)
 	versionBundles := givenVersionsBundle(kubeVersion)
-	return &controlplanev1.KubeadmControlPlane{
+	kcp := &controlplanev1.KubeadmControlPlane{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
 			Kind:       "KubeadmControlPlane",
@@ -200,6 +200,14 @@ func wantKubeadmControlPlane(kubeVersion v1alpha1.KubernetesVersion) *controlpla
 			Version:  versionBundles.KubeDistro.Kubernetes.Tag,
 		},
 	}
+
+	if kubeVersion == "1.29" {
+		kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.FeatureGates = map[string]bool{
+			"EtcdLearnerMode": false,
+		}
+	}
+
+	return kcp
 }
 
 func wantKubeadmControlPlaneUnstackedEtcd() *controlplanev1.KubeadmControlPlane {

--- a/pkg/providers/snow/etcd.go
+++ b/pkg/providers/snow/etcd.go
@@ -15,3 +15,11 @@ func addStackedEtcdExtraArgsInKubeadmControlPlane(kcp *controlplanev1.KubeadmCon
 	stackedEtcdExtraArgs["listen-peer-urls"] = "https://0.0.0.0:2380"
 	stackedEtcdExtraArgs["listen-client-urls"] = "https://0.0.0.0:2379"
 }
+
+func disableEtcdLearnerMode(kcp *controlplanev1.KubeadmControlPlane) {
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.FeatureGates == nil {
+		kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.FeatureGates = map[string]bool{}
+	}
+
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.FeatureGates["EtcdLearnerMode"] = false
+}

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -37,6 +37,11 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
+{{- if (ge (atoi $kube_minor_version) 29) }}
+      featureGates:
+        EtcdLearnerMode: false
+{{- end }}
       imageRepository: {{.kubernetesRepository}}
       etcd:
 {{- if .externalEtcd }}

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -1,3 +1,4 @@
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) -}}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -37,7 +38,6 @@ metadata:
 spec:
   kubeadmConfigSpec:
     clusterConfiguration:
-{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
 {{- if (ge (atoi $kube_minor_version) 29) }}
       featureGates:
         EtcdLearnerMode: false
@@ -400,7 +400,6 @@ spec:
       - {{ . }}
       {{- end }}
 {{- end }}
-{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .kubernetesVersion)) 1) }}
 {{- if and (or .registryMirrorMap .proxyConfig (ge (atoi $kube_minor_version) 29)) (ne .format "bottlerocket") }}
     preKubeadmCommands:
 {{- if .registryMirrorMap }}

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -86,6 +86,10 @@ spec:
       name: {{.controlPlaneTemplateName}}
   kubeadmConfigSpec:
     clusterConfiguration:
+{{- if (ge (atoi $kube_minor_version) 29) }}
+      featureGates:
+        EtcdLearnerMode: false
+{{- end }}
       imageRepository: {{.kubernetesRepository}}
       etcd:
 {{- if .externalEtcd }}

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
@@ -78,6 +78,8 @@ spec:
       name: test-control-plane-template-1234567890000
   kubeadmConfigSpec:
     clusterConfiguration:
+      featureGates:
+        EtcdLearnerMode: false
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:


### PR DESCRIPTION
ETCD Learner Mode went to Beta in k8s 1.29 and is now default enabled (see [here](https://kubernetes.io/blog/2023/09/25/kubeadm-use-etcd-learner-mode/), [here](https://github.com/kubernetes/kubeadm/issues/1793#issuecomment-1380585530)).

When a new stacked etcd instance comes up, it joins the cluster in learner mode.

The API Server cannot perform rpc calls against its etcd instance, and fails to come online.

In theory the etcd instance should be promoted to a full member as done in kubeadm [here](https://github.com/kubernetes/kubernetes/blob/fc7325fbec0fe379694e58b82e09f99f166c5e6d/cmd/kubeadm/app/phases/etcd/local.go#L164).

This is not happening because our bottlerocket bootstrap container is not allowing [etcd phase to complete](https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/aws/bottlerocket-bootstrap/pkg/kubeadm/controlplane_join.go#L134).

We are disabling this feature for 0.19 and will likely enable it for 0.20 when we also incorporate new CAPI work that allows feature gates to [be mutable](https://github.com/kubernetes-sigs/cluster-api/pull/10154).

The feature gate will [likely](https://github.com/kubernetes/kubeadm/issues/1793#issuecomment-1914077181) go GA in upstream 1.31.

*Issue #, if available:*
This was causing failures on *129StackedEtcdUpgrade end to end tests.

*Testing (if applicable):*
Ran TestVSphereKubernetes128BottlerocketTo129StackedEtcdUpgrade with a custom built controller image that set this EtcdLearnerEnabled feature flag to false.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

