### PR TITLE
Update RTOS image destination on S3

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -150,6 +150,7 @@ func RTOSArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.
 	var sourceS3Prefix string
 	var releaseS3Path string
 	var releaseName string
+	releaseDate := gitTag
 	eksDReleaseChannel = "1-29" // hardcoding because we vend RTOS artifacts only for 1-29 release branch
 
 	imageExtensions := map[string]string{
@@ -163,20 +164,22 @@ func RTOSArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.
 		sourceS3Key = fmt.Sprintf("%s.%s", archive.OSName, imageExtension)
 		sourceS3Prefix = fmt.Sprintf("%s/%s", projectPath, latestPath)
 	} else {
-		sourceS3Key = fmt.Sprintf("%s-%s-eks-a-%d-%s.%s",
+		sourceS3Key = fmt.Sprintf("%s-%s-%s-eks-a-%d-%s.%s",
 			archive.OSName,
 			eksDReleaseChannel,
+			releaseDate,
 			rc.BundleNumber,
 			arch,
 			imageExtension,
 		)
-		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/rtos/%s", rc.BundleNumber, eksDReleaseChannel)
+		sourceS3Prefix = fmt.Sprintf("releases/canonical/%s/artifacts/rtos/%s", releaseDate, eksDReleaseChannel)
 	}
 
 	if rc.DevRelease {
-		releaseName = fmt.Sprintf("%s-%s-eks-a-%s-%s.%s",
+		releaseName = fmt.Sprintf("%s-%s-%s-eks-a-%s-%s.%s",
 			archive.OSName,
 			eksDReleaseChannel,
+			releaseDate,
 			rc.DevReleaseUriVersion,
 			arch,
 			imageExtension,
@@ -187,14 +190,15 @@ func RTOSArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.
 			eksDReleaseChannel,
 		)
 	} else {
-		releaseName = fmt.Sprintf("%s-%s-eks-a-%d-%s.%s",
+		releaseName = fmt.Sprintf("%s-%s-%s-eks-a-%d-%s.%s",
 			archive.OSName,
 			eksDReleaseChannel,
+			releaseDate,
 			rc.BundleNumber,
 			arch,
 			imageExtension,
 		)
-		releaseS3Path = fmt.Sprintf("releases/bundles/%d/artifacts/rtos/%s", rc.BundleNumber, eksDReleaseChannel)
+		releaseS3Path = fmt.Sprintf("releases/canonical/%s/artifacts/rtos/%s", releaseDate, eksDReleaseChannel)
 	}
 
 	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -70,7 +70,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 	{
 		ProjectName:    "ubuntu-rtos",
 		ProjectPath:    "projects/canonical/ubuntu",
-		GitTagAssigner: tagger.NonExistentTagAssigner,
+		GitTagAssigner: tagger.RTOSReleaseDateAssigner,
 		Archives: []*assettypes.Archive{
 			{
 				Name:                "rtos",

--- a/release/cli/pkg/assets/tagger/tagger.go
+++ b/release/cli/pkg/assets/tagger/tagger.go
@@ -54,6 +54,19 @@ func CliGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranc
 	return gitTag, nil
 }
 
+func RTOSReleaseDateAssigner(rc *releasetypes.ReleaseConfig, rtosImageDatePath, overrideBranch string) (string, error) {
+	branchName := rc.BuildRepoBranchName
+	if overrideBranch != "" {
+		branchName = overrideBranch
+	}
+	releaseDate, err := filereader.ReadRTOSImageDate(rtosImageDatePath, rc.BuildRepoSource, branchName)
+	if err != nil {
+		return "", errors.Cause(err)
+	}
+
+	return releaseDate, nil
+}
+
 func NonExistentTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranch string) (string, error) {
 	return "non-existent", nil
 }

--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -365,3 +365,24 @@ func ReadGitTag(projectPath, gitRootPath, branch string) (string, error) {
 
 	return gitTag, nil
 }
+
+func ReadRTOSImageDate(projectPath, gitRootPath, branch string) (string, error) {
+	currentBranch, err := git.GetCurrentBranch(gitRootPath)
+	if err != nil {
+		return "", fmt.Errorf("error getting current branch: %v", err)
+	}
+	if currentBranch != branch {
+		_, err = git.CheckoutRepo(gitRootPath, branch)
+		if err != nil {
+			return "", fmt.Errorf("error checking out repo: %v", err)
+		}
+	}
+
+	dateFile := filepath.Join(gitRootPath, projectPath, "RTOS_IMAGE_DATE")
+	releaseDate, err := ReadFileContentsTrimmed(dateFile)
+	if err != nil {
+		return "", fmt.Errorf("error reading RTOS image date: %v", err)
+	}
+
+	return releaseDate, nil
+}


### PR DESCRIPTION
Update RTOS image destination on S3 to include image release date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

