### PR TITLE
Encode username and password in Kubernetes secrets

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -743,6 +744,11 @@ func compareEKSAClusterSpec(ctx context.Context, currentClusterSpec, newClusterS
 
 // CreateRegistryCredSecret creates the registry-credentials secret on a managment cluster.
 func (c *ClusterManager) CreateRegistryCredSecret(ctx context.Context, mgmt *types.Cluster) error {
+	registryUsername := os.Getenv("REGISTRY_USERNAME")
+	encodedRegistryUsername := base64.StdEncoding.EncodeToString([]byte(registryUsername))
+	registryPassword := os.Getenv("REGISTRY_PASSWORD")
+	encodedRegistryPassword := base64.StdEncoding.EncodeToString([]byte(registryPassword))
+
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -752,9 +758,9 @@ func (c *ClusterManager) CreateRegistryCredSecret(ctx context.Context, mgmt *typ
 			Namespace: constants.EksaSystemNamespace,
 			Name:      "registry-credentials",
 		},
-		StringData: map[string]string{
-			"username": os.Getenv("REGISTRY_USERNAME"),
-			"password": os.Getenv("REGISTRY_PASSWORD"),
+		Data: map[string][]byte{
+			"username": []byte(encodedRegistryUsername),
+			"password": []byte(encodedRegistryPassword),
 		},
 	}
 

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -2955,9 +2955,9 @@ func TestCreateRegistryCredSecretSuccess(t *testing.T) {
 			Namespace: constants.EksaSystemNamespace,
 			Name:      "registry-credentials",
 		},
-		StringData: map[string]string{
-			"username": "",
-			"password": "",
+		Data: map[string][]byte{
+			"username": []byte(""),
+			"password": []byte(""),
 		},
 	}
 

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -318,8 +318,8 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.registryUsername}}"
-  password: "{{.registryPassword}}"
+data:
+  username: {{.registryUsername | b64enc}}
+  password: {{.registryPassword | b64enc}}
 ---
 {{- end }}

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -377,7 +377,7 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "username"
-  password: "password"
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
 ---

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -540,9 +540,9 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.registryUsername}}"
-  password: "{{.registryPassword}}"
+data:
+  username: {{.registryUsername | b64enc}}
+  password: {{.registryPassword | b64enc}}
 ---
 {{- end }}
 apiVersion: v1

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -411,9 +411,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "username"
-  password: "password"
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -557,7 +557,7 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.registryUsername}}"
-  password: "{{.registryPassword}}"
+data:
+  username: {{.registryUsername | b64enc}}
+  password: {{.registryPassword | b64enc}}
 {{- end }}

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -1003,9 +1003,9 @@ func secret() *corev1.Secret {
 				"clusterctl.cluster.x-k8s.io/move": "true",
 			},
 		},
-		StringData: map[string]string{
-			"username": "username",
-			"password": "password",
+		Data: map[string][]byte{
+			"username": []byte("username"),
+			"password": []byte("password"),
 		},
 	}
 }

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -479,6 +479,6 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "username"
-  password: "password"
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
@@ -463,6 +463,6 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "username"
-  password: "password"
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=

--- a/pkg/providers/vsphere/config/secret.yaml
+++ b/pkg/providers/vsphere/config/secret.yaml
@@ -7,8 +7,8 @@ type: kubernetes.io/basic-auth
 data:
   username: {{.vsphereUsername | b64enc}}
   password: {{.vspherePassword | b64enc}}
-  usernameCP: "{{.eksaCloudProviderUsername | b64enc}}"
-  passwordCP: "{{.eksaCloudProviderPassword | b64enc}}"
+  usernameCP: {{.eksaCloudProviderUsername | b64enc}}
+  passwordCP: {{.eksaCloudProviderPassword | b64enc}}
 ---
 apiVersion: v1
 kind: Secret

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -651,9 +651,9 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.eksaVsphereUsername}}"
-  password: "{{.eksaVspherePassword}}"
+data:
+  username: {{.eksaVsphereUsername | b64enc}}
+  password: {{.eksaVspherePassword | b64enc}}
 ---
 {{- if .registryAuth }}
 apiVersion: v1
@@ -663,9 +663,9 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "{{.registryUsername}}"
-  password: "{{.registryPassword}}"
+data:
+  username: {{.registryUsername | b64enc}}
+  password: {{.registryPassword | b64enc}}
 ---
 {{- end }}
 apiVersion: v1
@@ -694,9 +694,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      {{.vsphereServer}}.password: "{{.eksaCloudProviderPassword}}"
-      {{.vsphereServer}}.username: "{{.eksaCloudProviderUsername}}"
+    data:
+      {{.vsphereServer}}.password: {{.eksaCloudProviderPassword | b64enc}}
+      {{.vsphereServer}}.username: {{.eksaCloudProviderUsername | b64enc}}
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/template_test.go
+++ b/pkg/providers/vsphere/template_test.go
@@ -1,7 +1,6 @@
 package vsphere_test
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -10,6 +9,11 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/providers/vsphere"
+)
+
+const (
+	expectedVSphereUsername = "vsphere_username"
+	expectedVSpherePassword = "vsphere_password"
 )
 
 func TestVsphereTemplateBuilderGenerateCAPISpecWorkersInvalidSSHKey(t *testing.T) {
@@ -52,8 +56,8 @@ func TestVsphereTemplateBuilderGenerateCAPISpecControlPlaneInvalidEtcdSSHKey(t *
 }
 
 func TestTemplateBuilder_CertSANs(t *testing.T) {
-	os.Unsetenv(config.EksavSphereUsernameKey)
-	os.Unsetenv(config.EksavSpherePasswordKey)
+	t.Setenv(config.EksavSphereUsernameKey, expectedVSphereUsername)
+	t.Setenv(config.EksavSpherePasswordKey, expectedVSpherePassword)
 
 	for _, tc := range []struct {
 		Input  string

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -388,9 +388,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: ""
-  password: ""
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -418,9 +418,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: ""
-      vsphere_server.username: ""
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -388,9 +388,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: ""
-  password: ""
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -418,9 +418,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: ""
-      vsphere_server.username: ""
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_boot_settings_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_boot_settings_config_cp.yaml
@@ -502,9 +502,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -532,9 +532,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
@@ -530,9 +530,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -560,9 +560,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -474,9 +474,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -504,9 +504,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -481,9 +481,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -511,9 +511,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -473,9 +473,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -503,9 +503,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_cp.yaml
@@ -527,9 +527,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -538,9 +538,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "username"
-  password: "password"
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
 ---
 apiVersion: v1
 kind: Secret
@@ -568,9 +568,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -527,9 +527,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -557,9 +557,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -479,9 +479,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -509,9 +509,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_settings_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_settings_config_cp.yaml
@@ -485,9 +485,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -515,9 +515,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -450,9 +450,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -480,9 +480,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
@@ -448,9 +448,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -478,9 +478,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_full_oidc_cp.yaml
@@ -394,9 +394,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -424,9 +424,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -448,9 +448,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -478,9 +478,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -448,9 +448,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -478,9 +478,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -448,9 +448,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -478,9 +478,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "EksavSphereCPPassword"
-      vsphere_server.username: "EksavSphereCPUsername"
+    data:
+      vsphere_server.password: RWtzYXZTcGhlcmVDUFBhc3N3b3Jk
+      vsphere_server.username: RWtzYXZTcGhlcmVDUFVzZXJuYW1l
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -448,9 +448,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -478,9 +478,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -450,9 +450,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -480,9 +480,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -468,9 +468,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -498,9 +498,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_cp.yaml
@@ -386,9 +386,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -416,9 +416,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_minimal_oidc_cp.yaml
@@ -389,9 +389,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -419,9 +419,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -459,9 +459,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -489,9 +489,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -501,9 +501,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -531,9 +531,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -502,9 +502,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -513,9 +513,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "username"
-  password: "password"
+data:
+  username: dXNlcm5hbWU=
+  password: cGFzc3dvcmQ=
 ---
 apiVersion: v1
 kind: Secret
@@ -543,9 +543,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -449,9 +449,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -479,9 +479,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp.yaml
@@ -498,9 +498,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -528,9 +528,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
@@ -530,9 +530,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -560,9 +560,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -460,9 +460,9 @@ metadata:
   namespace: eksa-system
   labels:
     clusterctl.cluster.x-k8s.io/move: "true"
-stringData:
-  username: "vsphere_username"
-  password: "vsphere_password"
+data:
+  username: dnNwaGVyZV91c2VybmFtZQ==
+  password: dnNwaGVyZV9wYXNzd29yZA==
 ---
 apiVersion: v1
 kind: Secret
@@ -490,9 +490,9 @@ stringData:
     metadata:
       name: cloud-provider-vsphere-credentials
       namespace: kube-system
-    stringData:
-      vsphere_server.password: "vsphere_password"
-      vsphere_server.username: "vsphere_username"
+    data:
+      vsphere_server.password: dnNwaGVyZV9wYXNzd29yZA==
+      vsphere_server.username: dnNwaGVyZV91c2VybmFtZQ==
     type: Opaque
 type: addons.cluster.x-k8s.io/resource-set
 ---


### PR DESCRIPTION
We need to encode the basic auth credentials to base64 when using them in templates to ensure that passwords containing special characters like escape characters and line separators are properly handled, and don't cause errors when unmarshaling or during `kubectl apply`.

Fixes: #7623

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

