### PR TITLE
Bump docs site version to 0.19

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -180,7 +180,7 @@ icon = "fab fa-github"
 desc = "Development takes place here!"
 
 [[params.versions]]
-fullversion = "v0.18"
-version = "v0.18"
+fullversion = "v0.19"
+version = "v0.19"
 docsbranch = "main"
 url = "/docs/"


### PR DESCRIPTION
Bump docs site version to 0.19.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

