### PR TITLE
Fixing registry mirror setup function return

### DIFF
--- a/internal/test/e2e/registryMirror.go
+++ b/internal/test/e2e/registryMirror.go
@@ -56,7 +56,9 @@ func (e *E2ESession) setupRegistryMirrorEnv(testRegex string) error {
 	}
 
 	if endpoint != "" && port != "" && caCert != "" {
-		return e.mountRegistryCert(caCert, net.JoinHostPort(endpoint, port))
+		if err := e.mountRegistryCert(caCert, net.JoinHostPort(endpoint, port)); err != nil {
+			return err
+		}
 	}
 
 	re = regexp.MustCompile(`^.*Docker.*Airgapped.*$`)


### PR DESCRIPTION
*Description of changes:*
Looks like the setup method was returning early and not checking the conditions below for Docker Airgapped and OCINamespaces.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

