### PR TITLE
Backport docs config changes to deprecate old minor release and rende…

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -180,13 +180,13 @@ icon = "fab fa-github"
 desc = "Development takes place here!"
 
 [[params.versions]]
-fullversion = "v0.19"
-version = "v0.19"
+fullversion = "v0.20"
+version = "v0.20"
 docsbranch = "main"
 url = "https://anywhere.eks.amazonaws.com"
 
 [[params.versions]]
-fullversion = "v0.18"
-version = "v0.18"
-docsbranch = "release-0.18"
-url = "https://release-0-18.anywhere.eks.amazonaws.com"
+fullversion = "v0.19"
+version = "v0.19"
+docsbranch = "release-0.19"
+url = "https://release-0-19.anywhere.eks.amazonaws.com"


### PR DESCRIPTION
Manually backport [config](https://github.com/aws/eks-anywhere/pull/8418/files)  changes for docs to render new version on the dropdown on release-19 branch.  

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

