### PR TITLE
Update airgapped env command in create cluster docs

### DIFF
--- a/docs/content/en/docs/getting-started/cloudstack/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloudstack-getstarted.md
@@ -118,10 +118,21 @@ Follow these steps to create an EKS Anywhere cluster that can be used either as 
    ```
 
 1. Create cluster
+   
+   For a regular cluster create (with internet access), type the following:
 
    ```bash
    eksctl anywhere create cluster \
       -f eksa-mgmt-cluster.yaml \
+      # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+   ```
+
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+   ```bash
+   eksctl anywhere create cluster \
+      -f eksa-mgmt-cluster.yaml \
+      --bundles-override ./eks-anywhere-downloads/bundle-release.yaml \
       # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
    ```
 

--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -133,8 +133,16 @@ sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
 
 1. Create Docker Cluster. Note the following command may take several minutes to complete. You can run the command with -v 6 to increase logging verbosity to see the progress of the command. 
 
+      For a regular cluster create (with internet access), type the following:
+      
       ```bash
       eksctl anywhere create cluster -f $CLUSTER_NAME.yaml
+      ```
+
+      For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+      ```bash
+      eksctl anywhere create cluster -f $CLUSTER_NAME.yaml --bundles-override ./eks-anywhere-downloads/bundle-release.yaml
       ```
 
      Expand for sample output:

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-getstarted.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-getstarted.md
@@ -107,9 +107,20 @@ Make sure you use single quotes around the values so that your shell does not in
      
 1. Create cluster
 
+   For a regular cluster create (with internet access), type the following:
+   
    ```bash
    eksctl anywhere create cluster \
       -f eksa-mgmt-cluster.yaml \
+      # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
+   ```
+
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+   ```bash
+   eksctl anywhere create cluster \
+      -f eksa-mgmt-cluster.yaml \
+      --bundles-override ./eks-anywhere-downloads/bundle-release.yaml \
       # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation
    ```
 

--- a/docs/content/en/docs/getting-started/snow/snow-getstarted.md
+++ b/docs/content/en/docs/getting-started/snow/snow-getstarted.md
@@ -107,13 +107,15 @@ Make sure you use single quotes around the values so that your shell does not in
 
 1. Create cluster
 
-   a. For none air-gapped environment
+   For a regular cluster create (with internet access), type the following:
+
    ```bash
    eksctl anywhere create cluster \
       -f eksa-mgmt-cluster.yaml
    ```
 
-   b. For air-gapped environment
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+   
    ```bash
    eksctl anywhere create cluster \
       -f eksa-mgmt-cluster.yaml \

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
@@ -110,9 +110,20 @@ Make sure you use single quotes around the values so that your shell does not in
      
 1. Create cluster
 
+   For a regular cluster create (with internet access), type the following:
+   
    ```bash
    eksctl anywhere create cluster \
       -f eksa-mgmt-cluster.yaml \
+      # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation      
+   ```
+
+   For an airgapped cluster create, follow [Preparation for airgapped deployments]({{< relref "../install#prepare-for-airgapped-deployments-optional" >}}) instructions, then type the following:
+
+   ```bash
+   eksctl anywhere create cluster \
+      -f eksa-mgmt-cluster.yaml \
+      --bundles-override ./eks-anywhere-downloads/bundle-release.yaml \
       # --install-packages packages.yaml \ # uncomment to install curated packages at cluster creation      
    ```
 


### PR DESCRIPTION
*Description of changes:*
Update create cluster docs to include command for airgapped env similar to what we have for baremetal [here](https://anywhere.eks.amazonaws.com/docs/getting-started/baremetal/baremetal-getstarted/#:~:text=For%20an%20airgapped%20cluster%20create%2C%20follow%20Preparation%20for%20airgapped%20deployments%20instructions%2C%20then%20type%20the%20following%3A)

*Testing (if applicable):*
make build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

