### PR TITLE
Add validation of cluster state after replacing with oss cilium in docker e2e test

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1218,6 +1218,7 @@ func TestDockerCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
 	test.GenerateClusterConfig(framework.ExecuteWithEksaRelease(previousRelease))
 	test.CreateCluster(framework.ExecuteWithEksaRelease(previousRelease))
 	test.ReplaceCiliumWithOSSCilium()
+	test.ValidateClusterState()
 	test.UpgradeClusterWithNewConfig(
 		[]framework.ClusterE2ETestOpt{
 			framework.WithClusterUpgrade(api.WithCiliumSkipUpgrade()),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have a validation that checks if the cluster is ready before performing an upgrade. So, it's possible that after replacing EKSA cilium with the OS cilium in the. `TestDockerCiliumSkipUpgrade_CLIUpgrade` , it can fail with the following error:
```
2024-02-21T20:43:15.230Z	V0	❌ Validation failed	{"validation": "control plane ready", "error": "1 control plane replicas are unavailable", "remediation": "ensure control plane nodes and pods for cluster release-i-0c0c6-2a90c82 are Ready"}
```

We should validate that the cluster is in a ready state after replacing EKSA cilium with OSS cilium before continuing with the upgrade because of that.
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

