### PR TITLE
Adding logic to apply new hardware on tink upgrades

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -1554,7 +1554,7 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorApplyHardware(t *testing.T) 
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
-	cluster := &types.Cluster{Name: "test"}
+	cluster := &types.Cluster{Name: "management-cluster"}
 	forceCleanup := false
 
 	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
@@ -1591,7 +1591,7 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorBMC(t *testing.T) {
 	kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
 	stackInstaller := stackmocks.NewMockStackInstaller(mockCtrl)
 	writer := filewritermocks.NewMockFileWriter(mockCtrl)
-	cluster := &types.Cluster{Name: "test"}
+	cluster := &types.Cluster{Name: "management-cluster"}
 	forceCleanup := false
 
 	clusterSpec := givenClusterSpec(t, clusterSpecManifest)
@@ -2128,6 +2128,12 @@ func TestTinkerbellProvider_GenerateCAPISpecForUpgrade_RegistryMirror(t *testing
 	kubectl.EXPECT().
 		GetMachineDeployment(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(machineDeployment, nil)
+	kubectl.EXPECT().
+		ApplyKubeSpecFromBytesForce(ctx, cluster, gomock.Any()).
+		Return(nil)
+	kubectl.EXPECT().
+		WaitForRufioMachines(ctx, cluster, "5m", "Contactable", gomock.Any()).
+		Return(nil)
 
 	provider := newProvider(datacenterConfig, machineConfigs, updatedClusterSpec.Cluster, writer, docker, helm, kubectl, false)
 	provider.stackInstaller = stackInstaller
@@ -2305,6 +2311,12 @@ func TestTinkerbellProvider_GenerateCAPISpecForUpgrade_CertBundles(t *testing.T)
 	kubectl.EXPECT().
 		GetMachineDeployment(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(machineDeployment, nil)
+	kubectl.EXPECT().
+		ApplyKubeSpecFromBytesForce(ctx, cluster, gomock.Any()).
+		Return(nil)
+	kubectl.EXPECT().
+		WaitForRufioMachines(ctx, cluster, "5m", "Contactable", gomock.Any()).
+		Return(nil)
 
 	provider := newProvider(datacenterConfig, machineConfigs, updatedClusterSpec.Cluster, writer, docker, helm, kubectl, false)
 	provider.stackInstaller = stackInstaller


### PR DESCRIPTION
*Issue https://github.com/aws/eks-anywhere/issues/8190:*

*Description of changes:*
In previous EKSA upgrade workflows we had operations that were performed on a bootstrap (KinD cluster) after it came up and after CAPI was installed on it.
https://github.com/aws/eks-anywhere/blob/main/pkg/providers/tinkerbell/upgrade.go#L186
https://github.com/aws/eks-anywhere/blob/main/pkg/providers/tinkerbell/upgrade.go#L208

Now looks like these are getting skipped since we have removed the KinD cluster requirement for upgrading. That lead to the above issue. These changes add back the steps for management and workload cluster upgrades. 

*Testing:*
```
./eksctl-anywhere upgrade cluster -f ./cluster.yaml -z ./new-node0102.csv
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

