### PR TITLE
Update generate cluster config command for Tinkerbell

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig.go
@@ -22,7 +22,9 @@ func NewTinkerbellDatacenterConfigGenerate(clusterName string) *TinkerbellDatace
 		ObjectMeta: ObjectMeta{
 			Name: clusterName,
 		},
-		Spec: TinkerbellDatacenterConfigSpec{},
+		Spec: TinkerbellDatacenterConfigSpec{
+			TinkerbellIP: "",
+		},
 	}
 }
 

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig.go
@@ -27,6 +27,7 @@ func NewTinkerbellMachineConfigGenerate(name string, opts ...TinkerbellMachineCo
 		Spec: TinkerbellMachineConfigSpec{
 			HardwareSelector: HardwareSelector{},
 			OSFamily:         Ubuntu,
+			OSImageURL:       "",
 			Users: []UserConfiguration{
 				{
 					Name:              "ec2-user",

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_types.go
@@ -18,7 +18,7 @@ type TinkerbellMachineConfigSpec struct {
 	// OSImageURL is a URL to the OS image used during provisioning. It must include
 	// the Kubernetes version(s). For example, a URL used for Kubernetes 1.27 could
 	// be http://localhost:8080/ubuntu-2204-1.27.tgz
-	OSImageURL          string               `json:"osImageURL,omitempty"`
+	OSImageURL          string               `json:"osImageURL"`
 	Users               []UserConfiguration  `json:"users,omitempty"`
 	HostOSConfiguration *HostOSConfiguration `json:"hostOSConfiguration,omitempty"`
 }

--- a/pkg/providers/tinkerbell/assert_test.go
+++ b/pkg/providers/tinkerbell/assert_test.go
@@ -143,6 +143,18 @@ func TestAssertMachineConfigK8sVersionBRWorker_Error(t *testing.T) {
 	g.Expect(err).ToNot(gomega.Succeed())
 }
 
+func TestAssertMachineConfigK8sVersionBRModularWorker_Error(t *testing.T) {
+	g := gomega.NewWithT(t)
+	builder := NewDefaultValidClusterSpecBuilder()
+	clusterSpec := builder.Build()
+	kube129 := eksav1alpha1.Kube129
+	clusterSpec.Spec.Cluster.Spec.ExternalEtcdConfiguration = nil
+	clusterSpec.Spec.Cluster.Spec.WorkerNodeGroupConfigurations[0].KubernetesVersion = &kube129
+	clusterSpec.MachineConfigs[builder.WorkerNodeGroupMachineName].Spec.OSFamily = "bottlerocket"
+	err := tinkerbell.AssertOsFamilyValid(clusterSpec)
+	g.Expect(err).ToNot(gomega.Succeed())
+}
+
 func TestAssertMachineConfigK8sVersionBR_Success(t *testing.T) {
 	g := gomega.NewWithT(t)
 	builder := NewDefaultValidClusterSpecBuilder()


### PR DESCRIPTION
*Issue #, if available:*
Update generate command for Tinkerbell to populate Tinkerbell IP in the Datacenter config and OSImage URL in Machine config object as we have defaulted the OS from BR to Ubuntu. This change also adds a check when a modular K8s version is specified with a value above 1.28 and the OS family is set to BR.
   
*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

