### PR TITLE
Fixing docker e2e emissary tests for hello application

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1610,7 +1610,7 @@ func (e *ClusterE2ETest) TestEmissaryPackageRouting(packageName, checkName strin
 	ctx := context.Background()
 	packageMetadatNamespace := fmt.Sprintf("%s-%s", constants.EksaPackagesName, e.ClusterName)
 
-	err := e.KubectlClient.ApplyKubeSpecFromBytes(ctx, e.Cluster(), emisarryPackage)
+	err := e.KubectlClient.ApplyKubeSpecFromBytesWithNamespace(ctx, e.Cluster(), emisarryPackage, packageMetadatNamespace)
 	if err != nil {
 		e.T.Errorf("Error upgrading emissary package: %v", err)
 		return
@@ -1634,6 +1634,8 @@ func (e *ClusterE2ETest) TestEmissaryPackageRouting(packageName, checkName strin
 		e.T.Errorf("Error applying roles for oids: %v", err)
 		return
 	}
+	e.T.Log("Waiting for hello service")
+	time.Sleep(60 * time.Second)
 
 	// Functional testing of Emissary Ingress
 	ingresssvcAddress := checkName + "." + constants.EksaPackagesName + ".svc.cluster.local"


### PR DESCRIPTION
*Description of changes:*
Emissary docker e2e tests were failing when trying to curl test deployed hello EKS Anywhere application. This worked manually and proved to be a timing issue as we were not giving enough time for the hello app to come up and start serving; hence curl vailed to hit the cluster endpoint.

*Testing (if applicable):*
```
./e2e.test -test.v --test.run "TestDockerKubernetes129CuratedPackagesEmissarySimpleFlow"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

