### PR TITLE
Fetch latest E2E test AMI ID dynamically

### DIFF
--- a/cmd/integration_test/build/script/create_infra_config.sh
+++ b/cmd/integration_test/build/script/create_infra_config.sh
@@ -17,11 +17,27 @@ set -e
 set -x
 set -o pipefail
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/test/e2e/E2E_AMI_FILTER_VARS
+
+INTEGRATION_TEST_AMI_ID=$(aws ec2 describe-images \
+  --profile ${AWS_PROFILE} \
+  --owners ${AMI_OWNER_ID_FILTER} \
+  --filters "Name=name,Values=${AMI_NAME_FILTER}" "Name=description,Values=${AMI_DESCRIPTION_FILTER}" \
+  --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' \
+  --output text
+)
+
+if [ -z "$INTEGRATION_TEST_AMI_ID" ]; then
+  echo "INTEGRATION_TEST_AMI_ID cannot be empty. Exiting"
+  exit 1
+fi
+
 cat << EOF > ${INTEGRATION_TEST_INFRA_CONFIG}
 ---
 
 ec2:
-  amiId: ${INTEGRATION_TEST_AL2_AMI_ID}
+  amiId: ${INTEGRATION_TEST_AMI_ID}
   subnetId: ${INTEGRATION_TEST_SUBNET_ID}
 
 vSphere:

--- a/test/e2e/E2E_AMI_FILTER_VARS
+++ b/test/e2e/E2E_AMI_FILTER_VARS
@@ -1,0 +1,3 @@
+AMI_OWNER_ID_FILTER=857151390494
+AMI_NAME_FILTER=eksa-integration-test-AL2-*
+AMI_DESCRIPTION_FILTER="*Kernel version 5.X*"


### PR DESCRIPTION
This PR adds the logic to dynamically fetch the latest AMI ID to use for E2E tests. We do this by calling the `DescribeImages` API with filters for the name, description and owner and then getting the latest image by creation time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

