### PR TITLE
Add K8s version 1.30 to supported versions list

### DIFF
--- a/docs/data/version_support.yml
+++ b/docs/data/version_support.yml
@@ -114,6 +114,10 @@ eksa:
 #                        when there is no EKS-A release in the eksa array above. Mutually exclusive
 #                        with `endOfLifeIn`.
 kube:
+- version: '1.30'
+  releasedIn: '0.20'
+  expectedEndOfLifeDate: 2025-06-23
+
 - version: '1.29'
   releasedIn: '0.19'
   expectedEndOfLifeDate: 2025-03-23


### PR DESCRIPTION
*Description of changes:*
Kubernetes version 1.30 support was added in EKS-A with release 0.20. Capture 1.30 as list of supported versions in the docs. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

