### PR TITLE
Upload RTOS artifacts to separate bucket

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -223,20 +223,21 @@ func GetArchiveAssets(rc *releasetypes.ReleaseConfig, archive *assettypes.Archiv
 	}
 
 	archiveArtifact := &releasetypes.ArchiveArtifact{
-		SourceS3Key:       sourceS3Key,
-		SourceS3Prefix:    sourceS3Prefix,
-		ArtifactPath:      filepath.Join(rc.ArtifactDir, fmt.Sprintf("%s-%s", archive.Name, archive.Format), eksDReleaseChannel, rc.BuildRepoHead),
-		ReleaseName:       releaseName,
-		ReleaseS3Path:     releaseS3Path,
-		ReleaseCdnURI:     cdnURI,
-		OS:                os,
-		OSName:            archive.OSName,
-		Arch:              []string{arch},
-		GitTag:            gitTag,
-		ProjectPath:       projectPath,
-		SourcedFromBranch: sourcedFromBranch,
-		ImageFormat:       archive.Format,
-		Private:           archive.Private,
+		SourceS3Key:        sourceS3Key,
+		SourceS3Prefix:     sourceS3Prefix,
+		ArtifactPath:       filepath.Join(rc.ArtifactDir, fmt.Sprintf("%s-%s", archive.Name, archive.Format), eksDReleaseChannel, rc.BuildRepoHead),
+		ReleaseName:        releaseName,
+		ReleaseS3Path:      releaseS3Path,
+		ReleaseCdnURI:      cdnURI,
+		OS:                 os,
+		OSName:             archive.OSName,
+		Arch:               []string{arch},
+		GitTag:             gitTag,
+		ProjectPath:        projectPath,
+		SourcedFromBranch:  sourcedFromBranch,
+		ImageFormat:        archive.Format,
+		Private:            archive.Private,
+		UploadToRTOSBucket: archive.UploadToRTOSBucket,
 	}
 
 	return archiveArtifact, nil

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -79,6 +79,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				OSVersion:           "22.04",
 				ArchiveS3PathGetter: archives.RTOSArtifactPathGetter,
 				Private:             true,
+				UploadToRTOSBucket:  true,
 			},
 		},
 	},

--- a/release/cli/pkg/assets/types/types.go
+++ b/release/cli/pkg/assets/types/types.go
@@ -49,6 +49,7 @@ type Archive struct {
 	ArchitectureOverride string
 	ArchiveS3PathGetter  ArchiveS3PathGenerator
 	Private              bool
+	UploadToRTOSBucket   bool
 }
 
 type AssetConfig struct {

--- a/release/cli/pkg/constants/constants.go
+++ b/release/cli/pkg/constants/constants.go
@@ -52,5 +52,6 @@ const (
 	//	01/02 03:04:05PM '06 -0700
 	//
 	// (January 2, 15:04:05, 2006, in time zone seven hours west of GMT).
-	YYYYMMDD = "2006-01-02"
+	YYYYMMDD                  = "2006-01-02"
+	RTOSArtifactsBucketEnvvar = "RTOS_ARTIFACTS_BUCKET"
 )

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -17,6 +17,7 @@ package operations
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -88,10 +89,14 @@ func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArt
 }
 
 func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artifact releasetypes.Artifact) error {
+	releaseBucket := r.ReleaseBucket
+	if artifact.Archive.UploadToRTOSBucket && r.ReleaseEnvironment == "production" {
+		releaseBucket = os.Getenv(constants.RTOSArtifactsBucketEnvvar)
+	}
 	archiveFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName)
 	fmt.Printf("Archive - %s\n", archiveFile)
 	key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName)
-	err := s3.UploadFile(archiveFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
+	err := s3.UploadFile(archiveFile, aws.String(releaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
 	if err != nil {
 		return fmt.Errorf("uploading archive file [%s] to S3: %v", key, err)
 	}
@@ -108,7 +113,7 @@ func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artif
 		checksumFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName) + extension
 		fmt.Printf("Checksum - %s\n", checksumFile)
 		key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName) + extension
-		err := s3.UploadFile(checksumFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
+		err := s3.UploadFile(checksumFile, aws.String(releaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
 		if err != nil {
 			return fmt.Errorf("uploading checksum file [%s] to S3: %v", key, err)
 		}

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -64,20 +64,21 @@ type ImageTagOverride struct {
 }
 
 type ArchiveArtifact struct {
-	SourceS3Key       string
-	SourceS3Prefix    string
-	ArtifactPath      string
-	ReleaseName       string
-	ReleaseS3Path     string
-	ReleaseCdnURI     string
-	OS                string
-	OSName            string
-	Arch              []string
-	GitTag            string
-	ProjectPath       string
-	SourcedFromBranch string
-	ImageFormat       string
-	Private           bool
+	SourceS3Key        string
+	SourceS3Prefix     string
+	ArtifactPath       string
+	ReleaseName        string
+	ReleaseS3Path      string
+	ReleaseCdnURI      string
+	OS                 string
+	OSName             string
+	Arch               []string
+	GitTag             string
+	ProjectPath        string
+	SourcedFromBranch  string
+	ImageFormat        string
+	Private            bool
+	UploadToRTOSBucket bool
 }
 
 type ImageArtifact struct {


### PR DESCRIPTION
Adding logic to upload RTOS artifacts to separate production bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

