### PR TITLE
Increase ssm wait time during e2e test

### DIFF
--- a/internal/pkg/ssm/command.go
+++ b/internal/pkg/ssm/command.go
@@ -24,7 +24,7 @@ var initE2EDirCommand = "mkdir -p /home/e2e/bin && cd /home/e2e"
 
 // WaitForSSMReady waits for the SSM command to be ready.
 func WaitForSSMReady(session *session.Session, instanceID string, timeout time.Duration) error {
-	err := retrier.Retry(10, 20*time.Second, func() error {
+	err := retrier.Retry(20, 20*time.Second, func() error {
 		return Run(session, logr.Discard(), instanceID, "ls", timeout)
 	})
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Increase waiting time for running dummy ssm command. To address the following error during e2e test:
```
2024-04-22T10:28:22.673Z	V-2	Failed running e2e tests for instance	
{
    "jobId": "aws-eks-anywhere-test-tinkerbell:371dbb84-1e72-4d38-8e59-90982e6d4aa7-30",
    "instanceId": "mi-05f84d7f050847040",
    "tests": "TestTinkerbellKubernetes129UbuntuWorkerNodeGroupsTaintsAndLabels",
    "status": "fail",
    "error": "waiting for ssm in new instance: waiting for ssm to be ready: ssm command returned not successful result Failed: "
}

```

*Testing (if applicable):* NA

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

