### PR TITLE
Use sourceImageURI for packages Helm chart modifications

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -153,13 +153,12 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "creating helm client")
 						}
 						fmt.Printf("Modifying helm chart for %s\n", trimmedAsset)
-						helmDest, err := helm.GetHelmDest(helmDriver, r, imageArtifact.ReleaseImageURI, trimmedAsset)
+						helmDest, err := helm.GetHelmDest(helmDriver, r, imageArtifact.SourceImageURI, trimmedAsset)
 						if err != nil {
 							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "getting Helm destination:")
 						}
 						fmt.Printf("helmDest=%v\n", helmDest)
 						fmt.Printf("Pulled helm chart locally to %s\n", helmDest)
-						fmt.Printf("r.sourceClients")
 						err = helm.ModifyAndPushChartYaml(*imageArtifact, r, helmDriver, helmDest, packagesArtifacts, bundleImageArtifacts)
 						if err != nil {
 							return anywherev1alpha1.PackageBundle{}, errors.Wrap(err, "modifying Chart.yaml and pushing Helm chart to destination:")

--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -66,7 +66,7 @@ func NewHelm() (*helmDriver, error) {
 	}, nil
 }
 
-func GetHelmDest(d *helmDriver, r *releasetypes.ReleaseConfig, ReleaseImageURI, assetName string) (string, error) {
+func GetHelmDest(d *helmDriver, r *releasetypes.ReleaseConfig, sourceImageURI, assetName string) (string, error) {
 	var chartPath string
 	var err error
 
@@ -75,9 +75,9 @@ func GetHelmDest(d *helmDriver, r *releasetypes.ReleaseConfig, ReleaseImageURI, 
 		return "", fmt.Errorf("logging into the source registry: %w", err)
 	}
 
-	helmChart := strings.Split(ReleaseImageURI, ":")
+	helmChart := strings.Split(sourceImageURI, ":")
 	fmt.Printf("Starting to modifying helm chart %s\n", helmChart[0])
-	fmt.Printf("Pulling helm chart %s\n", ReleaseImageURI)
+	fmt.Printf("Pulling helm chart %s\n", sourceImageURI)
 	chartPath, err = d.PullHelmChart(helmChart[0], helmChart[1])
 	if err != nil {
 		return "", fmt.Errorf("pulling the helm chart: %w", err)


### PR DESCRIPTION
Using sourceImageURI for packages Helm chart modifications.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

