### PR TITLE
Fix panic when datacenter obj is not found

### DIFF
--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -2,7 +2,9 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -38,6 +40,8 @@ func cloudstackEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.CloudStackDatacenter != nil {
 					return c.CloudStackDatacenter.Validate()
+				} else if c.Cluster.Spec.DatacenterRef.Kind == v1alpha1.CloudStackDatacenterKind { // We need this conditional check as CloudStackDatacenter will be nil for other providers
+					return fmt.Errorf("CloudStackDatacenterConfig %s not found", c.Cluster.Spec.DatacenterRef.Name)
 				}
 				return nil
 			},

--- a/pkg/cluster/cloudstack_test.go
+++ b/pkg/cluster/cloudstack_test.go
@@ -21,6 +21,16 @@ func TestParseConfigMissingCloudstackDatacenter(t *testing.T) {
 	g.Expect(got.CloudStackDatacenter).To(BeNil())
 }
 
+func TestValidateCloudStackDatacenterNotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	got, _ := cluster.ParseConfigFromFile("testdata/cluster_cloudstack_missing_datacenter.yaml")
+	g.Expect(got.CloudStackDatacenter).To(BeNil())
+
+	cm, _ := cluster.NewDefaultConfigManager()
+	err := cm.Validate(got)
+	g.Expect(err).To(MatchError(ContainSubstring("CloudStackDatacenterConfig eksa-unit-test not found")))
+}
+
 func TestDefaultConfigClientBuilderBuildCloudStackClusterSuccess(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -2,7 +2,9 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -20,6 +22,8 @@ func dockerEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.DockerDatacenter != nil {
 					return c.DockerDatacenter.Validate()
+				} else if c.Cluster.Spec.DatacenterRef.Kind == v1alpha1.DockerDatacenterKind { // We need this conditional check as DockerDatacenter will be nil for other providers
+					return fmt.Errorf("DockerDatacenterConfig %s not found", c.Cluster.Spec.DatacenterRef.Name)
 				}
 				return nil
 			},

--- a/pkg/cluster/docker_test.go
+++ b/pkg/cluster/docker_test.go
@@ -22,6 +22,16 @@ func TestParseConfigMissingDockerDatacenter(t *testing.T) {
 	g.Expect(got.DockerDatacenter).To(BeNil())
 }
 
+func TestValidateDockerDatacenterNotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	got, _ := cluster.ParseConfigFromFile("testdata/cluster_docker_missing_datacenter.yaml")
+	g.Expect(got.DockerDatacenter).To(BeNil())
+
+	cm, _ := cluster.NewDefaultConfigManager()
+	err := cm.Validate(got)
+	g.Expect(err).To(MatchError(ContainSubstring("DockerDatacenterConfig eksa-unit-test not found")))
+}
+
 func TestDefaultConfigClientBuilderDockerCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/pkg/cluster/nutanix.go
+++ b/pkg/cluster/nutanix.go
@@ -2,7 +2,9 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -24,6 +26,8 @@ func nutanixEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.NutanixDatacenter != nil {
 					return c.NutanixDatacenter.Validate()
+				} else if c.Cluster.Spec.DatacenterRef.Kind == v1alpha1.NutanixDatacenterKind { // We need this conditional check as NutanixDatacenter will be nil for other providers
+					return fmt.Errorf("NutanixDatacenterConfig %s not found", c.Cluster.Spec.DatacenterRef.Name)
 				}
 				return nil
 			},

--- a/pkg/cluster/nutanix_test.go
+++ b/pkg/cluster/nutanix_test.go
@@ -57,6 +57,11 @@ func TestValidateNutanixEntry(t *testing.T) {
 
 	err = cm.Validate(config)
 	assert.NoError(t, err)
+
+	config.NutanixDatacenter = nil
+	err = cm.Validate(config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NutanixDatacenterConfig eksa-unit-test not found")
 }
 
 func TestNutanixConfigClientBuilder(t *testing.T) {

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -2,7 +2,9 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -32,6 +34,8 @@ func tinkerbellEntry() *ConfigManagerEntry {
 					if err := validateSameNamespace(c, c.TinkerbellDatacenter); err != nil {
 						return err
 					}
+				} else if c.Cluster.Spec.DatacenterRef.Kind == v1alpha1.TinkerbellDatacenterKind { // We need this conditional check as TinkerbellDatacenter will be nil for other providers
+					return fmt.Errorf("TinkerbellDatacenterConfig %s not found", c.Cluster.Spec.DatacenterRef.Name)
 				}
 				return nil
 			},

--- a/pkg/cluster/tinkerbell_test.go
+++ b/pkg/cluster/tinkerbell_test.go
@@ -163,6 +163,16 @@ func TestParseConfigFromFileTinkerbellCluster(t *testing.T) {
 	)
 }
 
+func TestValidateTinkerbellDatacenterNotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	got, err := cluster.ParseConfigFromFile("testdata/cluster_tinkerbell_1_19.yaml")
+	g.Expect(err).NotTo(HaveOccurred())
+	got.TinkerbellDatacenter = nil
+	cm, _ := cluster.NewDefaultConfigManager()
+	err = cm.Validate(got)
+	g.Expect(err).To(MatchError(ContainSubstring("TinkerbellDatacenterConfig test not found")))
+}
+
 func TestDefaultConfigClientBuilderTinkerbellCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -2,7 +2,9 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
@@ -39,6 +41,8 @@ func vsphereEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.VSphereDatacenter != nil {
 					return c.VSphereDatacenter.Validate()
+				} else if c.Cluster.Spec.DatacenterRef.Kind == v1alpha1.VSphereDatacenterKind { // We need this conditional check as VSphereDatacenter will be nil for other providers
+					return fmt.Errorf("VSphereDatacenterConfig %s not found", c.Cluster.Spec.DatacenterRef.Name)
 				}
 				return nil
 			},

--- a/pkg/cluster/vsphere_test.go
+++ b/pkg/cluster/vsphere_test.go
@@ -23,6 +23,16 @@ func TestParseConfigMissingVSphereDatacenter(t *testing.T) {
 	g.Expect(got.VSphereDatacenter).To(BeNil())
 }
 
+func TestValidateVSphereDatacenterNotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	got, _ := cluster.ParseConfigFromFile("testdata/cluster_vsphere_missing_datacenter.yaml")
+	g.Expect(got.VSphereDatacenter).To(BeNil())
+
+	cm, _ := cluster.NewDefaultConfigManager()
+	err := cm.Validate(got)
+	g.Expect(err).To(MatchError(ContainSubstring("VSphereDatacenterConfig eksa-unit-test2 not found")))
+}
+
 func TestDefaultConfigClientBuilderVSphereCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()


### PR DESCRIPTION
*Description of changes:*
When the config parser is unable to find a object such as Datacenter/MachineConfig due to a typo in the DatacenterRef name (or if it was never passed in the spec), parser just doesn't set that object and doesn't do any validations around it. Accessing those objects later leads to a panic at runtime. 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x148 pc=0x103493f20]
```

This change adds validations on the config, around the Datacenter obj if it's not found in the config to explicitly error out.

```
Error: unable to get cluster config from file: invalid cluster config: VSphereDatacenterConfig name rahul-130-br-tst1 not found
```

Fixes #7531 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

