### PR TITLE
Set registry username and password as expected with new tink stack

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -229,8 +229,6 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 					"-e", gomock.Any(),
 					"-e", gomock.Any(),
 					"-e", gomock.Any(),
-					"-e", gomock.Any(),
-					"-e", gomock.Any(),
 				)
 			}
 

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -7,17 +7,13 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest HTTP_PROXY=1.2.3.4
-      HTTPS_PROXY=1.2.3.4 NO_PROXY=localhost,.svc
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs:
+    - HTTP_PROXY=1.2.3.4
+    - HTTPS_PROXY=1.2.3.4
+    - NO_PROXY=localhost,.svc
     osieUrl:
       host: my-local-web-server
       path: /hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -7,16 +7,11 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: false
   hostNetwork: true
   http:
+    additionalKernelArgs:
+    - tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -7,16 +7,11 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: false
   hostNetwork: true
   http:
+    additionalKernelArgs:
+    - tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: my-local-web-server
       path: /hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -7,16 +7,10 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs: []
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -7,17 +7,13 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest HTTP_PROXY=1.2.3.4:3128
-      HTTPS_PROXY=1.2.3.4:3128 NO_PROXY=
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs:
+    - HTTP_PROXY=1.2.3.4:3128
+    - HTTPS_PROXY=1.2.3.4:3128
+    - NO_PROXY=
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -7,20 +7,13 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
-  additionalEnv:
-  - name: DATA_MODEL_VERSION
-    value: kubernetes
-  - name: TINKERBELL_TLS
-    value: "false"
-  - name: REGISTRY_USERNAME
-    value: username
-  - name: REGISTRY_PASSWORD
-    value: password
-  - name: SMEE_EXTRA_KERNEL_ARGS
-    value: tink_worker_image=1.2.3.4:443/custom/eks-anywhere/tink-worker:latest insecure_registries=1.2.3.4:443
   deploy: true
   hostNetwork: true
   http:
+    additionalKernelArgs:
+    - insecure_registries=1.2.3.4:443
+    - registry_username=username
+    - registry_password=password
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
registry username and registry password is now expected as key value pairs of `SMEE_EXTRA_KERNEL_ARGS`. This PR updates how we set the registry username and password to be what is expected by the new version of smee.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


