### PR TITLE
Remove K8s 1.30 feature flag and default as cluster version

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -229,7 +229,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster.
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube129
+	return Kube130
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3980,7 +3980,7 @@ func TestValidateEksaVersion(t *testing.T) {
 
 func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
-	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube129))
+	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube130))
 }
 
 func TestClusterWorkerNodeConfigCount(t *testing.T) {

--- a/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
@@ -17,7 +17,7 @@ spec:
     upgradeRolloutStrategy:
       type: InPlace
   datacenterRef: {}
-  kubernetesVersion: "1.29"
+  kubernetesVersion: "1.30"
   managementCluster:
     name: test-cluster
   workerNodeGroupConfigurations:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -64,11 +64,3 @@ func APIServerExtraArgsEnabled() Feature {
 		IsActive: globalFeatures.isActiveForEnvVar(APIServerExtraArgsEnabledEnvVar),
 	}
 }
-
-// K8s130Support is the feature flag for Kubernetes 1.30 support.
-func K8s130Support() Feature {
-	return Feature{
-		Name:     "Kubernetes version 1.30 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s130SupportEnvVar),
-	}
-}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -8,7 +8,6 @@ const (
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
 	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 	APIServerExtraArgsEnabledEnvVar = "API_SERVER_EXTRA_ARGS_ENABLED"
-	K8s130SupportEnvVar             = "K8S_1_30_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -85,11 +85,3 @@ func TestAPIServerExtraArgsEnabledFeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(APIServerExtraArgsEnabledEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(APIServerExtraArgsEnabled())).To(BeTrue())
 }
-
-func TestWithK8s130FeatureFlag(t *testing.T) {
-	g := NewWithT(t)
-	setupContext(t)
-
-	g.Expect(os.Setenv(K8s130SupportEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(K8s130Support())).To(BeTrue())
-}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -265,16 +264,6 @@ func ValidateManagementComponentsVersionSkew(ctx context.Context, k KubectlClien
 
 	if majorVersionDifference != 0 || minorVersionDifference > supportedManagementComponentsMinorVersionIncrement {
 		return fmt.Errorf("management components version %s can only be one minor version greater than cluster version %s", newManagementComponentsSemVer, managementClusterSemVer)
-	}
-	return nil
-}
-
-// ValidateK8s130Support checks if the 1.30 feature flag is set when using k8s 1.30.
-func ValidateK8s130Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s130Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube130 {
-			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube130, features.K8s130SupportEnvVar)
-		}
 	}
 	return nil
 }

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -742,19 +741,4 @@ func TestValidateManagementComponentsVersionSkew(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateK8s130Support(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube130
-	tt.Expect(validations.ValidateK8s130Support(tt.clusterSpec)).To(
-		MatchError(ContainSubstring("kubernetes version 1.30 is not enabled. Please set the env variable K8S_1_30_SUPPORT")))
-}
-
-func TestValidateK8s130SupportActive(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube130
-	features.ClearCache()
-	os.Setenv(features.K8s130SupportEnvVar, "true")
-	tt.Expect(validations.ValidateK8s130Support(tt.clusterSpec)).To(Succeed())
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -7,7 +7,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -48,14 +47,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate cluster's eksaVersion matches EKS-A version",
 				Remediation: "ensure EksaVersion matches the EKS-A release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, v.Opts.CliVersion, v.Opts.Spec),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.30 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s130SupportEnvVar),
-				Err:         validations.ValidateK8s130Support(v.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,7 +9,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -121,14 +120,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate eksa controller is not paused",
 				Remediation: fmt.Sprintf("remove cluster controller reconciler pause annotation %s before upgrading the cluster %s", u.Opts.Spec.Cluster.PausedAnnotation(), targetCluster.Name),
 				Err:         validations.ValidatePauseAnnotation(ctx, k, targetCluster, targetCluster.Name),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.30 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s130SupportEnvVar),
-				Err:         validations.ValidateK8s130Support(u.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -2153,12 +2152,11 @@ func dumpFile(description, path string, t T) {
 func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
 	// Update this variable to equal the feature flagged k8s version when applicable.
 	// For example, if k8s 1.26 is under a feature flag, we would set this to v1alpha1.Kube126
-	unreleasedK8sVersion := v1alpha1.Kube130
+	var unreleasedK8sVersion v1alpha1.KubernetesVersion
 
 	if version == unreleasedK8sVersion {
 		// Set feature flag for the unreleased k8s version when applicable
 		e.T.Logf("Setting k8s version support feature flag...")
-		os.Setenv(features.K8s130SupportEnvVar, "true")
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
This change removes the feature flag for Kubernetes v1.30 support and makes it the default cluster version.

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

