### PR TITLE
Fix packages artifacts map assignment, bubble up errors returned

### DIFF
--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -89,10 +89,10 @@ func GetHelmDest(d *helmDriver, r *releasetypes.ReleaseConfig, ReleaseImageURI, 
 	}
 
 	pwd, err := os.Getwd()
-	dest := filepath.Join(pwd, assetName)
 	if err != nil {
 		return "", fmt.Errorf("getting current working dir: %w", err)
 	}
+	dest := filepath.Join(pwd, assetName)
 	fmt.Printf("Untar helm chart %s into %s\n", chartPath, dest)
 	err = UnTarHelmChart(chartPath, assetName, dest)
 	if err != nil {
@@ -140,6 +140,10 @@ func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.Releas
 	// If the chart is packages, we find the image tag values and overide them in the values.yaml.
 	if strings.Contains(helmDest, "eks-anywhere-packages") {
 		imageTagMap, err := GetPackagesImageTags(eksaArtifacts)
+		if err != nil {
+			return fmt.Errorf("getting packages image tags: %w", err)
+		}
+
 		fmt.Printf("Overwriting helm values.yaml version to new image tags %v\n", imageTagMap)
 		err = OverWriteChartValuesImageTag(helmDest, imageTagMap)
 		if err != nil {

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -49,7 +49,6 @@ func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArt
 	packagesArtifacts := map[string][]releasetypes.Artifact{}
 	if isBundleRelease {
 		projectsInBundle := []string{"eks-anywhere-packages"}
-		packagesArtifacts := map[string][]releasetypes.Artifact{}
 		for _, project := range projectsInBundle {
 			projectArtifacts, err := r.BundleArtifactsTable.Load(project)
 			if err != nil {


### PR DESCRIPTION
* Remove unnecessary packages artifacts map assignment
* Bubble up errors in getting tags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

