### PR TITLE
Add release logic for Ubuntu RTOS image

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -236,7 +236,7 @@ var releaseCmd = &cobra.Command{
 				}
 
 				bundleReleaseManifestKey := releaseConfig.BundlesManifestFilepath()
-				err = s3.UploadFile(bundleReleaseManifestFile, aws.String(releaseConfig.ReleaseBucket), aws.String(bundleReleaseManifestKey), releaseConfig.ReleaseClients.S3.Uploader)
+				err = s3.UploadFile(bundleReleaseManifestFile, aws.String(releaseConfig.ReleaseBucket), aws.String(bundleReleaseManifestKey), releaseConfig.ReleaseClients.S3.Uploader, false)
 				if err != nil {
 					fmt.Printf("Error uploading bundle manifest to release bucket: %+v", err)
 					os.Exit(1)
@@ -328,7 +328,7 @@ var releaseCmd = &cobra.Command{
 			}
 
 			eksAReleaseManifestKey := releaseConfig.ReleaseManifestFilepath()
-			err = s3.UploadFile(eksAReleaseManifestFile, aws.String(releaseConfig.ReleaseBucket), aws.String(eksAReleaseManifestKey), releaseConfig.ReleaseClients.S3.Uploader)
+			err = s3.UploadFile(eksAReleaseManifestFile, aws.String(releaseConfig.ReleaseBucket), aws.String(eksAReleaseManifestKey), releaseConfig.ReleaseClients.S3.Uploader, false)
 			if err != nil {
 				fmt.Printf("Error uploading EKS-A release manifest to release bucket: %v", err)
 				os.Exit(1)

--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -145,6 +145,60 @@ func KernelArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettype
 	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil
 }
 
+func RTOSArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.Archive, projectPath, gitTag, eksDReleaseChannel, eksDReleaseNumber, kubeVersion, latestPath, arch string) (string, string, string, string, error) {
+	var sourceS3Key string
+	var sourceS3Prefix string
+	var releaseS3Path string
+	var releaseName string
+
+	imageExtensions := map[string]string{
+		"ami": "gz",
+		"ova": "ova",
+		"raw": "gz",
+	}
+	imageExtension := imageExtensions[archive.Format]
+
+	if rc.DevRelease || rc.ReleaseEnvironment == "development" {
+		sourceS3Key = fmt.Sprintf("%s.%s", archive.OSName, imageExtension)
+		sourceS3Prefix = fmt.Sprintf("%s/%s/%s/%s/%s/%s", projectPath, eksDReleaseChannel, archive.Format, archive.OSName, archive.OSVersion, latestPath)
+	} else {
+		sourceS3Key = fmt.Sprintf("%s-%s-eks-a-%d-%s.%s",
+			archive.OSName,
+			eksDReleaseChannel,
+			rc.BundleNumber,
+			arch,
+			imageExtension,
+		)
+		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/rtos/%s", rc.BundleNumber, eksDReleaseChannel)
+	}
+
+	if rc.DevRelease {
+		releaseName = fmt.Sprintf("%s-%s-eks-a-%s-%s.%s",
+			archive.OSName,
+			eksDReleaseChannel,
+			rc.DevReleaseUriVersion,
+			arch,
+			imageExtension,
+		)
+		releaseS3Path = fmt.Sprintf("artifacts/%s/rtos/%s/%s",
+			rc.DevReleaseUriVersion,
+			archive.Format,
+			eksDReleaseChannel,
+		)
+	} else {
+		releaseName = fmt.Sprintf("%s-%s-eks-a-%d-%s.%s",
+			archive.OSName,
+			eksDReleaseChannel,
+			rc.BundleNumber,
+			arch,
+			imageExtension,
+		)
+		releaseS3Path = fmt.Sprintf("releases/bundles/%d/artifacts/rtos/%s", rc.BundleNumber, eksDReleaseChannel)
+	}
+
+	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil
+}
+
 func GetArchiveAssets(rc *releasetypes.ReleaseConfig, archive *assettypes.Archive, projectPath, gitTag, eksDReleaseChannel, eksDReleaseNumber, kubeVersion string) (*releasetypes.ArchiveArtifact, error) {
 	os := "linux"
 	arch := "amd64"
@@ -181,6 +235,7 @@ func GetArchiveAssets(rc *releasetypes.ReleaseConfig, archive *assettypes.Archiv
 		ProjectPath:       projectPath,
 		SourcedFromBranch: sourcedFromBranch,
 		ImageFormat:       archive.Format,
+		PrivateUpload:     archive.Private,
 	}
 
 	return archiveArtifact, nil

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -66,6 +66,22 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		},
 		HasReleaseBranches: true,
 	},
+	// Canonical Ubuntu RTOS artifacts
+	{
+		ProjectName:    "ubuntu-rtos",
+		ProjectPath:    "projects/canonical/ubuntu",
+		GitTagAssigner: tagger.NonExistentTagAssigner,
+		Archives: []*assettypes.Archive{
+			{
+				Name:                "rtos",
+				Format:              "ami",
+				OSName:              "ubuntu",
+				OSVersion:           "22.04",
+				ArchiveS3PathGetter: archives.RTOSArtifactPathGetter,
+				Private:             true,
+			},
+		},
+	},
 	// Cert-manager artifacts
 	{
 		ProjectName: "cert-manager",

--- a/release/cli/pkg/assets/manifests/manifests.go
+++ b/release/cli/pkg/assets/manifests/manifests.go
@@ -68,6 +68,7 @@ func GetManifestAssets(rc *releasetypes.ReleaseConfig, manifestComponent *assett
 		ProjectPath:       projectPath,
 		SourcedFromBranch: sourcedFromBranch,
 		Component:         componentName,
+		PrivateUpload:     manifestComponent.Private,
 	}
 
 	return manifestArtifact, nil

--- a/release/cli/pkg/assets/types/types.go
+++ b/release/cli/pkg/assets/types/types.go
@@ -23,6 +23,7 @@ type ManifestComponent struct {
 	ReleaseManifestPrefix string
 	ManifestFiles         []string
 	NoVersionSuffix       bool
+	Private               bool
 }
 
 type ImageTagConfiguration struct {
@@ -47,6 +48,7 @@ type Archive struct {
 	OSVersion            string
 	ArchitectureOverride string
 	ArchiveS3PathGetter  ArchiveS3PathGenerator
+	Private              bool
 }
 
 type AssetConfig struct {

--- a/release/cli/pkg/aws/s3/s3.go
+++ b/release/cli/pkg/aws/s3/s3.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
 )
@@ -67,18 +68,22 @@ func DownloadFile(filePath, bucket, key string) error {
 	return nil
 }
 
-func UploadFile(filePath string, bucket, key *string, s3Uploader *s3manager.Uploader) error {
+func UploadFile(filePath string, bucket, key *string, s3Uploader *s3manager.Uploader, private bool) error {
 	fd, err := os.Open(filePath)
 	if err != nil {
 		return errors.Cause(err)
 	}
 	defer fd.Close()
 
+	objectCannedACL := s3.ObjectCannedACLPublicRead
+	if private {
+		objectCannedACL = s3.ObjectCannedACLPrivate
+	}
 	result, err := s3Uploader.Upload(&s3manager.UploadInput{
 		Bucket: bucket,
 		Key:    key,
 		Body:   fd,
-		ACL:    aws.String("public-read"),
+		ACL:    aws.String(objectCannedACL),
 	})
 	if err != nil {
 		return errors.Cause(err)

--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -286,7 +286,7 @@ func PutEksAReleaseVersion(version string, r *releasetypes.ReleaseConfig) error 
 
 	// Upload the file to S3
 	fmt.Println("Uploading latest release version file")
-	err = s3.UploadFile(currentReleaseKey, aws.String(r.ReleaseBucket), aws.String(currentReleaseKey), r.ReleaseClients.S3.Uploader)
+	err = s3.UploadFile(currentReleaseKey, aws.String(r.ReleaseBucket), aws.String(currentReleaseKey), r.ReleaseClients.S3.Uploader, false)
 	if err != nil {
 		return errors.Cause(err)
 	}

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -92,7 +92,7 @@ func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artif
 	archiveFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName)
 	fmt.Printf("Archive - %s\n", archiveFile)
 	key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName)
-	err := s3.UploadFile(archiveFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader)
+	err := s3.UploadFile(archiveFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.PrivateUpload)
 	if err != nil {
 		return errors.Cause(err)
 	}
@@ -109,7 +109,7 @@ func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artif
 		checksumFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName) + extension
 		fmt.Printf("Checksum - %s\n", checksumFile)
 		key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName) + extension
-		err := s3.UploadFile(checksumFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader)
+		err := s3.UploadFile(checksumFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.PrivateUpload)
 		if err != nil {
 			return errors.Cause(err)
 		}
@@ -122,7 +122,7 @@ func handleManifestUpload(_ context.Context, r *releasetypes.ReleaseConfig, arti
 	manifestFile := filepath.Join(artifact.Manifest.ArtifactPath, artifact.Manifest.ReleaseName)
 	fmt.Printf("Manifest - %s\n", manifestFile)
 	key := filepath.Join(artifact.Manifest.ReleaseS3Path, artifact.Manifest.ReleaseName)
-	err := s3.UploadFile(manifestFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader)
+	err := s3.UploadFile(manifestFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Manifest.PrivateUpload)
 	if err != nil {
 		return errors.Cause(err)
 	}

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -77,6 +77,7 @@ type ArchiveArtifact struct {
 	ProjectPath       string
 	SourcedFromBranch string
 	ImageFormat       string
+	PrivateUpload     bool
 }
 
 type ImageArtifact struct {
@@ -102,6 +103,7 @@ type ManifestArtifact struct {
 	ProjectPath       string
 	SourcedFromBranch string
 	Component         string
+	PrivateUpload     bool
 }
 
 type Artifact struct {


### PR DESCRIPTION
This PR adds the EKS-A release logic for Ubuntu RTOS image.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

