### PR TITLE
Skip latest minor tests creating 130 cluster on previous release

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -63,6 +63,11 @@ skipped_tests:
 - TestCloudStackKubernetes130RedhatCuratedPackagesCertManagerSimpleFlow
 - TestCloudStackKubernetes130RedhatWorkloadClusterCuratedPackagesEmissarySimpleFlow
 
+# UpgradeFromLatestTests for new K8s version (expected to work only after the release is out)
+- TestDockerKubernetes130AirgappedUpgradeFromLatestRegistryMirrorAndCert
+- TestDockerKubernetes129to130UpgradeFromLatestMinorReleaseAPI
+- TestCloudStackKubernetes130WithOIDCManagementClusterUpgradeFromLatestSideEffects
+
 # Snow
 - TestSnowKubernetes125SimpleFlow
 - TestSnowKubernetes126SimpleFlow


### PR DESCRIPTION
*Issue #, if available:*
Skip 1.30 latest minor tests that are creating a 1.30 cluster using previous release. These tests can be un-skipped once we have 0.20 minor release out as they are expected to only work after that. 

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

