### PR TITLE
Add wait after replacing cilium in E2E test

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1218,6 +1218,13 @@ func TestDockerCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
 	test.GenerateClusterConfig(framework.ExecuteWithEksaRelease(previousRelease))
 	test.CreateCluster(framework.ExecuteWithEksaRelease(previousRelease))
 	test.ReplaceCiliumWithOSSCilium()
+
+	t.Log("Waiting for cilium replacement to complete")
+	// Wait two minutes before validating cluster state and attempting the upgrade
+	// After replacing cilium, the nodes can temporarily go into a not ready state
+	// and we want to give them time to recover before validating the cluster state
+	time.Sleep(5 * time.Minute)
+
 	test.ValidateClusterState()
 	test.UpgradeClusterWithNewConfig(
 		[]framework.ClusterE2ETestOpt{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a small wait time after replacing cilium in the test. Kind of a hack, but it’s annoying to fix without. The nodes basically can become unready / unavailable a bit after replacing cilium. The upgrade validates that the nodes are ready, so when this happens, it fails. I’m not sure exactly how long this time frame can be, but 5 minutes should be more than enough from what I’ve seen

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

