### PR TITLE
Configure SSM delivery

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -15,7 +15,10 @@ import (
 	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
-const ssmLogGroup = "/eks-anywhere/test/e2e"
+const (
+	ssmLogGroup               = "/eks-anywhere/test/e2e"
+	defaultSSMDeliveryTimeout = 300
+)
 
 var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
 
@@ -127,9 +130,10 @@ func RunCommand(session *session.Session, logger logr.Logger, instanceID, comman
 
 func sendCommand(service *ssm.SSM, logger logr.Logger, instanceID, command string, timeout time.Duration, opts ...CommandOpt) (*ssm.SendCommandOutput, error) {
 	in := &ssm.SendCommandInput{
-		DocumentName: aws.String("AWS-RunShellScript"),
-		InstanceIds:  []*string{aws.String(instanceID)},
-		Parameters:   map[string][]*string{"commands": {aws.String(initE2EDirCommand), aws.String(command)}, "executionTimeout": {aws.String(strconv.FormatFloat(timeout.Seconds(), 'f', 0, 64))}},
+		DocumentName:   aws.String("AWS-RunShellScript"),
+		InstanceIds:    []*string{aws.String(instanceID)},
+		Parameters:     map[string][]*string{"commands": {aws.String(initE2EDirCommand), aws.String(command)}, "executionTimeout": {aws.String(strconv.FormatFloat(timeout.Seconds(), 'f', 0, 64))}},
+		TimeoutSeconds: aws.Int64(defaultSSMDeliveryTimeout),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
*Description of changes:*
Currently, we don't set the delivery timeout for SSM commands. This defaults the delivery timeout to 3600s or 1 hour which is a really long time to wait for the command to just be delivered. If the SSM agent is unhealthy on the test runner, then waiting 1 hour doesn't make sense.

This PR configures the delivery timeout to 5 min. The tests also have another timeout called `Execution Timeout` which specifies how long the command has to finish execution, which is set separately and varies by command. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

