### PR TITLE
Adding permissions for controller packages helm upgrade

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -7140,6 +7140,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -170,7 +170,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch
 // +kubebuilder:rbac:groups="",namespace=eksa-system,resources=secrets,verbs=patch;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=create;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -310,9 +310,11 @@ func (pc *PackageControllerClient) generateHelmOverrideValues() ([]byte, error) 
 	endpoint, username, password, caCertContent, insecureSkipVerify := "", defaultRegistryMirrorUsername, defaultRegistryMirrorPassword, "", "false"
 	if pc.registryMirror != nil {
 		endpoint = pc.registryMirror.BaseRegistry
-		username, password, err = config.ReadCredentials()
-		if err != nil {
-			return []byte{}, err
+		if pc.registryMirror.Auth {
+			username, password, err = config.ReadCredentials()
+			if err != nil {
+				return []byte{}, err
+			}
 		}
 		caCertContent = pc.registryMirror.CACertContent
 		if pc.registryMirror.InsecureSkipVerify {


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2268*

*Description of changes:*
To ensure the `registry-mirror-secret` is created from EKS-A controller and updated from EKS-A controller we need the role permissions for patch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

