### PR TITLE
Enable Tinkerbell tests in quick-e2e suite

### DIFF
--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -25,6 +25,6 @@ quick_tests:
 # - TestSnowKubernetes128SimpleFlow
 # - TestSnowKubernetes128StackedEtcdSimpleFlow
 # Tinkerbell
-# - ^TestTinkerbellKubernetes127UbuntuTo128Upgrade$
-# - TestTinkerbellKubernetes128Ubuntu2004To2204Upgrade
-# - TestTinkerbellKubernetes127To128Ubuntu2204Upgrade
+- ^TestTinkerbellKubernetes127UbuntuTo128Upgrade$
+- TestTinkerbellKubernetes128Ubuntu2004To2204Upgrade
+- TestTinkerbellKubernetes127To128Ubuntu2204Upgrade


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
These were disabled to avoid conflict with the main pipeline running the full e2e suite. Now that it has been moved to run once nightly, we an re-enable these.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

