### PR TITLE
Replace DockerHub amazon-eks-pod-identity-webhook image with ECR Public image

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -63,6 +63,7 @@ env:
     T_IRSA_S3_BUCKET: "etcd-encryption:irsa_s3_bucket"
     T_KMS_IAM_ROLE: "etcd-encryption:kms_iam_role_arn"
     T_KMS_IMAGE: "etcd-encryption:kms_image"
+    T_POD_IDENTITY_WEBHOOK_IMAGE: "etcd-encryption:pod_identity_webhook_image"
     T_KMS_KEY_ARN: "etcd-encryption:kms_key_arn"
     T_KMS_KEY_REGION: "etcd-encryption:region"
     T_KMS_SOCKET: "etcd-encryption:socket"

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -84,6 +84,7 @@ env:
     T_IRSA_S3_BUCKET: "etcd-encryption:irsa_s3_bucket"
     T_KMS_IAM_ROLE: "etcd-encryption:kms_iam_role_arn"
     T_KMS_IMAGE: "etcd-encryption:kms_image"
+    T_POD_IDENTITY_WEBHOOK_IMAGE: "etcd-encryption:pod_identity_webhook_image"
     T_KMS_KEY_ARN: "etcd-encryption:kms_key_arn"
     T_KMS_KEY_REGION: "etcd-encryption:region"
     T_KMS_SOCKET: "etcd-encryption:socket"

--- a/test/framework/config/pod-identity-webhook.yaml
+++ b/test/framework/config/pod-identity-webhook.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: pod-identity-webhook
       containers:
       - name: pod-identity-webhook
-        image: amazon/amazon-eks-pod-identity-webhook:latest
+        image: {{ .podIdentityWebhookImage }}
         imagePullPolicy: Always
         command:
         - /webhook

--- a/test/framework/etcdencryption.go
+++ b/test/framework/etcdencryption.go
@@ -28,12 +28,13 @@ import (
 )
 
 const (
-	irsaS3BucketVar = "T_IRSA_S3_BUCKET"
-	kmsIAMRoleVar   = "T_KMS_IAM_ROLE"
-	kmsImageVar     = "T_KMS_IMAGE"
-	kmsKeyArn       = "T_KMS_KEY_ARN"
-	kmsKeyRegion    = "T_KMS_KEY_REGION"
-	kmsSocketVar    = "T_KMS_SOCKET"
+	irsaS3BucketVar            = "T_IRSA_S3_BUCKET"
+	kmsIAMRoleVar              = "T_KMS_IAM_ROLE"
+	kmsImageVar                = "T_KMS_IMAGE"
+	podIdentityWebhookImageVar = "T_POD_IDENTITY_WEBHOOK_IMAGE"
+	kmsKeyArn                  = "T_KMS_KEY_ARN"
+	kmsKeyRegion               = "T_KMS_KEY_REGION"
+	kmsSocketVar               = "T_KMS_SOCKET"
 
 	defaultRegion = "us-west-2"
 	keysFilename  = "keys.json"
@@ -54,27 +55,29 @@ type keyResponse struct {
 
 // etcdEncryptionTestVars stores all the environment variables needed by etcd encryption tests.
 type etcdEncryptionTestVars struct {
-	KmsKeyRegion string
-	S3Bucket     string
-	KmsIamRole   string
-	KmsImage     string
-	KmsKeyArn    string
-	KmsSocket    string
+	KmsKeyRegion            string
+	S3Bucket                string
+	KmsIamRole              string
+	KmsImage                string
+	PodIdentityWebhookImage string
+	KmsKeyArn               string
+	KmsSocket               string
 }
 
 // RequiredEtcdEncryptionEnvVars returns the environment variables required .
 func RequiredEtcdEncryptionEnvVars() []string {
-	return []string{irsaS3BucketVar, kmsIAMRoleVar, kmsImageVar, kmsKeyArn, kmsSocketVar}
+	return []string{irsaS3BucketVar, kmsIAMRoleVar, kmsImageVar, podIdentityWebhookImageVar, kmsKeyArn, kmsSocketVar}
 }
 
 func getEtcdEncryptionVarsFromEnv() *etcdEncryptionTestVars {
 	return &etcdEncryptionTestVars{
-		KmsKeyRegion: os.Getenv(kmsKeyRegion),
-		S3Bucket:     os.Getenv(irsaS3BucketVar),
-		KmsIamRole:   os.Getenv(kmsIAMRoleVar),
-		KmsImage:     os.Getenv(kmsImageVar),
-		KmsKeyArn:    os.Getenv(kmsKeyArn),
-		KmsSocket:    os.Getenv(kmsSocketVar),
+		KmsKeyRegion:            os.Getenv(kmsKeyRegion),
+		S3Bucket:                os.Getenv(irsaS3BucketVar),
+		KmsIamRole:              os.Getenv(kmsIAMRoleVar),
+		KmsImage:                os.Getenv(kmsImageVar),
+		PodIdentityWebhookImage: os.Getenv(podIdentityWebhookImageVar),
+		KmsKeyArn:               os.Getenv(kmsKeyArn),
+		KmsSocket:               os.Getenv(kmsSocketVar),
 	}
 }
 
@@ -212,12 +215,13 @@ func (e *ClusterE2ETest) deployPodIdentityWebhook(ctx context.Context, envVars *
 func (e *ClusterE2ETest) deployKMSProvider(ctx context.Context, envVars *etcdEncryptionTestVars) error {
 	e.T.Log("Deploying AWS KMS Encryption Provider")
 	values := map[string]string{
-		"kmsImage":           envVars.KmsImage,
-		"kmsIamRole":         envVars.KmsIamRole,
-		"kmsKeyArn":          envVars.KmsKeyArn,
-		"kmsKeyRegion":       envVars.KmsKeyRegion,
-		"kmsSocket":          envVars.KmsSocket,
-		"serviceAccountName": "kms-encrypter-decrypter",
+		"kmsImage":                envVars.KmsImage,
+		"podIdentityWebhookImage": envVars.PodIdentityWebhookImage,
+		"kmsIamRole":              envVars.KmsIamRole,
+		"kmsKeyArn":               envVars.KmsKeyArn,
+		"kmsKeyRegion":            envVars.KmsKeyRegion,
+		"kmsSocket":               envVars.KmsSocket,
+		"serviceAccountName":      "kms-encrypter-decrypter",
 	}
 
 	if e.OSFamily != v1alpha1.Bottlerocket {


### PR DESCRIPTION
This PR replaces the amazon-eks-pod-identity-webhook image from DockerHub with its ECR Public counterpart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

