### PR TITLE
Use right RHEL template during 1.30 upgrade

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3223,7 +3223,7 @@ func TestVSphereKubernetes129To130StackedEtcdRedHatUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube130,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat129Template()),
+		provider.WithProviderUpgrade(provider.Redhat130Template()),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*
The `TestVSphereKubernetes129To130StackedEtcdRedHatUpgrade` test was using the 1.29 template during the upgrade. Change fixes the test to use 1.30 template during the upgrade.  

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

