### PR TITLE
Revert "Update README.md conformance notification"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Full documentation for releases can be found on [https://anywhere.eks.amazonaws.
 <!-- 
 Source: https://github.com/cncf/artwork/tree/master/projects/kubernetes/certified-kubernetes
 -->
+[<img src="docs/static/images/certified-kubernetes-1.25-pantone.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/2454)
 [<img src="docs/static/images/certified-kubernetes-1.26-pantone.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/2531)
 [<img src="docs/static/images/certified-kubernetes-1.27-pantone.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/2636)
-[<img src="docs/static/images/certified-kubernetes-1.28-pantone.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/2865)
 
 ## Development
 


### PR DESCRIPTION
Reverts https://github.com/aws/eks-anywhere/pull/8145 because k8s v1.28 logos are missing
Related issue: https://github.com/cncf/artwork/issues/457