### PR TITLE
Skip cloudstack airgapped tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -3,6 +3,7 @@ skipped_tests:
 #Airgapped tests
 - TestCloudStackKubernetes125RedhatAirgappedRegistryMirror
 - TestCloudStackKubernetes126RedhatAirgappedRegistryMirror
+- TestCloudStackKubernetes128RedhatAirgappedProxy
 
 # Proxy tests
 - TestCloudStackKubernetes125RedhatProxyConfigAPI


### PR DESCRIPTION
*Description of changes:*
Cloudstack airgapped tests are failing with
```
2024-04-04T12:46:03.442Z	V0	❌ Validation failed	{"validation": "cloudstack Provider setup is valid", "error": "validating cluster spec: profile air-gapped does not exist", "remediation": ""}
```
Skipping cloudstack proxy tests until the CI environment is properly set up to be able to run these tests.



