### PR TITLE
Fixing a single quote

### DIFF
--- a/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
@@ -249,7 +249,7 @@ Follow these steps if you want to use your initial cluster to create and manage 
    * If your workload cluster was created with GitOps or Terraform, the kubeconfig for your new cluster is stored as a secret on the management cluster.
      You can get credentials and run the test application as follows:
       ```bash
-      kubectl get secret -n eksa-system w01-kubeconfig -o jsonpath=‘{.data.value}' | base64 —decode > w01.kubeconfig
+      kubectl get secret -n eksa-system w01-kubeconfig -o jsonpath='{.data.value}' | base64 —decode > w01.kubeconfig
       export KUBECONFIG=w01.kubeconfig
       kubectl apply -f "https://anywhere.eks.amazonaws.com/manifests/hello-eks-a.yaml"
       ```


### PR DESCRIPTION
Major contribution here. There was a rogue ‘ that should be a '.
