### PR TITLE
Update image-build support for baremental ubutu to uefi mode only

### DIFF
--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -1054,7 +1054,7 @@ The table below shows the possible firmware options for the hypervisor and OS co
 
 |            |       vSphere       |      Baremetal      | CloudStack | Nutanix | Snow |
 |:----------:|:-------------------:|:-------------------:|:----------:|:-------:|:----:|
-| **Ubuntu** | bios (default), efi | bios, efi (default) |    bios    |   bios  | bios |
+| **Ubuntu** | bios (default), efi |         efi         |    bios    |   bios  | bios |
 |  **RHEL**  |         bios        |         bios        |    bios    |   bios  | bios |
 
 ### Mounting additional files


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating this support matrix because it is misleading.

Ubuntu Raw builds only support EFI firmware, when you try to build one with bios enabled says it's not supported . 

```
image-builder@cxbrowne-dev:/home/eksadmin/workplace/cxbrowne-mgmt$ image-builder build --os ubuntu --hypervisor baremetal --release-channel 1-28 --firmware bios
Creating builder config
2024/05/31 14:08:23 Ubuntu Raw builds only support EFI firmware.
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

