### PR TITLE
Node upgrader changes to consume upgrader go binary instead of script

### DIFF
--- a/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_first_control_plane_upgrader_pod.yaml
@@ -13,8 +13,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - print_status_and_cleanup
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - status
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -46,8 +47,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - upgrade_containerd
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - containerd
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -62,8 +64,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - cni_plugins
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - cni-plugins
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -78,9 +81,14 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - kubeadm_in_first_cp
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - node
+    - --type
+    - FirstCP
+    - --k8sVersion
     - v1.28.3-eks-1-28-9
+    - --etcdVersion
     - v3.5.9-eks-1-28-9
     command:
     - nsenter
@@ -96,8 +104,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - kubelet_and_kubectl
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - kubelet-kubectl
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest

--- a/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
@@ -13,8 +13,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - print_status_and_cleanup
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - status
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -46,8 +47,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - upgrade_containerd
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - containerd
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -62,8 +64,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - cni_plugins
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - cni-plugins
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -78,8 +81,11 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - kubeadm_in_rest_cp
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - node
+    - --type
+    - RestCP
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -94,8 +100,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - kubelet_and_kubectl
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - kubelet-kubectl
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest

--- a/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_worker_upgrader_pod.yaml
@@ -13,8 +13,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - print_status_and_cleanup
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - status
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -43,8 +44,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - upgrade_containerd
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - containerd
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -59,8 +61,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - cni_plugins
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - cni-plugins
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -75,8 +78,11 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - kubeadm_in_worker
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - node
+    - --type
+    - Worker
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest
@@ -91,8 +97,9 @@ spec:
     - --uts
     - --ipc
     - --net
-    - /foo/eksa-upgrades/scripts/upgrade.sh
-    - kubelet_and_kubectl
+    - /foo/eksa-upgrades/tools/upgrader
+    - upgrade
+    - kubelet-kubectl
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest


### PR DESCRIPTION
*Issue #, if available:*
Consume Upgrader go binary for InPlace upgrades to upgrade nodes instead of using the upgrader script.

*Description of changes:*

*Testing (if applicable):*
Manually tested K8s version upgrades from 1.25 all the way until 1.29 with the binary embedded in the upgrader image instead of invoking the upgrader script. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

