### PR TITLE
Adding a helm login to packages reconcile flow for workload clusters

### DIFF
--- a/controllers/factory.go
+++ b/controllers/factory.go
@@ -561,7 +561,7 @@ func (f *Factory) withAWSIamConfigReconciler() *Factory {
 }
 
 func (f *Factory) withPackageControllerClient() *Factory {
-	f.dependencyFactory.WithHelm().WithKubectl()
+	f.dependencyFactory.WithHelm(helm.WithInsecure()).WithKubectl()
 
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		if f.packageControllerClient != nil {

--- a/pkg/curatedpackages/mocks/installer.go
+++ b/pkg/curatedpackages/mocks/installer.go
@@ -176,6 +176,20 @@ func (mr *MockChartManagerMockRecorder) InstallChart(ctx, chart, ociURI, version
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallChart", reflect.TypeOf((*MockChartManager)(nil).InstallChart), ctx, chart, ociURI, version, kubeconfigFilePath, namespace, valueFilePath, skipCRDs, values)
 }
 
+// RegistryLogin mocks base method.
+func (m *MockChartManager) RegistryLogin(ctx context.Context, registry, username, password string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegistryLogin", ctx, registry, username, password)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegistryLogin indicates an expected call of RegistryLogin.
+func (mr *MockChartManagerMockRecorder) RegistryLogin(ctx, registry, username, password interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistryLogin", reflect.TypeOf((*MockChartManager)(nil).RegistryLogin), ctx, registry, username, password)
+}
+
 // MockKubeDeleter is a mock of KubeDeleter interface.
 type MockKubeDeleter struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2269:*

*Description of changes:*
This solves part one of the issue when creating a workload clusters with an authenticated registry mirror. The EKS-A controller is responsible for performing a helm install of the `eks-anywhere-packages` helm chart for a workload cluster; this was failing because
1. We did pass the `--insecure-skip-tls-verify` flag during the helm install.
2. For authenticated registry mirrors; we did not perform a helm login before running the helm install.

The changes in this PR fixes both the issues, hence customers who use `kubectl` to create a workload cluster would now get have packages enabled successfully when having an auth registry mirror.

*Testing:*
```
eksctl-anywhere create cluster -f cluster.yaml --kubeconfig mgmt.kubeconfig --bundles-override bundle.yaml
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

