### PR TITLE
Add Nutanix as provider for ETCD encryption

### DIFF
--- a/docs/content/en/docs/getting-started/optional/etcdencryption.md
+++ b/docs/content/en/docs/getting-started/optional/etcdencryption.md
@@ -13,7 +13,7 @@ the KMS provider on the cluster and EKS Anywhere handles configuring `kube-apise
 Because of this model, etcd encryption can only be enabled on **_cluster upgrades_** after the KMS provider has been deployed on the cluster.
 
 {{% alert title="Note" color="warning" %}}
-Currently, etcd encryption is only supported for CloudStack and vSphere.
+Currently, etcd encryption is only supported for Nutanix, CloudStack and vSphere.
 Support for other providers will be added in a future release.
 {{% /alert %}}
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Nutanix has added ETCD encryption capabilities in 0.19 release, however this is not reflected in the documentation.

*Testing (if applicable):*
N/A

*Documentation added/planned (if applicable):*
This PR will update the documentation to reflect ETCD encryption support for Nutanix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

