### PR TITLE
Adding airgap support for list packages command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatepackage.go
+++ b/cmd/eksctl-anywhere/cmd/generatepackage.go
@@ -58,10 +58,6 @@ var generatePackageCommand = &cobra.Command{
 
 func runGeneratePackages(cmd *cobra.Command, args []string) error {
 	clusterName := gpOptions.clusterName
-	if len(gpOptions.kubeVersion) > 0 {
-		// allow both
-		clusterName = ""
-	}
 	if err := curatedpackages.ValidateKubeVersion(gpOptions.kubeVersion, clusterName); err != nil {
 		return err
 	}

--- a/pkg/curatedpackages/validations.go
+++ b/pkg/curatedpackages/validations.go
@@ -6,18 +6,16 @@ import (
 )
 
 func ValidateKubeVersion(kubeVersion string, clusterName string) error {
-	if len(clusterName) > 0 {
-		if len(kubeVersion) > 0 {
-			return fmt.Errorf("please specify either kube-version or cluster name not both")
-		}
-		return nil
-	}
-
 	if len(kubeVersion) > 0 {
 		versionSplit := strings.Split(kubeVersion, ".")
 		if len(versionSplit) != 2 {
 			return fmt.Errorf("please specify kube-version as <major>.<minor>")
 		}
+		return nil
+	}
+
+	if len(clusterName) > 0 {
+		// no-op since either cluster name or kube-version is needed.
 		return nil
 	}
 	return fmt.Errorf("please specify kube-version or cluster name")

--- a/pkg/curatedpackages/validations_test.go
+++ b/pkg/curatedpackages/validations_test.go
@@ -13,13 +13,6 @@ func TestValidateNoKubeVersionWhenClusterSucceeds(t *testing.T) {
 	}
 }
 
-func TestValidateKubeVersionWhenClusterFails(t *testing.T) {
-	err := curatedpackages.ValidateKubeVersion("1.21", "morby")
-	if err == nil {
-		t.Errorf("not both kube-version and cluster")
-	}
-}
-
 func TestValidateKubeVersionWhenNoClusterFails(t *testing.T) {
 	err := curatedpackages.ValidateKubeVersion("", "")
 	if err == nil {


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere-internal/issues/2270*

*Description of changes:*
Added support for `list packages` in an air gapped admin env.

*Testing:*
```bash
./eksctl anywhere list packages --cluster airgap-cluster  --bundles-override ./release-bundle.yaml -v6

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

