### PR TITLE
Updated prometheus pod labels for e2e test

### DIFF
--- a/docs/content/en/docs/packages/prometheus/prometheus_grafana.md
+++ b/docs/content/en/docs/packages/prometheus/prometheus_grafana.md
@@ -125,7 +125,7 @@ To ensure the Prometheus package is installed correctly in the cluster, a user c
 
 Port forward Prometheus to local host `9090`:
 ```bash
-export PROM_SERVER_POD_NAME=$(kubectl get pods --namespace <namespace> -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name")
+export PROM_SERVER_POD_NAME=$(kubectl get pods --namespace <namespace> -l "app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server" -o jsonpath="{.items[0].metadata.name")
 kubectl port-forward $PROM_SERVER_POD_NAME -n <namespace> 9090
 ```
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1812,7 +1812,7 @@ func (e *ClusterE2ETest) VerifyPrometheusPrometheusServerStates(packageName, tar
 	}
 
 	e.T.Log("Reading package", packageName, "pod prometheus-server logs")
-	podName, err := e.KubectlClient.GetPodNameByLabel(context.TODO(), targetNamespace, "app=prometheus,component=server", e.KubeconfigFilePath())
+	podName, err := e.KubectlClient.GetPodNameByLabel(context.TODO(), targetNamespace, "app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server", e.KubeconfigFilePath())
 	if err != nil {
 		e.T.Fatalf("unable to get name of the prometheus-server pod: %s", err)
 	}


### PR DESCRIPTION
#### Description of changes:
Prometheus e2e test were failing with the error:
`
cluster.go:1814: Reading package generated-prometheus pod prometheus-server logs
    cluster.go:1817: unable to get name of the prometheus-server pod: error: error executing jsonpath "'{.items[0].metadata.name}'": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
`
In the recent upgrade pod labels for prometheus charts were updated from `app=prometheus,component=server` to
`app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server`, because of which above issue occured, update the prometheus label in `VerifyPrometheusPrometheusServerStates` method.

#### Testing:
```
export LOCAL_E2E_TESTS=TestDockerKubernetes127CuratedPackagesPrometheusSimpleFlow
make local-e2e
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

