### PR TITLE
Update Docker test name for presubmit E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,14 @@ endif
 
 ifeq (,$(findstring $(BRANCH_NAME),main))
 ## use the branch-specific bundle manifest if the branch is not 'main'
-BUNDLE_MANIFEST_URL?=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/${BRANCH_NAME}/bundle-release.yaml
 RELEASE_MANIFEST_URL?=$(RELEASE_MANIFEST_HOST)/${BRANCH_NAME}/eks-a-release.yaml
 LATEST=$(BRANCH_NAME)
 else
 ## use the standard bundle manifest if the branch is 'main'
-BUNDLE_MANIFEST_URL?=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml
 RELEASE_MANIFEST_URL?=$(RELEASE_MANIFEST_HOST)/eks-a-release.yaml
 LATEST=latest
 endif
+BUNDLE_MANIFEST_URL?=$(shell curl $(RELEASE_MANIFEST_URL) | yq ".spec.releases[-1].bundleManifestUrl")
 
 # DEV_GIT_VERSION should be something like v0.19.0-dev+latest, depending on the base branch
 # and if this is a local build or a CI build.
@@ -160,7 +159,7 @@ EKS_A_CROSS_PLATFORMS := $(foreach platform,$(EKS_A_PLATFORMS),eks-a-cross-platf
 E2E_CROSS_PLATFORMS := $(foreach platform,$(EKS_A_PLATFORMS),e2e-cross-platform-$(platform))
 EKS_A_RELEASE_CROSS_PLATFORMS := $(foreach platform,$(EKS_A_PLATFORMS),eks-a-release-cross-platform-$(platform))
 
-DOCKER_E2E_TEST := TestDockerKubernetes125SimpleFlow
+DOCKER_E2E_TEST := TestDockerKubernetes130SimpleFlow
 LOCAL_E2E_TESTS ?= $(DOCKER_E2E_TEST)
 
 EMBED_CONFIG_FOLDER = pkg/files/config

--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -36,7 +36,7 @@ fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 BIN_FOLDER=$REPO_ROOT/bin
-TEST_REGEX="${1:-TestDockerKubernetes125SimpleFlow}"
+TEST_REGEX="${1:-TestDockerKubernetes130SimpleFlow}"
 BRANCH_NAME="${2:-main}"
 
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -11,8 +11,8 @@ or
 #
 # The makefile will include the .env file and export all the vars to the environment for you
 #
-# By default the local-e2e target will run TestDockerKubernetes125SimpleFlow. You can either 
-#   override LOCAL_E2E_TESTS in your .env file or pass it on the cli every time (i.e LOCAL_E2E_TESTS=TestDockerKubernetes125SimpleFlow)
+# By default the local-e2e target will run TestDockerKubernetes130SimpleFlow. You can either 
+#   override LOCAL_E2E_TESTS in your .env file or pass it on the cli every time (i.e LOCAL_E2E_TESTS=TestDockerKubernetes130SimpleFlow)
 make local-e2e
 ```
 or


### PR DESCRIPTION
Ever since `TestDockerKubernetes125SimpleFlow` was removed from the codebase, no E2E tests have actually been running in presubmits, since the compiled E2E binary would not contain the test that it was being asked to run. This PR updates this to run the Kubernetes 1.30 Docker test which is a part of the test suite.

This PR also updates the bundle manifest URL defined in the Makefile. The URL hardcoded before is the old endpoint which we stopped updating a few months ago. We are now fetching it dynamically from the corresponding release manifest URL, which itself is also dynamically constructed based on the branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

