### PR TITLE
Cleanup duplicate code in curated packages and rename function

### DIFF
--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -13,7 +13,7 @@ func runAutoscalerWithMetricsServerSimpleFlow(test *framework.ClusterE2ETest) {
 		metricServerName := "metrics-server"
 		targetNamespace := "eksa-packages"
 		test.InstallAutoScalerWithMetricServer(targetNamespace)
-		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
+		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withCluster(test))
 	})
 }
 
@@ -25,7 +25,7 @@ func runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test *framework.ClusterE
 	metricServerName := "metrics-server"
 	targetNamespace := "eksa-packages"
 	test.InstallAutoScalerWithMetricServer(targetNamespace)
-	test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withMgmtCluster(test))
+	test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withCluster(test))
 	test.DeleteCluster()
 	test.ValidateHardwareDecommissioned()
 }

--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -4,12 +4,9 @@
 package e2e
 
 import (
-	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
-	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -30,18 +27,11 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		packagePrefix := "test"
 		packageFile := e.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)
 		test.ManagementCluster.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ManagementCluster.ClusterName))
-		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withMgmtClusterSetup(test.ManagementCluster))
-		e.CleanupCerts(withMgmtClusterSetup(test.ManagementCluster))
+		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withCluster(test.ManagementCluster))
+		e.CleanupCerts(withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()
 		e.ValidateClusterDelete()
 	})
 	time.Sleep(5 * time.Minute)
 	test.DeleteManagementCluster()
-}
-
-func withMgmtClusterSetup(cluster *framework.ClusterE2ETest) *types.Cluster {
-	return &types.Cluster{
-		Name:           cluster.ClusterName,
-		KubeconfigFile: filepath.Join(cluster.ClusterName, fmt.Sprintf("%s-eks-a-cluster.kubeconfig", cluster.ClusterName)),
-	}
 }

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -33,7 +33,7 @@ func runCuratedPackageInstall(test *framework.ClusterE2ETest) {
 	packagePrefix := "test"
 	packageFile := test.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)
 	test.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ClusterName))
-	test.VerifyHelloPackageInstalled(packagePrefix+"-"+packageName, withMgmtCluster(test))
+	test.VerifyHelloPackageInstalled(packagePrefix+"-"+packageName, withCluster(test))
 }
 
 func runCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) {
@@ -65,7 +65,7 @@ func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.Multicluste
 		packagePrefix := "test"
 		packageFile := e.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)
 		test.ManagementCluster.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ManagementCluster.ClusterName))
-		e.VerifyHelloPackageInstalled(packagePrefix+"-"+packageName, withMgmtCluster(test.ManagementCluster))
+		e.VerifyHelloPackageInstalled(packagePrefix+"-"+packageName, withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()
 		e.ValidateClusterDelete()
 	})
@@ -219,7 +219,7 @@ func packageBundleURI(version v1alpha1.KubernetesVersion) string {
 	return fmt.Sprintf("%s:%s", EksaPackageBundleURI, tag)
 }
 
-func withMgmtCluster(cluster *framework.ClusterE2ETest) *types.Cluster {
+func withCluster(cluster *framework.ClusterE2ETest) *types.Cluster {
 	return &types.Cluster{
 		Name:           cluster.ClusterName,
 		KubeconfigFile: filepath.Join(cluster.ClusterName, fmt.Sprintf("%s-eks-a-cluster.kubeconfig", cluster.ClusterName)),

--- a/test/e2e/emissary.go
+++ b/test/e2e/emissary.go
@@ -20,9 +20,9 @@ func runCuratedPackageEmissaryInstall(test *framework.ClusterE2ETest) {
 	test.SetPackageBundleActive()
 	packageFile := test.BuildPackageConfigFile(emissaryPackageName, emissaryPackagePrefix, EksaPackagesNamespace)
 	test.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ClusterName))
-	test.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withMgmtCluster(test))
+	test.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withCluster(test))
 	if test.Provider.Name() == constants.DockerProviderName {
-		test.TestEmissaryPackageRouting(emissaryPackagePrefix+"-"+emissaryPackageName, "hello", withMgmtCluster(test))
+		test.TestEmissaryPackageRouting(emissaryPackagePrefix+"-"+emissaryPackageName, "hello", withCluster(test))
 	}
 }
 
@@ -41,7 +41,7 @@ func runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test *framework.Mul
 		test.ManagementCluster.SetPackageBundleActive()
 		packageFile := e.BuildPackageConfigFile(emissaryPackageName, emissaryPackagePrefix, EksaPackagesNamespace)
 		test.ManagementCluster.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ManagementCluster.ClusterName))
-		e.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withMgmtCluster(test.ManagementCluster))
+		e.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()
 		e.ValidateClusterDelete()
 	})


### PR DESCRIPTION
*Description of changes:*
This PR cleans up the same function used for different packages in e2e tests and renames it for better clarity.

*Testing (if applicable):*
make eks-a, make lint, make unit-test, make e2e-cross-platform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

