### PR TITLE
Compute signature digests separately for source and destination images

### DIFF
--- a/release/cli/pkg/operations/bundle_release.go
+++ b/release/cli/pkg/operations/bundle_release.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/eks-anywhere/release/cli/pkg/bundles"
 	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
 	"github.com/aws/eks-anywhere/release/cli/pkg/filereader"
+	"github.com/aws/eks-anywhere/release/cli/pkg/images"
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
 	artifactutils "github.com/aws/eks-anywhere/release/cli/pkg/util/artifacts"
 	commandutils "github.com/aws/eks-anywhere/release/cli/pkg/util/command"
@@ -160,23 +161,37 @@ func CopyImageSignatureUsingOras(r *releasetypes.ReleaseConfig, imageDigests rel
 		fmt.Println("Skipping image signature copy in dry-run mode")
 		return nil
 	}
+	sourceRegistryClient := r.SourceClients.ECR.EcrPublicClient
 	sourceRegistryUsername := r.SourceClients.ECR.AuthConfig.Username
 	sourceRegistryPassword := r.SourceClients.ECR.AuthConfig.Password
+	releaseRegistryClient := r.ReleaseClients.ECRPublic.Client
 	releaseRegistryUsername := r.ReleaseClients.ECRPublic.AuthConfig.Username
 	releaseRegistryPassword := r.ReleaseClients.ECRPublic.AuthConfig.Password
 	var rangeErr error
 	imageDigests.Range(func(k, v interface{}) bool {
 		image := k.(string)
 		digest := v.(string)
-		// Digest is in the form sha256:digest. Notation image index and signatures are in the form sha256-digest.
-		shaDigest := strings.Replace(digest, ":", "-", -1)
 
 		// Get imageRespository name since we have a different source and release registry.
-		imageRepository, _ := artifactutils.SplitImageUri(image, r.ReleaseContainerRegistry)
+		imageRepository, imageTag := artifactutils.SplitImageUri(image, r.ReleaseContainerRegistry)
+		// Compute image digest for source and destination images from manifest contents. The digest will be in the
+		// form sha256:digest, so we are changing it to Notation's image index and signatures format, sha256-digest.
+		sourceImageDigest, err := images.ComputeImageDigestFromManifest(sourceRegistryClient, r.SourceContainerRegistry, imageRepository, imageTag)
+		if err != nil {
+			rangeErr = fmt.Errorf("computing digest for source image %s from manifest: %v\n", image, err)
+			return false
+		}
+		sourceImageSignatureDigest := fmt.Sprintf("sha256-%s", sourceImageDigest)
+		releaseImageDigest, err := images.ComputeImageDigestFromManifest(releaseRegistryClient, r.ReleaseContainerRegistry, imageRepository, imageTag)
+		if err != nil {
+			rangeErr = fmt.Errorf("computing digest for destination image %s from manifest: %v\n", image, err)
+			return false
+		}
+		releaseImageSignatureDigest := fmt.Sprintf("sha256-%s", releaseImageDigest)
 		// Form releaseImageURI in the form <source-registry>/<repository>:<sha256-digest>
-		sourceImageURI := fmt.Sprintf("%s/%s:%s", r.SourceContainerRegistry, imageRepository, shaDigest)
+		sourceImageURI := fmt.Sprintf("%s/%s:%s", r.SourceContainerRegistry, imageRepository, sourceImageSignatureDigest)
 		// Form releaseImageURI in the form <release-registry>/<repository>:<sha256-digest>
-		releaseImageURI := fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, imageRepository, shaDigest)
+		releaseImageURI := fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, imageRepository, releaseImageSignatureDigest)
 
 		cmd := exec.Command("oras", "copy", "--from-username", sourceRegistryUsername, "--from-password", sourceRegistryPassword, sourceImageURI, "--to-username", releaseRegistryUsername, "--to-password", releaseRegistryPassword, releaseImageURI)
 		out, err := commandutils.ExecCommand(cmd)


### PR DESCRIPTION
In the staging releases, when we push Helm charts to ECR, they get a specific image digest, and when we sign them, a new image index with reference `sha256-<image digest>` gets created. However, in the prod releases, we pull the Helm chart locally and modify it and then push it, which gives it a different image digest than the one in staging, leading to a different reference for the signature image index. But when copying the signatures from source to destination, we assume the same signature image index which leads to an issue. This can be solved by re-computing the image digest signatures separately for source and release images and using them instead of the same digest for both. 

**Note:** This is an issue only for Helm charts because we modify them before pushing, but the PR changes the flow for all image artifacts. For regular images, the source and release image digest and signature digest will be the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

