### PR TITLE
cleanup and expand architecture page

### DIFF
--- a/docs/content/en/docs/concepts/deployment-architectures.md
+++ b/docs/content/en/docs/concepts/deployment-architectures.md
@@ -1,0 +1,7 @@
+---
+toc_hide: true
+---
+
+* **Standalone clusters**: If you are only running a single EKS Anywhere cluster, you can deploy a standalone cluster. This deployment type runs the EKS Anywhere management components on the same cluster that runs workloads. Standalone clusters must be managed with the `eksctl` CLI. A standalone cluster is effectively a management cluster, but in this deployment type, only manages itself.
+
+* **Management cluster with separate workload clusters**: If you plan to deploy multiple EKS Anywhere clusters, it's recommended to deploy a management cluster with separate workload clusters. With this deployment type, the EKS Anywhere management components are only run on the management cluster, and the management cluster can be used to perform cluster lifecycle operations on a fleet of workload clusters. The management cluster must be managed with the `eksctl` CLI, whereas workload clusters can be managed with the `eksctl` CLI or with Kubernetes API-compatible clients such as `kubectl`, GitOps, or Terraform.

--- a/docs/content/en/docs/concepts/support-versions.md
+++ b/docs/content/en/docs/concepts/support-versions.md
@@ -31,11 +31,11 @@ Reference the table below for release and support dates for each Kubernetes vers
 
 ## EKS Anywhere versions
 
-Each EKS Anywhere version includes all components required to create and manage EKS Anywhere clusters. For example, this includes:
+Each EKS Anywhere version includes all components required to create and manage EKS Anywhere clusters. This includes but is not limited to:
 
 - Administrative / CLI components (eksctl CLI, image-builder, diagnostics-collector)
 - Management components (Cluster API controller, EKS Anywhere controller, provider-specific controllers)
-- Workload components (Kubernetes, Cilium)
+- Cluster components (Kubernetes, Cilium)
 
 You can find details about each EKS Anywhere releases in the [EKS Anywhere release manifest.](https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml) The release manifest contains references to the corresponding bundle manifest for each EKS Anywhere version. Within the bundle manifest, you will find the components included in a specific EKS Anywhere version. The images running in your deployment use the same uri values specified in the bundle manifest for that component. For example, see the [bundle manifest](https://anywhere-assets.eks.amazonaws.com/releases/bundles/57/manifest.yaml) for EKS Anywhere v0.18.5.
 

--- a/docs/content/en/docs/getting-started/overview.md
+++ b/docs/content/en/docs/getting-started/overview.md
@@ -54,10 +54,7 @@ Before creating your first EKS Anywhere cluster, you must choose your infrastruc
 
 EKS Anywhere supports two deployment architectures:
 
-* **Standalone clusters**: If you want only a single EKS Anywhere cluster, you can deploy a standalone cluster.
-This deployment type runs the CAPI and EKS-A management components on a single standalone cluster alongside the Kubernetes cluster that runs workloads. Standalone clusters must be managed with the EKS Anywhere CLI. A standalone cluster is effectively a management cluster, but in this deployment type, only manages itself.
-
-* **Management cluster with separate workload clusters**: If you plan to deploy multiple EKS Anywhere clusters, you should deploy a management cluster with separate workload clusters. With this deployment type, the management cluster is used to perform cluster lifecycle operations on a fleet of workload clusters. The management cluster must be managed with the EKS Anywhere CLI, whereas workload clusters can be managed with the EKS Anywhere CLI, Kubernetes API-compatible tooling, or with Infrastructure as Code (IAC) tooling such as Terraform or GitOps.
+{{% content "../concepts/deployment-architectures.md" %}}
 
 For details on the EKS Anywhere architectures, see the [Architecture page.]({{< relref "../concepts/architecture.md" >}}) 
 


### PR DESCRIPTION
These changes include
1. Adding Components breakdown to the EKS Anywhere Architecture page
2. Cleaning up the descriptions of standalone and management cluster deployment architectures


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

