### PR TITLE
Enable BR 128 to 129 Stacked ETCD Upgrade (#7722)

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -21,7 +21,6 @@ skipped_tests:
 - TestCloudStackKubernetes129WithOIDCManagementClusterUpgradeFromLatestSideEffects
 
 # Temporary disables to stabilize tests. Owners should work on fixes and enable these test along with their fix's PR
-- TestVSphereKubernetes128BottlerocketTo129StackedEtcdUpgrade
 - TestTinkerbellAirgappedKubernetes129UbuntuProxyConfigFlow
 
 # Nutanix


### PR DESCRIPTION
*Issue #, if available:*

Manual cherry pick into release-0.19 because patch history of SKIPPED_TESTS.yaml differs in main.
https://github.com/aws/eks-anywhere/pull/7722#issuecomment-1966962363

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

