### PR TITLE
Fix Kubernetes version and template version for TestVSphereKubernetes130AWSIamAuth test

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -182,9 +182,9 @@ func TestVSphereKubernetes129AWSIamAuth(t *testing.T) {
 func TestVSphereKubernetes130AWSIamAuth(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
-		framework.NewVSphere(t, framework.WithUbuntu125()),
+		framework.NewVSphere(t, framework.WithUbuntu130()),
 		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube125)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
 	)
 	runAWSIamAuthFlow(test)
 }


### PR DESCRIPTION
Update Kubernetes Version and template version to 1.30 for `TestVSphereKubernetes130AWSIamAuth` E2E test.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

