### PR TITLE
Fix dev release, log paths of missing artifacts

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -160,7 +160,7 @@ func RTOSArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.
 
 	if rc.DevRelease || rc.ReleaseEnvironment == "development" {
 		sourceS3Key = fmt.Sprintf("%s.%s", archive.OSName, imageExtension)
-		sourceS3Prefix = fmt.Sprintf("%s/%s/%s/%s/%s/%s", projectPath, eksDReleaseChannel, archive.Format, archive.OSName, archive.OSVersion, latestPath)
+		sourceS3Prefix = fmt.Sprintf("%s/%s", projectPath, latestPath)
 	} else {
 		sourceS3Key = fmt.Sprintf("%s-%s-eks-a-%d-%s.%s",
 			archive.OSName,

--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -83,13 +83,13 @@ func PollForExistence(devRelease bool, authConfig *docker.AuthConfiguration, ima
 
 		bodyStr := string(body)
 		if strings.Contains(bodyStr, "MANIFEST_UNKNOWN") {
-			return fmt.Errorf("Requested image not found")
+			return fmt.Errorf("requested image not found")
 		}
 
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("retries exhausted waiting for source image %s to be available for copy: %v", imageUri, err)
+		return fmt.Errorf("retries exhausted waiting for source image [%s] to be available for copy: %v", imageUri, err)
 	}
 
 	return nil
@@ -118,7 +118,7 @@ func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfigura
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("retries exhausted performing image copy from source to destination: %v", err)
+		return fmt.Errorf("retries exhausted performing image copy from source [%s] to destination [%s]: %v", sourceImageUri, releaseImageUri, err)
 	}
 
 	return nil

--- a/release/cli/pkg/operations/download.go
+++ b/release/cli/pkg/operations/download.go
@@ -107,7 +107,7 @@ func handleArchiveDownload(_ context.Context, r *releasetypes.ReleaseConfig, art
 				}
 				objectKey = filepath.Join(latestSourceS3PrefixFromMain, sourceS3Key)
 			} else {
-				return fmt.Errorf("retries exhausted waiting for archive to be uploaded to source location: %v", err)
+				return fmt.Errorf("retries exhausted waiting for archive [%s] to be uploaded to source location: %v", objectKey, err)
 			}
 		}
 
@@ -156,7 +156,7 @@ func handleArchiveDownload(_ context.Context, r *releasetypes.ReleaseConfig, art
 					}
 					objectShasumFileKey = filepath.Join(latestSourceS3PrefixFromMain, objectShasumFileName)
 				} else {
-					return fmt.Errorf("retries exhausted waiting for checksum file to be uploaded to source location: %v", err)
+					return fmt.Errorf("retries exhausted waiting for checksum file [%s] to be uploaded to source location: %v", objectShasumFileKey, err)
 				}
 			}
 
@@ -180,7 +180,7 @@ func handleManifestDownload(_ context.Context, r *releasetypes.ReleaseConfig, ar
 
 	err := s3Retrier.Retry(func() error {
 		if !s3.KeyExists(r.SourceBucket, objectKey) {
-			return fmt.Errorf("Requested object not found")
+			return fmt.Errorf("requested object not found")
 		}
 		return nil
 	})
@@ -194,7 +194,7 @@ func handleManifestDownload(_ context.Context, r *releasetypes.ReleaseConfig, ar
 			latestSourceS3PrefixFromMain := strings.NewReplacer(r.BuildRepoBranchName, "latest", artifact.Manifest.GitTag, gitTagFromMain).Replace(sourceS3Prefix)
 			objectKey = filepath.Join(latestSourceS3PrefixFromMain, sourceS3Key)
 		} else {
-			return fmt.Errorf("retries exhausted waiting for archive to be uploaded to source location: %v", err)
+			return fmt.Errorf("retries exhausted waiting for manifest [%s] to be uploaded to source location: %v", objectKey, err)
 		}
 	}
 

--- a/release/cli/pkg/util/artifacts/artifacts.go
+++ b/release/cli/pkg/util/artifacts/artifacts.go
@@ -23,11 +23,11 @@ import (
 )
 
 func IsObjectNotFoundError(err error) bool {
-	return err.Error() == "Requested object not found"
+	return err.Error() == "requested object not found"
 }
 
 func IsImageNotFoundError(err error) bool {
-	return err.Error() == "Requested image not found"
+	return err.Error() == "requested image not found"
 }
 
 func GetFakeSHA(hashType int) (string, error) {


### PR DESCRIPTION
This PR fixes the source path for the Canonical RTOS image for dev release and improves the logging in case of missing artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

