### PR TITLE
Update expected values in MetalLB E2E tests based on the upstream updates

### DIFF
--- a/test/e2e/metallb.go
+++ b/test/e2e/metallb.go
@@ -222,8 +222,10 @@ spec:
 			ipTwo := "10.100.0.1"
 			ipTwoSub := ipTwo + "/32"
 			t.Cleanup(func() {
-				test.UninstallCuratedPackage(packagePrefix)
-				test.UninstallCuratedPackage(packageCrdName)
+				if !t.Failed() {
+					test.UninstallCuratedPackage(packagePrefix)
+					test.UninstallCuratedPackage(packageCrdName)
+				}
 			})
 			test.CreateResource(ctx, fmt.Sprintf(
 				`
@@ -317,7 +319,7 @@ spec:
 				t.Fatal(err)
 			}
 
-			expectedBGPPeer := `{"keepaliveTime":"30s","myASN":123,"peerASN":55001,"peerAddress":"12.2.4.2","peerPort":179}`
+			expectedBGPPeer := `{"disableMP":false,"keepaliveTime":"30s","myASN":123,"peerASN":55001,"peerAddress":"12.2.4.2","peerPort":179}`
 			err = WaitForResource(
 				test,
 				ctx,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Metallb e2e tests were failing when running the BGP configuration test case. This is due to our tests statically defining what the expected `bgppeers.metallb.io` resource should have in the spec field. Defined here: https://github.com/aws/eks-anywhere/blob/main/test/e2e/metallb.go#L320

With the new version bump of metallb, they added support for BGP disableMP, which defaults to false. This results in `bgppeers.metallb.io`  to have an extra line in its spec, which differs from the statically defined "expected". Updated the expected value in the e2e.

prev spec: 
```
  keepaliveTime: 30s
  myASN: 123
  peerASN: 55001
  peerAddress: 12.2.4.2
  peerPort: 179
```
current spec:
```
  disableMP: false
  keepaliveTime: 30s
  myASN: 123
  peerASN: 55001
  peerAddress: 12.2.4.2
  peerPort: 179
```
Also noticed that metallb packages always got uninstalled before the support bundle had a chance to be generated. Updated the metallb cleanup logic so that if a test case fails, it does not clean up the packages right away so that the support bundle can pick up the metallb resources

*Testing (if applicable):*
Ran the metallb e2e locally and verified it passes

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

