### PR TITLE
Log ssm command details when an e2e test finishes

### DIFF
--- a/internal/pkg/ssm/run_output.go
+++ b/internal/pkg/ssm/run_output.go
@@ -20,3 +20,8 @@ func buildRunOutput(commandOut *ssm.GetCommandInvocationOutput) *RunOutput {
 func (r *RunOutput) Successful() bool {
 	return *r.commandOut.Status == ssm.CommandInvocationStatusSuccess
 }
+
+// StatusDetails returns the status details of the ssm command.
+func (r *RunOutput) StatusDetails() string {
+	return *r.commandOut.StatusDetails
+}

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -172,6 +172,7 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 			"completedInstances", completedInstances,
 			"totalInstances", totalInstances,
 			"succeeded", succeeded,
+			"ssmStatusDetails", r.testCommandResult.StatusDetails(),
 		)
 		putInstanceTestResultMetrics(r)
 	}


### PR DESCRIPTION
*Issue #, if available:* E2E test runner can quit unexpectedly, leaving no track to debug.

*Description of changes:* Log ssm status details which could explain why a test runner quitted. 

From AWS SDK doc: 
```
StatusDetails can be one of the following values:

Pending: The command hasn't been sent to the managed node.

In Progress: The command has been sent to the managed node but hasn't reached a terminal state.

Delayed: The system attempted to send the command to the target, but the target wasn't available. The managed node might not be available because of network issues, because the node was stopped, or for similar reasons. The system will try to send the command again.

Success: The command or plugin ran successfully. This is a terminal state.

Delivery Timed Out: The command wasn't delivered to the managed node before the delivery timeout expired. Delivery timeouts don't count against the parent command's MaxErrors limit, but they do contribute to whether the parent command status is Success or Incomplete. This is a terminal state.

Execution Timed Out: The command started to run on the managed node, but the execution wasn't complete before the timeout expired. Execution timeouts count against the MaxErrors limit of the parent command. This is a terminal state.

Failed: The command wasn't run successfully on the managed node. For a plugin, this indicates that the result code wasn't zero. For a command invocation, this indicates that the result code for one or more plugins wasn't zero. Invocation failures count against the MaxErrors limit of the parent command. This is a terminal state.

Cancelled: The command was terminated before it was completed. This is a terminal state.

Undeliverable: The command can't be delivered to the managed node. The node might not exist or might not be responding. Undeliverable invocations don't count against the parent command's MaxErrors limit and don't contribute to whether the parent command status is Success or Incomplete. This is a terminal state.

Terminated: The parent command exceeded its MaxErrors limit and subsequent command invocations were canceled by the system. This is a terminal state.
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

