### PR TITLE
Skip airgapped proxy test until it can be run

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -3,6 +3,7 @@ skipped_tests:
 #Airgapped tests
 - TestCloudStackKubernetes125RedhatAirgappedRegistryMirror
 - TestCloudStackKubernetes126RedhatAirgappedRegistryMirror
+- TestCloudStackKubernetes128RedhatAirgappedProxy
 
 # Proxy tests
 - TestCloudStackKubernetes125RedhatProxyConfigAPI


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Aigrapped environment in cloudstack CI is not completely set up. Skipping `TestCloudStackKubernetes128RedhatAirgappedProxy` until it can be run.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

