### PR TITLE
Set non-empty defaults for registry mirror secret credentials

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -34,8 +34,10 @@ import (
 var secretsValueYaml string
 
 const (
-	eksaDefaultRegion = "us-west-2"
-	valueFileName     = "values.yaml"
+	eksaDefaultRegion             = "us-west-2"
+	valueFileName                 = "values.yaml"
+	defaultRegistryMirrorUsername = "username"
+	defaultRegistryMirrorPassword = "password"
 )
 
 type PackageControllerClientOpt func(client *PackageControllerClient)
@@ -304,7 +306,7 @@ func (pc *PackageControllerClient) CreateHelmOverrideValuesYaml() (string, []byt
 
 func (pc *PackageControllerClient) generateHelmOverrideValues() ([]byte, error) {
 	var err error
-	endpoint, username, password, caCertContent, insecureSkipVerify := "", "", "", "", "false"
+	endpoint, username, password, caCertContent, insecureSkipVerify := "", defaultRegistryMirrorUsername, defaultRegistryMirrorPassword, "", "false"
 	if pc.registryMirror != nil {
 		endpoint = pc.registryMirror.BaseRegistry
 		username, password, err = config.ReadCredentials()

--- a/pkg/curatedpackages/testdata/values_empty.yaml
+++ b/pkg/curatedpackages/testdata/values_empty.yaml
@@ -1,7 +1,7 @@
 registryMirrorSecret:
   endpoint: ""
-  username: ""
-  password: ""
+  username: "dXNlcm5hbWU="
+  password: "cGFzc3dvcmQ="
   cacertcontent: ""
   insecure: "ZmFsc2U="
 awsSecret:

--- a/pkg/curatedpackages/testdata/values_empty_registrymirrorsecret.yaml
+++ b/pkg/curatedpackages/testdata/values_empty_registrymirrorsecret.yaml
@@ -1,7 +1,7 @@
 registryMirrorSecret:
   endpoint: ""
-  username: ""
-  password: ""
+  username: "dXNlcm5hbWU="
+  password: "cGFzc3dvcmQ="
   cacertcontent: ""
   insecure: "ZmFsc2U="
 awsSecret:


### PR DESCRIPTION
The `registry-mirror-secret` Kubernetes `Secret` is created by EKS-A in the `eksa-packages` namespace with the required basic authentication and certificate information pertaining to registry mirrors. If registry mirror configuration is not provided, the credentials are left as empty strings by default. The details in this secret are used by the package controller to create another secret `registry-mirror-cred` which contains a Docker auth configuration `config.json` as the data. This auth file is then parsed and used to broadcast credentials to pull images from a registry mirror. This credentials broadcast operation is done always even when there is no registry mirror configured. In this case, the auth file has an empty string for username and password.

So far the empty strings did not cause an issue but it started failing after we bumped up the `github.com/docker/cli` Go module in the packages repo from `v20.10.24` to `v25.0.1`. The error we encountered was the following:
```console
2024-04-03T18:18:52.922Z	PackageBundleController	problem getting credential file	{"error": "/tmp/config/registry/config.json: Invalid auth configuration file"}
```
We discovered that, in between these versions (in version `v23.0.0-rc.2`, to be specific), there was a [change](https://github.com/docker/cli/commit/c8bd8932a18569455e5d1fae1abfed3c1d3c1e72) to the `decodeAuth` method which added a validation to the username being empty, and errors out if it's empty. Thus we are providing a default non-empty value when creating the original `registry-mirror-secret` in EKS-A so that the downstream references are non-empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

