### PR TITLE
Process packages artifacts only during bundle release

### DIFF
--- a/release/cli/pkg/operations/bundle_release.go
+++ b/release/cli/pkg/operations/bundle_release.go
@@ -74,7 +74,7 @@ func BundleArtifactsRelease(r *releasetypes.ReleaseConfig) error {
 		return errors.Cause(err)
 	}
 
-	err = UploadArtifacts(context.Background(), r, r.BundleArtifactsTable)
+	err = UploadArtifacts(context.Background(), r, r.BundleArtifactsTable, true)
 	if err != nil {
 		return errors.Cause(err)
 	}

--- a/release/cli/pkg/operations/eksa_release.go
+++ b/release/cli/pkg/operations/eksa_release.go
@@ -57,7 +57,7 @@ func EksAArtifactsRelease(r *releasetypes.ReleaseConfig) error {
 		return errors.Cause(err)
 	}
 
-	err = UploadArtifacts(context.Background(), r, r.EksAArtifactsTable)
+	err = UploadArtifacts(context.Background(), r, r.EksAArtifactsTable, false)
 	if err != nil {
 		return errors.Cause(err)
 	}

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -32,7 +32,7 @@ import (
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
 )
 
-func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArtifacts releasetypes.ArtifactsTable) error {
+func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArtifacts releasetypes.ArtifactsTable, isBundleRelease bool) error {
 	fmt.Println("\n==========================================================")
 	fmt.Println("                  Artifacts Upload")
 	fmt.Println("==========================================================")
@@ -46,14 +46,17 @@ func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArt
 	sourceEcrAuthConfig := r.SourceClients.ECR.AuthConfig
 	releaseEcrAuthConfig := r.ReleaseClients.ECRPublic.AuthConfig
 
-	projectsInBundle := []string{"eks-anywhere-packages"}
 	packagesArtifacts := map[string][]releasetypes.Artifact{}
-	for _, project := range projectsInBundle {
-		projectArtifacts, err := r.BundleArtifactsTable.Load(project)
-		if err != nil {
-			return fmt.Errorf("artifacts for project %s not found in bundle artifacts table", project)
+	if isBundleRelease {
+		projectsInBundle := []string{"eks-anywhere-packages"}
+		packagesArtifacts := map[string][]releasetypes.Artifact{}
+		for _, project := range projectsInBundle {
+			projectArtifacts, err := r.BundleArtifactsTable.Load(project)
+			if err != nil {
+				return fmt.Errorf("artifacts for project %s not found in bundle artifacts table", project)
+			}
+			packagesArtifacts[project] = projectArtifacts
 		}
-		packagesArtifacts[project] = projectArtifacts
 	}
 
 	eksaArtifacts.Range(func(k, v interface{}) bool {


### PR DESCRIPTION
This PR adds a check is we are performing a bundle release or CLI release, this ensures packages artifacts are processed only during bundle release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

