### PR TITLE
Adding wait before updating adot package in e2e tests

### DIFF
--- a/test/e2e/adot.go
+++ b/test/e2e/adot.go
@@ -4,6 +4,8 @@
 package e2e
 
 import (
+	"time"
+
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/test/framework"
 )
@@ -30,6 +32,8 @@ func runCuratedPackagesAdotInstallWithUpdate(test *framework.ClusterE2ETest) {
 		kubeconfig.FromClusterName(test.ClusterName),
 		"--set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
+	test.T.Log("Waiting before updating package")
+	time.Sleep(60 * time.Second)
 	test.VerifyAdotPackageDeploymentUpdated(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 	test.VerifyAdotPackageDaemonSetUpdated(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 }


### PR DESCRIPTION
*Description of changes:*
When running `CuratedPackagesAdotUpdateFlow` e2e tests we noticed random behavior where the package update happened at the same moment the package-controller reconciled and gets a latest image tag. When testing the workflow manually, we never ran into the issue. Hence this seems like a timing thing and adding a wait before trying to update Adot package gives the package-controller enough time to rollout to a newer image. 

*Testing (if applicable):*
```
T_BUNDLES_OVERRIDE=true ./e2e.test -test.v -test.run "TestVSphereKubernetes129CuratedPackagesAdotUpdateFlow"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

