### PR TITLE
Add docs for worker node kubelet client cert manual renewal

### DIFF
--- a/docs/content/en/docs/clustermgmt/security/manually-renew-certs.md
+++ b/docs/content/en/docs/clustermgmt/security/manually-renew-certs.md
@@ -219,6 +219,52 @@ systemctl restart kubelet
 {{< /tabpane >}}
 {{% /alert %}}
 
+#### Worker nodes
+If worker nodes are in `Not Ready` state and the kubelet fails to bootstrap then it's likely that the kubelet client-cert `kubelet-client-current.pem` did not automatically rotate. If this rotation process fails you might see errors such as `x509: certificate has expired or is not yet valid` in kube-apiserver logs. To fix the issue, do the following:
+
+1. Backup and delete `/etc/kubernetes/kubelet.conf` (ignore this file for BottleRocket) and `/var/lib/kubelet/pki/kubelet-client*` from the failed node.
+
+2. From a working control plane node in the cluster that has /etc/kubernetes/pki/ca.key execute `kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf`. `$NODE` must be set to the name of the existing failed node in the cluster.  Modify the resulted kubelet.conf manually to adjust the cluster name and server endpoint, or pass `kubeconfig user --config` (modifying `kubelet.conf` file can be ignored for BottleRocket).
+
+3. For Ubuntu or RHEL nodes, Copy this resulted `kubelet.conf` to `/etc/kubernetes/kubelet.conf` on the failed node. Restart the kubelet (`systemctl restart kubelet`) on the failed node and wait for `/var/lib/kubelet/pki/kubelet-client-current.pem` to be recreated. Manually edit the `kubelet.conf` to point to the rotated kubelet client certificates  by replacing client-certificate-data and client-key-data with `/var/lib/kubelet/pki/kubelet-client-current.pem` and `/var/lib/kubelet/pki/kubelet-client-current.pem`. For BottleRocket, manually copy over the base64 decoded values of `client-certificate-data` and `client-key-data` into the `kubelet-client-current.pem` on worker node. 
+
+{{< tabpane >}}
+{{< tab header="Ubuntu or RHEL" lang="bash" >}}
+kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE > kubelet.conf (from control plane node with renewed `/etc/kubernetes/pki/ca.key`)
+cp kubelet.conf /etc/kubernetes/kubelet.conf (on failed worker node)
+
+{{< /tab >}}
+{{< tab header="Bottlerocket" lang="bash" >}}
+# From control plane node with renewed certs
+# you would be in the admin container when you ssh to the Bottlerocket machine
+# open root shell
+sudo sheltie
+
+# pull the image
+IMAGE_ID=$(apiclient get | apiclient exec admin jq -r '.settings["host-containers"]["kubeadm-bootstrap"].source')
+ctr image pull ${IMAGE_ID}
+
+# set NODE value to the failed worker node name.
+ctr run \
+--mount type=bind,src=/var/lib/kubeadm,dst=/var/lib/kubeadm,options=rbind:rw \
+--mount type=bind,src=/var/lib/kubeadm,dst=/etc/kubernetes,options=rbind:rw \
+--rm \
+${IMAGE_ID} tmp-cert-renew \
+/opt/bin/kubeadm kubeconfig user --org system:nodes --client-name system:node:$NODE 
+
+# from the stdout base64 decode `client-certificate-data` and `client-key-data`
+# copy client-cert to kubelet-client-current.pem on worker node
+echo -n `<base64 decoded client-certificate-data value>` > kubelet-client-current.pem
+
+# append client key to kubelet-client-current.pem on worker node
+echo -n `<base64 decoded client-key-data value>` >> kubelet-client-current.pem
+
+{{< /tab >}}
+{{< /tabpane >}}
+
+4. Restart the kubelet. Make sure the node becomes `Ready`.
+
+See the [Kubernetes documentation](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/#kubelet-client-cert) for more details on manually updating kubelet client certificate.
 
 ### Post Renewal
 Once all the certificates are valid, verify the kcp object on the affected cluster(s) is not paused by running `kubectl describe kcp -n eksa-system | grep cluster.x-k8s.io/paused`. If it is paused, then this usually indicates an issue with the etcd cluster. Check the logs for pods under the `etcdadm-controller-system` namespace for any errors. 


### PR DESCRIPTION
*Issue #, if available:*
Our documentation manual cert renewal section, missed covering manual renewal of Kubelet client-cert on worker nodes in case they expire. Add documentation to manually renew them for worker nodes.  
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

