### PR TITLE
Fixing replace tinkerbell action images with registry endpoint

### DIFF
--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -454,9 +454,11 @@ func buildTemplateMapCP(
 		}
 
 		// Replace public.ecr.aws endpoint with the endpoint given in the cluster config file
-		localRegistry := values["publicMirror"].(string)
-		cpTemplateOverride = strings.ReplaceAll(cpTemplateOverride, defaultRegistry, localRegistry)
-		etcdTemplateOverride = strings.ReplaceAll(etcdTemplateOverride, defaultRegistry, localRegistry)
+		localRegistry := values["coreEKSAMirror"].(string)
+		if localRegistry != "" {
+			cpTemplateOverride = strings.ReplaceAll(cpTemplateOverride, defaultRegistry, localRegistry)
+			etcdTemplateOverride = strings.ReplaceAll(etcdTemplateOverride, defaultRegistry, localRegistry)
+		}
 	}
 
 	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
@@ -553,8 +555,10 @@ func buildTemplateMapMD(
 		}
 
 		// Replace public.ecr.aws endpoint with the endpoint given in the cluster config file
-		localRegistry := values["publicMirror"].(string)
-		workerTemplateOverride = strings.ReplaceAll(workerTemplateOverride, defaultRegistry, localRegistry)
+		localRegistry := values["coreEKSAMirror"].(string)
+		if localRegistry != "" {
+			workerTemplateOverride = strings.ReplaceAll(workerTemplateOverride, defaultRegistry, localRegistry)
+		}
 	}
 
 	if clusterSpec.Cluster.Spec.ProxyConfiguration != nil {
@@ -624,6 +628,8 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 	values["mirrorBase"] = registryMirror.BaseRegistry
 	values["insecureSkip"] = registryMirror.InsecureSkipVerify
 	values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
+	values["coreEKSAMirror"] = registryMirror.CoreEKSAMirror()
+
 	if len(registryMirror.CACertContent) > 0 {
 		values["registryCACert"] = registryMirror.CACertContent
 	}


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2242*

*Description of changes:*
When user specifies OCINamespaces with a `namespace` value on their `registryMirrorConfiguration`, we construct the containerd endpoints as `<registr-endpoint>:<port>/v2/<namespace-project>/<image-path>`. This is required when setting mirrors with containerd configuration. Example

```
  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
      endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
```
But when replacing the tinkerbell action image uri's on the `TinkerbellTemplateConfig` object; we are setting them up to be pulled down using docker running on Hook OS during the tinkerbell OS provisioning stage. This fails because docker does not understand the `/v2` and treats it as part of the image path.

The below fix resolves this but is temporary fix to be followed by a broader investigation around this feature. 

*Testing (if applicable):*
Setup a proxy cache on harbor registry and tested the feature by creating a cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

