### PR TITLE
Add release-0.19 to docs version dropdown

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -180,6 +180,12 @@ icon = "fab fa-github"
 desc = "Development takes place here!"
 
 [[params.versions]]
+fullversion = "v0.19"
+version = "v0.19"
+docsbranch = "main"
+url = "https://anywhere.eks.amazonaws.com/docs/"
+
+[[params.versions]]
 fullversion = "v0.18"
 version = "v0.18"
 docsbranch = "main"


### PR DESCRIPTION
Add release-0.19 to Versions dropdown so customers can switch to docs for that version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

