### PR TITLE
Cherry-pick: Fix bug causing installer does not create CCM secret for Nutanix workload cluster (#8191)

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -781,3 +781,31 @@ spec:
     name: user-ca-bundle
 {{- end }}
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{.clusterName}}-nutanix-ccm-secret"
+  namespace: "{{.eksaSystemNamespace}}"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "{{ .nutanixPCUsername }}",
+                "password": "{{ .nutanixPCPassword }}"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/controlplane.go
+++ b/pkg/providers/nutanix/controlplane.go
@@ -27,6 +27,7 @@ type ControlPlane struct {
 	BaseControlPlane
 	ConfigMaps          []*corev1.ConfigMap
 	ClusterResourceSets []*addonsv1.ClusterResourceSet
+	Secrets             []*corev1.Secret
 }
 
 // Objects returns the control plane objects associated with the Nutanix cluster.
@@ -34,6 +35,7 @@ func (p ControlPlane) Objects() []kubernetes.Object {
 	o := p.BaseControlPlane.Objects()
 	o = appendKubeObjects[*corev1.ConfigMap](o, p.ConfigMaps)
 	o = appendKubeObjects[*addonsv1.ClusterResourceSet](o, p.ClusterResourceSets)
+	o = appendKubeObjects[*corev1.Secret](o, p.Secrets)
 
 	return o
 }
@@ -154,6 +156,12 @@ func newControlPlaneParser(logger logr.Logger) (*yamlutil.Parser, *ControlPlaneB
 				return &addonsv1.ClusterResourceSet{}
 			},
 		),
+		yamlutil.NewMapping(
+			constants.SecretKind,
+			func() yamlutil.APIObject {
+				return &corev1.Secret{}
+			},
+		),
 	)
 
 	if err != nil {
@@ -183,6 +191,8 @@ func buildObjects(cp *ControlPlane, lookup yamlutil.ObjectLookup) {
 			cp.ConfigMaps = append(cp.ConfigMaps, obj.(*corev1.ConfigMap))
 		case constants.ClusterResourceSetKind:
 			cp.ClusterResourceSets = append(cp.ClusterResourceSets, obj.(*addonsv1.ClusterResourceSet))
+		case constants.SecretKind:
+			cp.Secrets = append(cp.Secrets, obj.(*corev1.Secret))
 		}
 	}
 }

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -59,7 +59,7 @@ func (ntb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Sp
 		etcdMachineSpec = *ntb.etcdMachineSpec
 	}
 
-	values, err := buildTemplateMapCP(ntb.datacenterSpec, clusterSpec, *ntb.controlPlaneMachineSpec, etcdMachineSpec)
+	values, err := buildTemplateMapCP(ntb.datacenterSpec, clusterSpec, *ntb.controlPlaneMachineSpec, etcdMachineSpec, ntb.creds)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +156,7 @@ func buildTemplateMapCP(
 	clusterSpec *cluster.Spec,
 	controlPlaneMachineSpec v1alpha1.NutanixMachineConfigSpec,
 	etcdMachineSpec v1alpha1.NutanixMachineConfigSpec,
+	creds credentials.BasicAuthCredential,
 ) (map[string]interface{}, error) {
 	versionsBundle := clusterSpec.RootVersionsBundle()
 	format := "cloud-config"
@@ -217,6 +218,8 @@ func buildTemplateMapCP(
 		"subnetName":                   controlPlaneMachineSpec.Subnet.Name,
 		"subnetUUID":                   controlPlaneMachineSpec.Subnet.UUID,
 		"apiServerCertSANs":            clusterSpec.Cluster.Spec.ControlPlaneConfiguration.CertSANs,
+		"nutanixPCUsername":            creds.PrismCentral.BasicAuth.Username,
+		"nutanixPCPassword":            creds.PrismCentral.BasicAuth.Password,
 	}
 
 	if controlPlaneMachineSpec.Project != nil {

--- a/pkg/providers/nutanix/template_test.go
+++ b/pkg/providers/nutanix/template_test.go
@@ -549,6 +549,9 @@ func TestTemplateBuilder_CertSANs(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
@@ -574,6 +577,9 @@ func TestTemplateBuilder_additionalTrustBundle(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
@@ -599,6 +605,9 @@ func TestTemplateBuilderEtcdEncryption(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,
@@ -624,6 +633,9 @@ func TestTemplateBuilderEtcdEncryptionKubernetes129(t *testing.T) {
 		clusterSpec := test.NewFullClusterSpec(t, tc.Input)
 
 		machineCfg := clusterSpec.NutanixMachineConfig(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name)
+
+		t.Setenv(constants.EksaNutanixUsernameKey, "admin")
+		t.Setenv(constants.EksaNutanixPasswordKey, "password")
 		creds := GetCredsFromEnv()
 
 		bldr := NewNutanixTemplateBuilder(&clusterSpec.NutanixDatacenter.Spec, &machineCfg.Spec, nil,

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -641,3 +641,31 @@ spec:
   - kind: ConfigMap
     name: user-ca-bundle
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -582,3 +582,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -582,3 +582,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
@@ -586,3 +586,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
@@ -631,3 +631,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
@@ -661,3 +661,31 @@ spec:
   - kind: Secret
     name: test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -643,3 +643,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
@@ -657,3 +657,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -625,3 +625,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -582,3 +582,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -591,3 +591,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -583,3 +583,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -585,3 +585,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -590,3 +590,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -631,3 +631,31 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   strategy: Reconcile
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "eksa-unit-test-nutanix-ccm-secret"
+  namespace: "eksa-system"
+stringData:
+  nutanix-ccm-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nutanix-creds
+      namespace: kube-system
+    stringData:
+      credentials: |-
+        [
+          {        
+            "type": "basic_auth",
+            "data": {
+              "prismCentral": {
+                "username": "admin",
+                "password": "password"
+              },
+              "prismElements": null
+            }
+          }
+        ]
+type: addons.cluster.x-k8s.io/resource-set


### PR DESCRIPTION
*Description of changes:*
Cherry-pick: Fix bug causing installer doesn't create CCM secret for Nutanix worker cluster (#8191)

 - fixed templates
 - fixed reconciler
 - improved tests

*Testing (if applicable):*
**Management cluster**
```
$ eksctl anywhere create cluster -f ./mgmt-cluster.yaml -v10 --bundles-override bin/local-bundle-release.yaml
2024-05-27T10:14:59.817Z	V6	Executing command	{"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2024-05-27T10:14:59.838Z	V6	Executing command	{"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2024-05-27T10:14:59.888Z	V4	Reading bundles manifest	{"url": "bin/local-bundle-release.yaml"}
2024-05-27T10:14:59.907Z	V4	Using CAPI provider versions	{"Core Cluster API": "v1.6.0+ae39aac", "Kubeadm Bootstrap": "v1.6.0+49ef750", "Kubeadm Control Plane": "v1.6.0+a7122b7", "External etcd Bootstrap": "v1.0.10+1ceb898", "External etcd Controller": "v1.0.17+5e33062", "Cluster API Provider Nutanix": "v1.3.3"}
2024-05-27T10:15:00.006Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-27T10:15:00.006Z	V2	Pulling docker image	{"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-27T10:15:00.006Z	V6	Executing command	{"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-27T10:15:00.709Z	V5	Retry execution successful	{"retries": 1, "duration": "702.687825ms"}
2024-05-27T10:15:00.709Z	V3	Initializing long running container	{"name": "eksa_1716804900006523562", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-27T10:15:00.709Z	V6	Executing command	{"cmd": "/usr/bin/docker run -d --name eksa_1716804900006523562 --network host -w /home/ubuntu/mgmt016 -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321 infinity"}
2024-05-27T10:15:00.872Z	V0	Using the new workflow using the controller for management cluster create
2024-05-27T10:15:00.872Z	V4	Task start	{"task_name": "setup-validate"}
2024-05-27T10:15:00.872Z	V0	Performing setup and validations
2024-05-27T10:15:00.872Z	V0	ValidateClusterSpec for Nutanix datacenter	{"NutanixDatacenter": "il-mgmt"}
2024-05-27T10:15:00.872Z	V0	Warning: Skipping TLS validation for insecure connection to Nutanix Prism Central; this is not recommended for production use
2024-05-27T10:15:05.527Z	V0	✅ Nutanix Provider setup is valid
2024-05-27T10:15:05.527Z	V0	✅ Validate OS is compatible with registry mirror configuration
2024-05-27T10:15:05.527Z	V0	✅ Validate certificate for registry mirror
2024-05-27T10:15:05.527Z	V0	✅ Validate authentication for git provider
2024-05-27T10:15:05.527Z	V0	✅ Validate cluster's eksaVersion matches EKS-A version
2024-05-27T10:15:05.527Z	V4	Task finished	{"task_name": "setup-validate", "duration": "4.655757346s"}
2024-05-27T10:15:05.527Z	V4	----------------------------------
2024-05-27T10:15:05.527Z	V4	Task start	{"task_name": "bootstrap-cluster-init"}
2024-05-27T10:15:05.527Z	V0	Creating new bootstrap cluster
...
2024-05-27T10:27:05.742Z	V4	Task finished	{"task_name": "eksa-components-workload-install", "duration": "2m30.253252255s"}
2024-05-27T10:27:05.742Z	V4	----------------------------------
2024-05-27T10:27:05.742Z	V4	Task start	{"task_name": "gitops-manager-install"}
2024-05-27T10:27:05.742Z	V0	Installing GitOps Toolkit on workload cluster
2024-05-27T10:27:05.742Z	V0	GitOps field not specified, bootstrap flux skipped
2024-05-27T10:27:05.742Z	V4	Task finished	{"task_name": "gitops-manager-install", "duration": "32.622µs"}
2024-05-27T10:27:05.742Z	V4	----------------------------------
2024-05-27T10:27:05.742Z	V4	Task start	{"task_name": "write-cluster-config"}
2024-05-27T10:27:05.742Z	V0	Writing cluster config file
2024-05-27T10:27:05.744Z	V4	Task finished	{"task_name": "write-cluster-config", "duration": "1.940759ms"}
2024-05-27T10:27:05.744Z	V4	----------------------------------
2024-05-27T10:27:05.744Z	V4	Task start	{"task_name": "delete-kind-cluster"}
2024-05-27T10:27:05.744Z	V0	Deleting bootstrap cluster
2024-05-27T10:27:05.744Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-27T10:27:05.744Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716804900006523562 kind get clusters"}
2024-05-27T10:27:05.904Z	V5	Executed kind get clusters	{"response": "il-mgmt-eks-a-cluster\n"}
2024-05-27T10:27:05.904Z	V5	Retry execution successful	{"retries": 1, "duration": "159.60547ms"}
2024-05-27T10:27:05.904Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-27T10:27:05.904Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716804900006523562 kubectl get customresourcedefinition clusters.cluster.x-k8s.io --kubeconfig il-mgmt/generated/il-mgmt.kind.kubeconfig"}
2024-05-27T10:27:06.058Z	V5	Retry execution successful	{"retries": 1, "duration": "154.36575ms"}
2024-05-27T10:27:06.058Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-27T10:27:06.058Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716804900006523562 kubectl get clusters.cluster.x-k8s.io -o json --kubeconfig il-mgmt/generated/il-mgmt.kind.kubeconfig --namespace eksa-system"}
2024-05-27T10:27:06.223Z	V5	Retry execution successful	{"retries": 1, "duration": "164.397381ms"}
2024-05-27T10:27:06.223Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-27T10:27:06.223Z	V4	Deleting kind cluster	{"name": "il-mgmt-eks-a-cluster"}
2024-05-27T10:27:06.223Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716804900006523562 kind delete cluster --name il-mgmt-eks-a-cluster"}
2024-05-27T10:27:07.437Z	V5	Retry execution successful	{"retries": 1, "duration": "1.214737506s"}
2024-05-27T10:27:07.437Z	V0	🎉 Cluster created!
2024-05-27T10:27:07.437Z	V4	Task finished	{"task_name": "delete-kind-cluster", "duration": "1.693353192s"}
2024-05-27T10:27:07.437Z	V4	----------------------------------
2024-05-27T10:27:07.437Z	V4	Task start	{"task_name": "install-curated-packages"}
...
```

**Workload cluster**
```
$ eksctl anywhere create cluster -f ./wrk1-cluster.yaml -v10 --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig  --bundles-override bin/local-bundle-release.yaml
2024-05-27T10:35:01.422Z	V6	Executing command	{"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2024-05-27T10:35:01.441Z	V6	Executing command	{"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2024-05-27T10:35:01.483Z	V4	Reading bundles manifest	{"url": "bin/local-bundle-release.yaml"}
2024-05-27T10:35:01.501Z	V4	Using CAPI provider versions	{"Core Cluster API": "v1.6.0+ae39aac", "Kubeadm Bootstrap": "v1.6.0+49ef750", "Kubeadm Control Plane": "v1.6.0+a7122b7", "External etcd Bootstrap": "v1.0.10+1ceb898", "External etcd Controller": "v1.0.17+5e33062", "Cluster API Provider Nutanix": "v1.3.3"}
2024-05-27T10:35:01.585Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-05-27T10:35:01.585Z	V2	Pulling docker image	{"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-27T10:35:01.585Z	V6	Executing command	{"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-27T10:35:02.172Z	V5	Retry execution successful	{"retries": 1, "duration": "586.926522ms"}
2024-05-27T10:35:02.172Z	V3	Initializing long running container	{"name": "eksa_1716806101585803291", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321"}
2024-05-27T10:35:02.172Z	V6	Executing command	{"cmd": "/usr/bin/docker run -d --name eksa_1716806101585803291 --network host -w /home/ubuntu/mgmt016 -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/mgmt016/il-mgmt:/home/ubuntu/mgmt016/il-mgmt -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 -v /home/ubuntu/mgmt016:/home/ubuntu/mgmt016 --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.18.6-eks-a-v0.0.0-dev-build.8321 infinity"}
2024-05-27T10:35:02.314Z	V4	Task start	{"task_name": "setup-validate-create"}
2024-05-27T10:35:02.314Z	V0	ValidateClusterSpec for Nutanix datacenter	{"NutanixDatacenter": "il-mgmt-wrk1"}
2024-05-27T10:35:02.314Z	V0	Warning: Skipping TLS validation for insecure connection to Nutanix Prism Central; this is not recommended for production use
2024-05-27T10:35:07.897Z	V0	✅ Workload cluster's nutanix Provider setup is valid
2024-05-27T10:35:07.898Z	V0	✅ Validate OS is compatible with registry mirror configuration
2024-05-27T10:35:07.898Z	V0	✅ Validate certificate for registry mirror
2024-05-27T10:35:07.898Z	V0	✅ Validate authentication for git provider
2024-05-27T10:35:07.898Z	V0	✅ Validate cluster's eksaVersion matches EKS-A version
2024-05-27T10:35:07.898Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716806101585803291 kubectl get clusters.cluster.x-k8s.io -o json --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig --namespace eksa-system"}
2024-05-27T10:35:08.049Z	V0	✅ Validate cluster name
2024-05-27T10:35:08.049Z	V0	✅ Validate gitops
2024-05-27T10:35:08.049Z	V5	skipping ValidateIdentityProviderNameIsUnique
2024-05-27T10:35:08.049Z	V0	✅ Validate identity providers' name
2024-05-27T10:35:08.049Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716806101585803291 kubectl get customresourcedefinition clusters.cluster.x-k8s.io --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig"}
2024-05-27T10:35:08.169Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716806101585803291 kubectl get customresourcedefinition clusters.anywhere.eks.amazonaws.com --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig"}
2024-05-27T10:35:08.301Z	V0	✅ Validate management cluster has eksa crds
2024-05-27T10:35:08.302Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716806101585803291 kubectl get clusters.anywhere.eks.amazonaws.com -A -o jsonpath={.items[0]} --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig --field-selector=metadata.name=il-mgmt"}
2024-05-27T10:35:08.470Z	V0	✅ Validate management cluster name is valid
2024-05-27T10:35:08.471Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716806101585803291 kubectl get clusters.anywhere.eks.amazonaws.com -A -o jsonpath={.items[0]} --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig --field-selector=metadata.name=il-mgmt"}
2024-05-27T10:35:08.647Z	V0	✅ Validate management cluster eksaVersion compatibility
2024-05-27T10:35:08.647Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1716806101585803291 kubectl get --ignore-not-found -o json --kubeconfig il-mgmt/il-mgmt-eks-a-cluster.kubeconfig EKSARelease.v1alpha1.anywhere.eks.amazonaws.com --namespace eksa-system eksa-v0-0-0-dev"}
2024-05-27T10:35:08.774Z	V0	✅ Validate eksa release components exist on management cluster
2024-05-27T10:35:08.774Z	V4	Task finished	{"task_name": "setup-validate-create", "duration": "6.459774906s"}
2024-05-27T10:35:08.774Z	V4	----------------------------------
2024-05-27T10:35:08.774Z	V4	Task start	{"task_name": "create-workload-cluster"}
2024-05-27T10:35:08.774Z	V0	Creating workload cluster
2024-05-27T10:35:08.774Z	V3	Applying cluster spec
...
2024-05-27T10:41:21.043Z	V4	Task finished	{"task_name": "create-workload-cluster", "duration": "6m12.269029883s"}
2024-05-27T10:41:21.043Z	V4	----------------------------------
2024-05-27T10:41:21.043Z	V4	Task start	{"task_name": "gitops-manager-install"}
2024-05-27T10:41:21.043Z	V0	Installing GitOps Toolkit on workload cluster
2024-05-27T10:41:21.043Z	V0	GitOps field not specified, bootstrap flux skipped
2024-05-27T10:41:21.043Z	V4	Task finished	{"task_name": "gitops-manager-install", "duration": "37.452µs"}
2024-05-27T10:41:21.043Z	V4	----------------------------------
2024-05-27T10:41:21.043Z	V4	Task start	{"task_name": "write-cluster-config"}
2024-05-27T10:41:21.043Z	V0	Writing cluster config file
2024-05-27T10:41:21.046Z	V0	🎉 Cluster created!
2024-05-27T10:41:21.046Z	V4	Task finished	{"task_name": "write-cluster-config", "duration": "3.356527ms"}
2024-05-27T10:41:21.046Z	V4	----------------------------------
2024-05-27T10:41:21.046Z	V4	Tasks completed	{"duration": "6m18.73237454s"}
2024-05-27T10:41:21.046Z	V3	Cleaning up long running container	{"name": "eksa_1716806101585803291"}
2024-05-27T10:41:21.046Z	V6	Executing command	{"cmd": "/usr/bin/docker rm -f -v eksa_1716806101585803291"}
```
<img width="1419" alt="Screenshot 2024-05-27 at 12 42 08" src="https://github.com/aws/eks-anywhere/assets/506414/1ffeabae-f8ee-4297-a42e-0926ed57c523">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

