### PR TITLE
Create S3 downloader using source session instead of release session

### DIFF
--- a/release/cli/pkg/clients/clients.go
+++ b/release/cli/pkg/clients/clients.go
@@ -165,7 +165,7 @@ func CreateStagingReleaseClients() (*SourceClients, *ReleaseClients, error) {
 
 	// Release S3 client and uploader
 	releaseS3Client := s3.New(releaseSession)
-	downloader := s3manager.NewDownloader(releaseSession)
+	downloader := s3manager.NewDownloader(sourceSession)
 	uploader := s3manager.NewUploader(releaseSession)
 
 	// Get source ECR auth config
@@ -242,7 +242,7 @@ func CreateProdReleaseClients() (*SourceClients, *ReleaseClients, error) {
 
 	// Release S3 client and uploader
 	releaseS3Client := s3.New(releaseSession)
-	downloader := s3manager.NewDownloader(releaseSession)
+	downloader := s3manager.NewDownloader(sourceSession)
 	uploader := s3manager.NewUploader(releaseSession)
 
 	// Get source ECR Public auth config


### PR DESCRIPTION
Create S3 downloader using source session instead of release session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

