### PR TITLE
Update boots reference in baremetal docs

### DIFF
--- a/docs/content/en/docs/clustermgmt/cluster-delete.md
+++ b/docs/content/en/docs/clustermgmt/cluster-delete.md
@@ -9,9 +9,6 @@ description: >
   How to delete an EKS Anywhere cluster
 ---
 
->**_NOTE_**: EKS Anywhere Bare Metal clusters do not yet support separate workload and management clusters. Use the instructions for Deleting a management cluster to delete a Bare Metal cluster.
->
-
 ### Deleting a workload cluster
 
 Follow these steps to delete your EKS Anywhere cluster that is managed by a separate management cluster.

--- a/docs/content/en/docs/getting-started/baremetal/tinkerbell-overview.md
+++ b/docs/content/en/docs/getting-started/baremetal/tinkerbell-overview.md
@@ -6,6 +6,9 @@ description: >
   Overview of Tinkerbell and network booting for EKS Anywhere on Bare Metal
 ---
 
+>**_NOTE_**: The Boots service has been renamed to Smee by the upstream Tinkerbell community. Any reference to Boots or Smee refer to the same service. The commands for the logs and
+> expected pods mentioned in this doc are still the proper commands to run.
+
 EKS Anywhere uses [Tinkerbell](https://docs.tinkerbell.org/) to provision machines for a Bare Metal cluster.
 Understanding what Tinkerbell is and how it works with EKS Anywhere can help you take advantage of advanced provisioning features or overcome provisioning problems you encounter.
 
@@ -17,7 +20,7 @@ As someone deploying an EKS Anywhere cluster on Bare Metal, you have several opp
 
 When you run the command to create an EKS Anywhere Bare Metal cluster, a set of Tinkerbell components start up on the Admin machine. One of these components runs in a container on Docker (Boots), while other components run as either controllers or services in pods on the Kubernetes [kind](https://kind.sigs.k8s.io/) cluster that is started up on the Admin machine. Tinkerbell components include Boots, Hegel, Rufio, and Tink.
 
-### Tinkerbell Boots service
+### Tinkerbell Boots service (Smee service)
 
 The Boots service runs in a single container to handle the DHCP service and network booting activities.
 In particular, Boots hands out IP addresses, serves iPXE binaries via HTTP and TFTP, delivers an iPXE script to the provisioned machines, and runs a syslog server.
@@ -279,7 +282,7 @@ kubectl get pods -n eksa-system
 ```
 ```
 NAME                                        READY   STATUS    RESTARTS   AGE
-boots-5dc66b5d4-klhmj                       1/1     Running   0          3d
+smee-5dc66b5d4-klhmj                       1/1     Running   0          3d
 hegel-sbchp                                 1/1     Running   0          3d
 rufio-controller-manager-5dcc568c79-9kllz   1/1     Running   0          3d
 tink-controller-manager-54dc786db6-tm2c5    1/1     Running   0          3d


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tinkerbell boots service has been renamed to smee upstream. Update the docs to mention boots and smee refer to the same service.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

