### PR TITLE
Update docs to make worker nodes count optional

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/bare-spec.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-spec.md
@@ -185,7 +185,7 @@ You can omit `workerNodeGroupConfigurations` when creating Bare Metal clusters. 
 >**_NOTE:_** Empty `workerNodeGroupConfigurations` is not supported when Kubernetes version <= 1.21.
 
 ### workerNodeGroupConfigurations[*].count (optional)
-Number of worker nodes. Optional if autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
+Number of worker nodes. (default: `1`) Optional if autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
 
 Refers to [troubleshooting machine health check remediation not allowed]({{< relref "../../troubleshooting/troubleshooting/#machine-health-check-shows-remediation-is-not-allowed" >}}) and choose a sufficient number to allow machine health check remediation.
 

--- a/docs/content/en/docs/getting-started/cloudstack/cloud-spec.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloud-spec.md
@@ -235,8 +235,8 @@ If this is a standalone cluster or if it were serving as the management cluster 
 This takes in a list of node groups that you can define for your workers.
 You may define one or more worker node groups.
 
-### workerNodeGroupConfigurations[*].count (required)
-Number of worker nodes. Optional if autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
+### workerNodeGroupConfigurations[*].count (optional)
+Number of worker nodes. (default: `1`) Optional if autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
 
 Refers to [troubleshooting machine health check remediation not allowed]({{< relref "../../troubleshooting/troubleshooting/#machine-health-check-shows-remediation-is-not-allowed" >}}) and choose a sufficient number to allow machine health check remediation.
 

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
@@ -190,8 +190,8 @@ creation process are [here]({{< relref "./nutanix-prereq/#prepare-a-nutanix-envi
 ### workerNodeGroupConfigurations (required)
 This takes in a list of node groups that you can define for your workers. You may define one or more worker node groups.
 
-### workerNodeGroupConfigurations[*].count (required)
-Number of worker nodes. Optional if `autoscalingConfiguration` is used, in which case count will default to `autoscalingConfiguration.minCount`.
+### workerNodeGroupConfigurations[*].count (optional)
+Number of worker nodes. (default: `1`) Optional if `autoscalingConfiguration` is used, in which case count will default to `autoscalingConfiguration.minCount`.
 
 Refers to [troubleshooting machine health check remediation not allowed]({{< relref "../../troubleshooting/troubleshooting/#machine-health-check-shows-remediation-is-not-allowed" >}}) and choose a sufficient number to allow machine health check remediation.
 

--- a/docs/content/en/docs/getting-started/snow/snow-spec.md
+++ b/docs/content/en/docs/getting-started/snow/snow-spec.md
@@ -147,8 +147,8 @@ the existing nodes.
 This takes in a list of node groups that you can define for your workers.
 You may define one or more worker node groups.
 
-### workerNodeGroupConfigurations[*].count (required)
-Number of worker nodes. Optional if autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
+### workerNodeGroupConfigurations[*].count (optional)
+Number of worker nodes. (default: `1`) Optional if autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
 
 Refers to [troubleshooting machine health check remediation not allowed]({{< relref "../../troubleshooting/troubleshooting/#machine-health-check-shows-remediation-is-not-allowed" >}}) and choose a sufficient number to allow machine health check remediation.
 

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-spec.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-spec.md
@@ -51,7 +51,7 @@ spec:
         name: my-cluster-machines
    kubernetesVersion: <span>"1.25"</span>         <a href="#kubernetesversion-required"># Kubernetes version to use for the cluster (required)</a>
    workerNodeGroupConfigurations:    <a href="#workernodegroupconfigurations-required"># List of node groups you can define for workers (required) </a>
-   - count: <span style="color:green">2</span>                        <a href="#workernodegroupconfigurationscount-required"># Number of worker nodes </a>
+   - count: <span style="color:green">2</span>                        <a href="#workernodegroupconfigurationscount-optional"># Number of worker nodes </a>
      machineGroupRef:                <a href="#workernodegroupconfigurationsmachinegroupref-required"># vSphere-specific Kubernetes node objects (required) </a>
        kind: VSphereMachineConfig
        name: my-cluster-machines
@@ -159,8 +159,8 @@ the existing nodes.
 This takes in a list of node groups that you can define for your workers.
 You may define one or more worker node groups.
 
-### workerNodeGroupConfigurations[*].count (required)
-Number of worker nodes. Optional if the [cluster autoscaler curated package]({{< relref "../../packages/cluster-autoscaler/addclauto" >}}) is installed and autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
+### workerNodeGroupConfigurations[*].count (optional)
+Number of worker nodes. (default: `1`) Optional if the [cluster autoscaler curated package]({{< relref "../../packages/cluster-autoscaler/addclauto" >}}) is installed and autoscalingConfiguration is used, in which case count will default to `autoscalingConfiguration.minCount`.
 
 Refers to [troubleshooting machine health check remediation not allowed]({{< relref "../../troubleshooting/troubleshooting/#machine-health-check-shows-remediation-is-not-allowed" >}}) and choose a sufficient number to allow machine health check remediation.
 


### PR DESCRIPTION
*Description of changes:*
Updated docs to change the worker nodes count field from "required" to "optional" and specifying the default value as 1.

*Testing (if applicable):*
make build

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

