### PR TITLE
Fix cluster directory being created with root ownership

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -341,6 +341,12 @@ func (f *Factory) WithDockerLogin() *Factory {
 }
 
 func (f *Factory) WithExecutableBuilder() *Factory {
+	// Ensure the file writer is created before the tools container is launched. This is necessary
+	// because we bind mount the cluster directory into the tools container. If the directory
+	// doesn't exist, dockerd (running as root) creates the hostpath for the bind mount with root
+	// ownership. This prevents further files from being written to the cluster directory.
+	f.WithWriter()
+
 	if f.executablesConfig.useDockerContainer {
 		f.WithExecutableImage().WithDocker()
 		if f.registryMirror != nil && f.registryMirror.Auth {


### PR DESCRIPTION
On occasion we find the cluster directory created by EKS-A is created with root ownership.

When hostpaths used for bind mounting in Docker don't exist at the time the container is created, dockerd creates the directory. dockerd runs as root on most systems hence the directory is created with root ownership.

This ensures the directory exists before we attempt to launch the tools container that bind mounts the cluster directory.

---

The docker command was demonstrated to be executing before the directory is created through an strace.

```
3195314 21:24:01.454557 execve("/usr/bin/docker", ["docker", "run", "-d", "--name", "eksa_1715203440722790952", "--network", "host", "-w", "/home/chrisdoherty", "-v", "/var/run/docker.sock:/var/run/do"..., "-v", "/home/chrisdoherty:/home/chrisdo"..., "-v", "/home/chrisdoherty:/home/chrisdo"..., "--entrypoint", "sleep", "public.ecr.aws/l0g8r8j6/eks-anyw"..., "infinity"], 0xc000ab2000 /* 32 vars */) = 0
...
3195265 21:24:01.715948 mkdirat(AT_FDCWD, "persistent-mgmt", 0777) = 0
3195265 21:24:01.716067 mkdirat(AT_FDCWD, "persistent-mgmt/generated", 0777) = 0
```

An analysis of stracing the docker daemon with timestamps suggested on successful runs that the timing was extremely close and on failed runs the container launched first, hence dockerd created the host path with root ownership.

The fix inverts the syscalls removing any race.

```
18416 21:51:24.197012 mkdirat(AT_FDCWD, "persistent-mgmt", 0777) = 0
18416 21:51:24.197097 mkdirat(AT_FDCWD, "persistent-mgmt/generated", 0777) = 0
...
18470 21:51:24.388620 execve("/usr/bin/docker", ["docker", "run", "-d", "--name", "eksa_1715205084197278143", "--network", "host", "-w", "/home/eksadmin", "-v", "/var/run/docker.sock:/var/run/do"..., "-v", "/home/eksadmin/persistent-mgmt:/"..., "-v", "/home/eksadmin:/home/eksadmin", "-v", "/home/eksadmin:/home/eksadmin", "--entrypoint", "sleep", "public.ecr.aws/l0g8r8j6/eks-anyw"..., "infinity"], 0xc000ab2120 /* 34 vars */) = 0
``` 
