### PR TITLE
Updating doc to match suggested task (Harbor Package Create)

### DIFF
--- a/docs/content/en/docs/packages/prereq.md
+++ b/docs/content/en/docs/packages/prereq.md
@@ -171,9 +171,10 @@ prometheus              2.41.0-b53c8be243a6cc3ac2553de24ab9f726d9b851ca
 
 ### Generate curated packages configuration
 
-The example shows how to install the `harbor` package from the [curated package list]({{< relref "./packagelist/" >}}).
+The example shows how to generate the package manifest, then create `harbor` package from the [curated package list]({{< relref "./packagelist/" >}}).
 
 ```bash
 export CLUSTER_NAME=<your-cluster-name>
 eksctl anywhere generate package harbor --cluster ${CLUSTER_NAME} --kube-version 1.27 > harbor-spec.yaml
+eksctl anywhere create packages -f harbor-spec.yaml
 ```


### PR DESCRIPTION
*Issue #, if available:*
The verbiage indicated you would be creating a package, however the commands were not complete

*Description of changes:*
-begin-
The example shows how to install the harbor package from the [curated package list](https://anywhere.eks.amazonaws.com/docs/packages/packagelist/) .
export CLUSTER_NAME=<your-cluster-name>
eksctl anywhere generate package harbor --cluster ${CLUSTER_NAME} --kube-version 1.27 > harbor-spec.yaml
-end-

Updating to reflect 
-begin-
The example shows how to generate the package manifest, then create `harbor` package from the [curated package list](https://anywhere.eks.amazonaws.com/docs/packages/packagelist/) .
export CLUSTER_NAME=<your-cluster-name>
eksctl anywhere generate package harbor --cluster ${CLUSTER_NAME} --kube-version 1.27 > harbor-spec.yaml
eksctl anywhere create packages -f harbor-spec.yaml
-end-
As shown in other Harbor example:
https://anywhere.eks.amazonaws.com/docs/packages/harbor/addharbor/

*Testing (if applicable):*
N/A

*Documentation added/planned (if applicable):*
(see "Description" (above))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

