### PR TITLE
Update validation for the cluster name length

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -396,9 +396,12 @@ func ValidateClusterName(clusterName string) error {
 }
 
 func ValidateClusterNameLength(clusterName string) error {
-	// vSphere has the maximum length for clusters to be 80 chars
-	if len(clusterName) > 80 {
-		return fmt.Errorf("number of characters in %v should be less than 81", clusterName)
+	// docker container hostname can have a maximum length of 64 characters. we append "-eks-a-cluster"
+	// to get the KinD cluster's name and on top of this, KinD also adds a "-control-plane suffix" to
+	// the cluster name to arrive at the name for the control plane node (container), which makes the
+	// control plane node name 64 characters in length.
+	if len(clusterName) > 35 {
+		return fmt.Errorf("number of characters in %v should be less than 36", clusterName)
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -79,13 +79,13 @@ func TestClusterNameLength(t *testing.T) {
 	}{
 		{
 			name:        "SuccessClusterNameLength",
-			clusterName: "qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm",
+			clusterName: "cluster-name-less-than-36-chars",
 			wantErr:     nil,
 		},
 		{
 			name:        "FailureClusterNameLength",
-			clusterName: "qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm12345",
-			wantErr:     errors.New("number of characters in qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm12345 should be less than 81"),
+			clusterName: "cluster-name-equals-to-36-characters",
+			wantErr:     errors.New("number of characters in cluster-name-equals-to-36-characters should be less than 36"),
 		},
 	}
 

--- a/pkg/validations/input_test.go
+++ b/pkg/validations/input_test.go
@@ -94,9 +94,9 @@ func TestValidateClusterNameArg(t *testing.T) {
 		},
 		{
 			name:          "Failure Cluster Length",
-			args:          []string{"qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm12345"},
-			expectedError: errors.New("number of characters in qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm12345 should be less than 81"),
-			expectedArg:   "qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm12345",
+			args:          []string{"cluster-name-equals-to-36-characters"},
+			expectedError: errors.New("number of characters in cluster-name-equals-to-36-characters should be less than 36"),
+			expectedArg:   "cluster-name-equals-to-36-characters",
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
#7302 
#8016 

*Description of changes:*
Updated the cluster config validation for the cluster name length to be not more than 35 characters. 

*Testing (if applicable):*
Tested locally with a cluster name length of more than 35 characters on docker provider

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

