### PR TITLE
CLI commands support for packages in airgapped admin

### DIFF
--- a/cmd/eksctl-anywhere/cmd/common.go
+++ b/cmd/eksctl-anywhere/cmd/common.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"context"
 
+	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/files"
 	"github.com/aws/eks-anywhere/pkg/helm"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
+	"github.com/aws/eks-anywhere/pkg/registrymirror"
 	"github.com/aws/eks-anywhere/pkg/version"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -50,7 +52,7 @@ func getKubeconfigPath(clusterName, override string) string {
 
 func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*dependencies.Dependencies, error) {
 	config := New(opts...)
-	return dependencies.NewFactory().
+	f := dependencies.NewFactory().
 		WithExecutableMountDirs(config.mountPaths...).
 		WithCustomBundles(config.bundlesOverride).
 		WithExecutableBuilder().
@@ -59,8 +61,13 @@ func NewDependenciesForPackages(ctx context.Context, opts ...PackageOpt) (*depen
 		WithHelm(helm.WithInsecure()).
 		WithCuratedPackagesRegistry(config.registryName, config.kubeVersion, version.Get()).
 		WithPackageControllerClient(config.spec, config.kubeConfig).
-		WithLogger().
-		Build(ctx)
+		WithLogger()
+
+	if config.cluster != nil && config.cluster.Spec.RegistryMirrorConfiguration != nil {
+		f.WithRegistryMirror(registrymirror.FromCluster(config.cluster))
+	}
+
+	return f.Build(ctx)
 }
 
 type PackageOpt func(*PackageConfig)
@@ -72,6 +79,7 @@ type PackageConfig struct {
 	mountPaths      []string
 	spec            *cluster.Spec
 	bundlesOverride string
+	cluster         *anywherev1.Cluster
 }
 
 func New(options ...PackageOpt) *PackageConfig {
@@ -116,5 +124,12 @@ func WithKubeConfig(kubeConfig string) func(*PackageConfig) {
 func WithBundlesOverride(bundlesOverride string) func(*PackageConfig) {
 	return func(config *PackageConfig) {
 		config.bundlesOverride = bundlesOverride
+	}
+}
+
+// WithCluster sets cluster in the config with incoming value.
+func WithCluster(cluster *anywherev1.Cluster) func(config *PackageConfig) {
+	return func(config *PackageConfig) {
+		config.cluster = cluster
 	}
 }

--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -59,7 +59,12 @@ func installPackageController(ctx context.Context) error {
 		return fmt.Errorf("the cluster config file provided is invalid: %v", err)
 	}
 
-	deps, err := NewDependenciesForPackages(ctx, WithMountPaths(kubeConfig), WithClusterSpec(clusterSpec), WithKubeConfig(ico.kubeConfig), WithBundlesOverride(ico.bundlesOverride))
+	deps, err := NewDependenciesForPackages(ctx,
+		WithMountPaths(kubeConfig),
+		WithClusterSpec(clusterSpec),
+		WithKubeConfig(ico.kubeConfig),
+		WithBundlesOverride(ico.bundlesOverride),
+		WithCluster(clusterSpec.Cluster))
 	if err != nil {
 		return fmt.Errorf("unable to initialize executables: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/net v0.23.0
 	golang.org/x/oauth2 v0.15.0
-	golang.org/x/sys v0.18.0
 	golang.org/x/text v0.14.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -183,6 +182,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect


### PR DESCRIPTION
*Issues*
https://github.com/aws/eks-anywhere-internal/issues/2252
https://github.com/aws/eks-anywhere-internal/issues/2270

*Description of changes:*
Below changes ensure that if a customer has a registry mirror setup as part of their EKS-A cluster config; we ensure to perform eksctl anywhere CLI commands for packages using the mirror.

This is significant for folks with an airgapped admin machine; when running these commands the CLI dependencies will know to be pulled from their mirror and not use `public.ecr.aws `.
*Testing:*
```shell
./eksctl-anywhere install packagecontroller -f ./regauth-cluster/regauth-cluster-eks-a-cluster.yaml

./eksctl-anywhere generate package harbor --cluster ramaliar-tink-regauth --kubeconfig ./regauth-cluster/regauth-cluster-eks-a-cluster.kubeconfig
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

