### PR TITLE
Fix machine config panic when ref object not found

### DIFF
--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -48,14 +48,13 @@ func cloudstackEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.CloudStackMachineConfigs != nil { // We need this conditional check as CloudStackMachineConfigs will be nil for other providers
 					for _, mcRef := range c.Cluster.MachineConfigRefs() {
-						if _, ok := c.CloudStackMachineConfigs[mcRef.Name]; !ok {
+						m, ok := c.CloudStackMachineConfigs[mcRef.Name]
+						if !ok {
 							return fmt.Errorf("CloudStackMachineConfig %s not found", mcRef.Name)
 						}
-					}
-				}
-				for _, m := range c.CloudStackMachineConfigs {
-					if err := m.Validate(); err != nil {
-						return err
+						if err := m.Validate(); err != nil {
+							return err
+						}
 					}
 				}
 				return nil

--- a/pkg/cluster/cloudstack.go
+++ b/pkg/cluster/cloudstack.go
@@ -46,6 +46,13 @@ func cloudstackEntry() *ConfigManagerEntry {
 				return nil
 			},
 			func(c *Config) error {
+				if c.CloudStackMachineConfigs != nil { // We need this conditional check as CloudStackMachineConfigs will be nil for other providers
+					for _, mcRef := range c.Cluster.MachineConfigRefs() {
+						if _, ok := c.CloudStackMachineConfigs[mcRef.Name]; !ok {
+							return fmt.Errorf("CloudStackMachineConfig %s not found", mcRef.Name)
+						}
+					}
+				}
 				for _, m := range c.CloudStackMachineConfigs {
 					if err := m.Validate(); err != nil {
 						return err

--- a/pkg/cluster/cloudstack_test.go
+++ b/pkg/cluster/cloudstack_test.go
@@ -31,6 +31,16 @@ func TestValidateCloudStackDatacenterNotFoundError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("CloudStackDatacenterConfig eksa-unit-test not found")))
 }
 
+func TestValidateCloudStackMachineConfigNotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	got, _ := cluster.ParseConfigFromFile("testdata/cluster_1_20_cloudstack.yaml")
+	got.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "dummy-machine-config"
+
+	cm, _ := cluster.NewDefaultConfigManager()
+	err := cm.Validate(got)
+	g.Expect(err).To(MatchError(ContainSubstring("CloudStackMachineConfig dummy-machine-config not found")))
+}
+
 func TestDefaultConfigClientBuilderBuildCloudStackClusterSuccess(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/pkg/cluster/nutanix.go
+++ b/pkg/cluster/nutanix.go
@@ -39,6 +39,16 @@ func nutanixEntry() *ConfigManagerEntry {
 				}
 				return nil
 			},
+			func(c *Config) error {
+				if c.NutanixMachineConfigs != nil { // We need this conditional check as NutanixMachineConfigs will be nil for other providers
+					for _, mcRef := range c.Cluster.MachineConfigRefs() {
+						if _, ok := c.NutanixMachineConfigs[mcRef.Name]; !ok {
+							return fmt.Errorf("NutanixMachineConfig %s not found", mcRef.Name)
+						}
+					}
+				}
+				return nil
+			},
 		},
 	}
 }

--- a/pkg/cluster/nutanix_test.go
+++ b/pkg/cluster/nutanix_test.go
@@ -62,6 +62,12 @@ func TestValidateNutanixEntry(t *testing.T) {
 	err = cm.Validate(config)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "NutanixDatacenterConfig eksa-unit-test not found")
+
+	missingMachineconfig := "dummy-machine-config"
+	config.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = missingMachineconfig
+	err = cm.Validate(config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("NutanixMachineConfig %s not found", missingMachineconfig))
 }
 
 func TestNutanixConfigClientBuilder(t *testing.T) {

--- a/pkg/cluster/testdata/cluster_tinkerbell_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_tinkerbell_1_19.yaml
@@ -58,6 +58,22 @@ spec:
 
 ---
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: TinkerbellMachineConfig
+metadata:
+  name: test-md
+  namespace: test-namespace
+spec:
+  osFamily: ubuntu
+  templateRef:
+    kind: TinkerbellTemplateConfig
+    name: tink-test
+  users:
+    - name: tink-user
+      sshAuthorizedKeys:
+        - "ssh-rsa AAAAB3"
+
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: TinkerbellTemplateConfig
 metadata:
   name: tink-test

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -42,14 +42,13 @@ func tinkerbellEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.TinkerbellMachineConfigs != nil { // We need this conditional check as TinkerbellMachineConfigs will be nil for other providers
 					for _, mcRef := range c.Cluster.MachineConfigRefs() {
-						if _, ok := c.TinkerbellMachineConfigs[mcRef.Name]; !ok {
+						m, ok := c.TinkerbellMachineConfigs[mcRef.Name]
+						if !ok {
 							return fmt.Errorf("TinkerbellMachineConfig %s not found", mcRef.Name)
 						}
-					}
-				}
-				for _, t := range c.TinkerbellMachineConfigs {
-					if err := validateSameNamespace(c, t); err != nil {
-						return err
+						if err := validateSameNamespace(c, m); err != nil {
+							return err
+						}
 					}
 				}
 				return nil

--- a/pkg/cluster/tinkerbell.go
+++ b/pkg/cluster/tinkerbell.go
@@ -40,6 +40,13 @@ func tinkerbellEntry() *ConfigManagerEntry {
 				return nil
 			},
 			func(c *Config) error {
+				if c.TinkerbellMachineConfigs != nil { // We need this conditional check as TinkerbellMachineConfigs will be nil for other providers
+					for _, mcRef := range c.Cluster.MachineConfigRefs() {
+						if _, ok := c.TinkerbellMachineConfigs[mcRef.Name]; !ok {
+							return fmt.Errorf("TinkerbellMachineConfig %s not found", mcRef.Name)
+						}
+					}
+				}
 				for _, t := range c.TinkerbellMachineConfigs {
 					if err := validateSameNamespace(c, t); err != nil {
 						return err

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -47,6 +47,13 @@ func vsphereEntry() *ConfigManagerEntry {
 				return nil
 			},
 			func(c *Config) error {
+				if c.VSphereMachineConfigs != nil { // We need this conditional check as VSphereMachineConfigs will be nil for other providers
+					for _, mcRef := range c.Cluster.MachineConfigRefs() {
+						if _, ok := c.VSphereMachineConfigs[mcRef.Name]; !ok {
+							return fmt.Errorf("VSphereMachineConfig %s not found", mcRef.Name)
+						}
+					}
+				}
 				for _, m := range c.VSphereMachineConfigs {
 					if err := m.Validate(); err != nil {
 						return err

--- a/pkg/cluster/vsphere.go
+++ b/pkg/cluster/vsphere.go
@@ -49,14 +49,13 @@ func vsphereEntry() *ConfigManagerEntry {
 			func(c *Config) error {
 				if c.VSphereMachineConfigs != nil { // We need this conditional check as VSphereMachineConfigs will be nil for other providers
 					for _, mcRef := range c.Cluster.MachineConfigRefs() {
-						if _, ok := c.VSphereMachineConfigs[mcRef.Name]; !ok {
+						m, ok := c.VSphereMachineConfigs[mcRef.Name]
+						if !ok {
 							return fmt.Errorf("VSphereMachineConfig %s not found", mcRef.Name)
 						}
-					}
-				}
-				for _, m := range c.VSphereMachineConfigs {
-					if err := m.Validate(); err != nil {
-						return err
+						if err := m.Validate(); err != nil {
+							return err
+						}
 					}
 				}
 				return nil

--- a/pkg/cluster/vsphere_test.go
+++ b/pkg/cluster/vsphere_test.go
@@ -33,6 +33,16 @@ func TestValidateVSphereDatacenterNotFoundError(t *testing.T) {
 	g.Expect(err).To(MatchError(ContainSubstring("VSphereDatacenterConfig eksa-unit-test2 not found")))
 }
 
+func TestValidateVsphereMachineConfigNotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	got, _ := cluster.ParseConfigFromFile("testdata/cluster_1_19.yaml")
+	got.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "dummy-machine-config"
+
+	cm, _ := cluster.NewDefaultConfigManager()
+	err := cm.Validate(got)
+	g.Expect(err).To(MatchError(ContainSubstring("VSphereMachineConfig dummy-machine-config not found")))
+}
+
 func TestDefaultConfigClientBuilderVSphereCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()


### PR DESCRIPTION
Description of changes:

When the config parser is unable to find a object such as Datacenter/MachineConfig due to a typo in the MachineGroupRef name (or if it was never passed in the spec), parser just doesn't set that object and doesn't do any validations around it. Accessing those objects later leads to a panic at runtime.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x148 pc=0x103493f20]

```

This change adds validations on the config, around the MachineConfig obj if it's not found in the config to explicitly error out.

```
Error: unable to get cluster config from file: invalid cluster config: VSphereMachineConfig name rahul-130-br-tst-cp1 not found
```

*Testing (if applicable):*
Tested manually by passing in invalid MachineRef for CP, etcd and worker nodes.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

