### PR TITLE
Marking packages commands as deprecated

### DIFF
--- a/cmd/eksctl-anywhere/cmd/applypackages.go
+++ b/cmd/eksctl-anywhere/cmd/applypackages.go
@@ -50,6 +50,7 @@ var applyPackagesCommand = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "use `kubectl apply` instead",
 }
 
 func applyPackages(ctx context.Context) error {

--- a/cmd/eksctl-anywhere/cmd/createpackages.go
+++ b/cmd/eksctl-anywhere/cmd/createpackages.go
@@ -50,6 +50,7 @@ var createPackagesCommand = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "use `kubectl apply` instead",
 }
 
 func createPackages(ctx context.Context) error {

--- a/cmd/eksctl-anywhere/cmd/deletepackages.go
+++ b/cmd/eksctl-anywhere/cmd/deletepackages.go
@@ -45,7 +45,8 @@ var deletePackageCommand = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteResources(cmd.Context(), args)
 	},
-	Args: cobra.MinimumNArgs(1),
+	Args:       cobra.MinimumNArgs(1),
+	Deprecated: "use `kubectl delete package` instead",
 }
 
 func deleteResources(ctx context.Context, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/describepackages.go
+++ b/cmd/eksctl-anywhere/cmd/describepackages.go
@@ -47,6 +47,7 @@ var describePackagesCommand = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "use `kubectl describe packages` instead",
 }
 
 func describeResources(ctx context.Context, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/getpackage.go
+++ b/cmd/eksctl-anywhere/cmd/getpackage.go
@@ -49,4 +49,5 @@ var getPackageCommand = &cobra.Command{
 		}
 		return getResources(cmd.Context(), "packages", gpo.output, kubeConfig, gpo.clusterName, gpo.bundlesOverride, args)
 	},
+	Deprecated: "use `kubectl get packages` instead",
 }

--- a/cmd/eksctl-anywhere/cmd/getpackagebundle.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundle.go
@@ -41,4 +41,5 @@ var getPackageBundleCommand = &cobra.Command{
 		}
 		return getResources(cmd.Context(), "packagebundles", gpbo.output, kubeConfig, "", gpbo.bundlesOverride, args)
 	},
+	Deprecated: "use `kubectl get packagebundle` instead",
 }

--- a/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/getpackagebundlecontroller.go
@@ -41,4 +41,5 @@ var getPackageBundleControllerCommand = &cobra.Command{
 		}
 		return getResources(cmd.Context(), "packagebundlecontrollers", gpbco.output, kubeConfig, "", gpbco.bundlesOverride, args)
 	},
+	Deprecated: "use `kubectl get packagebundlecontroller` instead",
 }

--- a/cmd/eksctl-anywhere/cmd/installpackages.go
+++ b/cmd/eksctl-anywhere/cmd/installpackages.go
@@ -64,6 +64,7 @@ var installPackageCommand = &cobra.Command{
 		}
 		return fmt.Errorf("The name of the package to install must be specified as an argument")
 	},
+	Deprecated: "use `kubectl apply` instead",
 }
 
 func runInstallPackages(cmd *cobra.Command, args []string) error {

--- a/cmd/eksctl-anywhere/cmd/upgradepackages.go
+++ b/cmd/eksctl-anywhere/cmd/upgradepackages.go
@@ -55,6 +55,7 @@ var upgradePackagesCommand = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "refer to `https://anywhere.eks.amazonaws.com/docs/packages/packagebundles` for upgrading",
 }
 
 func upgradePackages(ctx context.Context) error {

--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -57,10 +57,7 @@ eksa-packages   mgmt   v1-27-125     active
 eksa-packages   w01    v1-27-125     active 
 ```
 
-Use the EKS Anywhere packages CLI to upgrade the active package bundle of the target cluster. This command can also be used to downgrade to a previous package bundle version.
+To upgrade the active package bundle for the target cluster, edit the `packagebundlecontroller` object on the cluster and set the `activeBundle` field to the new bundle number that is available.
 ```
-export CLUSTER_NAME=mgmt
-eksctl anywhere upgrade packages --bundle-version v1-27-126 --cluster $CLUSTER_NAME
+kubectl edit packagebundlecontroller <cluster name> -n eksa-packages
 ```
-
-


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2270*

*Description of changes:*
As described in the issue we want to mark packages commands as deprecated. For release v0.20.0 the commands are still present and in the next release we would remove the commands themselves.

*Documentation added/planned:*
Will update the docs and call out that these commands are not supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

