### PR TITLE
Adding namespaces read permissions to eksa-controller

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -7115,6 +7115,8 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,8 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -172,7 +172,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch
 // +kubebuilder:rbac:groups="",namespace=eksa-system,resources=secrets,verbs=patch;update
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=create;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;create;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters;gitopsconfigs;snowmachineconfigs;snowdatacenterconfigs;snowippools;vspheredatacenterconfigs;vspheremachineconfigs;dockerdatacenterconfigs;tinkerbellmachineconfigs;tinkerbelltemplateconfigs;tinkerbelldatacenterconfigs;cloudstackdatacenterconfigs;cloudstackmachineconfigs;nutanixdatacenterconfigs;nutanixmachineconfigs;awsiamconfigs;oidcconfigs;awsiamconfigs;fluxconfigs,verbs=get;list;watch;update;patch


### PR DESCRIPTION
*Issue #https://github.com/aws/eks-anywhere-internal/issues/2268*

*Description of changes:*
eksa controller did not have permissions to read namespaces. The packages helm chart does a lookup to check if namespace needs to be created. This was failing and hence packages were not installed on workload cluster.

```
 error calling lookup: namespaces \"eksa-packages-workload\" is forbidden: User \"system:serviceaccount:eksa-system:eksa-controller-manager\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"eksa-packages-workload\"\
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

