### PR TITLE
Add token for codecov to fix coverage upload

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -9,7 +9,6 @@ on:
     paths-ignore:
     - 'release/**'
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,3 +25,4 @@ jobs:
         uses: codecov/codecov-action@v4.1.0
         with:
           files: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
*Description of changes:*
Without the token, the new v4 action fails when uploading coverage from the jobs in main. The PR actions don't need it and, in fact, github should not pass the token to PRs coming from a fork.

More info: `https://github.com/codecov/codecov-action/issues/1274`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

