### PR TITLE
Include Helm chart name in push error

### DIFF
--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -246,7 +246,7 @@ func PushHelmChart(packaged, URI string) error {
 	fmt.Println(out)
 
 	if err != nil {
-		return fmt.Errorf("running Helm push command on URI %s: %v", URI, err)
+		return fmt.Errorf("running Helm push command on chart %s with destination URI %s: %v", packaged, URI, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Include Helm chart name in push error for easier debugging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

