### PR TITLE
[release-0.19] Log ssm command details when an e2e test finishes

### DIFF
--- a/internal/pkg/ssm/run_output.go
+++ b/internal/pkg/ssm/run_output.go
@@ -20,3 +20,8 @@ func buildRunOutput(commandOut *ssm.GetCommandInvocationOutput) *RunOutput {
 func (r *RunOutput) Successful() bool {
 	return *r.commandOut.Status == ssm.CommandInvocationStatusSuccess
 }
+
+// StatusDetails returns the status details of the ssm command.
+func (r *RunOutput) StatusDetails() string {
+	return *r.commandOut.StatusDetails
+}

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -157,6 +157,7 @@ func RunTestsInParallel(conf ParallelRunConf) error {
 			"instanceId", r.conf.instanceId,
 			"completedInstances", completedInstances,
 			"totalInstances", totalInstances,
+			"ssmStatusDetails", r.testCommandResult.StatusDetails(),
 		)
 	}
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/aws/eks-anywhere/pull/8313