### PR TITLE
Cloudstack kubelet configuration cp and wn

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -538,7 +538,6 @@ func validateControlPlaneKubeletConfiguration(clusterConfig *Cluster) error {
 	cpKubeletConfig := clusterConfig.Spec.ControlPlaneConfiguration.KubeletConfiguration
 
 	return validateKubeletConfiguration(cpKubeletConfig)
-
 }
 
 func validateWorkerNodeKubeletConfiguration(clusterConfig *Cluster) error {

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -538,6 +538,7 @@ func validateControlPlaneKubeletConfiguration(clusterConfig *Cluster) error {
 	cpKubeletConfig := clusterConfig.Spec.ControlPlaneConfiguration.KubeletConfiguration
 
 	return validateKubeletConfiguration(cpKubeletConfig)
+
 }
 
 func validateWorkerNodeKubeletConfiguration(clusterConfig *Cluster) error {

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -156,6 +156,13 @@ spec:
 {{ .schedulerExtraArgs.ToYaml | indent 10 }}
 {{- end }}
     files:
+{{- if .kubeletConfiguration }}
+    - content: |
+{{ .kubeletConfiguration | indent 8}}
+      owner: root:root
+      permissions: "0644"
+      path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.yaml
+{{- end }}
 {{- if .encryptionProviderConfig }}
     - content: |
 {{ .encryptionProviderConfig | indent 8}}
@@ -294,6 +301,10 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
 {{- end}}
     initConfiguration:
+{{- if .kubeletConfiguration }}
+      patches: 
+        directory: /etc/kubernetes/patches
+{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
@@ -316,6 +327,10 @@ spec:
 {{- end }}
 {{- end }}
     joinConfiguration:
+{{- if .kubeletConfiguration }}
+      patches: 
+        directory: /etc/kubernetes/patches
+{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:

--- a/pkg/providers/cloudstack/config/template-md.yaml
+++ b/pkg/providers/cloudstack/config/template-md.yaml
@@ -7,6 +7,10 @@ spec:
   template:
     spec:
       joinConfiguration:
+{{- if .kubeletConfiguration }}
+        patches: 
+          directory: /etc/kubernetes/patches
+{{- end }}
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
 {{- if .workerNodeGroupTaints }}
@@ -29,8 +33,15 @@ spec:
 {{ .kubeletExtraArgs.ToYaml | indent 12 }}
 {{- end }}
           name: "{{`{{ ds.meta_data.hostname }}`}}"
-{{- if or .proxyConfig .registryMirrorMap }}
+{{- if or (or .proxyConfig .registryMirrorMap) .kubeletConfiguration }}
       files:
+{{- end }}
+{{- if .kubeletConfiguration }}
+      - content: |
+{{ .kubeletConfiguration | indent 10 }}
+        owner: root:root
+        permissions: "0644"
+        path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.yaml
 {{- end }}
 {{- if .proxyConfig }}
       - content: |

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 
+	"sigs.k8s.io/yaml"
+
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
@@ -257,6 +259,17 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		values["encryptionProviderConfig"] = conf
 	}
 
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.KubeletConfiguration != nil {
+		cpKubeletConfig := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.KubeletConfiguration.Object
+
+		kcString, err := yaml.Marshal(cpKubeletConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling %v", err)
+		}
+
+		values["kubeletConfiguration"] = string(kcString)
+	}
+
 	return values, nil
 }
 
@@ -387,6 +400,16 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 			return nil, err
 		}
 		fillProxyConfigurations(values, clusterSpec, endpoint)
+	}
+
+	if workerNodeGroupConfiguration.KubeletConfiguration != nil {
+		wnKubeletConfig := workerNodeGroupConfiguration.KubeletConfiguration.Object
+		kcString, err := yaml.Marshal(wnKubeletConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling %v", err)
+		}
+
+		values["kubeletConfiguration"] = string(kcString)
 	}
 
 	return values, nil

--- a/pkg/providers/cloudstack/template_test.go
+++ b/pkg/providers/cloudstack/template_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -168,4 +169,33 @@ func TestTemplateBuilder_CertSANs(t *testing.T) {
 
 		test.AssertContentToFile(t, string(data), tc.Output)
 	}
+}
+
+func TestVsphereTemplateBuilderGenerateCAPISpecControlPlaneValidKubeletConfigWN(t *testing.T) {
+	g := NewWithT(t)
+	spec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
+	spec.Cluster.Spec.WorkerNodeGroupConfigurations[0].KubeletConfiguration = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"maxPods": 20,
+		},
+	}
+	builder := cloudstack.NewTemplateBuilder(time.Now)
+	_, err := builder.GenerateCAPISpecWorkers(spec, nil, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestVsphereTemplateBuilderGenerateCAPISpecControlPlaneValidKubeletConfigCP(t *testing.T) {
+	g := NewWithT(t)
+	spec := test.NewFullClusterSpec(t, path.Join(testDataDir, testClusterConfigMainFilename))
+	spec.Cluster.Spec.ControlPlaneConfiguration.KubeletConfiguration = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"maxPods": 20,
+		},
+	}
+	spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	builder := cloudstack.NewTemplateBuilder(time.Now)
+	_, err := builder.GenerateCAPISpecControlPlane(spec, func(values map[string]interface{}) {
+		values["controlPlaneTemplateName"] = clusterapi.ControlPlaneMachineTemplateName(spec.Cluster)
+	})
+	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -246,6 +246,13 @@ spec:
       certificatesDir: /var/lib/kubeadm/pki
 {{- end }}
     files:
+{{- if .kubeletConfiguration }}
+    - content: |
+{{ .kubeletConfiguration | indent 8}}
+      owner: root:root
+      permissions: "0644"
+      path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.yaml
+{{- end }}
 {{- if .encryptionProviderConfig }}
     - content: |
 {{ .encryptionProviderConfig | indent 8}}
@@ -393,6 +400,10 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
 {{- end}}
     initConfiguration:
+{{- if .kubeletConfiguration }}
+      patches: 
+        directory: /etc/kubernetes/patches
+{{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
@@ -415,6 +426,10 @@ spec:
         {{- end }}
 {{- end }}
     joinConfiguration:
+{{- if .kubeletConfiguration }}
+      patches: 
+        directory: /etc/kubernetes/patches
+{{- end }}
 {{- if (eq .format "bottlerocket") }}
       pause:
         imageRepository: {{.pauseRepository}}

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -7,6 +7,10 @@ spec:
   template:
     spec:
       joinConfiguration:
+{{- if .kubeletConfiguration }}
+        patches: 
+          directory: /etc/kubernetes/patches
+{{- end }}
 {{- if (eq .format "bottlerocket") }}
         pause:
           imageRepository: {{.pauseRepository}}
@@ -76,8 +80,15 @@ spec:
 {{ .kubeletExtraArgs.ToYaml | indent 12 }}
 {{- end }}
           name: '{{"{{"}} ds.meta_data.hostname {{"}}"}}'
-{{- if and (ne .format "bottlerocket") (or .proxyConfig .registryMirrorMap) }}
+{{- if or (and (ne .format "bottlerocket") (or .proxyConfig .registryMirrorMap)) .kubeletConfiguration }}
       files:
+{{- end }}
+{{- if .kubeletConfiguration }}
+      - content: |
+{{ .kubeletConfiguration | indent 10 }}
+        owner: root:root
+        permissions: "0644"
+        path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.yaml
 {{- end }}
 {{- if and .proxyConfig (ne .format "bottlerocket") }}
       - content: |

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -3,6 +3,8 @@ package vsphere
 import (
 	"fmt"
 
+	"sigs.k8s.io/yaml"
+
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
@@ -354,6 +356,17 @@ func buildTemplateMapCP(
 		values["encryptionProviderConfig"] = conf
 	}
 
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.KubeletConfiguration != nil {
+		cpKubeletConfig := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.KubeletConfiguration.Object
+
+		kcString, err := yaml.Marshal(cpKubeletConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling %v", err)
+		}
+
+		values["kubeletConfiguration"] = string(kcString)
+	}
+
 	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy != nil {
 		values["upgradeRolloutStrategy"] = true
 		if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy.Type == anywherev1.InPlaceStrategyType {
@@ -486,6 +499,16 @@ func buildTemplateMapMD(
 			return nil, err
 		}
 		values["bottlerocketSettings"] = brSettings
+	}
+
+	if workerNodeGroupConfiguration.KubeletConfiguration != nil {
+		wnKubeletConfig := workerNodeGroupConfiguration.KubeletConfiguration.Object
+		kcString, err := yaml.Marshal(wnKubeletConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling %v", err)
+		}
+
+		values["kubeletConfiguration"] = string(kcString)
 	}
 
 	return values, nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a new field KubeletConfiguration in the eksa spec for control plane and worker node configuration. This is an unstructured object that is of the kind value KubeletConfiguration. This PR adds the code for Cloudstack provider.

Testing (if applicable):
- unit tests
- e2e tests

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

