### PR TITLE
Add check for nil eksaversion when setting etcd url

### DIFF
--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SetUbuntuConfigInEtcdCluster sets up the etcd config in EtcdadmCluster.
-func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle, eksaVersion string) {
+func SetUbuntuConfigInEtcdCluster(etcd *etcdv1.EtcdadmCluster, versionsBundle *cluster.VersionsBundle, eksaVersion *v1alpha1.EksaVersion) {
 	etcd.Spec.EtcdadmConfigSpec.Format = etcdbootstrapv1.Format("cloud-config")
 	etcd.Spec.EtcdadmConfigSpec.CloudInitConfig = &etcdbootstrapv1.CloudInitConfig{
 		Version:    versionsBundle.KubeDistro.EtcdVersion,

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -15,7 +15,6 @@ import (
 func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 	g := newApiBuilerTest(t)
 	eksaVersion := anywherev1.EksaVersion("v0.19.2")
-	g.clusterSpec.Cluster.Spec.EksaVersion = &eksaVersion
 	got := wantEtcdCluster()
 	versionBundle := g.clusterSpec.VersionsBundles["1.21"]
 
@@ -26,14 +25,13 @@ func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
 		InstallDir:     "/usr/bin",
 		EtcdReleaseURL: versionBundle.KubeDistro.EtcdURL,
 	}
-	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, string(eksaVersion))
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, &eksaVersion)
 	g.Expect(got).To(Equal(want))
 }
 
 func TestSetUbuntuConfigInEtcdClusterNoEtcdUrl(t *testing.T) {
 	g := newApiBuilerTest(t)
 	eksaVersion := anywherev1.EksaVersion("v0.18.2")
-	g.clusterSpec.Cluster.Spec.EksaVersion = &eksaVersion
 	got := wantEtcdCluster()
 	versionBundle := g.clusterSpec.VersionsBundles["1.21"]
 
@@ -43,7 +41,7 @@ func TestSetUbuntuConfigInEtcdClusterNoEtcdUrl(t *testing.T) {
 		Version:    versionBundle.KubeDistro.EtcdVersion,
 		InstallDir: "/usr/bin",
 	}
-	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, string(eksaVersion))
+	clusterapi.SetUbuntuConfigInEtcdCluster(got, versionBundle, &eksaVersion)
 	g.Expect(got).To(Equal(want))
 }
 

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -231,7 +231,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
-		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 		if etcdURL != "" {
 			values["externalEtcdReleaseUrl"] = etcdURL
 		}

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -152,8 +152,12 @@ func GetCAPIBottlerocketSettingsConfig(config *v1alpha1.BottlerocketConfiguratio
 
 // GetExternalEtcdReleaseURL returns a valid etcd URL  from version bundles if the eksaVersion is greater than
 // MinEksAVersionWithEtcdURL. Return "" if eksaVersion < MinEksAVersionWithEtcdURL to prevent etcd node rolled out.
-func GetExternalEtcdReleaseURL(clusterVersion string, versionBundle *cluster.VersionsBundle) (string, error) {
-	clusterVersionSemVer, err := semver.New(clusterVersion)
+func GetExternalEtcdReleaseURL(clusterVersion *v1alpha1.EksaVersion, versionBundle *cluster.VersionsBundle) (string, error) {
+	if clusterVersion == nil {
+		logger.V(4).Info("Eks-a cluster version is not specified. Skip setting etcd url")
+		return "", nil
+	}
+	clusterVersionSemVer, err := semver.New(string(*clusterVersion))
 	if err != nil {
 		return "", fmt.Errorf("invalid semver for clusterVersion: %v", err)
 	}

--- a/pkg/providers/common/common_test.go
+++ b/pkg/providers/common/common_test.go
@@ -175,7 +175,8 @@ func TestGetExternalEtcdReleaseURL(t *testing.T) {
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := common.GetExternalEtcdReleaseURL(tt.clusterVersion, test.VersionBundle())
+			eksaVersion := v1alpha1.EksaVersion(tt.clusterVersion)
+			got, err := common.GetExternalEtcdReleaseURL(&eksaVersion, test.VersionBundle())
 			if tt.err == nil {
 				g.Expect(err).ToNot(HaveOccurred())
 			} else {
@@ -184,4 +185,11 @@ func TestGetExternalEtcdReleaseURL(t *testing.T) {
 			g.Expect(got).To(Equal(tt.etcdURL))
 		})
 	}
+}
+
+func TestGetExternalEtcdReleaseURLWithNilEksaVersion(t *testing.T) {
+	g := NewWithT(t)
+	got, err := common.GetExternalEtcdReleaseURL(nil, test.VersionBundle())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(got).To(BeEmpty())
 }

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -329,7 +329,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
-		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 		if etcdURL != "" {
 			values["externalEtcdReleaseUrl"] = etcdURL
 		}

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -297,7 +297,7 @@ func buildTemplateMapCP(
 		values["maxSurge"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.RollingUpdate.MaxSurge
 	}
 
-	etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+	etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 	if etcdURL != "" {
 		values["externalEtcdReleaseUrl"] = etcdURL
 	}

--- a/pkg/providers/snow/apibuilder.go
+++ b/pkg/providers/snow/apibuilder.go
@@ -183,7 +183,7 @@ func EtcdadmCluster(log logr.Logger, clusterSpec *cluster.Spec, snowMachineTempl
 		clusterapi.SetBottlerocketHostConfigInEtcdCluster(etcd, machineConfig.Spec.HostOSConfiguration)
 
 	case v1alpha1.Ubuntu:
-		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle, string(*clusterSpec.Cluster.Spec.EksaVersion))
+		clusterapi.SetUbuntuConfigInEtcdCluster(etcd, versionsBundle, clusterSpec.Cluster.Spec.EksaVersion)
 		etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands = append(etcd.Spec.EtcdadmConfigSpec.PreEtcdadmCommands,
 			"/etc/eks/bootstrap.sh",
 		)

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -476,7 +476,7 @@ func buildTemplateMapCP(
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 		values["etcdTemplateOverride"] = etcdTemplateOverride
 		values["etcdHardwareSelector"] = etcdMachineSpec.HardwareSelector
-		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 		if etcdURL != "" {
 			values["externalEtcdReleaseUrl"] = etcdURL
 		}

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -308,7 +308,7 @@ func buildTemplateMapCP(
 				}
 			}
 		}
-		etcdURL, _ := common.GetExternalEtcdReleaseURL(string(*clusterSpec.Cluster.Spec.EksaVersion), versionsBundle)
+		etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 		if etcdURL != "" {
 			values["externalEtcdReleaseUrl"] = etcdURL
 		}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Related to https://github.com/aws/eks-anywhere/pull/7295

If a user has a management cluster with the new version but workload clusters created from pre 0.17, the eksaversion field is not set as bundlesRef was used then. Due to this for external etcd clusters, there would be a nil dereference, causing a panic in the controller. This will return an empty string if the cluster does not have the eksaversion set, which is usually set when a cluster is upgraded to a newer version.

*Testing (if applicable):*
unit testing and functional testing

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

