### PR TITLE
Improve error message when old cluster config file exists

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -139,8 +139,8 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 	kubeconfigPath := kubeconfig.FromClusterName(clusterConfig.Name)
 	if validations.FileExistsAndIsNotEmpty(kubeconfigPath) {
 		return fmt.Errorf(
-			"old cluster config file exists under %s, please use a different clusterName to proceed",
-			clusterConfig.Name,
+			`old cluster config file already exists under the "%s" folder, please use a different cluster name or remove the existing "%s" folder to proceed`,
+			clusterConfig.Name, clusterConfig.Name,
 		)
 	}
 

--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -142,13 +142,13 @@ Error: loading config file "cluster.yaml": error unmarshaling JSON: while decodi
 ```
 Use `eksctl anywhere create cluster -f cluster.yaml` instead of `eksctl create cluster -f cluster.yaml` to create an EKS Anywhere cluster.
 
-### Error: old cluster config file exists under my-cluster, please use a different clusterName to proceed
+### Error: old cluster config file already exists under the "my-cluster" folder, please use a different cluster name or remove the existing "my-cluster" folder to proceed
 
 ```
-Error: old cluster config file exists under my-cluster, please use a different clusterName to proceed
+Error: old cluster config file already exists under the "my-cluster" folder, please use a different cluster name or remove the existing "my-cluster" folder to proceed
 ```
 The `my-cluster` directory already exists in the current directory.
-Either use a different cluster name or move the directory.
+Either use a different cluster name or remove the existing directory.
 
 ### At least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints
 

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -127,8 +127,8 @@ func ValidateKubeconfigPath(clusterName string, parentFolders ...string) error {
 	info, err := os.Stat(kubeconfigPath)
 	if err == nil && info.Size() > 0 {
 		return fmt.Errorf(
-			"old cluster config file exists under %s, please use a different clusterName to proceed",
-			clusterName,
+			`old cluster config file already exists under the "%s" folder, please use a different cluster name or remove the existing "%s" folder to proceed`,
+			clusterName, clusterName,
 		)
 	}
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

