### PR TITLE
Improve validation error messages

### DIFF
--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -888,20 +888,18 @@ func (k *Kubectl) ValidateControlPlaneNodes(ctx context.Context, cluster *types.
 	observedGeneration := cp.Status.ObservedGeneration
 	generation := cp.Generation
 	if observedGeneration != generation {
-		return fmt.Errorf("kubeadm control plane %s status needs to be refreshed: observed generation is %d, want %d", cp.Name, observedGeneration, generation)
+		return fmt.Errorf("kubeadm control plane %s status needs to be refreshed: generation=%v, observedGeneration=%d", cp.Name, generation, observedGeneration)
 	}
 
 	if !cp.Status.Ready {
-		return errors.New("control plane is not ready")
+		return errors.New("api server is not ready")
 	}
 
 	if cp.Status.UnavailableReplicas != 0 {
-		return fmt.Errorf("%v control plane replicas are unavailable", cp.Status.UnavailableReplicas)
+		return fmt.Errorf("%v/%v control plane replicas are unavailable",
+			cp.Status.UnavailableReplicas, cp.Status.Replicas)
 	}
 
-	if cp.Status.ReadyReplicas != cp.Status.Replicas {
-		return fmt.Errorf("%v control plane replicas are not ready", cp.Status.Replicas-cp.Status.ReadyReplicas)
-	}
 	return nil
 }
 

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -48,14 +48,14 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
 				Name:        "control plane ready",
-				Remediation: fmt.Sprintf("ensure control plane nodes and pods for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
+				Remediation: fmt.Sprintf("ensure control plane nodes and pods for cluster %s are ready", u.Opts.WorkloadCluster.Name),
 				Err:         k.ValidateControlPlaneNodes(ctx, targetCluster, targetCluster.Name),
 			}
 		},
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
 				Name:        "worker nodes ready",
-				Remediation: fmt.Sprintf("ensure machine deployments for cluster %s are Ready", u.Opts.WorkloadCluster.Name),
+				Remediation: fmt.Sprintf("ensure machine deployments for cluster %s are ready", u.Opts.WorkloadCluster.Name),
 				Err:         k.ValidateWorkerNodes(ctx, u.Opts.Spec.Cluster.Name, targetCluster.KubeconfigFile),
 			}
 		},


### PR DESCRIPTION
* Add information to error messages regarding the total unavailable replicas
* Provide a more meaningful explanation when the API server isn't ready
* Lowercase the word 'Ready' which makes it seem like 'Ready' has special meaning in the error message.
* Removed redundant check for ready control plane nodes.