### PR TITLE
Fix TestDockerCiliumSkipUpgrade_CLIUpgrade E2E test : Use latest minor release instead of previous latest minor release

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1201,8 +1201,8 @@ func TestDockerCiliumSkipUpgrade_CLICreate(t *testing.T) {
 	test.DeleteCluster()
 }
 
-func TestDockerCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
-	previousRelease := prevLatestMinorRelease(t)
+func TestDockerUpgradeFromLatestMinorReleaseCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
+	release := latestMinorRelease(t)
 
 	provider := framework.NewDocker(t)
 	test := framework.NewClusterE2ETest(t, provider,
@@ -1215,8 +1215,8 @@ func TestDockerCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
 
 	test.ValidateCiliumCLIAvailable()
 
-	test.GenerateClusterConfig(framework.ExecuteWithEksaRelease(previousRelease))
-	test.CreateCluster(framework.ExecuteWithEksaRelease(previousRelease))
+	test.GenerateClusterConfig(framework.ExecuteWithEksaRelease(release))
+	test.CreateCluster(framework.ExecuteWithEksaRelease(release))
 	test.ReplaceCiliumWithOSSCilium()
 
 	t.Log("Waiting for cilium replacement to complete")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the `TestDockerCiliumSkipUpgrade_CLIUpgrade` to use the latest minor release instead of the previous latest minor release. It has been trying to upgrade two minor versions at once, which is not allowed and prevented by a preflight validation, failing with the following error:

```
2024-03-04T08:35:52.563Z	V0	❌ Validation failed	{"validation": "validate eksaVersion skew is one minor version", "error": "spec.EksaVersion: Invalid value: \"v0.20.0-dev+build.22\": cannot upgrade to v0.20.0 from v0.18.7: EksaVersion upgrades must have a skew of 1 minor version", "remediation": "ensure eksaVersion upgrades are sequential by minor version"}
```
After talking with the team, it's been determined that this test is supposed to be using the latest minor release instead.

*Testing (if applicable):*
- Ran the test locally from the `main` and `release-0.19`

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

