### PR TITLE
Update airgapped configuration step

### DIFF
--- a/docs/content/en/docs/getting-started/airgapped/airgap-steps.md
+++ b/docs/content/en/docs/getting-started/airgapped/airgap-steps.md
@@ -18,7 +18,7 @@ toc_hide: true
 
 1. Set up a local registry mirror to host the downloaded EKS Anywhere images and configure your Admin machine with the certificates and authentication information if your registry requires it. For details, refer to the [Registry Mirror Configuration documentation.]({{< relref "../../getting-started/optional/registrymirror/#configure-local-registry-mirror" >}})
 
-1. Import images to the local registry mirror using the following command. Set `REGISTRY_MIRROR_URL` to the url of the local registry mirror you created in the previous step. This command may take several minutes to complete. To monitor the progress of the command, you can run with the `-v 6` command line argument.  
+1. Import images to the local registry mirror using the following command. Set `REGISTRY_MIRROR_URL` to the url of the local registry mirror you created in the previous step. This command may take several minutes to complete. To monitor the progress of the command, you can run with the `-v 6` command line argument. When using self-signed certificates for your registry, you should run with the `--insecure` command line argument to indicate skipping TLS verification while pushing helm charts and bundles.
    ```bash
    export REGISTRY_MIRROR_URL=<registryurl>
    ```


### PR DESCRIPTION
*Issue #, if available:*
Adding the `--insecure` flag to the airgapped docs when running the `eksctl anywhere import images` command to indicate skipping TLS verification when using a self-signed registry mirror.

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

