### PR TITLE
Add callout for packages not working with latest patch

### DIFF
--- a/docs/content/en/docs/whatsnew/changelog.md
+++ b/docs/content/en/docs/whatsnew/changelog.md
@@ -56,6 +56,8 @@ description: >
 - Added nil check for eksa-version when setting etcd url [#8018](https://github.com/aws/eks-anywhere/pull/8018)
 - Fixed registry mirror secret credentials set to empty [#7933](https://github.com/aws/eks-anywhere/pull/7933)
 
+**Note:** EKS Anywhere Packages workflow doesn't work with the current version as there was a bug identified with the associated package controller. Team is actively working on a fix and will have a follow up patch version shortly with the fix for packages workflow.
+
 ## [v0.19.3](https://github.com/aws/eks-anywhere/releases/tag/v0.19.3)
 
 ### Supported OS version details


### PR DESCRIPTION
*Issue #, if available:*
Update call out on the packages workflow not working with the latest patch.

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

