### PR TITLE
Set go version in govulncheck action for release

### DIFF
--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -7,8 +7,9 @@ on:
       - main
   pull_request:
     paths-ignore:
-    - '**.yaml'
-    - '**.yml'
+    - 'cmd/integration_test/build/buildspecs/*.yaml'
+    - 'cmd/integration_test/build/buildspecs/*.yml'
+    - 'test/e2e/QUICK_TESTS.yaml'
   workflow_dispatch:
   schedule:
     # every day at 7am UTC
@@ -48,4 +49,4 @@ jobs:
           repo-checkout: false
           cache: false # cache will be already setup by previous step
           work-dir: release/cli
-          go-version-file: release/cli/go.mod
+          go-version-input: '1.22'


### PR DESCRIPTION
## Description of changes
For some reason, we can't use `go 1.22` in the release/cli go.mod. It needs to have a patch version of `go mod tidy` will change it. I'm not sure why this is, since not specifying the patch is completely valid. I suspect one of our dependencies has set 1.22.0 in their go.mod, and that makes it a requirement for us, which is annoying.

The issue with selecting a particular patch is that, when a new version of go is required bc of a CVE, govulncheck will fail until the the go.mod is updated, it won't pull the latest version.

For now, we update the github action so we set the go version explicitly instead of reading from the go.mod file.

The drawback is the github action will also need to be updated when we bump to 1.23. But probably not a big deal.


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

