### PR TITLE
Ensure release branch is prefix of test cluster names

### DIFF
--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -285,10 +285,6 @@ func clusterPrefix(branch, instanceId string) (clusterPrefix string) {
 		sanitizedBranch = strings.ReplaceAll(sanitizedBranch, char, "-")
 	}
 
-	if len(sanitizedBranch) > 7 {
-		sanitizedBranch = sanitizedBranch[:7]
-	}
-
 	if len(instanceId) > 7 {
 		instanceId = instanceId[:7]
 	}
@@ -299,9 +295,9 @@ func clusterPrefix(branch, instanceId string) (clusterPrefix string) {
 
 func (e *E2ESession) clusterName(branch, instanceId, testName string) (clusterName string) {
 	clusterName = fmt.Sprintf("%s-%s", clusterPrefix(branch, instanceId), e2etests.GetTestNameHash(testName))
-	if len(clusterName) > 63 {
-		e.logger.Info("Cluster name is longer than 63 characters; truncating to 63 characters.", "original cluster name", clusterName, "truncated cluster name", clusterName[:63])
-		clusterName = clusterName[:63]
+	if len(clusterName) > 35 {
+		e.logger.Info("Cluster name is longer than 35 characters; truncating to 35 characters.", "original cluster name", clusterName, "truncated cluster name", clusterName[:35])
+		clusterName = clusterName[:35]
 	}
 	return clusterName
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The pre and post vm cleanup steps were failing with for cloudstack (an probably other providers) on the release branch

```
2024-06-17T05:38:03.656Z V0 virtual machines not found {"cluster": "release-0-20"}
```

We run the clean up commands before and after tests passing a `CLUSTER_PREFIX` based on the branch name. However, during setup, we seem to trim the branch name down to 7 characters when constructing the cluster name, thus, only having  "release" as the prefix

Removing the trim on the branch name preserves the full branch name, enabling us to run cleanups based on release branch name as the `CLUSTER_PREFIX`.

Additionally, the cluster name can only be < 36 characters, but we handle that by an overall trim before returning the cluster name.
Ref: https://github.com/aws/eks-anywhere/pull/8046

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

