### PR TITLE
Add some quick commands for checking certificates

### DIFF
--- a/docs/content/en/docs/clustermgmt/security/manually-renew-certs.md
+++ b/docs/content/en/docs/clustermgmt/security/manually-renew-certs.md
@@ -9,7 +9,7 @@ description: >
   How to rotate certificates for etcd and control plane nodes
 ---
 
-Certificates for external etcd and control plane nodes expire after 1 year in EKS Anywhere. EKS Anywhere automatically rotates these certificates when new machines are rolled out in the cluster. New machines are rolled out during cluster lifecycle operations such as `upgrade`. If you upgrade your cluster at least once a year, you do not have to manually rotate the cluster certificates. 
+Certificates for external etcd and control plane nodes expire after 1 year in EKS Anywhere. EKS Anywhere automatically rotates these certificates when new machines are rolled out in the cluster. New machines are rolled out during cluster lifecycle operations such as `upgrade`. If you upgrade your cluster at least once a year, as recommended, manual rotation of cluster certificates will not be necessary.
 
 This page shows the process for manually rotating certificates if you have not upgraded your cluster in 1 year.
 
@@ -25,6 +25,16 @@ The following table lists the cluster certificate files:
 |                       | apiserver-kubelet-client |
 |                       | apiserver                |
 |                       | front-proxy-client       |
+
+Commands below can be used for quickly checking your certificates expiring date:
+
+```bash
+# The expiry time of api-server certificate on you cp node
+echo | openssl s_client -connect ${CONTROL_PLANE_IP}:6443 2>/dev/null | openssl x509 -noout -dates
+
+# The expiry time of certificate used by your external etcd server, if you configured one
+echo | openssl s_client -connect ${EXTERNAL_ETCD_IP}:2379 2>/dev/null | openssl x509 -noout -dates
+```
 
 You can rotate certificates by following the steps given below. You cannot rotate the `ca` certificate because it is the root certificate. Note that the commands used for Bottlerocket nodes are different than those for Ubuntu and RHEL nodes.
 

--- a/docs/content/en/docs/troubleshooting/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting/troubleshooting.md
@@ -583,7 +583,7 @@ kubectl get nodes --no-headers -l '!node-role.kubernetes.io/control-plane' -o js
 ```
 
 ### No static pods is running in container runtime on control plane nodes
-When the kubelet systemd service is running on a control plane node and you notice that no static pods are running, this could be due to a certificate issue. Check the kubelet service logs. If you see error messages like the ones below, renew the kubelet-client-current.pem certificate by following [these steps]({{< relref "../clustermgmt/security/manually-renew-certs/#kubelet" >}}):
+When the kubelet systemd service is running on a control plane node and you notice that no [static pods](https://kubernetes.io/docs/concepts/workloads/pods/#static-pods) are running, this could be due to a certificate issue. Check the kubelet service logs. If you see error messages like the ones below, renew the kubelet-client-current.pem certificate by following [these steps]({{< relref "../clustermgmt/security/manually-renew-certs/#kubelet" >}}):
 ```
 part of the existing bootstrap client certificate in /etc/kubernetes/kubelet/kubeconfig
 Loading cert/key pair from "/var/lib/kubelet/pki/kubelet-client-current.pem


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/eks-anywhere-internal/issues/2452

*Description of changes:* We have documented the steps to check certificate expiration from within the nodes, but we had not previously covered how to perform this check from outside the nodes. The newly added steps address this gap, providing a useful method for automated certificate health checks

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

