### PR TITLE
Fix issue where incorrect flag is getting passed to helm commands

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -432,6 +432,7 @@ func (s *Installer) UpgradeInstallCRDs(ctx context.Context, bundle releasev1alph
 	if s.proxyConfig != nil {
 		envMap["NO_PROXY"] = strings.Join(s.proxyConfig.NoProxy, ",")
 	}
+
 	return s.helm.UpgradeInstallChartWithValuesFile(
 		ctx,
 		bundle.TinkerbellStack.TinkerbellCrds.Name,
@@ -441,6 +442,7 @@ func (s *Installer) UpgradeInstallCRDs(ctx context.Context, bundle releasev1alph
 		s.namespace,
 		"",
 		helm.WithProxyConfig(envMap),
+		helm.WithExtraFlags([]string{}),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix issue where incorrect additional flags were being passed to the helm upgrade command. Pass in empty additional flags if none are provided to prevent reusing the flags from a previous helm command. 

We might want to revisit the logic regarding passing in helm opts to the upgrade and uninstall helm commands. We currently need it due to the changing `NO_PROXY` values during the create/upgrade flow using proxy configs. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
