### PR TITLE
Use an uncached direct client to read the kcp and md to bypass delay in cache

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -602,6 +602,7 @@ func (f *Factory) WithKubeadmControlPlaneReconciler() *Factory {
 
 		f.reconcilers.KubeadmControlPlaneReconciler = NewKubeadmControlPlaneReconciler(
 			f.manager.GetClient(),
+			f.manager.GetAPIReader(),
 		)
 
 		return nil
@@ -619,6 +620,7 @@ func (f *Factory) WithMachineDeploymentReconciler() *Factory {
 
 		f.reconcilers.MachineDeploymentReconciler = NewMachineDeploymentReconciler(
 			f.manager.GetClient(),
+			f.manager.GetAPIReader(),
 		)
 
 		return nil

--- a/controllers/factory_test.go
+++ b/controllers/factory_test.go
@@ -237,6 +237,7 @@ func TestFactoryWithKubeadmControlPlaneReconciler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	manager := mocks.NewMockManager(ctrl)
 	manager.EXPECT().GetClient().AnyTimes()
+	manager.EXPECT().GetAPIReader().AnyTimes()
 	manager.EXPECT().GetScheme().AnyTimes()
 
 	f := controllers.NewFactory(logger, manager).
@@ -257,6 +258,7 @@ func TestFactoryWithMachineDeploymentReconciler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	manager := mocks.NewMockManager(ctrl)
 	manager.EXPECT().GetClient().AnyTimes()
+	manager.EXPECT().GetAPIReader().AnyTimes()
 	manager.EXPECT().GetScheme().AnyTimes()
 
 	f := controllers.NewFactory(logger, manager).

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -39,7 +39,7 @@ type kcpObjects struct {
 
 func TestKCPSetupWithManager(t *testing.T) {
 	client := env.Client()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 
 	g := NewWithT(t)
 	g.Expect(r.SetupWithManager(env.Manager())).To(Succeed())
@@ -54,7 +54,7 @@ func TestKCPReconcileNotNeeded(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.kcp, kcpObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -72,7 +72,7 @@ func TestKCPReconcile(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.cpUpgrade, kcpObjs.kcp, kcpObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -89,7 +89,7 @@ func TestKCPReconcileCreateControlPlaneUpgrade(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.kcp, kcpObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -121,7 +121,7 @@ func TestKCPReconcileKCPAndControlPlaneUpgradeReady(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.cpUpgrade, kcpObjs.kcp, kcpObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -149,7 +149,7 @@ func TestKCPReconcileFullFlow(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.kcp, kcpObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -207,7 +207,7 @@ func TestKCPReconcileNotFound(t *testing.T) {
 	kcpObjs := getObjectsForKCP()
 
 	client := fake.NewClientBuilder().WithRuntimeObjects().Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("kubeadmcontrolplanes.controlplane.cluster.x-k8s.io \"my-cluster\" not found"))
@@ -220,7 +220,7 @@ func TestKCPReconcileMHCNotFound(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.machines[0], kcpObjs.machines[1], kcpObjs.kcp}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("machinehealthchecks.cluster.x-k8s.io \"my-cluster-kcp-unhealthy\" not found"))
@@ -235,7 +235,7 @@ func TestKCPReconcileClusterConfigurationMissing(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.kcp}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("ClusterConfiguration not set for KubeadmControlPlane \"my-cluster\", unable to retrieve etcd information"))
@@ -250,7 +250,7 @@ func TestKCPReconcileStackedEtcdMissing(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{kcpObjs.kcp}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewKubeadmControlPlaneReconciler(client)
+	r := controllers.NewKubeadmControlPlaneReconciler(client, client)
 	req := kcpRequest(kcpObjs.kcp)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("local etcd configuration is missing"))

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -31,7 +31,7 @@ type mdObjects struct {
 
 func TestMDSetupWithManager(t *testing.T) {
 	client := env.Client()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 
 	g := NewWithT(t)
 	g.Expect(r.SetupWithManager(env.Manager())).To(Succeed())
@@ -46,7 +46,7 @@ func TestMDReconcileNotNeeded(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.md, mdObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -64,7 +64,7 @@ func TestMDReconcile(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.machine, mdObjs.mdUpgrade, mdObjs.md, mdObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -86,7 +86,7 @@ func TestMDReconcileCreateMachineDeploymentUpgrade(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.machine, mdObjs.md, mdObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -114,7 +114,7 @@ func TestMDReconcileMDAndMachineDeploymentUpgradeReady(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.machine, mdObjs.md, mdObjs.mdUpgrade, mdObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -142,7 +142,7 @@ func TestMDReconcileFullFlow(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.machine, mdObjs.md, mdObjs.mhc}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -204,7 +204,7 @@ func TestMDReconcileNotFound(t *testing.T) {
 	mdObjs := getObjectsForMD()
 
 	client := fake.NewClientBuilder().WithRuntimeObjects().Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("machinedeployments.cluster.x-k8s.io \"my-cluster\" not found"))
@@ -217,7 +217,7 @@ func TestMDReconcileMHCNotFound(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.machine, mdObjs.md}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("machinehealthchecks.cluster.x-k8s.io \"my-cluster-worker-unhealthy\" not found"))
@@ -232,7 +232,7 @@ func TestMDReconcileVersionMissing(t *testing.T) {
 
 	runtimeObjs := []runtime.Object{mdObjs.md}
 	client := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjs...).Build()
-	r := controllers.NewMachineDeploymentReconciler(client)
+	r := controllers.NewMachineDeploymentReconciler(client, client)
 	req := mdRequest(mdObjs.md)
 	_, err := r.Reconcile(ctx, req)
 	g.Expect(err).To(MatchError("unable to retrieve kubernetes version from MachineDeployment \"my-cluster\""))


### PR DESCRIPTION
*Issue #, if available:*
Some of the InPlace tests fail intermittently after a successful upgrade during the validation phase as some of the InPlace CRs are not cleaned up. We use an `in-place-upgrade-needed` on the kcp and md objects to identify the InPlace flow and remove those annotations once the upgrade is successful. In some cases, after the InPlace upgrade is successful the cache used to read the state of objects doesn't get updated quick enough. This leads to our controllers creating the InPlace custom resources again which leads to another upgrade on the node. Moreover since the annotation is removed, cache does get updated eventually leaving these objects in an untracked state as the kcp and md controller do not reconcile for InPlace flow anymore after the removal of annotation. 

*Description of changes:*
Use an uncached direct client to read kcp and md, so that we track these objects on realtime. This way we can rely on annotations on the objects to reconcile for the InPlace flow.

*Testing (if applicable):*
Ran all InPlace tests locally.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

