### PR TITLE
Un-Skipping reconciler unit tests for the all providers

### DIFF
--- a/pkg/awsiamauth/reconciler/reconciler_test.go
+++ b/pkg/awsiamauth/reconciler/reconciler_test.go
@@ -206,7 +206,7 @@ func TestReconcileKCPObjectNotFound(t *testing.T) {
 	r := reconciler.New(certs, generateUUID, cl, remoteClientRegistry)
 	result, err := r.Reconcile(ctx, nullLog(), cluster)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result).To(Equal(controller.ResultWithRequeue(5 * time.Second)))
+	g.Expect(result).To(Equal(controller.ResultWithRequeue(4 * time.Second)))
 }
 
 func TestReconcileRemoteGetClientError(t *testing.T) {

--- a/pkg/controller/clusters/clusterapi.go
+++ b/pkg/controller/clusters/clusterapi.go
@@ -25,7 +25,7 @@ func CheckControlPlaneReady(ctx context.Context, client client.Client, log logr.
 
 	if kcp == nil {
 		log.Info("KCP does not exist yet, requeuing")
-		return controller.ResultWithRequeue(5 * time.Second), nil
+		return controller.ResultWithRequeue(4 * time.Second), nil
 	}
 
 	// We make sure to check that the status is up to date before using it

--- a/pkg/controller/clusters/clusterapi_test.go
+++ b/pkg/controller/clusters/clusterapi_test.go
@@ -55,7 +55,7 @@ func TestCheckControlPlaneReadyNoKcp(t *testing.T) {
 	result, err := clusters.CheckControlPlaneReady(ctx, client, test.NewNullLogger(), eksaCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result).To(Equal(
-		controller.Result{Result: &controllerruntime.Result{RequeueAfter: 5 * time.Second}}),
+		controller.Result{Result: &controllerruntime.Result{RequeueAfter: 4 * time.Second}}),
 	)
 }
 

--- a/pkg/providers/docker/reconciler/reconciler_test.go
+++ b/pkg/providers/docker/reconciler/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -38,9 +39,7 @@ const (
 	clusterNamespace = "test-namespace"
 )
 
-func TestReconcilerReconcileSuccess(t *testing.T) {
-	t.Skip("Flaky (https://github.com/aws/eks-anywhere/issues/6996)")
-
+func TestDockerReconcilerReconcileSuccess(t *testing.T) {
 	tt := newReconcilerTest(t)
 	logger := test.NewNullLogger()
 
@@ -476,14 +475,17 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		c.Spec.EksaVersion = &version
 	})
 
+	kcpVersion := "v1.19.8"
 	kcp := test.KubeadmControlPlane(func(kcp *controlplanev1.KubeadmControlPlane) {
 		kcp.Name = cluster.Name
+		kcp.ObjectMeta.Generation = 2
 		kcp.Spec = controlplanev1.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
 				InfrastructureRef: corev1.ObjectReference{
 					Name: fmt.Sprintf("%s-control-plane-1", cluster.Name),
 				},
 			},
+			Version: kcpVersion,
 		}
 		kcp.Status = controlplanev1.KubeadmControlPlaneStatus{
 			Conditions: clusterv1.Conditions{
@@ -494,6 +496,8 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 				},
 			},
 			ObservedGeneration: 2,
+			Ready:              true,
+			Version:            pointer.String(kcpVersion),
 		}
 	})
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2193

*Description of changes:*
We have skipped a few unit tests which were failing randomly on a PR as a part of eks-anywhere-presubmit job. Un-skipping a those unit tests of all the providers.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

