### PR TITLE
Generate support bundle for InPlace test in case the validations fail

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4288,7 +4288,7 @@ spec:
                           type: string
                       type: object
                     machineHealthCheck:
-                      description: MachineHealthCheck is a control-plane level override
+                      description: MachineHealthCheck is a worker node level override
                         for the timeouts and maxUnhealthy specified in the top-level
                         MHC configuration. If not configured, the defaults in the
                         top-level MHC configuration are used.

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -64,6 +64,7 @@ func runInPlaceMultipleUpgradesFlow(test *framework.ClusterE2ETest, clusterOpts 
 	test.CreateCluster()
 	for _, opts := range clusterOpts {
 		test.UpgradeClusterWithNewConfig(opts)
+		test.GenerateSupportBundleOnCleanupIfTestFailed()
 		test.ValidateClusterState()
 		test.StopIfFailed()
 	}
@@ -75,6 +76,7 @@ func runInPlaceMultipleUpgradesFlow(test *framework.ClusterE2ETest, clusterOpts 
 func runInPlaceUpgradeFlow(test *framework.ClusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.CreateCluster()
 	test.UpgradeClusterWithNewConfig(clusterOpts)
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.ValidateClusterState()
 	test.StopIfFailed()
 	test.DeleteCluster()
@@ -84,6 +86,7 @@ func runInPlaceUpgradeFlowForBareMetal(test *framework.ClusterE2ETest, clusterOp
 	test.GenerateHardwareConfig()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.UpgradeClusterWithNewConfig(clusterOpts)
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.ValidateClusterState()
 	test.StopIfFailed()
 	test.DeleteCluster()


### PR DESCRIPTION
*Issue #, if available:*
For the InPlace E2Es it so happens that sometimes the CRDs are left behind after a successful upgrade. In such scenarios, the test fails as the validations do not succeed but since the CLI in itself didn't fail we do not have access to support bundles, which makes it hard to investigate the failure. This change generates support bundle for InPlace tests in case the validations on the cluster fail. 
 
*Description of changes:*

*Testing (if applicable):*
Tested locally by mocking a failed scenario. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

