### PR TITLE
Fix Delete Encrypted Etcd Cluster

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -66,7 +66,7 @@ func (r *Cluster) ValidateCreate() (admission.Warnings, error) {
 		return nil, apierrors.NewBadRequest("creating new cluster on existing cluster is not supported for self managed clusters")
 	}
 
-	if r.Spec.EtcdEncryption != nil {
+	if !r.IsReconcilePaused() && r.Spec.EtcdEncryption != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec.etcdEncryption"), r.Spec.EtcdEncryption, "etcdEncryption is not supported during cluster creation"))
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Delete workflow uses mover to create a paused cluster on bootstrap with encrypted etcd configuration. Our webhook does not allow this, so we can skip this validation when paused to allow moving cluster to bootstrap.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

