### PR TITLE
Add api server extra args feature flag to eksa controller deployment

### DIFF
--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -247,6 +247,11 @@ func setManagerEnvVars(d *appsv1.Deployment, spec *cluster.Spec) {
 		envVars = append(envVars, v1.EnvVar{Name: features.VSphereInPlaceEnvVar, Value: "true"})
 	}
 
+	// TODO: remove this feature flag when we support API server flags.
+	if features.IsActive(features.APIServerExtraArgsEnabled()) {
+		envVars = append(envVars, v1.EnvVar{Name: features.APIServerExtraArgsEnabledEnvVar, Value: "true"})
+	}
+
 	d.Spec.Template.Spec.Containers[0].Env = envVars
 }
 

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -420,6 +420,26 @@ func TestSetManagerEnvVarsVSphereInPlaceUpgrade(t *testing.T) {
 	g.Expect(deploy).To(Equal(want))
 }
 
+func TestSetManagerEnvVarsAPIServerExtraArgs(t *testing.T) {
+	g := NewWithT(t)
+	features.ClearCache()
+	t.Setenv(features.APIServerExtraArgsEnabledEnvVar, "true")
+
+	deploy := deployment()
+	spec := test.NewClusterSpec()
+	want := deployment(func(d *appsv1.Deployment) {
+		d.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+			{
+				Name:  "API_SERVER_EXTRA_ARGS_ENABLED",
+				Value: "true",
+			},
+		}
+	})
+
+	clustermanager.SetManagerEnvVars(deploy, spec)
+	g.Expect(deploy).To(Equal(want))
+}
+
 func TestEKSAInstallerNewUpgraderConfigMap(t *testing.T) {
 	tt := newInstallerTest(t)
 


### PR DESCRIPTION
*Description of changes:*
Fix e2e test failures for api server extra args

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

