### PR TITLE
Shuffle hardware inventory for tinkerbell before reservation

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"regexp"
 	"sort"
@@ -217,6 +218,9 @@ func RunTests(conf instanceRunConf, inventoryCatalogue map[string]*hardwareCatal
 		} else {
 			hardwareCatalogue = inventoryCatalogue[nonAirgappedHardware]
 		}
+		conf.Logger.Info("Shuffling hardware inventory for tinkerbell")
+		// shuffle hardware to introduce randomness during hardware reservation.
+		shuffleHardwareInventory(hardwareCatalogue)
 		err = reserveTinkerbellHardware(&conf, hardwareCatalogue)
 		if err != nil {
 			return "", nil, err
@@ -591,4 +595,11 @@ func logTinkerbellTestHardwareInfo(conf *instanceRunConf, action string) {
 		hardwareInfo = append(hardwareInfo, hardware.Hostname)
 	}
 	conf.Logger.V(1).Info(action+" hardware for TestRunner", "hardwarePool", strings.Join(hardwareInfo, ", "))
+}
+
+func shuffleHardwareInventory(invCatalogue *hardwareCatalogue) {
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	random.Shuffle(len(invCatalogue.hws), func(i, j int) {
+		invCatalogue.hws[i], invCatalogue.hws[j] = invCatalogue.hws[j], invCatalogue.hws[i]
+	})
 }

--- a/internal/test/e2e/tinkerbell_hardware_queue.go
+++ b/internal/test/e2e/tinkerbell_hardware_queue.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -39,6 +40,15 @@ func (hwQu *hardwareCatalogue) reserveHardware(count int) ([]*api.Hardware, erro
 func (hwQu *hardwareCatalogue) releaseHardware(hws []*api.Hardware) {
 	hwQu.mu.Lock()
 	hwQu.hws = append(hwQu.hws, hws...)
+	hwQu.mu.Unlock()
+}
+
+func (hwQu *hardwareCatalogue) shuffleHardware() {
+	hwQu.mu.Lock()
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	random.Shuffle(len(hwQu.hws), func(i, j int) {
+		hwQu.hws[i], hwQu.hws[j] = hwQu.hws[j], hwQu.hws[i]
+	})
 	hwQu.mu.Unlock()
 }
 


### PR DESCRIPTION
*Description of changes:*
Shuffle hardware inventory before reserving hardware for Tinkerbell E2E tests. As we run quick e2e more frequently the boot entries on the boot list get populated quickly leading to an error when there's no space left to add to that boot list. Ideally we should have an automation around removing the boot entries periodically on the BMCs but until then we should try reserving the hardware  in random order for quick test to not burden the boot entries on the first few hardware. Also, with randomness we reduce the likelihood of picking up an erroneous hardware in case during repetitive quick E2E runs.

*Testing (if applicable):*
Kicked of [run](https://tiny.amazon.com/10c5mxgd8/IsenLink) against my branch and verified that the hardware reserved for the test were different from the regular hardware (`eksa-ci01 to eksa-ci12`) that gets reserved at present. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

