### PR TITLE
Adding docs for regional packages migration

### DIFF
--- a/docs/content/en/docs/packages/legacypackagesregions.md
+++ b/docs/content/en/docs/packages/legacypackagesregions.md
@@ -1,0 +1,22 @@
+---
+toc_hide: true
+---
+
+| AWS Region|
+| :---- |
+| us-east-2 |
+| us-east-1 |
+| us-west-1 |
+| us-west-2 |
+| ap-northeast-3 |
+| ap-northeast-2 |
+| ap-southeast-1 |
+| ap-southeast-2 |
+| ap-northeast-1 |
+| ca-central-1 |
+| eu-central-1 |
+| eu-west-1 |
+| eu-west-2 |
+| eu-west-3 |
+| eu-north-1 |
+| sa-east-1 |

--- a/docs/content/en/docs/packages/packagecontroller.md
+++ b/docs/content/en/docs/packages/packagecontroller.md
@@ -41,14 +41,14 @@ If you created a cluster without the package controller or if the package contro
     aws sts get-caller-identity
     ```
 
-4. Authenticate docker to the private AWS ECR registry on account `783794618700` with your AWS credentials. It houses the EKS Anywhere packages artifacts. Authentication is required to pull images from it.
+4. Authenticate docker to the private AWS ECR registry with your AWS credentials. Reference prerequisites to identity the AWS account that houses the EKS Anywhere packages artifacts. Authentication is required to pull images from it.
     ```bash
-    aws ecr get-login-password | docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
+    aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_PACKAGES_ACCOUNT.dkr.ecr.$EKSA_AWS_REGION.amazonaws.com
     ```
 
 5. Verify you can pull an image from the packages registry:
     ```bash
-    docker pull 783794618700.dkr.ecr.us-west-2.amazonaws.com/emissary-ingress/emissary:v3.5.1-bf70150bcdfe3a5383ec8ad9cd7eea801a0cb074
+    docker pull $ECR_PACKAGES_ACCOUNT.dkr.ecr.$EKSA_AWS_REGION.amazonaws.com/emissary-ingress/emissary:v3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
     ```
     If the image downloads successfully, it worked!
 

--- a/docs/content/en/docs/packages/packagesecrmigration.md
+++ b/docs/content/en/docs/packages/packagesecrmigration.md
@@ -1,0 +1,52 @@
+---
+title: "Packages regional ECR migration"
+linkTitle: "Packages regional ECR migration"
+weight: 4
+description: >
+    Migrating EKS Anywhere Curated Packages to latest regional ECR repositories
+---
+
+When you purchase an EKS Anywhere Enterprise Subscription through the Amazon EKS console or APIs, the AWS account that purchased the subscription is automatically granted access to EKS Anywhere Curated Packages in the AWS Region where the subscription is created. If you received trial access to EKS Anywhere Curated Packages or if you have an EKS Anywhere Enterprise Subscription that was created before October 2023, then you need to migrate your EKS Anywhere Curated Packages configuration to use the latest ECR regional repositories. This process would cause all the Curated Packages installed on the cluster to rollout and be deployed from the latest ECR regional repositories.
+
+<details>
+  <summary>Expand for packages registry to AWS Region table</summary>
+  <br /> 
+  {{% content "../clustermgmt/support/packages-registries.md" %}}
+</details>
+
+### Steps for Migration
+1. Ensure you have an active EKS Anywhere Enterprise Subscription. For more information, refer [Purchase subscriptions.]({{< relref "../clustermgmt/support/purchase-subscription.md" >}})
+
+2. If the AWS account that created the EKS Anywhere Enterprise Subscription through the Amazon EKS console or APIs and the AWS IAM user credentials for curated packages on your existing cluster are different, you need to update the aws-secret object on the cluster with new credentials. Refer [Updating the package credentials 
+.]({{< relref "./packagecontroller.md#updating-the-package-credentials" >}})
+
+3. Edit the `ecr-credential-provider-package` package on the cluster and update `matchImages` with the correct ECR package registry for the AWS Region where you created your subscription. Example, `346438352937.dkr.ecr.us-west-2.amazonaws.com` for `us-west-2`. Reference the table in the expanded output at the top of this page for a mapping of AWS Regions to ECR package registries.
+    ```bash
+    kubectl edit package ecr-credential-provider-package  -n eksa-packages-<cluster name>
+    ```
+    This causes `ecr-credential-provider-package` pods to rollout and the kubelet is configured to use AWS credentials for pulling images from the new regional ECR packages registry.
+
+4. Edit the `PackageBundleController` object on the cluster and set the `defaultImageRegistry` and `defaultRegistry` to point to the ECR package registry for the AWS Region where you created your subscription.
+    ```bash
+    kubectl edit packagebundlecontroller <cluster name> -n eksa-packages
+    ```
+5. Restart the eks-anywhere-packages controller deployment.
+    ```bash
+    kubectl rollout restart deployment eks-anywhere-packages -n eksa-packages
+    ```
+    This step causes the package controller to pull down a new package bundle onto the cluster and marks the `PackageBundleController` as upgrade available. Example
+    ```bash
+    NAMESPACE       NAME              ACTIVEBUNDLE   STATE               DETAIL
+    eksa-packages   my-cluster-name   v1-28-160      upgrade available   v1-28-274 available
+    ```
+6. Edit the `PackageBundleController` object on the cluster and set the `activeBundle` field to the new bundle number that is available.
+    ```bash
+    kubectl edit packagebundlecontroller <cluster name> -n eksa-packages
+    ```
+    This step causes all the packages on the cluster to be reinstalled and pods rolled out from the new registry.
+
+7. Edit the `ecr-credential-provider-package` package again and now set the `sourceRegistry` to point to the ECR package registry for the AWS Region where you created your subscription.
+    ```bash
+    kubectl edit package ecr-credential-provider-package  -n eksa-packages-<cluster name>
+    ```
+    This causes `ecr-credential-provider-package` to be reinstalled from the new registry.

--- a/docs/content/en/docs/packages/prereq.md
+++ b/docs/content/en/docs/packages/prereq.md
@@ -31,6 +31,31 @@ Before installing any curated packages for EKS Anywhere, do the following:
 
 To request a free trial, talk to your Amazon representative or connect with one [here](https://aws.amazon.com/contact-us/sales-support-eks/).
 
+### Identify AWS account ID for ECR packages registry
+
+The AWS account ID for ECR packages registry depends on the EKS Anywhere Enterprise Subscription.
+
+* For EKS Anywhere Enterprise Subscriptions purchased through the AWS console or APIs the AWS account ID for ECR packages registry varies depending on the region the Enterprise Subscription was purchased. Reference the table in the expanded output below for a mapping of AWS Regions to ECR package registries.
+<details>
+  <summary>Expand for packages registry to AWS Region table</summary>
+  <br /> 
+  {{% content "../clustermgmt/support/packages-registries.md" %}}
+</details>
+  <br/>
+
+* For EKS Anywhere Curated Packages trials or EKS Anywhere Enterprise Subscriptions purchased before October 2023 the AWS account ID for ECR packages registry is `783794618700`. This supports pulling images from the following regions.
+<details>
+  <summary>Expand for AWS Regions table</summary>
+  <br />
+  {{% content "./legacypackagesregions.md" %}}
+</details>
+<br/>
+
+After identifying the AWS account ID; export it for further reference. Example
+```bash
+export ECR_PACKAGES_ACCOUNT=346438352937
+```
+
 ### Setup authentication to use curated packages
 
 When you have been notified that your account has been given access to curated packages, create an IAM user in your account with a policy that only allows ECR read access to the Curated Packages repository; similar to this:
@@ -55,7 +80,7 @@ When you have been notified that your account has been given access to curated p
                 "ecr:DescribeRepositories",
                 "ecr:BatchCheckLayerAvailability"
             ],
-            "Resource": "arn:aws:ecr:*:783794618700:repository/*"
+            "Resource": "arn:aws:ecr:*:<ECR_PACKAGES_ACCOUNT>:repository/*"
         },
         {
             "Sid": "ECRLogin",
@@ -69,32 +94,13 @@ When you have been notified that your account has been given access to curated p
 }
 ```
 
-**Note** Curated Packages now supports pulling images from the following regions. Use the corresponding `EKSA_AWS_REGION` prior to cluster creation to choose which region to pull form, if not set it will default to pull from `us-west-2`.
-```
-"us-east-2",
-"us-east-1",
-"us-west-1",
-"us-west-2",
-"ap-northeast-3",
-"ap-northeast-2",
-"ap-southeast-1",
-"ap-southeast-2",
-"ap-northeast-1",
-"ca-central-1",
-"eu-central-1",
-"eu-west-1",
-"eu-west-2",
-"eu-west-3",
-"eu-north-1",
-"sa-east-1"
-```
-
+**Note** Use the corresponding `EKSA_AWS_REGION` prior to cluster creation to choose which region to pull form.
 
 Create credentials for this user and set and export the following environment variables:
 ```bash
 export EKSA_AWS_ACCESS_KEY_ID="your*access*id"
 export EKSA_AWS_SECRET_ACCESS_KEY="your*secret*key"
-export EKSA_AWS_REGION="us-west-2"
+export EKSA_AWS_REGION="aws*region"
 ```
 Make sure you are authenticated with the AWS CLI
 
@@ -107,12 +113,12 @@ aws sts get-caller-identity
 Login to docker
 
 ```bash
-aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 783794618700.dkr.ecr.us-west-2.amazonaws.com
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ECR_PACKAGES_ACCOUNT.dkr.ecr.$EKSA_AWS_REGION.amazonaws.com
 ```
 
 Verify you can pull an image
 ```bash
-docker pull 783794618700.dkr.ecr.us-west-2.amazonaws.com/emissary-ingress/emissary:v3.5.1-bf70150bcdfe3a5383ec8ad9cd7eea801a0cb074
+docker pull $ECR_PACKAGES_ACCOUNT.dkr.ecr.$EKSA_AWS_REGION.amazonaws.com/emissary-ingress/emissary:v3.9.1-828e7d186ded23e54f6bd95a5ce1319150f7e325
 ```
 If the image downloads successfully, it worked!
 


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2141*

*Description of changes:*
Adding documentation for the steps that a user needs to perform to migrate their cluster to use an EKS Enterprise subscription granted regional curated packages from the legacy ECR registries. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

