### PR TITLE
Bumping go patch version in go mod for release/cli

### DIFF
--- a/release/cli/go.mod
+++ b/release/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-anywhere/release/cli
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/aws/aws-sdk-go v1.53.19


### PR DESCRIPTION
*Description of changes:*
Vulnerability checks were failing on release/cli. Example github action https://github.com/aws/eks-anywhere/actions/runs/9475742609/job/26107520278?pr=8293

*Testing:*
```
govulncheck -C ./release/cli -format text ./...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

