### PR TITLE
Clear Cluster failure in status on successful reconciliation

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1445,6 +1445,11 @@ func (c *Cluster) ClearFailure() {
 	c.Status.FailureReason = nil
 }
 
+// HasFailure checks whether there is a failureMessage and/or failureReason set on the Cluster status.
+func (c *Cluster) HasFailure() bool {
+	return c.Status.FailureMessage != nil || c.Status.FailureReason != nil
+}
+
 // KubernetesVersions returns a set of all unique k8s versions specified in the cluster
 // for both CP and workers.
 func (c *Cluster) KubernetesVersions() []KubernetesVersion {

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -2889,6 +2889,64 @@ func TestCluster_ClearFailure(t *testing.T) {
 	g.Expect(cluster.Status.FailureReason).To(BeNil())
 }
 
+func TestCluster_HasFailure(t *testing.T) {
+	g := NewWithT(t)
+	wantFailureMessage := "invalid cluster"
+	wantFailureReason := v1alpha1.FailureReasonType("InvalidCluster")
+
+	tests := []struct {
+		name    string
+		cluster *v1alpha1.Cluster
+		want    bool
+	}{
+		{
+			name: "failureReason and failureMessage set",
+			cluster: &v1alpha1.Cluster{
+				Status: v1alpha1.ClusterStatus{
+					FailureMessage: &wantFailureMessage,
+					FailureReason:  &wantFailureReason,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "failureMessage only set",
+			cluster: &v1alpha1.Cluster{
+				Status: v1alpha1.ClusterStatus{
+					FailureMessage: &wantFailureMessage,
+					FailureReason:  nil,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "failureReason only set",
+			cluster: &v1alpha1.Cluster{
+				Status: v1alpha1.ClusterStatus{
+					FailureMessage: nil,
+					FailureReason:  &wantFailureReason,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no failure",
+			cluster: &v1alpha1.Cluster{
+				Status: v1alpha1.ClusterStatus{
+					FailureMessage: nil,
+					FailureReason:  &wantFailureReason,
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g.Expect(tt.cluster.HasFailure()).To(Equal(tt.want))
+		})
+	}
+}
+
 func TestClusterDisableControlPlaneIPCheck(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Failure messages are cleared in the reconciler loop after running validations. But sometimes,
it seems that Cluster failure messages on the status are is not cleared for some reason
after successfully passing the validation. The theory is that if the initial patch operation
is not successful, and the reconcile loop is skipped going forward, it may never be cleared.

This PR addresses this issue by clearing the Cluster failure status when there is no further processing to do for the controller (there is no difference between the aggregated generation and childrenReconciledGeneration, and there is no difference in the reconciled generation and .`metadata.generation` of the cluster). At this point, it starts to skip reconciliation denoting that the reconciliation process is complete with no errors or re-queues.  When the controller reaches here, it denotes a completion of reconciliation process. So, we can safely clear any failure messages or reasons that may be left over as there is no further processing for the controller to do.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

