### PR TITLE
BR limited settings validations for Kubelet configuration

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -554,14 +554,14 @@ func validateWorkerNodeKubeletConfiguration(clusterConfig *Cluster) error {
 	return nil
 }
 
-func validateKubeletConfiguration(eksakubeconfig *unstructured.Unstructured) error {
-	if eksakubeconfig == nil {
+func validateKubeletConfiguration(kubeletConfig *unstructured.Unstructured) error {
+	if kubeletConfig == nil {
 		return nil
 	}
 
-	var kubeletConfig v1beta1.KubeletConfiguration
+	var kubeletConfiguration v1beta1.KubeletConfiguration
 
-	kcString, err := yaml.Marshal(eksakubeconfig)
+	kcString, err := yaml.Marshal(kubeletConfig)
 	if err != nil {
 		return err
 	}
@@ -571,12 +571,12 @@ func validateKubeletConfiguration(eksakubeconfig *unstructured.Unstructured) err
 		return fmt.Errorf("unmarshaling the yaml, malformed yaml %v", err)
 	}
 
-	err = yaml.UnmarshalStrict(kcString, &kubeletConfig)
+	err = yaml.UnmarshalStrict(kcString, &kubeletConfiguration)
 	if err != nil {
 		return fmt.Errorf("unmarshaling KubeletConfiguration for %v", err)
 	}
 
-	if _, ok := eksakubeconfig.Object["providerID"]; ok {
+	if _, ok := kubeletConfig.Object["providerID"]; ok {
 		return errors.New("can not override providerID or cloudProvider (set by EKS Anywhere)")
 	}
 

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/internal/test"
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -34,7 +34,7 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 		KubeconfigFile: "kubeconfig",
 	}
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
+		s.Cluster.Spec.GitOpsRef = &anywherev1.Ref{
 			Name: "gitops",
 		}
 	})
@@ -69,12 +69,12 @@ func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
 	tt.c.Opts.ManagementCluster.Name = mgmtClusterName
 	version := test.DevEksaVersion()
 
-	mgmt := &v1alpha1.Cluster{
+	mgmt := &anywherev1.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "mgmt-cluster",
 		},
-		Spec: v1alpha1.ClusterSpec{
-			ManagementCluster: v1alpha1.ManagementCluster{
+		Spec: anywherev1.ClusterSpec{
+			ManagementCluster: anywherev1.ManagementCluster{
 				Name: "mgmt-cluster",
 			},
 			BundlesRef: &anywherev1.BundlesRef{
@@ -82,6 +82,38 @@ func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
 				Namespace: constants.EksaSystemNamespace,
 			},
 			EksaVersion: &version,
+			ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+				KubeletConfiguration: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"staticPodPath": "path",
+					},
+				},
+			},
+		},
+	}
+
+	tt.c.Opts.Spec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef = &anywherev1.Ref{
+		Name: "cpRef",
+	}
+	tt.c.Opts.Spec.VSphereMachineConfigs = map[string]*anywherev1.VSphereMachineConfig{
+		"cpRef": {
+			Spec: anywherev1.VSphereMachineConfigSpec{
+				OSFamily: anywherev1.Bottlerocket,
+			},
+		},
+	}
+
+	tt.c.Opts.Spec.Cluster.Spec.WorkerNodeGroupConfigurations = []anywherev1.WorkerNodeGroupConfiguration{
+		{
+			MachineGroupRef: &anywherev1.Ref{
+				Name: "wnRef",
+			},
+		},
+	}
+
+	tt.c.Opts.Spec.VSphereMachineConfigs["wnRef"] = &anywherev1.VSphereMachineConfig{
+		Spec: anywherev1.VSphereMachineConfigSpec{
+			OSFamily: anywherev1.Bottlerocket,
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
BR limited settings validations for Kubelet configuration. Bottlerocket only supports a subset of settings for Kubelet Configuration. This PR validates and makes sure that only those are configured in the cluster when Bottlerocket is being used. This PR includes preflights for CLI. Another PR will be created for controller validations.

*Testing (if applicable):*
- unit test
- E2E test

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

