### PR TITLE
Docs: add instructions for generating support bundle when using a private authenticated registry

### DIFF
--- a/docs/content/en/docs/clustermgmt/support/supportbundle.md
+++ b/docs/content/en/docs/clustermgmt/support/supportbundle.md
@@ -62,7 +62,7 @@ export REGISTRY_USERNAME=<username>
 export REGISTRY_PASSWORD=<password>
 ```
 
-The generate support-bundle command will collect the information from your cluster
+The `generate support-bundle` command will collect the information from your cluster
 and run an analysis of the collected information.
 
 The collected information will be saved to your local disk in an archive which can be used for 

--- a/docs/content/en/docs/clustermgmt/support/supportbundle.md
+++ b/docs/content/en/docs/clustermgmt/support/supportbundle.md
@@ -50,10 +50,19 @@ Flags:
 ```
 
 ### Collecting and analyzing a bundle
+
 You only need to run a single command to generate a support bundle, collect information and analyze the output:
 `eksctl anywhere generate support-bundle -f my-cluster.yaml`
 
-This command will collect the information from your cluster
+If you have an airgapped Amazon EKS Anywhere installation with an authenticated private registry, you will need 
+to export the following registry authentication environment variables before generating the support bundle:
+
+```
+export REGISTRY_USERNAME=<username>
+export REGISTRY_PASSWORD=<password>
+```
+
+The generate support-bundle command will collect the information from your cluster
 and run an analysis of the collected information.
 
 The collected information will be saved to your local disk in an archive which can be used for 


### PR DESCRIPTION
…vate registry which is authenticated

*Issue #, if available:*
N/A

*Description of changes:*
Added instructions for generating a support bundle when using a private authenticated registry

*Testing (if applicable):*
N/A

*Documentation added/planned (if applicable):*
Added instructions for generating a support bundle when using a private authenticated registr

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

