### PR TITLE
Fix get worker node logic for Kubelet config e2e

### DIFF
--- a/test/framework/kubeletconfig.go
+++ b/test/framework/kubeletconfig.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"context"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,17 +50,17 @@ func (e *ClusterE2ETest) ValidateKubeletConfig() {
 	kubectlClient := buildLocalKubectl()
 
 	e.T.Log("Getting control plane nodes for kubelet max pod verification")
-	nodes, err := kubectlClient.GetControlPlaneNodes(ctx,
+	cpNodes, err := kubectlClient.GetControlPlaneNodes(ctx,
 		e.KubeconfigFilePath(),
 	)
 	if err != nil {
 		e.T.Fatalf("Error getting nodes: %v", err)
 	}
-	if len(nodes) == 0 {
+	if len(cpNodes) == 0 {
 		e.T.Fatalf("no control plane nodes found")
 	}
 
-	got, _ := nodes[0].Status.Capacity.Pods().AsInt64()
+	got, _ := cpNodes[0].Status.Capacity.Pods().AsInt64()
 	if got != int64(maxPod50) {
 		e.T.Fatalf("Node capacity for control plane pods not equal to %v", maxPod50)
 	}
@@ -80,20 +79,25 @@ func (e *ClusterE2ETest) ValidateKubeletConfig() {
 	}
 
 	e.T.Log("Getting worker nodes for kubelet max pod verification")
-	var workerNode corev1.Node
-	for i := range allNodes {
-		if strings.Contains(allNodes[i].Name, "-md-") {
-			workerNode = allNodes[i]
-		}
-	}
-	if err != nil {
-		e.T.Fatalf("Error getting nodes: %v", err)
-	}
-
+	workerNode := getWorkerNodes(allNodes, cpNodes)
 	got, _ = workerNode.Status.Capacity.Pods().AsInt64()
 	if got != int64(maxPod60) {
 		e.T.Fatalf("Node capacity for worker node pods not equal to %v", maxPod60)
 	}
 
 	e.T.Log("Successfully verified Kubelet Configuration for worker nodes")
+}
+
+func getWorkerNodes(all, cpNodes []corev1.Node) *corev1.Node {
+	cpNodeMap := make(map[string]bool)
+	for _, node := range cpNodes {
+		cpNodeMap[node.Name] = true
+	}
+
+	for _, node := range all {
+		if !cpNodeMap[node.Name] {
+			return &node
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix get worker node logic for Kubelet config e2e. Tinkerbell tests had a different naming for nodes which caused failures for Kubelet config e2e tests.

*Testing (if applicable):*
- e2e

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

