### PR TITLE
Added verbiage about infra-specific commands

### DIFF
--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -33,6 +33,18 @@ More information on troubleshooting EKS Anywhere is available from the [AWS Know
 
 ## General troubleshooting
 
+### Infrastructure-specific commands and output (vSphere vs Bare Metal, for example)
+
+You may need to adapt the commands in the troubleshooting examples provided on this page for the infrastructure you are using.  
+Here are examples of what you may see depending on which infrastrurcture you are deploying to:
+
+* capi-system (General)
+* capv-system (vSphere) 
+* capc-system (CloudStack) 
+* capv-system (Nutanix) 
+* capd-system (Docker) 
+* capt-system (Tinkerbell) 
+
 ### Increase eksctl anywhere output
 
 If you’re having trouble running `eksctl anywhere` you may get more verbose output with the `-v 6` option. The highest level of verbosity is `-v 9` and the default level of logging is level equivalent to `-v 0`.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/8517

*Description of changes:*
Added verbiage about infra-specific commands 
capc-system vs capv-system (CloudStack vs vSphere - for example)

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

