### PR TITLE
Group all dependabot go changes in one PR a week

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,16 +10,21 @@ updates:
   labels:
     - "dependabot"
     - "ok-to-test"
-# Main Go module
+# Main Go module and release module
+# grouped together since frequently updates
+# in main cascade down to the release module.
 - package-ecosystem: "gomod"
-  directory: "/"
+  directories:
+  - "/"
+  - "/release/cli"
   schedule:
     interval: "weekly"
     day: "monday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
+  ## group all dependencies in one PR to avoid churn.
   groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
+    all-go-mod-patch-and-minor:
+      patterns: [ "*" ]
+      update-types: [ "patch", "minor" ]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
@@ -27,26 +32,6 @@ updates:
     # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
   - dependency-name: "k8s.io/*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  labels:
-    - "dependabot"
-    - "ok-to-test"
-# Release Go module
-- package-ecosystem: "gomod"
-  directory: "/release/cli"
-  schedule:
-    interval: "weekly"
-    day: "tuesday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
-  groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
-  ignore:
-    # Ignore controller-runtime as its upgraded manually.
-    - dependency-name: "sigs.k8s.io/controller-runtime"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
-    - dependency-name: "k8s.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   labels:
     - "dependabot"
     - "ok-to-test"


### PR DESCRIPTION
*Description of changes:*
Having one PR per module can be annoying. On top of that, a lot of the times, changes in main have effects in the release module (since we do an import with a replace from disk).

The drawback of this change is that when code changes are required for a particular module, the go.mod change will be mixed with other modules, thus requiring us to separate the problematic node from the rest before merging. From the experience running this bot during the past few months, there is usually no work to do except to approve, no code required most of the time. Hence this will reduce the amount of PRs we need to review and the amount of time we need to manually update them to simply run go mod tidy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

