### PR TITLE
Properly generate support bundle for packages test failures

### DIFF
--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -21,7 +21,6 @@ import (
 
 func runCuratedPackageInstall(test *framework.ClusterE2ETest) {
 	test.SetPackageBundleActive()
-	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	err := WaitForPackageToBeInstalled(test, context.Background(), "eks-anywhere-packages", 3*time.Minute)
 	if err != nil {
 		test.T.Fatalf("packages controller not in installed state: %s", err)


### PR DESCRIPTION
*Description of changes:*
This PR fixes the issue where the support bundle was being generated after the cluster was already deleted for packages test.
This also ensures the support bundle generation occurs for all the packages tests if they fail.

*Testing (if applicable):*
Before
```
2024-04-05T00:50:46.489Z	V0	🎉 Cluster deleted!
2024-04-05T00:50:46.489Z	V4	Task finished	{"task_name": "kind-cluster-delete", "duration": "2.045545406s"}
2024-04-05T00:50:46.489Z	V4	----------------------------------
2024-04-05T00:50:46.489Z	V4	Tasks completed	{"duration": "8m21.550512339s"}
2024-04-05T00:50:46.491Z	V3	Cleaning up long running container	{"name": "eksa_1712277744498997388"}
    cluster.go:950: Generating support bundle for failed test
    cluster.go:962: Running shell command [ /usr/bin/sh -c eksctl anywhere generate support-bundle -f main-i-04887-cb59d25/main-i-04887-cb59d25-eks-a.yaml ]
Warning: The recommended size of an external etcd cluster is 3 or 5
WARNING: failed to create eksa-diagnostics namespace. Some collectors may fail to run.	{"err": "creating namespace eksa-diagnostics: Unable to connect to the server: dial tcp 10.80.215.22:6443: connect: no route to host\n"}
WARNING: failed to create roles for eksa-diagnostic-collector. Some collectors may fail to run.	{"err": "executing apply: Unable to connect to the server: dial tcp 10.80.215.22:6443: connect: no route to host\n"}
⏳ Collecting support bundle from cluster, this can take a while	{"cluster": "main-i-04887-cb59d25", "bundle": "main-i-04887-cb59d25/generated/main-i-04887-cb59d25-2024-04-05T00:50:47Z-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "main-i-04887-cb59d25/main-i-04887-cb59d25-eks-a-cluster.kubeconfig"}
Error: failed to create support bundle: collecting and analyzing bundle: failed to Collect support bundle: executing support-bundle: Error: failed to run collect and analyze process: failed to generate support bundle: failed to run collectors: failed to check RBAC for collectors: failed to run subject review: Post "https://10.80.215.22:6443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews": dial tcp 10.80.215.22:6443: connect: no route to host
    cluster.go:969: Command failed, scanning output for error
    cluster.go:989: Command eksctl anywhere [generate support-bundle -f main-i-04887-cb59d25/main-i-04887-cb59d25-eks-a.yaml] failed with error: exit status 255: Error: failed to create support bundle: collecting and analyzing bundle: failed to Collect support bundle: executing support-bundle: Error: failed to run collect and analyze process: failed to generate support bundle: failed to run collectors: failed to check RBAC for collectors: failed to run subject review: Post "https://10.80.215.22:6443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews": dial tcp 10.80.215.22:6443: connect: no route to host
--- FAIL: TestCloudStackKubernetes128RedhatCuratedPackagesPrometheusSimpleFlow (2172.24s)
```

After 
```
2024-04-08T21:40:35.995Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1712612435101114412 kubectl get packageBundle -o json --kubeconfig eksa-test-1c04d96/eksa-test-1c04d96-eks-a-cluster.kubeconfig --namespace eksa-packages v1-28-2632"}
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the 
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
2024-04-08T21:40:36.201Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1712612435101114412 kubectl create -f - --kubeconfig eksa-test-1c04d96/eksa-test-1c04d96-eks-a-cluster.kubeconfig"}
package.packages.eks.amazonaws.com/generated-prometheus created
    cluster.go:1661: Waiting for package generated-prometheus to be installed
    cluster.go:1862: Waiting for package generated-prometheus daemonset node-exporter to be rolled out
    cluster.go:1872: Validate content at endpoint generated-prometheus-node-exporter.observability.svc.cluster.local:9100/metrics
    cluster.go:2098: Launching pod to curl endpoint generated-prometheus-node-exporter.observability.svc.cluster.local:9100/metrics
waiting 5 seconds.... current state='', desired state='Completed'
waiting 5 seconds.... current state='', desired state='Completed'
waiting 5 seconds.... current state='', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
waiting 5 seconds.... current state='Error', desired state='Completed'
    cluster.go:2109: waiting for pod curl-test-t96bw94 timed out: executing wait: waiting for status.containerStatuses[0].state.terminated.reason Completed on pod/curl-test-t96bw94: timed out
    cluster.go:959: Generating support bundle for failed test
    cluster.go:970: Running shell command [ /usr/bin/sh -c eksctl anywhere generate support-bundle -f eksa-test-1c04d96/eksa-test-1c04d96-eks-a.yaml ]
⏳ Collecting support bundle from cluster, this can take a while        {"cluster": "eksa-test-1c04d96", "bundle": "eksa-test-1c04d96/generated/eksa-test-1c04d96-2024-04-08T21:42:21Z-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "eksa-test-1c04d96/eksa-test-1c04d96-eks-a-cluster.kubeconfig"}
Support bundle archive created  {"path": "support-bundle-2024-04-08T21_42_22.tar.gz"}
Analyzing support bundle        {"bundle": "eksa-test-1c04d96/generated/eksa-test-1c04d96-2024-04-08T21:42:21Z-bundle.yaml", "archive": "support-bundle-2024-04-08T21_42_22.tar.gz"}
Analysis output generated       {"path": "eksa-test-1c04d96/generated/eksa-test-1c04d96-2024-04-08T21:42:34Z-analysis.yaml"}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

