### PR TITLE
Allow downloading private objects from S3

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -235,7 +235,7 @@ func GetArchiveAssets(rc *releasetypes.ReleaseConfig, archive *assettypes.Archiv
 		ProjectPath:       projectPath,
 		SourcedFromBranch: sourcedFromBranch,
 		ImageFormat:       archive.Format,
-		PrivateUpload:     archive.Private,
+		Private:           archive.Private,
 	}
 
 	return archiveArtifact, nil

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -74,7 +74,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		Archives: []*assettypes.Archive{
 			{
 				Name:                "rtos",
-				Format:              "ami",
+				Format:              "raw",
 				OSName:              "ubuntu",
 				OSVersion:           "22.04",
 				ArchiveS3PathGetter: archives.RTOSArtifactPathGetter,

--- a/release/cli/pkg/assets/manifests/manifests.go
+++ b/release/cli/pkg/assets/manifests/manifests.go
@@ -68,7 +68,7 @@ func GetManifestAssets(rc *releasetypes.ReleaseConfig, manifestComponent *assett
 		ProjectPath:       projectPath,
 		SourcedFromBranch: sourcedFromBranch,
 		Component:         componentName,
-		PrivateUpload:     manifestComponent.Private,
+		Private:           manifestComponent.Private,
 	}
 
 	return manifestArtifact, nil

--- a/release/cli/pkg/clients/clients.go
+++ b/release/cli/pkg/clients/clients.go
@@ -41,7 +41,8 @@ type ReleaseClients struct {
 }
 
 type SourceS3Clients struct {
-	Client *s3.S3
+	Client     *s3.S3
+	Downloader *s3manager.Downloader
 }
 
 type ReleaseS3Clients struct {
@@ -88,6 +89,7 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 
 	// S3 client and uploader
 	s3Client := s3.New(pdxSession)
+	downloader := s3manager.NewDownloader(pdxSession)
 	uploader := s3manager.NewUploader(pdxSession)
 
 	// Get source ECR auth config
@@ -107,7 +109,8 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 	// Constructing source clients
 	sourceClients := &SourceClients{
 		S3: &SourceS3Clients{
-			Client: s3Client,
+			Client:     s3Client,
+			Downloader: downloader,
 		},
 		ECR: &SourceECRClient{
 			EcrClient:  ecrClient,
@@ -162,6 +165,7 @@ func CreateStagingReleaseClients() (*SourceClients, *ReleaseClients, error) {
 
 	// Release S3 client and uploader
 	releaseS3Client := s3.New(releaseSession)
+	downloader := s3manager.NewDownloader(releaseSession)
 	uploader := s3manager.NewUploader(releaseSession)
 
 	// Get source ECR auth config
@@ -181,7 +185,8 @@ func CreateStagingReleaseClients() (*SourceClients, *ReleaseClients, error) {
 	// Constructing source clients
 	sourceClients := &SourceClients{
 		S3: &SourceS3Clients{
-			Client: sourceS3Client,
+			Client:     sourceS3Client,
+			Downloader: downloader,
 		},
 		ECR: &SourceECRClient{
 			EcrClient:  ecrClient,
@@ -237,6 +242,7 @@ func CreateProdReleaseClients() (*SourceClients, *ReleaseClients, error) {
 
 	// Release S3 client and uploader
 	releaseS3Client := s3.New(releaseSession)
+	downloader := s3manager.NewDownloader(releaseSession)
 	uploader := s3manager.NewUploader(releaseSession)
 
 	// Get source ECR Public auth config
@@ -256,7 +262,8 @@ func CreateProdReleaseClients() (*SourceClients, *ReleaseClients, error) {
 	// Constructing release clients
 	sourceClients := &SourceClients{
 		S3: &SourceS3Clients{
-			Client: sourceS3Client,
+			Client:     sourceS3Client,
+			Downloader: downloader,
 		},
 		ECR: &SourceECRClient{
 			EcrPublicClient: sourceEcrPublicClient,

--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -180,6 +180,9 @@ func GetEksDReleaseManifestUrl(releaseChannel, releaseNumber string, dev bool) s
 
 // GetNextEksADevBuildNumber computes next eksa dev build number for the current eks-a dev build
 func GetNextEksADevBuildNumber(releaseVersion string, r *releasetypes.ReleaseConfig) (int, error) {
+	if r.DryRun {
+		return 0, nil
+	}
 	tempFileName := "latest-dev-release-version"
 
 	var latestReleaseKey, latestBuildVersion string
@@ -189,8 +192,14 @@ func GetNextEksADevBuildNumber(releaseVersion string, r *releasetypes.ReleaseCon
 	} else {
 		latestReleaseKey = fmt.Sprintf("%s/LATEST_RELEASE_VERSION", r.BuildRepoBranchName)
 	}
-	if s3.KeyExists(r.ReleaseBucket, latestReleaseKey) {
-		err := s3.DownloadFile(tempFileName, r.ReleaseBucket, latestReleaseKey)
+
+	keyExists, err := s3.KeyExists(r.ReleaseClients.S3.Client, r.ReleaseBucket, latestReleaseKey, false)
+	if err != nil {
+		return -1, errors.Cause(err)
+	}
+
+	if keyExists {
+		err := s3.DownloadFile(tempFileName, r.ReleaseBucket, latestReleaseKey, r.SourceClients.S3.Downloader, false)
 		if err != nil {
 			return -1, errors.Cause(err)
 		}

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -92,7 +92,7 @@ func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artif
 	archiveFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName)
 	fmt.Printf("Archive - %s\n", archiveFile)
 	key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName)
-	err := s3.UploadFile(archiveFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.PrivateUpload)
+	err := s3.UploadFile(archiveFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
 	if err != nil {
 		return errors.Cause(err)
 	}
@@ -109,7 +109,7 @@ func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artif
 		checksumFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName) + extension
 		fmt.Printf("Checksum - %s\n", checksumFile)
 		key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName) + extension
-		err := s3.UploadFile(checksumFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.PrivateUpload)
+		err := s3.UploadFile(checksumFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
 		if err != nil {
 			return errors.Cause(err)
 		}
@@ -122,7 +122,7 @@ func handleManifestUpload(_ context.Context, r *releasetypes.ReleaseConfig, arti
 	manifestFile := filepath.Join(artifact.Manifest.ArtifactPath, artifact.Manifest.ReleaseName)
 	fmt.Printf("Manifest - %s\n", manifestFile)
 	key := filepath.Join(artifact.Manifest.ReleaseS3Path, artifact.Manifest.ReleaseName)
-	err := s3.UploadFile(manifestFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Manifest.PrivateUpload)
+	err := s3.UploadFile(manifestFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Manifest.Private)
 	if err != nil {
 		return errors.Cause(err)
 	}

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -77,7 +77,7 @@ type ArchiveArtifact struct {
 	ProjectPath       string
 	SourcedFromBranch string
 	ImageFormat       string
-	PrivateUpload     bool
+	Private           bool
 }
 
 type ImageArtifact struct {
@@ -103,7 +103,7 @@ type ManifestArtifact struct {
 	ProjectPath       string
 	SourcedFromBranch string
 	Component         string
-	PrivateUpload     bool
+	Private           bool
 }
 
 type Artifact struct {

--- a/release/cli/pkg/util/artifacts/artifacts.go
+++ b/release/cli/pkg/util/artifacts/artifacts.go
@@ -23,11 +23,11 @@ import (
 )
 
 func IsObjectNotFoundError(err error) bool {
-	return err.Error() == "requested object not found"
+	return strings.Contains(err.Error(), "requested object not found")
 }
 
 func IsImageNotFoundError(err error) bool {
-	return err.Error() == "requested image not found"
+	return strings.Contains(err.Error(), "requested image not found")
 }
 
 func GetFakeSHA(hashType int) (string, error) {

--- a/release/cli/pkg/util/release/release.go
+++ b/release/cli/pkg/util/release/release.go
@@ -40,7 +40,12 @@ func GetPreviousReleaseIfExists(r *releasetypes.ReleaseConfig) (*anywherev1alpha
 	release := &anywherev1alpha1.Release{}
 	eksAReleaseManifestKey := r.ReleaseManifestFilepath()
 
-	if !s3.KeyExists(r.ReleaseBucket, eksAReleaseManifestKey) {
+	keyExists, err := s3.KeyExists(r.ReleaseClients.S3.Client, r.ReleaseBucket, eksAReleaseManifestKey, false)
+	if err != nil {
+		return nil, fmt.Errorf("checking if object [%s] is present in S3 bucket: %v", eksAReleaseManifestKey, err)
+	}
+
+	if !keyExists {
 		return emptyRelease, nil
 	}
 


### PR DESCRIPTION
This PR adds the logic to download private source artifacts from S3 locally. This is achieved by leveraging the S3 Download Manager which effectively performs a `GetObject` API call on the private object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

