### PR TITLE
Ensure no duplicate networks in CloudStack

### DIFF
--- a/cmd/eks-a-tool/cmd/cloudstackrmvms.go
+++ b/cmd/eks-a-tool/cmd/cloudstackrmvms.go
@@ -25,7 +25,7 @@ var cloudstackRmVmsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = cleanup.CleanUpCloudstackTestResources(cmd.Context(), clusterName, viper.GetBool(dryRunFlag))
+		err = cleanup.CloudstackTestResources(cmd.Context(), clusterName, viper.GetBool(dryRunFlag), false)
 		if err != nil {
 			log.Fatalf("Error removing vms: %v", err)
 		}

--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -82,7 +82,8 @@ phases:
       - >
         ./bin/test e2e cleanup cloudstack
         -n ${CLUSTER_NAME_PREFIX}
-        -v 4
+        --delete-duplicate-networks
+        -v 6
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -177,7 +177,8 @@ phases:
       - >
         ./bin/test e2e cleanup cloudstack
         -n ${CLUSTER_NAME_PREFIX}
-        -v 4
+        --delete-duplicate-networks
+        -v 6
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/cmd/cleanupcloudstack.go
+++ b/cmd/integration_test/cmd/cleanupcloudstack.go
@@ -37,11 +37,14 @@ func preRunCleanUpCloudstackSetup(cmd *cobra.Command, args []string) {
 	})
 }
 
+const deleteDuplicateNetworksFlag = "delete-duplicate-networks"
+
 var requiredCloudstackCleanUpFlags = []string{clusterNameFlagName}
 
 func init() {
 	cleanUpInstancesCmd.AddCommand(cleanUpCloudstackCmd)
 	cleanUpCloudstackCmd.Flags().StringP(clusterNameFlagName, "n", "", "Cluster name for associated vms")
+	cleanUpCloudstackCmd.Flags().Bool(deleteDuplicateNetworksFlag, false, "Delete duplicate isolated networks")
 
 	for _, flag := range requiredCloudstackCleanUpFlags {
 		if err := cleanUpCloudstackCmd.MarkFlagRequired(flag); err != nil {
@@ -52,7 +55,8 @@ func init() {
 
 func cleanUpCloudstackTestResources(ctx context.Context) error {
 	clusterName := viper.GetString(clusterNameFlagName)
-	err := cleanup.CleanUpCloudstackTestResources(ctx, clusterName, false)
+	deleteDuplicateNetworks := viper.IsSet(deleteDuplicateNetworksFlag)
+	err := cleanup.CloudstackTestResources(ctx, clusterName, false, deleteDuplicateNetworks)
 	if err != nil {
 		return fmt.Errorf("running cleanup for cloudstack vms: %v", err)
 	}

--- a/pkg/executables/testdata/cmk_list_network_duplicates.json
+++ b/pkg/executables/testdata/cmk_list_network_duplicates.json
@@ -1,0 +1,20 @@
+{
+  "count": 3,
+  "network": [
+    {
+      "id": "fe1a7310-51d4-4299-b3d0-a627a57bb4b0",
+      "name": "eksa-cloudstack-ci-net",
+      "type": "Isolated"
+    },
+    {
+      "id": "24fd6849-3016-4afe-948d-4ce2bb396cf5",
+      "name": "eksa-cloudstack-ci-net",
+      "type": "Isolated"
+    },
+    {
+      "id": "13b501c1-5629-40e1-ba1e-a31caa9aead4",
+      "name": "eksa-cloudstack-ci-net",
+      "type": "Shared"
+    }
+  ]
+}

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -255,7 +255,7 @@ func (c *CloudStack) ClusterConfigUpdates() []api.ClusterConfigFiller {
 }
 
 func (c *CloudStack) CleanupVMs(clusterName string) error {
-	return cleanup.CleanUpCloudstackTestResources(context.Background(), clusterName, false)
+	return cleanup.CloudstackTestResources(context.Background(), clusterName, false, false)
 }
 
 func (c *CloudStack) WithProviderUpgrade(fillers ...api.CloudStackFiller) ClusterE2ETestOpt {


### PR DESCRIPTION
*Description of changes:*
This PR ensures that there are no duplicate networks in CloudStack CI environment before running the e2e tests.
If it finds any duplicate networks that are not of type `Shared`, it deletes them.
This ensures that the tests don't run into duplicate network issues.

*Testing (if applicable):*
Ran the command manually and verified that it works
```
./test e2e cleanup cloudstack -n adhbsdhbsahbfsahj --delete-duplicate-networks -v9
2024-04-09T01:16:18.227Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-04-09T01:16:18.227Z        V2      Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.4-eks-a-v0.0.0-dev-build.8100"}
2024-04-09T01:16:18.227Z        V6      Executing command       {"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.4-eks-a-v0.0.0-dev-build.8100"}
2024-04-09T01:16:18.924Z        V5      Retry execution successful      {"retries": 1, "duration": "697.322219ms"}
2024-04-09T01:16:18.925Z        V3      Initializing long running container     {"name": "eksa_1712625378227629946", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.4-eks-a-v0.0.0-dev-build.8100"}
2024-04-09T01:16:18.925Z        V6      Executing command       {"cmd": "/usr/bin/docker run -d --name eksa_1712625378227629946 --network host -w /home/eksadmin/e2e -v /var/run/docker.sock:/var/run/docker.sock -v /home/eksadmin/e2e:/home/eksadmin/e2e --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.4-eks-a-v0.0.0-dev-build.8100 infinity"}
2024-04-09T01:16:19.117Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-04-09T01:16:19.118Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1712625378227629946 cmk -c /home/eksadmin/e2e/rmvms/generated/cmk_ci.ini list virtualmachines keyword=\"adhbsdhbsahbfsahj\" listall=true"}
2024-04-09T01:16:19.259Z        V0      virtual machines not found      {"cluster": "adhbsdhbsahbfsahj"}
2024-04-09T01:16:19.259Z        V5      Retry execution successful      {"retries": 1, "duration": "142.040222ms"}
2024-04-09T01:16:19.260Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1712625378227629946 cmk -c /home/eksadmin/e2e/rmvms/generated/cmk_ci.ini list networks filter=name,id,type keyword=eksa-cloudstack-ci-net"}
2024-04-09T01:16:21.028Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1712625378227629946 cmk -c /home/eksadmin/e2e/rmvms/generated/cmk_ci.ini delete network id=fe1a7310-51d4-4299-b3d0-a627a57bb4b0 force=true"}
2024-04-09T01:16:23.172Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1712625378227629946 cmk -c /home/eksadmin/e2e/rmvms/generated/cmk_ci.ini delete network id=24fd6849-3016-4afe-948d-4ce2bb396cf5 force=true"}
2024-04-09T01:16:25.302Z        V3      Cleaning up long running container      {"name": "eksa_1712625378227629946"}
2024-04-09T01:16:25.302Z        V6      Executing command       {"cmd": "/usr/bin/docker rm -f -v eksa_1712625378227629946"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

