### PR TITLE
Navigate to same page when switching EKS-A versions

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -183,10 +183,10 @@ desc = "Development takes place here!"
 fullversion = "v0.19"
 version = "v0.19"
 docsbranch = "main"
-url = "https://anywhere.eks.amazonaws.com/docs/"
+url = "https://anywhere.eks.amazonaws.com"
 
 [[params.versions]]
 fullversion = "v0.18"
 version = "v0.18"
-docsbranch = "main"
-url = "/docs/"
+docsbranch = "release-0.18"
+url = "https://release-0-18.anywhere.eks.amazonaws.com"

--- a/docs/layouts/partials/navbar-version-selector.html
+++ b/docs/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,9 @@
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	Versions
+</a>
+<div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
+	{{ $p := . }}
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}{{ $p.RelPermalink }}">{{ .version }}</a>
+	{{ end }}
+</div>


### PR DESCRIPTION
Backporting #8021 to release-0.18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

