### PR TITLE
Add docs for Ubuntu Real-time OS images

### DIFF
--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -29,8 +29,10 @@ See descriptions of the [`osImageURL`]({{< relref "../getting-started/baremetal/
 
 ### Ubuntu or RHEL OS images for Bare Metal
 
-EKS Anywhere does not distribute Ubuntu or RHEL OS images.
-However, see [Building node images]({{< relref "#building-node-images">}}) for information on how to build EKS Anywhere images from those Linux distributions.  Note:  if you utilize your Admin Host to build images, you will need to review  the DHCP integration provided by Libvirtd and ensure it is disabled.  If the Libvirtd DHCP is enabled, the "boots container" will detect a port conflict and terminate.
+Generally speaking, EKS Anywhere does not distribute Ubuntu or RHEL OS images<sup>*</sup>.
+However, see [Building node images]({{< relref "#building-node-images">}}) for information on how to build EKS Anywhere images from those Linux distributions. Note: if you utilize your Admin Host to build images, you will need to review the DHCP integration provided by Libvirtd and ensure it is disabled. If the Libvirtd DHCP is enabled, the "boots container" will detect a port conflict and terminate.
+
+<sup>*</sup>Starting from version v0.20.0, EKS Anywhere will distribute Real-time Ubuntu images. Refer to the [Ubuntu RTOS]({{< relref "rtos" >}}) documentation to learn more.
 
 ### Bottlerocket OS images for Bare Metal
 
@@ -345,7 +347,7 @@ cd /tmp
 BUNDLE_MANIFEST_URL=$(curl -s https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.releases[] | select(.version==\"$EKSA_RELEASE_VERSION\").bundleManifestUrl")
 IMAGEBUILDER_TARBALL_URI=$(curl -s $BUNDLE_MANIFEST_URL | yq ".spec.versionsBundles[0].eksD.imagebuilder.uri")
 curl -s $IMAGEBUILDER_TARBALL_URI | tar xz ./image-builder
-sudo install -m 0755 ./image-builder /usr/local/bin/image-builder   
+sudo install -m 0755 ./image-builder /usr/local/bin/image-builder
 cd -
 ```
 
@@ -905,7 +907,7 @@ These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV a
    * Once you have Python 3.9, you can install Ansible using `pip`.
      ```bash
      python3 -m pip install --user ansible
-     ``` 
+     ```
 1. Create a `nutanix.json` config file. More details on values can be found in the [image-builder documentation](https://image-builder.sigs.k8s.io/capi/providers/nutanix.html). See example below:
    ```json
    {
@@ -1110,7 +1112,7 @@ Run `image-builder` CLI with the hypervisor configuration file
 
 While building Red Hat node images, `image-builder` uses public Red Hat subscription endpoints to register the build virtual machine with the provided Red Hat account and download required packages.
 
-Alternatively, `image-builder` can also use a private Red Hat Satellite to register the build virtual machine and pull packages from the Satellite. 
+Alternatively, `image-builder` can also use a private Red Hat Satellite to register the build virtual machine and pull packages from the Satellite.
 In order to use Red Hat Satellite in the image build process follow the steps below.
 
 #### Prerequisites
@@ -1143,10 +1145,10 @@ In order to use Red Hat Satellite in the image build process follow the steps be
 
 #### Prerequisites
 1. Air-gapped image building requires
-   - private artifacts server e.g. artifactory from JFrog 
-   - private git server. 
-3. Ensure the host running `image-builder` has bi-directional network connectivity with the artifacts server and git server 
-4. Artifacts server should have the ability to host and serve, standalone artifacts and Ubuntu OS packages 
+   - private artifacts server e.g. artifactory from JFrog
+   - private git server.
+3. Ensure the host running `image-builder` has bi-directional network connectivity with the artifacts server and git server
+4. Artifacts server should have the ability to host and serve, standalone artifacts and Ubuntu OS packages
 
 #### Building node images in an air-gapped environment
 1. Identify the EKS-D release channel (generally aligning with Kubernetes version) to build. For example, 1.27 or 1.28

--- a/docs/content/en/docs/osmgmt/rtos.md
+++ b/docs/content/en/docs/osmgmt/rtos.md
@@ -1,0 +1,34 @@
+---
+title: "Ubuntu RTOS"
+linkTitle: "Ubuntu RTOS"
+weight: 55
+description: >
+  Ubuntu RTOS Artifacts distributed by EKS Anywhere
+---
+
+Starting from EKS Anywhere version v0.20.0, Ubuntu ProRealTime bare metal images will be included in every release of EKS Anywhere. Real-time Ubuntu images contain a real-time Linux kernel which includes the `PREEMPT_RT patchset` to increase predictability and determinism of job execution and response times. These images are designed for workloads with mission-critical latency and security requirements.
+
+These images will be available to use only for specific customers whose AWS accounts have been allowlisted for RTOS image access. If you are a customer whose account is part of the allowlist, you can access the images through the following ways.
+
+1. Install the latest release of the AWS CLI version 2. For more information, refer to the [installion docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) in the AWS Command Line Interface User Guide.
+
+2. Configure your AWS CLI to use the credentials of the AWS account which has access to the RTOS artifacts.
+
+3. List the `eks-anywhere-rtos-artifacts` S3 bucket to see the available releases of the Ubuntu RTOS images.
+    ```bash
+    aws s3 ls s3://eks-anywhere-rtos-artifacts/releases/canonical/
+    ```
+    This will provide a list of releases ordered by release date, for example,
+    ```
+    PRE 20240606/
+    PRE 20240614/
+    PRE 20240624/
+    ```
+
+4. Once you have decided the Ubuntu release you wish to use for your EKS Anywhere Tinkerbell cluster, you can download the corresponding Ubuntu image as follows.
+    ```bash
+    aws s3 cp s3://eks-anywhere-rtos-artifacts/releases/canonical/20240624/artifacts/rtos/1-29/ . --recursive --exclude "*" --include "ubuntu*"
+    ```
+    The images are also pushed to a `latest` folder which always points to the latest available release of the Ubuntu real-time image.
+
+5. You can now host the downloaded image locally and provide the location as the [`osImageURL`]({{< ref "../getting-started/baremetal/bare-spec#osimageurl-optional" >}}) value in your cluster config.


### PR DESCRIPTION
Add docs for Ubuntu Real-time OS images.

/cherrypick release-0.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

