### PR TITLE
Passing along ocinamespaces env var to tests

### DIFF
--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -71,6 +71,16 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 		}
 	}
 
+	re = regexp.MustCompile(`^.*OciNamespaces.*$`)
+	if re.MatchString(testRegex) {
+		ociNamespacesEnvVar := e2etests.RequiredOciNamespacesEnvVars()
+		for _, eVar := range ociNamespacesEnvVar {
+			if val, ok := os.LookupEnv(eVar); ok {
+				e.testEnvVars[eVar] = val
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/test/framework/registry_mirror.go
+++ b/test/framework/registry_mirror.go
@@ -147,6 +147,11 @@ func RequiredRegistryMirrorEnvVars() []string {
 	return append(registryMirrorRequiredEnvVars, registryMirrorDockerAirgappedRequiredEnvVars...)
 }
 
+// RequiredOciNamespacesEnvVars returns the Env variables to set for OCI Namespaces tests.
+func RequiredOciNamespacesEnvVars() []string {
+	return append(registryMirrorOciNamespacesRequiredEnvVars, RegistryMirrorOciNamespacesRegistry2Var, RegistryMirrorOciNamespacesNamespace2Var)
+}
+
 func setupRegistryMirrorEndpointAndCert(e *ClusterE2ETest, providerName string, insecureSkipVerify bool, ociNamespaces ...v1alpha1.OCINamespace) {
 	var endpoint, hostPort, username, password, registryCert string
 	port := "443"


### PR DESCRIPTION
*Description of changes:*
E2e tests did not pass along the required env var for ocinamespaces tests to running test env.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

