### PR TITLE
Skip dependency review and govulncheck actions when only YAML files are changed

### DIFF
--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+    - '**.yaml'
+    - '**.yml'
   workflow_dispatch:
   schedule:
     # every day at 7am UTC


### PR DESCRIPTION
This PR changes the GitHub actions workflow configuration to skip the dependency review and govulncheck actions when only YAML files are changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

