### PR TITLE
Modify the incorrect command for generating a config file

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/overview.md
+++ b/docs/content/en/docs/getting-started/baremetal/overview.md
@@ -17,7 +17,7 @@ The following diagram illustrates what happens when you create an EKS Anywhere c
 ![Start creating EKS Anywhere Bare Metal cluster](/images/eksa-baremetal-start.png)
 
 #### 1. Generate a config file for Bare Metal
-Identify the provider (`--provider tinkerbell`) and the cluster name to the `eksctl anywhere create clusterconfig` command and direct the output into a cluster config `.yaml` file.
+Identify the provider (`--provider tinkerbell`) and the cluster name to the `eksctl anywhere generate clusterconfig` command and direct the output into a cluster config `.yaml` file.
 
 #### 2. Modify the config file and hardware CSV file
 Modify the generated cluster config file to suit your situation.

--- a/docs/content/en/docs/getting-started/nutanix/overview.md
+++ b/docs/content/en/docs/getting-started/nutanix/overview.md
@@ -17,7 +17,7 @@ The following diagram illustrates the cluster creation process for the Nutanix p
 
 #### 1. Generate a config file for Nutanix
 
-Identify the provider (`--provider nutanix`) and the cluster name in the `eksctl anywhere create clusterconfig` command and direct the output to a cluster config `.yaml` file.
+Identify the provider (`--provider nutanix`) and the cluster name in the `eksctl anywhere generate clusterconfig` command and direct the output to a cluster config `.yaml` file.
 
 #### 2. Modify the config file
 


### PR DESCRIPTION
*Issue:*

For generating a config file, you need to use `eksctl anywhere "generate" clusterconfig` command.
`eksctl anywhere "create" clusterconfig` command does not work.

*Description of changes:*

Change the incorrect command `eksctl anywhere create clusterconfig` to `eksctl anywhere generate clusterconfig`.

*Testing (if applicable):*

```
$ eksctl anywhere generate clusterconfig baremetal-test --provider tinkerbell
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: Cluster
metadata:
  name: baremetal-test
...
```

```
$ eksctl anywhere create clusterconfig baremetal-test --provider tinkerbell
Error: unknown flag: --provider
Usage:
  anywhere create [command]

Available Commands:
  cluster     Create workload cluster
  package(s)  Create curated packages

Flags:
  -h, --help   help for create

Global Flags:
  -v, --verbosity int   Set the log level verbosity

Use "anywhere create [command] --help" for more information about a command.
```

*Documentation added/planned (if applicable):*

Modified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

