### PR TITLE
Update cluster status

### DIFF
--- a/pkg/api/v1alpha1/condition_consts.go
+++ b/pkg/api/v1alpha1/condition_consts.go
@@ -58,6 +58,12 @@ const (
 
 	// AutoscalerConstraintNotMetReason reports the Cluster status is waiting for autoscaler constraint to be met.
 	AutoscalerConstraintNotMetReason = "AutoscalerConstraintNotMet"
+
+	// KubeadmControlPlaneNotReadyReason reports that the kubeadm control plane is not ready.
+	KubeadmControlPlaneNotReadyReason = "KubeadmControlPlaneNotReady"
+
+	// MachineDeploymentNotReadyReason reports that the machine deployment is not ready.
+	MachineDeploymentNotReadyReason = "MachineDeploymentNotReady"
 )
 
 const (

--- a/pkg/controller/clusters/status.go
+++ b/pkg/controller/clusters/status.go
@@ -18,8 +18,8 @@ import (
 
 // UpdateClusterStatusForControlPlane checks the current state of the Cluster's control plane and updates the
 // Cluster status information.
-// There is a posibility that UpdateClusterStatusForControlPlane does not update the
-// controleplane status specially in case where it still waiting for cluster objects to be created.
+// There is a possibility that UpdateClusterStatusForControlPlane does not update the
+// controlplane status specially in case where it is still waiting for cluster objects to be created.
 func UpdateClusterStatusForControlPlane(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
 	kcp, err := controller.GetKubeadmControlPlane(ctx, client, cluster)
 	if err != nil {
@@ -114,8 +114,8 @@ func updateControlPlaneReadyCondition(cluster *anywherev1.Cluster, kcp *controlp
 	totalReplicas := int(kcp.Status.Replicas)
 
 	// First, in the case of a rolling upgrade, we get the number of outdated nodes, and as long as there are some,
-	// we want to reflect in the message that the Cluster is in progres upgdating the old nodes with the
-	// the new machine spec.
+	// we want to reflect in the message that the Cluster is in progress updating the old nodes with the
+	// new machine spec.
 	updatedReplicas := int(kcp.Status.UpdatedReplicas)
 	totalOutdated := totalReplicas - updatedReplicas
 
@@ -243,7 +243,7 @@ func updateWorkersReadyCondition(cluster *anywherev1.Cluster, machineDeployments
 	}
 
 	// There may be worker nodes that are not up to date yet in the case of a rolling upgrade,
-	// so reflect that on the conditon with an appropriate message.
+	// so reflect that on the condition with an appropriate message.
 	totalOutdated := totalReplicas - totalUpdatedReplicas
 	if totalOutdated > 0 {
 		upgradeReason := anywherev1.RollingUpgradeInProgress


### PR DESCRIPTION
*Issue #, if available:*
[#2383](https://github.com/aws/eks-anywhere-internal/issues/2383)

*Description of changes:*
Added a check on the `Ready` condition for the kcp and md objects as a final validation before marking the `controlPlaneReady` and `workersReady` condition to `True` in the cluster status.

*Testing (if applicable):*
make eks-a
make unit-test
make lint

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

