### PR TITLE
Fixing dir for sourcing E2E_AMI_FILTER_VARS

### DIFF
--- a/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/build-eks-a-cli.yml
@@ -32,3 +32,4 @@ artifacts:
   - "cmd/integration_test/build/**/*"
   - "test/e2e/SKIPPED_TESTS.yaml"
   - "ATTRIBUTION.txt"
+  - "test/e2e/E2E_AMI_FILTER_VARS"

--- a/cmd/integration_test/build/script/create_infra_config.sh
+++ b/cmd/integration_test/build/script/create_infra_config.sh
@@ -17,8 +17,7 @@ set -e
 set -x
 set -o pipefail
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-source $REPO_ROOT/test/e2e/E2E_AMI_FILTER_VARS
+source ${CODEBUILD_SRC_DIR}/test/e2e/E2E_AMI_FILTER_VARS
 
 INTEGRATION_TEST_AMI_ID=$(aws ec2 describe-images \
   --profile ${AWS_PROFILE} \


### PR DESCRIPTION
*Description of changes:*
The changes fixes the error when running create_infra_config.sh

```
Running command source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
++ set -o pipefail
+++ git rev-parse --show-toplevel
fatal: not a git repository (or any parent up to mount point /codebuild)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
++ REPO_ROOT=
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

