### PR TITLE
Change delete timeout to 30 mins

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1210,7 +1210,7 @@ func (f *Factory) WithClusterDeleter() *Factory {
 	f.buildSteps = append(f.buildSteps, func(ctx context.Context) error {
 		var opts []clustermanager.DeleterOpt
 		if f.config.noTimeouts {
-			opts = append(opts, clustermanager.WithDeleterApplyClusterTimeout(time.Hour))
+			opts = append(opts, clustermanager.WithDeleterApplyClusterTimeout(30*time.Minute))
 		}
 
 		f.dependencies.ClusterDeleter = clustermanager.NewDeleter(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lots of E2E tests were failing timing out while a delete was in progress. Shorten the delete timeout to 30 mins so that we can more determine whether the test runners timed out or if the test timed out trying to delete.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



