### PR TITLE
Update new CAPI tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ replace (
 	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/service/snowballdevice => ./internal/aws-sdk-go-v2/service/snowballdevice
 
 	// need the modifications eksa made to the capi api structs
-	sigs.k8s.io/cluster-api => github.com/abhay-krishna/cluster-api v1.6.0-eksa.1
+	sigs.k8s.io/cluster-api => github.com/abhay-krishna/cluster-api v1.6.0-eksa.2
 
 	// Temporary until capc is updated to use a newer version of cluster-api and thus
 	// a new version of controller-runtime.

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230 h1:t95Grn2
 github.com/VictorLowther/simplexml v0.0.0-20180716164440-0bff93621230/go.mod h1:t2EzW1qybnPDQ3LR/GgeF0GOzHUXT5IVMLP2gkW1cmc=
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0NcthLKCljZHe1mxlN6oahCQHHThnSwB4=
 github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22/go.mod h1:/B7V22rcz4860iDqstGvia/2+IYWXf3/JdQCVd/1D2A=
-github.com/abhay-krishna/cluster-api v1.6.0-eksa.1 h1:6lMCyOdl+DmsC92OfvazDrdRoORIriXinNj7c00pqJg=
-github.com/abhay-krishna/cluster-api v1.6.0-eksa.1/go.mod h1:LB7u/WxiWj4/bbpHNOa1oQ8nq0MQ5iYlD0pGfRSBGLI=
+github.com/abhay-krishna/cluster-api v1.6.0-eksa.2 h1:1bv3j/+SONI2ipcVr7vd2rKoqFb+AFyYpOozYB7xZ20=
+github.com/abhay-krishna/cluster-api v1.6.0-eksa.2/go.mod h1:LB7u/WxiWj4/bbpHNOa1oQ8nq0MQ5iYlD0pGfRSBGLI=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.1.0 h1:n6qGwyHG61v3ABce1rPVZklEYRT8NFpCMrpZdBUbYGM=
 github.com/agnivade/levenshtein v1.1.0/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update new CAPI tag for https://github.com/abhay-krishna/cluster-api/tree/v1.6.0-eksa.2
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

