### PR TITLE
Fix bug when installer do not in create CCM secret for Nutanix workload cluster

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -781,3 +781,31 @@ spec:
     name: user-ca-bundle
 {{- end }}
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{.clusterName}}-nutanix-ccm-secret"
+  namespace: "{{.eksaSystemNamespace}}"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "{{ .nutanixPCUsername }}",
+                "password": "{{ .nutanixPCPassword }}"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/controlplane.go
+++ b/pkg/providers/nutanix/controlplane.go
@@ -27,6 +27,7 @@ type ControlPlane struct {
 	BaseControlPlane
 	ConfigMaps          []*corev1.ConfigMap
 	ClusterResourceSets []*addonsv1.ClusterResourceSet
+	Secrets				[]*corev1.Secret
 }
 
 // Objects returns the control plane objects associated with the Nutanix cluster.
@@ -34,6 +35,7 @@ func (p ControlPlane) Objects() []kubernetes.Object {
 	o := p.BaseControlPlane.Objects()
 	o = appendKubeObjects[*corev1.ConfigMap](o, p.ConfigMaps)
 	o = appendKubeObjects[*addonsv1.ClusterResourceSet](o, p.ClusterResourceSets)
+	o = appendKubeObjects[*corev1.Secret](o, p.Secrets)
 
 	return o
 }
@@ -154,6 +156,12 @@ func newControlPlaneParser(logger logr.Logger) (*yamlutil.Parser, *ControlPlaneB
 				return &addonsv1.ClusterResourceSet{}
 			},
 		),
+		yamlutil.NewMapping(
+			constants.SecretKind,
+			func() yamlutil.APIObject {
+				return &corev1.Secret{}
+			},
+		),
 	)
 
 	if err != nil {
@@ -183,6 +191,8 @@ func buildObjects(cp *ControlPlane, lookup yamlutil.ObjectLookup) {
 			cp.ConfigMaps = append(cp.ConfigMaps, obj.(*corev1.ConfigMap))
 		case constants.ClusterResourceSetKind:
 			cp.ClusterResourceSets = append(cp.ClusterResourceSets, obj.(*addonsv1.ClusterResourceSet))
+		case constants.SecretKind:
+			cp.Secrets = append(cp.Secrets, obj.(*corev1.Secret))
 		}
 	}
 }

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -59,7 +59,7 @@ func (ntb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Sp
 		etcdMachineSpec = *ntb.etcdMachineSpec
 	}
 
-	values, err := buildTemplateMapCP(ntb.datacenterSpec, clusterSpec, *ntb.controlPlaneMachineSpec, etcdMachineSpec)
+	values, err := buildTemplateMapCP(ntb.datacenterSpec, clusterSpec, *ntb.controlPlaneMachineSpec, etcdMachineSpec, ntb.creds)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +156,7 @@ func buildTemplateMapCP(
 	clusterSpec *cluster.Spec,
 	controlPlaneMachineSpec v1alpha1.NutanixMachineConfigSpec,
 	etcdMachineSpec v1alpha1.NutanixMachineConfigSpec,
+	creds credentials.BasicAuthCredential,
 ) (map[string]interface{}, error) {
 	versionsBundle := clusterSpec.RootVersionsBundle()
 	format := "cloud-config"
@@ -218,6 +219,8 @@ func buildTemplateMapCP(
 		"subnetName":                   controlPlaneMachineSpec.Subnet.Name,
 		"subnetUUID":                   controlPlaneMachineSpec.Subnet.UUID,
 		"apiServerCertSANs":            clusterSpec.Cluster.Spec.ControlPlaneConfiguration.CertSANs,
+		"nutanixPCUsername":        	creds.PrismCentral.BasicAuth.Username,
+		"nutanixPCPassword":        	creds.PrismCentral.BasicAuth.Password,
 	}
 
 	if controlPlaneMachineSpec.Project != nil {

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -549,6 +549,9 @@ func TestTemplateBuilder_CertSANs(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")	
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
@@ -574,6 +577,9 @@ func TestTemplateBuilder_additionalTrustBundle(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")	
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
@@ -599,6 +605,9 @@ func TestTemplateBuilderEtcdEncryption(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")	
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
@@ -624,6 +633,9 @@ func TestTemplateBuilderEtcdEncryptionKubernetes129(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")	
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -641,3 +641,31 @@ spec:
   - kind: ConfigMap
     name: user-ca-bundle
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -582,3 +582,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -582,3 +582,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
@@ -586,3 +586,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
@@ -631,3 +631,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
@@ -661,3 +661,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -643,3 +643,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
@@ -657,3 +657,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -625,3 +625,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -582,3 +582,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -591,3 +591,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -583,3 +583,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -585,3 +585,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -590,3 +590,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -631,3 +631,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set


### PR DESCRIPTION
*Description of changes:*
Fix bug when installer do not in create CCM secret for Nutanix workload cluster
Following fixes applied:
 - fixed templates
 - fixed reconciler
 - improved tests
 
*Testing (if applicable):*
**Management cluster**
```
$ eksctl anywhere create cluster -f ./mgmt-cluster.yaml -v10 --bundles-override bin/local-bundle-release.yaml
2024-05-21T16:47:16.491Z        V6      Executing command       {"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2024-05-21T16:47:16.513Z        V6      Executing command       {"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2024-05-21T16:47:16.564Z        V4      Reading bundles manifest        {"url": "bin/local-bundle-release.yaml"}
2024-05-21T16:47:16.584Z        V4      Using CAPI provider versions    {"Core Cluster API": "v1.6.0+ae39aac", "Kubeadm Bootstrap": "v1.6.0+49ef750", "Kubeadm Control Plane": "v1.6.0+a7122b7", "External etcd Bootstrap": "v1.0.10+1ceb898", "External etcd Controller": "v1.0.17+5e33062", "Cluster API Provider Nutanix": "v1.3.4"}
2024-05-21T16:47:16.671Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-21T16:47:16.671Z        V2      Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-21T16:47:16.671Z        V6      Executing command       {"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-21T16:47:17.247Z        V5      Retry execution successful      {"retries": 1, "duration": "575.366823ms"}
2024-05-21T16:47:17.247Z        V3      Initializing long running container     {"name": "eksa_1716310036671798518", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-21T16:47:17.247Z        V6      Executing command       {"cmd": "/usr/bin/docker run -d --name eksa_1716310036671798518 --network host -w /home/ubuntu/mgmt016 -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321 infinity"}
2024-05-21T16:47:17.395Z        V0      Using the new workflow using the controller for management cluster create
2024-05-21T16:47:17.395Z        V4      Task start      {"task_name": "setup-validate"}
2024-05-21T16:47:17.395Z        V0      Performing setup and validations
2024-05-21T16:47:17.395Z        V0      ValidateClusterSpec for Nutanix datacenter      {"NutanixDatacenter": "mgmt"}
2024-05-21T16:47:20.993Z        V0      ✅ Nutanix Provider setup is valid
2024-05-21T16:47:20.993Z        V0      ✅ Validate OS is compatible with registry mirror configuration
2024-05-21T16:47:20.993Z        V0      ✅ Validate certificate for registry mirror
2024-05-21T16:47:20.994Z        V0      ✅ Validate authentication for git provider
2024-05-21T16:47:20.994Z        V0      ✅ Validate cluster's eksaVersion matches EKS-A version
2024-05-21T16:47:20.994Z        V4      Task finished   {"task_name": "setup-validate", "duration": "3.598307666s"}
...
2024-05-21T16:56:14.066Z        V5      Retry execution successful      {"retries": 1, "duration": "169.568405ms"}
2024-05-21T16:56:14.066Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-21T16:56:14.066Z        V4      Deleting kind cluster   {"name": "mgmt-eks-a-cluster"}
2024-05-21T16:56:14.066Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310036671798518 kind delete cluster --name mgmt-eks-a-cluster"}
2024-05-21T16:56:15.400Z        V5      Retry execution successful      {"retries": 1, "duration": "1.333492054s"}
2024-05-21T16:56:15.400Z        V0      🎉 Cluster created!
2024-05-21T16:56:15.400Z        V4      Task finished   {"task_name": "delete-kind-cluster", "duration": "1.795673206s"}
2024-05-21T16:56:15.400Z        V4      ----------------------------------
2024-05-21T16:56:15.400Z        V4      Task start      {"task_name": "install-curated-packages"}
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
2024-05-21T16:56:15.400Z        V0      Enabling curated packages on the cluster
...
```
**Workload cluster**
```
2024-05-21T17:01:57.443Z        V6      Executing command       {"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2024-05-21T17:01:57.466Z        V6      Executing command       {"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2024-05-21T17:01:57.517Z        V4      Reading bundles manifest        {"url": "bin/local-bundle-release.yaml"}
2024-05-21T17:01:57.537Z        V4      Using CAPI provider versions    {"Core Cluster API": "v1.6.0+ae39aac", "Kubeadm Bootstrap": "v1.6.0+49ef750", "Kubeadm Control Plane": "v1.6.0+a7122b7", "External etcd Bootstrap": "v1.0.10+1ceb898", "External etcd Controller": "v1.0.17+5e33062", "Cluster API Provider Nutanix": "v1.3.4"}
2024-05-21T17:01:57.628Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-21T17:01:57.628Z        V2      Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-21T17:01:57.628Z        V6      Executing command       {"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-21T17:01:58.198Z        V5      Retry execution successful      {"retries": 1, "duration": "570.833773ms"}
2024-05-21T17:01:58.199Z        V3      Initializing long running container     {"name": "eksa_1716310917628126682", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-21T17:01:58.199Z        V6      Executing command       {"cmd": "/usr/bin/docker run -d --name eksa_1716310917628126682 --network host -w /home/ubuntu/mgmt016 -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/mgmt016/mgmt:/home/ubuntu/mgmt016/mgmt -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321 infinity"}
2024-05-21T17:01:58.354Z        V4      Task start      {"task_name": "setup-validate-create"}
2024-05-21T17:01:58.354Z        V0      ValidateClusterSpec for Nutanix datacenter      {"NutanixDatacenter": "mgmt-wrk1"}
2024-05-21T17:02:04.544Z        V0      ✅ Workload cluster's nutanix Provider setup is valid
2024-05-21T17:02:04.544Z        V0      ✅ Validate OS is compatible with registry mirror configuration
2024-05-21T17:02:04.544Z        V0      ✅ Validate certificate for registry mirror
2024-05-21T17:02:04.544Z        V0      ✅ Validate authentication for git provider
2024-05-21T17:02:04.544Z        V0      ✅ Validate cluster's eksaVersion matches EKS-A version
2024-05-21T17:02:04.545Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310917628126682 kubectl get clusters.cluster.x-k8s.io -o json --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig --namespace eksa-system"}
2024-05-21T17:02:04.737Z        V0      ✅ Validate cluster name
2024-05-21T17:02:04.737Z        V0      ✅ Validate gitops
2024-05-21T17:02:04.737Z        V5      skipping ValidateIdentityProviderNameIsUnique
2024-05-21T17:02:04.737Z        V0      ✅ Validate identity providers' name
2024-05-21T17:02:04.737Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310917628126682 kubectl get customresourcedefinition clusters.cluster.x-k8s.io --kubeconfig mgmt
/mgmt-eks-a-cluster.kubeconfig"}
2024-05-21T17:02:04.881Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310917628126682 kubectl get customresourcedefinition clusters.anywhere.eks.amazonaws.com --kubec
onfig mgmt/mgmt-eks-a-cluster.kubeconfig"}
2024-05-21T17:02:05.028Z        V0      ✅ Validate management cluster has eksa crds
2024-05-21T17:02:05.028Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310917628126682 kubectl get clusters.anywhere.eks.amazonaws.com -A -o jsonpath={.items[0]} --kub
econfig mgmt/mgmt-eks-a-cluster.kubeconfig --field-selector=metadata.name=mgmt"}
2024-05-21T17:02:05.206Z        V0      ✅ Validate management cluster name is valid
2024-05-21T17:02:05.206Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310917628126682 kubectl get clusters.anywhere.eks.amazonaws.com -A -o jsonpath={.items[0]} --kub
econfig mgmt/mgmt-eks-a-cluster.kubeconfig --field-selector=metadata.name=mgmt"}
2024-05-21T17:02:05.385Z        V0      ✅ Validate management cluster eksaVersion compatibility
2024-05-21T17:02:05.385Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i eksa_1716310917628126682 kubectl get --ignore-not-found -o json --kubeconfig mgmt/mgmt-eks-a-cluster.kube
config EKSARelease.v1alpha1.anywhere.eks.amazonaws.com --namespace eksa-system eksa-v0-0-0-dev"}
2024-05-21T17:02:05.530Z        V0      ✅ Validate eksa release components exist on management cluster
2024-05-21T17:02:05.530Z        V4      Task finished   {"task_name": "setup-validate-create", "duration": "7.175213484s"}
2024-05-21T17:02:05.530Z        V4      ----------------------------------
2024-05-21T17:02:05.530Z        V4      Task start      {"task_name": "create-workload-cluster"}
2024-05-21T17:02:05.530Z        V0      Creating workload cluster
...
2024-05-21T17:23:10.516Z        V4      Task finished   {"task_name": "create-workload-cluster", "duration": "21m4.98645452s"}
2024-05-21T17:23:10.516Z        V4      ----------------------------------
2024-05-21T17:23:10.516Z        V4      Task start      {"task_name": "gitops-manager-install"}
2024-05-21T17:23:10.516Z        V0      Installing GitOps Toolkit on workload cluster
2024-05-21T17:23:10.516Z        V0      GitOps field not specified, bootstrap flux skipped
2024-05-21T17:23:10.516Z        V4      Task finished   {"task_name": "gitops-manager-install", "duration": "24.769µs"}
2024-05-21T17:23:10.516Z        V4      ----------------------------------
2024-05-21T17:23:10.516Z        V4      Task start      {"task_name": "write-cluster-config"}
2024-05-21T17:23:10.516Z        V0      Writing cluster config file
2024-05-21T17:23:10.519Z        V0      🎉 Cluster created!
2024-05-21T17:23:10.519Z        V4      Task finished   {"task_name": "write-cluster-config", "duration": "2.649362ms"}
2024-05-21T17:23:10.519Z        V4      ----------------------------------
2024-05-21T17:23:10.519Z        V4      Tasks completed {"duration": "21m12.164496416s"}
2024-05-21T17:23:10.519Z        V3      Cleaning up long running container      {"name": "eksa_1716310917628126682"}
2024-05-21T17:23:10.519Z        V6      Executing command       {"cmd": "/usr/bin/docker rm -f -v eksa_1716310917628126682"}
```
<img width="1419" alt="Screenshot 2024-05-21 at 19 32 44" src="https://github.com/aws/eks-anywhere/assets/506414/55b4cfab-10f7-4e76-a1aa-de98a00f3b37">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

