### PR TITLE
Override the nginx image properly in tinkerbell stack chart

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -558,6 +558,7 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 			},
 		},
 		stack: map[string]interface{}{
+			image: bundle.TinkerbellStack.Tink.Nginx.URI,
 			kubevip: map[string]interface{}{
 				image:   bundle.KubeVip.URI,
 				enabled: s.loadBalancer,

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -42,6 +42,7 @@ func getTinkBundle() releasev1alpha1.TinkerbellBundle {
 	return releasev1alpha1.TinkerbellBundle{
 		TinkerbellStack: releasev1alpha1.TinkerbellStackBundle{
 			Tink: releasev1alpha1.TinkBundle{
+				Nginx:          releasev1alpha1.Image{URI: "public.ecr.aws/eks-anywhere/nginx:latest"},
 				TinkController: releasev1alpha1.Image{URI: "public.ecr.aws/eks-anywhere/tink-controller:latest"},
 				TinkServer:     releasev1alpha1.Image{URI: "public.ecr.aws/eks-anywhere/tink-server:latest"},
 				TinkWorker:     releasev1alpha1.Image{URI: "public.ecr.aws/eks-anywhere/tink-worker:latest"},

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -35,6 +35,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: true
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: true
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -34,6 +34,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -35,6 +35,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -38,6 +38,7 @@ stack:
   hook:
     enabled: false
   hostNetwork: false
+  image: public.ecr.aws/eks-anywhere/nginx:latest
   kubevip:
     additionalEnv:
     - name: prometheus_server


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Nginx images were not getting overridden properly in the values file. This makes sure we are overriding the nginx image in the tinkerbell stack chart with the one in our bundles.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
