### PR TITLE
Updated information about static IP requirement

### DIFF
--- a/docs/content/en/docs/getting-started/vsphere/vsphere-prereq.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-prereq.md
@@ -56,8 +56,7 @@ You will need one IP address for the management cluster control plane endpoint, 
 For those, you would need three IP addresses, one for each cluster.
 All of those addresses will be configured the same way in the configuration file you will generate for each cluster.
 
-  A static IP address will be used for each control plane VM in your EKS Anywhere cluster.
-Choose IP addresses in your network range that do not conflict with other VMs and make sure they are excluded from your DHCP offering.
+  All EKS Anywhere clusters require a static IP for the control plane endpoint. The IP should be excluded from your DHCP range.
 
   An IP address will be the value of the property `controlPlaneConfiguration.endpoint.host` in the config file of the management cluster.
 A separate IP address must be assigned for each workload cluster.


### PR DESCRIPTION
*Issue #, if available:*
The existing verbiage was a bit confusing - and depending on interpretation it was not accurate.
There is only 1 "static IP" needed per EKS Anywhere cluster, and that is for the management endpoint (API)

*Description of changes:*
I removed the confusing phrasing and added an update after reviewing with peers.

*Testing (if applicable):*
N/A - just a doc update

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

