### PR TITLE
Remove ServiceLoadBalancerClass feature gate

### DIFF
--- a/pkg/clusterapi/extraargs.go
+++ b/pkg/clusterapi/extraargs.go
@@ -53,17 +53,6 @@ func EtcdEncryptionExtraArgs(config *[]v1alpha1.EtcdEncryption) ExtraArgs {
 	return args
 }
 
-// FeatureGatesExtraArgs takes a list of features with the value and returns it in the proper format
-// Example FeatureGatesExtraArgs("ServiceLoadBalancerClass=true").
-func FeatureGatesExtraArgs(features ...string) ExtraArgs {
-	if len(features) == 0 {
-		return nil
-	}
-	return ExtraArgs{
-		"feature-gates": strings.Join(features[:], ","),
-	}
-}
-
 func PodIAMAuthExtraArgs(podIAMConfig *v1alpha1.PodIAMConfig) ExtraArgs {
 	if podIAMConfig == nil {
 		return nil

--- a/pkg/clusterapi/extraargs_test.go
+++ b/pkg/clusterapi/extraargs_test.go
@@ -621,39 +621,3 @@ func TestEtcdEncryptionExtraArgs(t *testing.T) {
 		})
 	}
 }
-
-func TestFeatureGatesExtraArgs(t *testing.T) {
-	tests := []struct {
-		testName string
-		features []string
-		want     clusterapi.ExtraArgs
-	}{
-		{
-			testName: "no feature gates",
-			features: []string{},
-			want:     nil,
-		},
-		{
-			testName: "single feature gate",
-			features: []string{"feature1=true"},
-			want: clusterapi.ExtraArgs{
-				"feature-gates": "feature1=true",
-			},
-		},
-		{
-			testName: "multiple feature gates",
-			features: []string{"feature1=true", "feature2=false", "feature3=true"},
-			want: clusterapi.ExtraArgs{
-				"feature-gates": "feature1=true,feature2=false,feature3=true",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
-			if got := clusterapi.FeatureGatesExtraArgs(tt.features...); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FeatureGatesExtraArgs() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -246,7 +246,6 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           authentication-token-webhook-config-file: /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
           - hostPath: /etc/kubernetes/audit-policy.yaml
             mountPath: /etc/kubernetes/audit-policy.yaml
@@ -574,7 +573,6 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           authentication-token-webhook-config-file: /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -401,11 +401,6 @@ func buildTemplateMapCP(
 		Append(clusterapi.AwsIamAuthExtraArgs(clusterSpec.AWSIamConfig)).
 		Append(clusterapi.PodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig))
 
-	// LoadBalancerClass is feature gated in K8S v1.21 and needs to be enabled manually
-	if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube121 {
-		apiServerExtraArgs.Append(clusterapi.FeatureGatesExtraArgs("ServiceLoadBalancerClass=true"))
-	}
-
 	kubeletExtraArgs := clusterapi.SecureTlsCipherSuitesExtraArgs().
 		Append(clusterapi.ResolvConfExtraArgs(clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf)).
 		Append(clusterapi.ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration))

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
@@ -48,7 +48,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
@@ -48,7 +48,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
@@ -82,7 +82,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -65,7 +65,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -52,7 +52,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
@@ -61,7 +61,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_upgrade_cert_bundles_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_upgrade_cert_bundles_config_cp.yaml
@@ -40,7 +40,6 @@ spec:
           audit-log-maxsize: "512"
           audit-log-path: /var/log/kubernetes/api-audit.log
           audit-policy-file: /etc/kubernetes/audit-policy.yaml
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
@@ -54,7 +54,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -72,7 +72,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -72,7 +72,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /var/lib/kubeadm/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
@@ -47,7 +47,6 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           authentication-token-webhook-config-file: /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
           oidc-client-id: my-client-id
           oidc-groups-claim: claim1
           oidc-groups-prefix: prefix-for-groups

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
           oidc-client-id: my-client-id
           oidc-issuer-url: https://mydomain.com/issuer
         extraVolumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
@@ -40,7 +40,6 @@ spec:
           audit-log-maxsize: "512"
           audit-log-path: /var/log/kubernetes/api-audit.log
           audit-policy-file: /etc/kubernetes/audit-policy.yaml
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_pod_iam_config.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_pod_iam_config.yaml
@@ -47,7 +47,6 @@ spec:
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
           authentication-token-webhook-config-file: /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml
-          feature-gates: ServiceLoadBalancerClass=true
           service-account-issuer: https://test
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -46,7 +46,6 @@ spec:
           audit-log-maxage: "30"
           audit-log-maxbackup: "10"
           audit-log-maxsize: "512"
-          feature-gates: ServiceLoadBalancerClass=true
         extraVolumes:
         - hostPath: /etc/kubernetes/audit-policy.yaml
           mountPath: /etc/kubernetes/audit-policy.yaml


### PR DESCRIPTION
*Description of changes:*
ServiceLoadBalancerClass feature was enabled in [#2955](https://github.com/aws/eks-anywhere/pull/2955) for baremetal v1.21 clusters. It is enabled by default from 1.22 onwards. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

