### PR TITLE
Adding a registry mirror packages test for vsphere

### DIFF
--- a/pkg/curatedpackages/regional_registry.go
+++ b/pkg/curatedpackages/regional_registry.go
@@ -17,7 +17,7 @@ import (
 const (
 	devRegionalECR       string = "067575901363.dkr.ecr.us-west-2.amazonaws.com"
 	devRegionalPublicECR string = "public.ecr.aws/x3k6m8v0"
-	stagingRegionalECR   string = "TODO.dkr.ecr.us-west-2.amazonaws.com"
+	stagingRegionalECR   string = "067575901363.dkr.ecr.us-west-2.amazonaws.com"
 )
 
 var prodRegionalECRMap = map[string]string{

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -48,6 +48,10 @@ func runDisabledCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) 
 	test.WithCluster(runDisabledCuratedPackage)
 }
 
+func runCuratedPackageInstallSimpleFlowRegistryMirror(test *framework.ClusterE2ETest) {
+	test.WithClusterRegistryMirror(runCuratedPackageInstall)
+}
+
 func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(e *framework.WorkloadCluster) {

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2030,6 +2030,23 @@ func TestVSphereKubernetes130BottlerocketRegistryMirrorOciNamespaces(t *testing.
 	runRegistryMirrorConfigFlow(test)
 }
 
+func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSimpleFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
+		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube129),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+	)
+	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
+}
+
 // Clone mode
 func TestVSphereKubernetes128FullClone(t *testing.T) {
 	diskSize := 30


### PR DESCRIPTION
*Description of changes:*
Currently we did not have any registry mirror tests that also tried to install curated packages. 
This tests adds support for creating a cluster with registry mirror and having the hello world packages installed and verified after cluster creation.
*Testing (if applicable):*
```
./e2e.test -test.v -test.run "TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSimpleFlow"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

