### PR TITLE
Retry pulling artifacts when running download images cmd

### DIFF
--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/docker"
 	"github.com/aws/eks-anywhere/pkg/docker/mocks"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
 func TestNewRegistryDestination(t *testing.T) {
@@ -119,6 +120,7 @@ func TestNewOriginalRegistrySource(t *testing.T) {
 	images := []string{"image1:1", "image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewOriginalRegistrySource(client)
+	dstLoader.Retrier = *retrier.NewWithMaxRetries(1, 0)
 	for _, i := range images {
 		client.EXPECT().PullImage(test.AContext(), i)
 	}
@@ -134,6 +136,7 @@ func TestOriginalRegistrySourceError(t *testing.T) {
 	images := []string{"image1:1", "image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewOriginalRegistrySource(client)
+	dstLoader.Retrier = *retrier.NewWithMaxRetries(1, 0)
 	client.EXPECT().PullImage(test.AContext(), images[0]).Return(errors.New("error pulling"))
 	client.EXPECT().PullImage(test.AContext(), images[1]).MaxTimes(1)
 

--- a/pkg/helm/download_test.go
+++ b/pkg/helm/download_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/helm"
 	"github.com/aws/eks-anywhere/pkg/helm/mocks"
+	"github.com/aws/eks-anywhere/pkg/retrier"
 )
 
 func TestChartRegistryDownloaderDownload(t *testing.T) {
@@ -37,5 +38,6 @@ func TestChartRegistryDownloaderDownloadError(t *testing.T) {
 	client.EXPECT().SaveChart(ctx, "oci://ecr.com/chart2", "v2.2.0", folder).Return(errors.New("failed downloading"))
 
 	d := helm.NewChartRegistryDownloader(client, folder)
+	d.Retrier = *retrier.NewWithMaxRetries(1, 0)
 	g.Expect(d.Download(ctx, charts...)).To(MatchError(ContainSubstring("downloading chart [ecr.com/chart2:v2.2.0] from registry: failed downloading")))
 }


### PR DESCRIPTION
Pulling images and charts can fail due to network blips, rate limits and more. This retries pulling artifacts that are required for the `download images` cmd.