### PR TITLE
Support installing previous version of EKS-A CLI using Homebrew

### DIFF
--- a/scripts/brew_formula_pr.sh
+++ b/scripts/brew_formula_pr.sh
@@ -32,8 +32,6 @@ By submitting this pull request, I confirm that you can use, modify, copy, and r
 EOF
 )
 
-cd ${SCRIPT_ROOT}/
-cd ../../
 gh auth login --with-token < /secrets/github-secrets/token
 
 cd ${SCRIPT_ROOT}
@@ -44,7 +42,7 @@ then
   exit 1
 fi
 
-LATEST_VERSION=$(echo $(/home/prow/go/src/github.com/aws/eks-anywhere/scripts/$BREW_UPDATE_SCRIPT))
+LATEST_VERSION=$(echo $($SCRIPT_ROOT/$BREW_UPDATE_SCRIPT))
 
 cd ${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}
 git config --global push.default current
@@ -62,7 +60,7 @@ PR_BRANCH="eks-anywhere-formula-update"
 git checkout -b $PR_BRANCH
 
 git diff
-git add Formula/eks-anywhere.rb
+git add Formula/eks-anywhere*.rb
 # If some other files get modified, the changes should be ignored
 git restore .
 FILES_ADDED=$(git diff --staged --name-only)

--- a/scripts/brew_formula_update.sh
+++ b/scripts/brew_formula_update.sh
@@ -16,7 +16,9 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO="homebrew-tap"
 ORIGIN_ORG="eks-anywhere-brew-pr-bot"
 UPSTREAM_ORG="aws"
+EKS_ANYWHERE_RELEASES_MANIFEST_URL="https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
 YQ_LATEST_RELEASE_URL="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
+source "$SCRIPT_ROOT/common.sh"
 
 if ! command -v yq &> /dev/null
 then
@@ -24,9 +26,21 @@ then
   chmod a+x /usr/local/bin/yq
 fi
 
-curl --silent 'https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml' -o release.yaml
+curl --silent $EKS_ANYWHERE_RELEASES_MANIFEST_URL -o release.yaml
 
-latest_release_version=$(cat release.yaml | yq e '.spec.latestVersion')
+BRANCH_NAME=$PULL_BASE_REF
+ALL_RELEASE_BRANCHES=($(build::common::get_release_branches))
+LATEST_RELEASE_BRANCHES=($(get_latest_release_branches "${ALL_RELEASE_BRANCHES[@]}"))
+
+# Get the latest release version corresponding to this release branch
+if [[ "$BRANCH_NAME" == "${LATEST_RELEASE_BRANCHES[0]}" ]]; then
+  latest_release_version=$(cat release.yaml | yq e '.spec.latestVersion')
+elif [[ "$BRANCH_NAME" == "${LATEST_RELEASE_BRANCHES[1]}" ]]; then
+  latest_release_version=$(build::common::get_latest_release_for_release_branch $BRANCH_NAME)
+else
+  echo "Unsupported EKS Anywhere release branch $BRANCH_NAME!"
+  exit 1
+fi
 
 latest_release=$(cat release.yaml | yq e '.spec.releases[] | select(.version == "'$latest_release_version'")' >> latest_release.yaml)
 
@@ -46,7 +60,14 @@ latest_release_version="${latest_release_version:1}"
 export VERSION=$latest_release_version
 
 EKSA_TEMPLATE="eks-anywhere.rb.tmpl"
-EKSA_FORMULA="${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}/Formula/eks-anywhere.rb"
+if [[ "$BRANCH_NAME" == "${LATEST_RELEASE_BRANCHES[0]}" ]]; then
+  EKSA_FORMULA="${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}/Formula/eks-anywhere.rb"
+  export VERSION_SUFFIX=""
+elif [[ "$BRANCH_NAME" == "${LATEST_RELEASE_BRANCHES[1]}" ]]; then
+  minor_version="${BRANCH_NAME##release-}"
+  EKSA_FORMULA="${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}/Formula/eks-anywhere@$minor_version.rb"
+  export VERSION_SUFFIX="AT${minor_version/.}"
+fi
 
 if [ ! -f "$EKSA_TEMPLATE" ]
 then
@@ -54,13 +75,7 @@ then
   exit 1
 fi
 
-if [ ! -f "$EKSA_FORMULA" ]
-then
-  echo "Can not find the ${EKSA_FORMULA} file, exiting.."
-  exit 1
-fi
-
-envsubst '$VERSION:$darwin_arm64_url:$darwin_arm64_sha256:$darwin_amd64_url:$darwin_amd64_sha256:$linux_arm64_url:$linux_arm64_sha256:$linux_amd64_url:$linux_amd64_sha256' \
+envsubst '$VERSION:$VERSION_SUFFIX:$darwin_arm64_url:$darwin_arm64_sha256:$darwin_amd64_url:$darwin_amd64_sha256:$linux_arm64_url:$linux_arm64_sha256:$linux_amd64_url:$linux_amd64_sha256' \
  < "${EKSA_TEMPLATE}" \
  > "${EKSA_FORMULA}"
 

--- a/scripts/eks-anywhere.rb.tmpl
+++ b/scripts/eks-anywhere.rb.tmpl
@@ -1,4 +1,4 @@
-class EksAnywhere < Formula
+class EksAnywhere$VERSION_SUFFIX < Formula
   desc "CLI for managing EKS Anywhere Kubernetes clusters"
   homepage "https://github.com/aws/eks-anywhere"
   version "$VERSION"


### PR DESCRIPTION
This PR improves the Brew update script to support updating Brew formulae for both the latest and second latest versions of EKS Anywhere.

Tested by generating a Brew formula for release-0.18 and installing from source and verifying the installed binary is good to use
```console
$ brew install --build-from-source Formula/eks-anywhere@0.18.rb
...
Fetching eks-anywhere@0.18
==> Downloading https://anywhere-assets.eks.amazonaws.com/releases/eks-a/59/artifacts/eks-a/v0.18.7/darwin/arm64/eksctl-anywhere
...
Installing eks-anywhere@0.18
...

$ eksctl anywhere version
Version: v0.18.7
Bundle Manifest URL: https://anywhere-assets.eks.amazonaws.com/releases/bundles/59/manifest.yaml                           
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

