### PR TITLE
Elaborate the note when kubelet service failed to start

### DIFF
--- a/docs/content/en/docs/clustermgmt/security/manually-renew-certs.md
+++ b/docs/content/en/docs/clustermgmt/security/manually-renew-certs.md
@@ -194,7 +194,10 @@ rm pki/*
 systemctl restart kubelet
 ```
 
-In some cases, the certs might not regenerate and kubelet will fail to start due to a missing `kubelet-client-current.pem`. If this happens, run the following commands:
+{{% alert title="Note" color="primary" %}}
+When the control plane endpoint is unavailable because the API server pod is not running, the kubelet service may fail to start all static pods in the container runtime. Its logs may contain `failed to connect to apiserver`.
+
+If this occurs, update `kubelet-client-current.pem` by running the following commands:
 
 {{< tabpane >}}
 {{< tab header="Ubuntu or RHEL" lang="bash" >}}
@@ -214,6 +217,8 @@ systemctl restart kubelet
 
 {{< /tab >}}
 {{< /tabpane >}}
+{{% /alert %}}
+
 
 ### Post Renewal
 Once all the certificates are valid, verify the kcp object on the affected cluster(s) is not paused by running `kubectl describe kcp -n eksa-system | grep cluster.x-k8s.io/paused`. If it is paused, then this usually indicates an issue with the etcd cluster. Check the logs for pods under the `etcdadm-controller-system` namespace for any errors. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Elaborate the note when kubelet service failed to start, due to cert expiration.

*Testing (if applicable):* Manually checked the new doc with `hugo serve`

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

