### PR TITLE
Add preflight validation to check management components vs cluster components version skew

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
@@ -84,7 +84,7 @@ var upgradeManagementComponentsCmd = &cobra.Command{
 			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		}
 
-		validator := management.NewUMCValidator(managementCluster, deps.Kubectl)
+		validator := management.NewUMCValidator(managementCluster, clusterSpec.EKSARelease, deps.UnAuthKubectlClient)
 		return runner.Run(ctx, clusterSpec, managementCluster, validator)
 	},
 }

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -18,6 +18,8 @@ import (
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
+const supportedManagementComponentsMinorVersionIncrement int64 = 1
+
 // ValidateOSForRegistryMirror checks if the OS is valid for the provided registry mirror configuration.
 func ValidateOSForRegistryMirror(clusterSpec *cluster.Spec, provider providers.Provider) error {
 	cluster := clusterSpec.Cluster
@@ -241,6 +243,36 @@ func ValidatePauseAnnotation(ctx context.Context, k KubectlClient, cluster *type
 	}
 	if currentCluster.IsReconcilePaused() {
 		return fmt.Errorf("cluster cannot be upgraded with paused cluster controller reconciler")
+	}
+	return nil
+}
+
+// ValidateManagementComponentsVersionSkew checks if the management components version is only one minor version greater than the cluster version.
+func ValidateManagementComponentsVersionSkew(ctx context.Context, k KubectlClient, mgmtCluster *types.Cluster, eksaRelease *releasev1alpha1.EKSARelease) error {
+	mgmt, err := k.GetEksaCluster(ctx, mgmtCluster, mgmtCluster.Name)
+	if err != nil {
+		return err
+	}
+
+	newManagementComponentsSemVer, err := semver.New(string(eksaRelease.Spec.Version))
+	if err != nil {
+		return fmt.Errorf("parsing management components version: %v", err)
+	}
+
+	if mgmt.Spec.EksaVersion == nil {
+		return fmt.Errorf("management cluster has nil EksaVersion")
+	}
+
+	managementClusterSemVer, err := semver.New(string(*mgmt.Spec.EksaVersion))
+	if err != nil {
+		return fmt.Errorf("parsing management components version: %v", err)
+	}
+
+	majorVersionDifference := int64(newManagementComponentsSemVer.Major) - int64(managementClusterSemVer.Major)
+	minorVersionDifference := int64(newManagementComponentsSemVer.Minor) - int64(managementClusterSemVer.Minor)
+
+	if majorVersionDifference != 0 || minorVersionDifference > supportedManagementComponentsMinorVersionIncrement {
+		return fmt.Errorf("management components version %s can only be one minor version greater than cluster version %s", newManagementComponentsSemVer, managementClusterSemVer)
 	}
 	return nil
 }

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -260,7 +260,7 @@ func ValidateManagementComponentsVersionSkew(ctx context.Context, k KubectlClien
 	}
 
 	if mgmt.Spec.EksaVersion == nil {
-		return fmt.Errorf("management cluster has nil EksaVersion")
+		return fmt.Errorf("management cluster EksaVersion not specified")
 	}
 
 	managementClusterSemVer, err := semver.New(string(*mgmt.Spec.EksaVersion))

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -720,7 +720,7 @@ func TestValidateManagementComponentsVersionSkew(t *testing.T) {
 				c.Spec.EksaVersion = nil
 			}),
 			managementComponentsVersion: "v1.19.0",
-			wantErr:                     fmt.Errorf("management cluster has nil EksaVersion"),
+			wantErr:                     fmt.Errorf("management cluster EksaVersion not specified"),
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -657,3 +657,88 @@ func TestValidatePauseAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateManagementComponentsVersionSkew(t *testing.T) {
+	mgmtName := "test"
+	devEksaVersion := test.DevEksaVersion()
+
+	tests := []struct {
+		name                        string
+		cluster                     *anywherev1.Cluster
+		managementComponentsVersion string
+		wantErr                     error
+	}{
+		{
+			name: "no version difference",
+			cluster: test.Cluster(func(c *anywherev1.Cluster) {
+				c.Name = mgmtName
+				c.Spec.EksaVersion = &devEksaVersion
+			}),
+			managementComponentsVersion: "v0.19.0",
+			wantErr:                     nil,
+		},
+		{
+			name: "one minor version difference",
+			cluster: test.Cluster(func(c *anywherev1.Cluster) {
+				c.Name = mgmtName
+				c.Spec.EksaVersion = &devEksaVersion
+			}),
+			managementComponentsVersion: "v0.20.0",
+			wantErr:                     nil,
+		},
+		{
+			name: "three patch version difference",
+			cluster: test.Cluster(func(c *anywherev1.Cluster) {
+				c.Name = mgmtName
+				c.Spec.EksaVersion = &devEksaVersion
+			}),
+			managementComponentsVersion: "v0.19.3",
+			wantErr:                     nil,
+		},
+		{
+			name: "two minor version difference",
+			cluster: test.Cluster(func(c *anywherev1.Cluster) {
+				c.Name = mgmtName
+				c.Spec.EksaVersion = &devEksaVersion
+			}),
+			managementComponentsVersion: "v0.21.0",
+			wantErr:                     fmt.Errorf("management components version v0.21.0 can only be one minor version greater than cluster version v0.19.0"),
+		},
+		{
+			name: "one major version difference",
+			cluster: test.Cluster(func(c *anywherev1.Cluster) {
+				c.Name = mgmtName
+				c.Spec.EksaVersion = &devEksaVersion
+			}),
+			managementComponentsVersion: "v1.19.0",
+			wantErr:                     fmt.Errorf("management components version v1.19.0 can only be one minor version greater than cluster version v0.19.0"),
+		},
+		{
+			name: "nil cluster eksa version",
+			cluster: test.Cluster(func(c *anywherev1.Cluster) {
+				c.Name = mgmtName
+				c.Spec.EksaVersion = nil
+			}),
+			managementComponentsVersion: "v1.19.0",
+			wantErr:                     fmt.Errorf("management cluster has nil EksaVersion"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tt := newTest(t, withKubectl())
+			ctx := context.Background()
+
+			tt.kubectl.EXPECT().GetEksaCluster(ctx, managementCluster(mgmtName), mgmtName).Return(tc.cluster, nil)
+
+			eksaRelease := test.EKSARelease()
+			eksaRelease.Spec.Version = tc.managementComponentsVersion
+
+			err := validations.ValidateManagementComponentsVersionSkew(ctx, tt.kubectl, managementCluster(mgmtName), eksaRelease)
+			if err != nil {
+				tt.Expect(err.Error()).To(ContainSubstring(tc.wantErr.Error()))
+			} else {
+				tt.Expect(tc.wantErr).To(BeNil())
+			}
+		})
+	}
+}

--- a/pkg/workflows/management/upgrade_management_components.go
+++ b/pkg/workflows/management/upgrade_management_components.go
@@ -88,7 +88,7 @@ func (u *UMCValidator) PreflightValidations(ctx context.Context) []validations.V
 		},
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
-				Name:        "validate management components version to cluster eksaVersion compatibility",
+				Name:        "validate compatibility of management components version to cluster eksaVersion",
 				Remediation: "",
 				Err:         validations.ValidateManagementComponentsVersionSkew(ctx, u.kubectl, u.cluster, u.eksaRelease),
 			}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have added to the [docs](https://github.com/aws/eks-anywhere/pull/7668/files#diff-82e16c4f0007f799c0aba82707c850bb5217d02327e0fcf935638382887fc342R8) that the suppported version difference of management components can be at most 1 EKS Anywhere minor version greater than the EKS Anywhere version of cluster components. However, we have no pre-flight validation that ensures that. This PR adds that preflight validation.

*Testing (if applicable):*
- Unit testing
- Manual testing:
  - Created cluster with v0.19.0 release
  - Upgraded management components with main 
  
```
s-1-27-eks-22"}
2024-03-06T22:22:54.328Z        V0      ✅ Vsphere provider setup and validation
2024-03-06T22:22:54.328Z        V6      Getting KubeadmControlPlane CRDs        {"cluster": "mgmt"}
2024-03-06T22:22:54.328Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1709763772371803610 kubectl get kubeadmcontrolplanes.controlplane.cluster.x-k8s.io mgmt -o json --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig --namespace eksa-system"}
2024-03-06T22:22:54.525Z        V0      ✅ Control plane ready
2024-03-06T22:22:54.525Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1709763772371803610 kubectl get customresourcedefinition clusters.cluster.x-k8s.io --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig"}
2024-03-06T22:22:54.692Z        V0      ✅ Cluster CRDs ready
2024-03-06T22:22:54.692Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1709763772371803610 kubectl get clusters.anywhere.eks.amazonaws.com -A -o jsonpath={.items[0]} --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig --field-selector=metadata.name=mgmt"}
2024-03-06T22:22:54.911Z        V0      ✅ Validate management components version to cluster version skew
2024-03-06T22:22:54.911Z        V4      Task finished   {"task_name": "validate", "duration": "2.067429957s"}
2024-03-06T22:22:54.911Z        V4      ----------------------------------
2024-03-06T22:22:54.911Z        V4      Task start      {"task_name": "upgrade-core-components-mc"}
2024-03-06T22:22:54.911Z        V0      Upgrading core components
2024-03-06T22:22:54.911Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1709763772371803610 kubectl get --ignore-not-found -o json --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig EKSARelease.v1alpha1.anywhere.eks.amazonaws.com --namespace eksa-system eksa-v0-19-0"}
2024-03-06T22:22:55.082Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_170
 ```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

