### PR TITLE
Updating suggestion for Global Role name to align with other examples…

### DIFF
--- a/docs/content/en/docs/getting-started/vsphere/vsphere-preparation.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-preparation.md
@@ -161,7 +161,7 @@ So you have to add this user to groups with the required permissions, or assign 
 
 Three roles are needed to be able to create the EKS Anywhere cluster:
 
-1. **Create a global custom role**: For example, you could name this EKS Anywhere Global.
+1. **Create a global custom role**: For example, you could name this: EKSAGlobalRole.
    Define it for the user on the vCenter domain level and its children objects.
    Create this role with the following privileges:
    ```


### PR DESCRIPTION
*Issue #, if available:*
I believe the vSphere Preparation doc may be inconsistent.  If this is a suggestion to allow a different value, then it should indicate that if you *do* use a bespoke value, that there is potential impact that needs to be considered.

*Description of changes:*
Updated this text-based suggestion to align with all other references
from "EKS Anywhere Global" to "EKSAGlobalRole"

```
  globalRole: "MyGlobalRole"      # optional, default EKSAGlobalRole
```
Also - the image located in 
https://anywhere.eks.amazonaws.com/docs/getting-started/vsphere/vsphere-preparation/#manually-set-global-permissions-role-in-global-permissions-ui
Indicates using EKSAGlobalRole

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

