### PR TITLE
Curated packages tests using regional packages for vSphere

### DIFF
--- a/test/e2e/adot.go
+++ b/test/e2e/adot.go
@@ -27,6 +27,7 @@ func runCuratedPackagesAdotInstall(test *framework.ClusterE2ETest) {
 
 func runCuratedPackagesAdotInstallWithUpdate(test *framework.ClusterE2ETest) {
 	test.SetPackageBundleActive()
+	test.ValidateIfRegionalCuratedPackage()
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),

--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -12,6 +12,7 @@ func runAutoscalerWithMetricsServerSimpleFlow(test *framework.ClusterE2ETest) {
 		autoscalerName := "cluster-autoscaler"
 		metricServerName := "metrics-server"
 		targetNamespace := "eksa-packages"
+		test.ValidateIfRegionalCuratedPackage()
 		test.InstallAutoScalerWithMetricServer(targetNamespace)
 		test.CombinedAutoScalerMetricServerTest(autoscalerName, metricServerName, targetNamespace, withCluster(test))
 	})

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -29,6 +29,9 @@ func runCuratedPackageInstall(test *framework.ClusterE2ETest) {
 	if err != nil {
 		test.T.Fatalf("packages controller crds not in installed state: %s", err)
 	}
+
+	test.ValidateIfRegionalCuratedPackage()
+
 	packageName := "hello-eks-anywhere"
 	packagePrefix := "test"
 	packageFile := test.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1352,17 +1352,7 @@ func TestDockerKubernetesRegionalCuratedPackages(t *testing.T) {
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
 	)
 
-	test.WithCluster(func(e *framework.ClusterE2ETest) {
-		runCuratedPackageInstall(e)
-
-		pbc, err := test.KubectlClient.GetPackageBundleController(context.Background(), test.KubeconfigFilePath(), test.ClusterName)
-		if err != nil {
-			e.T.Fatalf("cannot get PackageBundleController: %v", err)
-		}
-		if pbc.Spec.DefaultImageRegistry != pbc.Spec.DefaultRegistry {
-			e.T.Fatal("in regional pbc, DefaultImageRegistry should equal to DefaultRegistry")
-		}
-	})
+	runCuratedPackageInstallSimpleFlow(test)
 }
 
 func TestDockerKubernetesUpgradeManagementComponents(t *testing.T) {

--- a/test/e2e/emissary.go
+++ b/test/e2e/emissary.go
@@ -18,6 +18,7 @@ const (
 
 func runCuratedPackageEmissaryInstall(test *framework.ClusterE2ETest) {
 	test.SetPackageBundleActive()
+	test.ValidateIfRegionalCuratedPackage()
 	packageFile := test.BuildPackageConfigFile(emissaryPackageName, emissaryPackagePrefix, EksaPackagesNamespace)
 	test.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ClusterName))
 	test.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withCluster(test))

--- a/test/e2e/harbor.go
+++ b/test/e2e/harbor.go
@@ -10,6 +10,7 @@ import (
 
 func runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test *framework.ClusterE2ETest) {
 	test.WithCluster(func(test *framework.ClusterE2ETest) {
+		test.ValidateIfRegionalCuratedPackage()
 		test.InstallLocalStorageProvisioner()
 
 		packagePrefix := "test"

--- a/test/e2e/prometheus.go
+++ b/test/e2e/prometheus.go
@@ -19,6 +19,7 @@ func runCuratedPackagesPrometheusInstall(test *framework.ClusterE2ETest) {
 	test.InstallLocalStorageProvisioner()
 	test.CreateNamespace(prometheusPackageTargetNamespace)
 	test.SetPackageBundleActive()
+	test.ValidateIfRegionalCuratedPackage()
 	test.InstallCuratedPackage(prometheusPackageName, packageFullName,
 		kubeconfig.FromClusterName(test.ClusterName),
 		"--set server.persistentVolume.storageClass=local-path")

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -268,7 +268,7 @@ func TestVSphereKubernetes126CuratedPackagesSimpleFlow(t *testing.T) {
 	runCuratedPackageInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127CuratedPackagesSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127RegionalCuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu127()),
@@ -292,7 +292,7 @@ func TestVSphereKubernetes128CuratedPackagesSimpleFlow(t *testing.T) {
 	runCuratedPackageInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes129CuratedPackagesSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129RegionalCuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu129()),
@@ -328,7 +328,7 @@ func TestVSphereKubernetes126BottleRocketCuratedPackagesSimpleFlow(t *testing.T)
 	runCuratedPackageInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127BottleRocketCuratedPackagesSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127BottleRocketRegionalCuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket127()),
@@ -352,7 +352,7 @@ func TestVSphereKubernetes128BottleRocketCuratedPackagesSimpleFlow(t *testing.T)
 	runCuratedPackageInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes129BottleRocketCuratedPackagesSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129BottleRocketRegionalCuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket129()),
@@ -388,7 +388,7 @@ func TestVSphereKubernetes126CuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	runCuratedPackageEmissaryInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127CuratedPackagesEmissarySimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127RegionalCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu127()),
@@ -412,7 +412,7 @@ func TestVSphereKubernetes128CuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	runCuratedPackageEmissaryInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes129CuratedPackagesEmissarySimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129RegionalCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu129()),
@@ -448,7 +448,7 @@ func TestVSphereKubernetes126BottleRocketCuratedPackagesEmissarySimpleFlow(t *te
 	runCuratedPackageEmissaryInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127BottleRocketCuratedPackagesEmissarySimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127BottleRocketRegionalCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket127()),
@@ -472,7 +472,7 @@ func TestVSphereKubernetes128BottleRocketCuratedPackagesEmissarySimpleFlow(t *te
 	runCuratedPackageEmissaryInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes129BottleRocketCuratedPackagesEmissarySimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129BottleRocketRegionalCuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket129()),
@@ -508,7 +508,7 @@ func TestVSphereKubernetes126CuratedPackagesHarborSimpleFlow(t *testing.T) {
 	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
 }
 
-func TestVSphereKubernetes127CuratedPackagesHarborSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127RegionalCuratedPackagesHarborSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu127()),
@@ -532,7 +532,7 @@ func TestVSphereKubernetes128CuratedPackagesHarborSimpleFlow(t *testing.T) {
 	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
 }
 
-func TestVSphereKubernetes129CuratedPackagesHarborSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129RegionalCuratedPackagesHarborSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu129()),
@@ -568,7 +568,7 @@ func TestVSphereKubernetes126BottleRocketCuratedPackagesHarborSimpleFlow(t *test
 	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
 }
 
-func TestVSphereKubernetes127BottleRocketCuratedPackagesHarborSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127BottleRocketRegionalCuratedPackagesHarborSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket127()),
@@ -592,7 +592,7 @@ func TestVSphereKubernetes128BottleRocketCuratedPackagesHarborSimpleFlow(t *test
 	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
 }
 
-func TestVSphereKubernetes129BottleRocketCuratedPackagesHarborSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129BottleRocketRegionalCuratedPackagesHarborSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket129()),
@@ -628,7 +628,7 @@ func TestVSphereKubernetes126CuratedPackagesAdotUpdateFlow(t *testing.T) {
 	runCuratedPackagesAdotInstallUpdateFlow(test)
 }
 
-func TestVSphereKubernetes127CuratedPackagesAdotUpdateFlow(t *testing.T) {
+func TestVSphereKubernetes127RegionalCuratedPackagesAdotUpdateFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu127()),
@@ -652,7 +652,7 @@ func TestVSphereKubernetes128CuratedPackagesAdotUpdateFlow(t *testing.T) {
 	runCuratedPackagesAdotInstallUpdateFlow(test)
 }
 
-func TestVSphereKubernetes129CuratedPackagesAdotUpdateFlow(t *testing.T) {
+func TestVSphereKubernetes129RegionalCuratedPackagesAdotUpdateFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu129()),
@@ -688,7 +688,7 @@ func TestVSphereKubernetes126BottleRocketCuratedPackagesAdotUpdateFlow(t *testin
 	runCuratedPackagesAdotInstallUpdateFlow(test)
 }
 
-func TestVSphereKubernetes127BottleRocketCuratedPackagesAdotUpdateFlow(t *testing.T) {
+func TestVSphereKubernetes127BottleRocketRegionalCuratedPackagesAdotUpdateFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket127()),
@@ -712,7 +712,7 @@ func TestVSphereKubernetes128BottleRocketCuratedPackagesAdotUpdateFlow(t *testin
 	runCuratedPackagesAdotInstallUpdateFlow(test)
 }
 
-func TestVSphereKubernetes129BottleRocketCuratedPackagesAdotUpdateFlow(t *testing.T) {
+func TestVSphereKubernetes129BottleRocketRegionalCuratedPackagesAdotUpdateFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket129()),
@@ -750,7 +750,7 @@ func TestVSphereKubernetes126UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t 
 	runAutoscalerWithMetricsServerSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127UbuntuRegionalCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2
 	framework.CheckCuratedPackagesCredentials(t)
@@ -778,7 +778,7 @@ func TestVSphereKubernetes128UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t 
 	runAutoscalerWithMetricsServerSimpleFlow(test)
 }
 
-func TestVSphereKubernetes129UbuntuCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129UbuntuRegionalCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2
 	framework.CheckCuratedPackagesCredentials(t)
@@ -820,7 +820,7 @@ func TestVSphereKubernetes126BottleRocketCuratedPackagesClusterAutoscalerSimpleF
 	runAutoscalerWithMetricsServerSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127BottleRocketCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127BottleRocketRegionalCuratedPackagesClusterAutoscalerSimpleFlow(t *testing.T) {
 	minNodes := 1
 	maxNodes := 2
 	framework.CheckCuratedPackagesCredentials(t)
@@ -915,7 +915,7 @@ func TestVSphereKubernetes126UbuntuCuratedPackagesPrometheusSimpleFlow(t *testin
 	runCuratedPackagesPrometheusInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127UbuntuCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127UbuntuRegionalCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu127()),
@@ -939,7 +939,7 @@ func TestVSphereKubernetes128UbuntuCuratedPackagesPrometheusSimpleFlow(t *testin
 	runCuratedPackagesPrometheusInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes129UbuntuCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes129UbuntuRegionalCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu129()),
@@ -975,7 +975,7 @@ func TestVSphereKubernetes126BottleRocketCuratedPackagesPrometheusSimpleFlow(t *
 	runCuratedPackagesPrometheusInstallSimpleFlow(test)
 }
 
-func TestVSphereKubernetes127BottleRocketCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
+func TestVSphereKubernetes127BottleRocketRegionalCuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithBottleRocket127()),

--- a/test/framework/cluster_test.go
+++ b/test/framework/cluster_test.go
@@ -1,0 +1,41 @@
+package framework
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	packagesv1 "github.com/aws/eks-anywhere-packages/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/executables"
+	mockexecutables "github.com/aws/eks-anywhere/pkg/executables/mocks"
+)
+
+func TestValidateIfRegionalCuratedPackage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	executable := mockexecutables.NewMockExecutable(ctrl)
+	testPbc := &packagesv1.PackageBundleController{
+		Spec: packagesv1.PackageBundleControllerSpec{
+			DefaultRegistry:      "123.ecr",
+			DefaultImageRegistry: "123.ecr",
+		},
+	}
+	respJSON, err := json.Marshal(testPbc)
+	if err != nil {
+		t.Errorf("marshaling test service: %s", err)
+	}
+	ret := bytes.NewBuffer(respJSON)
+	expectedParam := []string{"get", "packagebundlecontroller.packages.eks.amazonaws.com", "test", "-o", "json", "--kubeconfig", "test/test-eks-a-cluster.kubeconfig", "--namespace", "eksa-packages", "--ignore-not-found=true"}
+	t.Run("IsARegionalCuratedPackagesTest", func(t *testing.T) {
+		e := &ClusterE2ETest{
+			T:                   t,
+			ClusterConfigFolder: "test",
+			ClusterName:         "test",
+			KubectlClient:       executables.NewKubectl(executable),
+		}
+
+		executable.EXPECT().Execute(gomock.Any(), gomock.Eq(expectedParam)).Return(*ret, nil).AnyTimes()
+		e.ValidateIfRegionalCuratedPackage()
+	})
+}

--- a/test/framework/testingt.go
+++ b/test/framework/testingt.go
@@ -105,7 +105,7 @@ func (t LoggingOnlyT) Logf(format string, args ...any) {
 
 // Name implements T.
 func (t LoggingOnlyT) Name() string {
-	panic("LoggingOnlyT implements only the logging methods of T")
+	return (&testing.T{}).Name()
 }
 
 // Parallel implements T.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Today we have only one e2e test that uses the regional (subscriptions) package registries. We want to increase the testing since we hope to make regional the default. 

*Testing:*
```
./e2e.test -test.v -test.run "TestVSphereKubernetes129RegionalCuratedPackagesSimpleFlow"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

