### PR TITLE
Provide link to bottlerocket for bare metal deprecation notice

### DIFF
--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -17,7 +17,7 @@ EKS Anywhere supports three different node operating systems:
 Bottlerocket OVAs and images are distributed by the EKS Anywhere project.
 To build your own Ubuntu-based or RHEL-based EKS Anywhere node, see [Building node images]({{< relref "#building-node-images">}}).
 
-**_NOTE:_** [Starting with the v0.19 EKS Anywhere release, we are deprecating Bottlerocket support for bare metal](https://github.com/aws/eks-anywhere/issues/7754) )
+**_NOTE:_** [Starting with the v0.19 EKS Anywhere release, we are deprecating Bottlerocket support for bare metal](https://github.com/aws/eks-anywhere/issues/7754)
 
 ## Prerequisites
 

--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -17,6 +17,8 @@ EKS Anywhere supports three different node operating systems:
 Bottlerocket OVAs and images are distributed by the EKS Anywhere project.
 To build your own Ubuntu-based or RHEL-based EKS Anywhere node, see [Building node images]({{< relref "#building-node-images">}}).
 
+**_NOTE:_** [Starting with the v0.19 EKS Anywhere release, we are deprecating Bottlerocket support for bare metal](https://github.com/aws/eks-anywhere/issues/7754) )
+
 ## Prerequisites
 
 Several code snippets on this page use `curl` and `yq` commands. Refer to the [Tools section]({{< relref "../getting-started/install/#tools" >}}) to learn how to install them.
@@ -33,6 +35,7 @@ EKS Anywhere does not distribute Ubuntu or RHEL OS images.
 However, see [Building node images]({{< relref "#building-node-images">}}) for information on how to build EKS Anywhere images from those Linux distributions.  Note:  if you utilize your Admin Host to build images, you will need to review  the DHCP integration provided by Libvirtd and ensure it is disabled.  If the Libvirtd DHCP is enabled, the "boots container" will detect a port conflict and terminate.
 
 ### Bottlerocket OS images for Bare Metal
+**_NOTE:_** [Starting with the v0.19 EKS Anywhere release, we are deprecating Bottlerocket support for bare metal](https://github.com/aws/eks-anywhere/issues/7754) )
 
 Bottlerocket vends its Baremetal variant Images using a secure distribution tool called `tuftool`. Please refer to [Download Bottlerocket node images]({{< relref "#download-bottlerocket-node-images">}}) to download Bottlerocket image. You can also get the download URIs for Bottlerocket Baremetal images from the bundle release by running the following commands:
 


### PR DESCRIPTION

*Issue #, if available:*
Provide link to bottlerocket for bare metal deprecation notice

 @csplinter posted that bottlerocket is being deprecated as a supported method for bare metal as of EKS-A v0.19 (2024-02-29)
 The EKS-A documentation should also reflect that change.  Bottlerocket is still viable for previous versions which are still supported, therefore references to bottlerocket and bare metal should not yet be removed - and instead just provide guidance for the change.

*Description of changes:*
Provide a link to the github issue #7754 to guide the reader 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

