### PR TITLE
Log in to public ECR for E2E test

### DIFF
--- a/internal/test/e2e/ecr.go
+++ b/internal/test/e2e/ecr.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-anywhere/internal/pkg/ssm"
+)
+
+func (e *E2ESession) loginToPublicECR() error {
+	e.logger.V(1).Info("Logging in to public ECR")
+
+	command := "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"
+	if err := ssm.Run(e.session, logr.Discard(), e.instanceId, command, ssmTimeout); err != nil {
+		return fmt.Errorf("sign in to public ecr: %v", err)
+	}
+
+	e.logger.V(1).Info("Logged in to public ECR")
+
+	return nil
+}

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -178,6 +178,11 @@ func (e *E2ESession) setup(regex string) error {
 		return err
 	}
 
+	err = e.loginToPublicECR()
+	if err != nil {
+		return err
+	}
+
 	ipPool := e.ipPool.ToString()
 	if ipPool != "" {
 		e.testEnvVars[e2etests.ClusterIPPoolEnvVar] = ipPool


### PR DESCRIPTION
Some tests are being rate limited when pulling from public ECR. This logs all tests into public ECR when running the CI so we avoid the 100 pull rate limit.