### PR TITLE
Fixed typo in command (extra 's' in word: packagess)

### DIFF
--- a/docs/content/en/docs/packages/troubleshoot.md
+++ b/docs/content/en/docs/packages/troubleshoot.md
@@ -131,7 +131,7 @@ kubectl get packages,packagebundles,packagebundlecontrollers -A
 ```
 You should see a PackageBundleController for the workload cluster named with the name of the workload cluster and the status should be set. There should be a namespace for the workload cluster as well:
 ```bash
-kubectl get ns | grep eksa-packagess
+kubectl get ns | grep eksa-packages
 ```
 Create a PackageBundlecController for the workload cluster if it does not exist (where billy here is the cluster name):
 ```bash


### PR DESCRIPTION
*Issue #, if available:*
Troubleshooting guide had extra character

*Description of changes:*
removed the last 's' in this command
```
kubectl get ns | grep eksa-packagess
```

*Testing (if applicable):*
N/A

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

