### PR TITLE
Enable lb_class_only env var in tink stack kubevip

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -563,6 +563,12 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 						"name":  "prometheus_server",
 						"value": ":2213",
 					},
+					// The Tinkerbell stack needs a load balancer to work properly.
+					// We bundle Kube-vip in, as the load balancer, when we deploy the stack.
+					// We don't want this load balancer to be used by any other workloads.
+					// It allows us greater confidence in successful lifecycle events for the Tinkerbell stack, amongst other things.
+					// Also, the user should be free from Tinkerbell stack constraints
+					// and free to deploy a load balancer of their choosing and not be coupled to ours.
 					{
 						"name":  "lb_class_only",
 						"value": "true",

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -562,7 +562,8 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 					{
 						"name":  "prometheus_server",
 						"value": ":2213",
-					}, {
+					},
+					{
 						"name":  "lb_class_only",
 						"value": "true",
 					},

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -562,6 +562,9 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 					{
 						"name":  "prometheus_server",
 						"value": ":2213",
+					}, {
+						"name":  "lb_class_only",
+						"value": "true",
 					},
 				},
 			},

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -569,6 +569,8 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 					// It allows us greater confidence in successful lifecycle events for the Tinkerbell stack, amongst other things.
 					// Also, the user should be free from Tinkerbell stack constraints
 					// and free to deploy a load balancer of their choosing and not be coupled to ours.
+					// setting lb_class_only=true means that k8s services must explicitly populate
+					// the kube-vip loadBalancerClass with the kube-vip value for kube-vip to serve an IP.
 					{
 						"name":  "lb_class_only",
 						"value": "true",

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -36,6 +36,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"    
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -34,6 +34,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -34,6 +34,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -33,6 +33,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -36,6 +36,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -36,6 +36,8 @@ stack:
     additionalEnv:
     - name: prometheus_server
       value: :2213
+    - name: lb_class_only
+      value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
   loadBalancerIP: 1.2.3.4


### PR DESCRIPTION
*Description of changes:*
Enable `lb_class_only` env var on kube-vip so that it only manages IP for services with LoadBalancerClass set to `kube-vip.io/kube-vip-class` on the service. Without this env var, kube-vip is trying to manage IPs for any service requesting for a Load Balancer IP which isn't expected.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

