### PR TITLE
Cilium reconciler to use provider namespace in generating network policy

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -250,7 +250,7 @@ func (f *Factory) WithNutanixDatacenterReconciler() *Factory {
 // withNutanixClusterReconciler adds the NutanixClusterReconciler to the controller factory.
 func (f *Factory) withNutanixClusterReconciler() *Factory {
 	f.dependencyFactory.WithNutanixDefaulter().WithNutanixValidator()
-	f.withTracker().withCNIReconciler().withIPValidator()
+	f.withTracker().withCNIReconciler(f.getProviderNamespace(constants.NutanixProviderName)).withIPValidator()
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.nutanixClusterReconciler != nil {
 			return nil
@@ -345,7 +345,7 @@ func (f *Factory) WithProviderClusterReconcilerRegistry(capiProviders []clusterc
 }
 
 func (f *Factory) withDockerClusterReconciler() *Factory {
-	f.withCNIReconciler().withTracker()
+	f.withCNIReconciler(f.getProviderNamespace(constants.DockerProviderName)).withTracker()
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.dockerClusterReconciler != nil {
 			return nil
@@ -366,7 +366,7 @@ func (f *Factory) withDockerClusterReconciler() *Factory {
 
 func (f *Factory) withVSphereClusterReconciler() *Factory {
 	f.dependencyFactory.WithVSphereDefaulter().WithVSphereValidator()
-	f.withTracker().withCNIReconciler().withIPValidator()
+	f.withTracker().withCNIReconciler(f.getProviderNamespace(constants.VSphereProviderName)).withIPValidator()
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.vsphereClusterReconciler != nil {
 			return nil
@@ -389,7 +389,7 @@ func (f *Factory) withVSphereClusterReconciler() *Factory {
 }
 
 func (f *Factory) withSnowClusterReconciler() *Factory {
-	f.withCNIReconciler().withTracker().withIPValidator()
+	f.withCNIReconciler(f.getProviderNamespace(constants.SnowProviderName)).withTracker().withIPValidator()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.snowClusterReconciler != nil {
@@ -411,7 +411,7 @@ func (f *Factory) withSnowClusterReconciler() *Factory {
 }
 
 func (f *Factory) withTinkerbellClusterReconciler() *Factory {
-	f.withCNIReconciler().withTracker().withIPValidator()
+	f.withCNIReconciler(f.getProviderNamespace(constants.TinkerbellProviderName)).withTracker().withIPValidator()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.tinkerbellClusterReconciler != nil {
@@ -433,7 +433,7 @@ func (f *Factory) withTinkerbellClusterReconciler() *Factory {
 }
 
 func (f *Factory) withCloudStackClusterReconciler() *Factory {
-	f.withCNIReconciler().withTracker().withIPValidator().withCloudStackValidatorRegistry()
+	f.withCNIReconciler(f.getProviderNamespace(constants.CloudStackProviderName)).withTracker().withIPValidator().withCloudStackValidatorRegistry()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.cloudstackClusterReconciler != nil {
@@ -504,7 +504,7 @@ func (f *Factory) withCiliumTemplater() *Factory {
 	return f
 }
 
-func (f *Factory) withCNIReconciler() *Factory {
+func (f *Factory) withCNIReconciler(providerNamespace string) *Factory {
 	f.withCiliumTemplater()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
@@ -512,7 +512,7 @@ func (f *Factory) withCNIReconciler() *Factory {
 			return nil
 		}
 
-		f.cniReconciler = cnireconciler.New(ciliumreconciler.New(f.ciliumTemplater))
+		f.cniReconciler = cnireconciler.New(ciliumreconciler.New(f.ciliumTemplater, []string{providerNamespace}))
 
 		return nil
 	})
@@ -680,4 +680,25 @@ func (f *Factory) WithNodeUpgradeReconciler() *Factory {
 	})
 
 	return f
+}
+
+func (f *Factory) getProviderNamespace(providerName string) string {
+	var providerNamespace string
+	switch providerName {
+	case snowProviderName:
+		providerNamespace = constants.CapasSystemNamespace
+	case vSphereProviderName:
+		providerNamespace = constants.CapvSystemNamespace
+	case tinkerbellProviderName:
+		providerNamespace = constants.CaptSystemNamespace
+	case cloudstackProviderName:
+		providerNamespace = constants.CapcSystemNamespace
+	case nutanixProviderName:
+		providerNamespace = constants.CapxSystemNamespace
+	case dockerProviderName:
+		providerNamespace = constants.CapdSystemNamespace
+	default:
+		f.logger.Info("Found unknown CAPI provider, ignoring", "providerName", providerName)
+	}
+	return providerNamespace
 }

--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -21,11 +21,6 @@ skipped_tests:
 - TestCloudStackKubernetes129WithOIDCManagementClusterUpgradeFromLatestSideEffects
 
 # Temporary disables to stabilize tests. Owners should work on fixes and enable these test along with their fix's PR
-- TestCloudStackKubernetes126CiliumAlwaysPolicyEnforcementModeSimpleFlow
-- TestCloudStackKubernetes125CiliumAlwaysPolicyEnforcementModeSimpleFlow
-- TestCloudStackKubernetes127CiliumAlwaysPolicyEnforcementModeSimpleFlow
-- TestCloudStackKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow
-- TestVSphereKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow
 - TestTinkerbellAirgappedKubernetes129UbuntuProxyConfigFlow
 
 # Nutanix


### PR DESCRIPTION
*Description of changes:*
Cilium reconciler when generating manifests were not using the provider namespaces when generating cilium manifests. This is not a problem for the most scenarios except when running cilium in "always" policy enforcement mode, where cilium expects explicit network policies to enable routing between any pods/services. This change enables the cilium reconciler to generate network policy for the provider's namespace that allows routing between the provider's controller and other services like kubernetes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

