### PR TITLE
Update CLI logging output to be cluster type aware:

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -262,7 +262,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		err = createWorkloadCluster.Run(ctx, clusterSpec, createValidations)
 
 	} else if clusterSpec.Cluster.IsSelfManaged() {
-		logger.Info("Using the new workflow using the controller for management cluster create")
+		logger.V(1).Info("Using the eksa controller to create the management cluster")
 
 		createMgmtCluster := management.NewCreate(
 			deps.Bootstrapper,

--- a/pkg/workflows/management/create_install_eksa.go
+++ b/pkg/workflows/management/create_install_eksa.go
@@ -47,7 +47,7 @@ func (s *installEksaComponentsOnWorkloadTask) Run(ctx context.Context, commandCo
 		commandContext.ClusterSpec.Cluster.ClearTinkerbellIPAnnotation()
 	}
 
-	logger.Info("Installing EKS-A custom components on workload cluster")
+	logger.Info("Installing EKS-A custom components on the management cluster")
 
 	err := installEKSAComponents(ctx, commandContext, commandContext.WorkloadCluster)
 	if err != nil {

--- a/pkg/workflows/management/create_move_capi.go
+++ b/pkg/workflows/management/create_move_capi.go
@@ -18,7 +18,7 @@ func (s *moveClusterManagementTask) Run(ctx context.Context, commandContext *tas
 		return &workflows.CollectDiagnosticsTask{}
 	}
 
-	logger.Info("Moving cluster management from bootstrap to workload cluster")
+	logger.Info("Moving the cluster management components from the bootstrap cluster to the management cluster")
 	err = commandContext.ClusterManager.MoveCAPI(ctx, commandContext.BootstrapCluster, commandContext.WorkloadCluster, commandContext.WorkloadCluster.Name, commandContext.ClusterSpec, types.WithNodeRef())
 	if err != nil {
 		commandContext.SetError(err)

--- a/pkg/workflows/management/create_test.go
+++ b/pkg/workflows/management/create_test.go
@@ -93,6 +93,9 @@ func newCreateTest(t *testing.T) *createTestSetup {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = "test-cluster"
 		s.Cluster.Namespace = "test-ns"
+		s.ManagementCluster = &types.Cluster{
+			Name: "test-cluster",
+		}
 	})
 	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpec.Bundles)
 

--- a/pkg/workflows/management/create_test.go
+++ b/pkg/workflows/management/create_test.go
@@ -93,9 +93,6 @@ func newCreateTest(t *testing.T) *createTestSetup {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = "test-cluster"
 		s.Cluster.Namespace = "test-ns"
-		s.ManagementCluster = &types.Cluster{
-			Name: "test-cluster",
-		}
 	})
 	managementComponents := cluster.ManagementComponentsFromBundles(clusterSpec.Bundles)
 

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -2,7 +2,6 @@ package management
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/logger"
@@ -14,11 +13,7 @@ import (
 type createWorkloadClusterTask struct{}
 
 func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
-	clusterType := "workload"
-	if commandContext.ClusterSpec.Config.Cluster.IsSelfManaged() {
-		clusterType = "management"
-	}
-	logger.Info(fmt.Sprintf("Creating new %s cluster", clusterType))
+	logger.Info("Creating new management cluster")
 
 	commandContext.ClusterSpec.Cluster.AddManagedByCLIAnnotation()
 	commandContext.ClusterSpec.Cluster.SetManagementComponentsVersion(commandContext.ClusterSpec.EKSARelease.Spec.Version)
@@ -50,7 +45,7 @@ func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 		return &workflows.CollectDiagnosticsTask{}
 	}
 
-	logger.Info(fmt.Sprintf("Installing cluster-api providers on %s cluster", clusterType))
+	logger.Info("Installing cluster-api providers on management cluster")
 	managementComponents := cluster.ManagementComponentsFromBundles(commandContext.ClusterSpec.Bundles)
 	err = commandContext.ClusterManager.InstallCAPI(ctx, managementComponents, commandContext.ClusterSpec, commandContext.WorkloadCluster, commandContext.Provider)
 	if err != nil {
@@ -58,7 +53,7 @@ func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *tas
 		return &workflows.CollectDiagnosticsTask{}
 	}
 
-	logger.Info(fmt.Sprintf("Installing EKS-A secrets on %s cluster", clusterType))
+	logger.Info("Installing EKS-A secrets on management cluster")
 	err = commandContext.Provider.UpdateSecrets(ctx, commandContext.WorkloadCluster, commandContext.ClusterSpec)
 	if err != nil {
 		commandContext.SetError(err)

--- a/pkg/workflows/management/create_workload.go
+++ b/pkg/workflows/management/create_workload.go
@@ -15,7 +15,7 @@ type createWorkloadClusterTask struct{}
 
 func (s *createWorkloadClusterTask) Run(ctx context.Context, commandContext *task.CommandContext) task.Task {
 	clusterType := "workload"
-	if commandContext.ClusterSpec.Cluster.Name == commandContext.ClusterSpec.ManagementCluster.Name {
+	if commandContext.ClusterSpec.Config.Cluster.IsSelfManaged() {
 		clusterType = "management"
 	}
 	logger.Info(fmt.Sprintf("Creating new %s cluster", clusterType))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This removes the confusion in the CLI logs when creating a management cluster as the log lines say it's creating a workload cluster. This is a leak of implementation details about how clusters are created. While CAPI calls the initial cluster a workload cluster and then pivots its control plane objects to make it a permanent management cluster this is an implementation detail we shouldn't expose to users. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

