### PR TITLE
Use specific version of sonobuoy which supports both mode and e2e-skip

### DIFF
--- a/pkg/executables/sonobuoy.go
+++ b/pkg/executables/sonobuoy.go
@@ -27,7 +27,7 @@ func (k *Sonobuoy) Run(ctx context.Context, contextName string, args ...string) 
 		"--context",
 		contextName,
 		"run",
-		"--mode=certified-conformance",
+		`--e2e-focus="\[Conformance\]"`,
 		"--wait",
 	}
 	executionArgs = append(executionArgs, args...)

--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -60,7 +60,7 @@ func (e *ClusterE2ETest) RunConformanceTests() {
 	// 2. https://github.com/cilium/cilium/issues/29913
 	// 3. https://github.com/cncf/k8s-conformance/pull/3049
 	if k8s129Compare != -1 {
-		args = append(args, fmt.Sprintf("--e2e-skip='%s'", skippedTestName))
+		args = append(args, fmt.Sprintf(`--e2e-skip="%s"`, skippedTestName))
 	}
 	e.T.Logf("Running k8s conformance tests with Image: %s", kubeConformanceImageTagged)
 	output, err := conformance.RunTests(ctx, contextName, args...)


### PR DESCRIPTION
Sonobuoy versions `v0.56.9` and above include a [commit](https://github.com/vmware-tanzu/sonobuoy/commit/94848503b11fd6555da2f9cb18e0cb4ac4b59e86) which errors out when we use both `mode` and `e2e-skip` flags together, so we're hardcoding to the immediate previous version `v0.56.8`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

