### PR TITLE
Allow users to access docs for penultimate EKS-A version

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -184,3 +184,9 @@ fullversion = "v0.19"
 version = "v0.19"
 docsbranch = "main"
 url = "/docs/"
+
+[[params.versions]]
+fullversion = "v0.18"
+version = "v0.18"
+docsbranch = "release-0.18"
+url = "https://release-0-18.anywhere.eks.amazonaws.com/docs/"


### PR DESCRIPTION
This PR adds the version 0.18 to the `Versions` dropdown on the EKS Anywhere docs site so that users can switch to that version.

/cherrypick release-0.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

