### PR TITLE
Handle CLI tagging when latest tag is of n-1 branch

### DIFF
--- a/scripts/eksa_version.sh
+++ b/scripts/eksa_version.sh
@@ -15,7 +15,6 @@
 
 # get_closest_ancestor_branch returns the branch that is the closest ancestor of the current branch.
 # only main and release-* branches are considered as ancestors.
-set -x
 function eksa-version::get_closest_ancestor_branch() {
     # Get the name of the current branch
     local current_branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
*Description of changes:*
When a 'n-1' version of eks-a is released, the script responsible for tagging the dev CLI pulls in the latest tag, bumps it by 1 to arrive at the next Dev tag for the CLI. This had worked fine until we supported for release branch n. With n-1 support, we need to factor in if the latest release is of 'n-1' and ignore it during the dev tagging.    


*Testing:*
Ran the make eks-a command before and after this change to see the Dev CLI tag.

Before:
`/Library/Developer/CommandLineTools/usr/bin/make eks-a-binary GIT_VERSION=v0.20.0-dev+latest`
After: 
`/Library/Developer/CommandLineTools/usr/bin/make eks-a-binary GIT_VERSION=v0.21.0-dev+latest`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

