### PR TITLE
fix custom resource name for eksaVersion

### DIFF
--- a/docs/content/en/docs/clustermgmt/cluster-upgrades/management-components-upgrade.md
+++ b/docs/content/en/docs/clustermgmt/cluster-upgrades/management-components-upgrade.md
@@ -75,4 +75,4 @@ Installing new eksa components
 🎉 Management components upgraded!
 ```
 
-At this point, a new `eksaVersion` custom resource will be available in your management cluster, which means new cluster components that correspond to the `eksaVersion` are available for cluster upgrades. You can subsequently run a workload cluster upgrade with the `eksctl anywhere upgrade cluster command`, or by updating `eksaVersion` field in your workload cluster's spec and applying it to your management cluster with Kubernetes API-compatible tooling such as kubectl, GitOps, or Terraform.
+At this point, a new `EKSARelease` custom resource will be available in your management cluster, which means new cluster components that correspond to the `eksaVersion` are available for cluster upgrades. You can subsequently run a workload cluster upgrade with the `eksctl anywhere upgrade cluster command`, or by updating `eksaVersion` field in your workload cluster's spec and applying it to your management cluster with Kubernetes API-compatible tooling such as kubectl, GitOps, or Terraform.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`EKSARelease` is the correct custom resource name and there is no resource named `eksaVersion`. `eksaVersion` is a field in the cluster spec file.

```sh
$ kubectl api-resources  | grep -i eksa
eksareleases                                     anywhere.eks.amazonaws.com/v1alpha1       true         EKSARelease
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

