### PR TITLE
Run conformance for 1.29 and above in default mode

### DIFF
--- a/pkg/executables/sonobuoy.go
+++ b/pkg/executables/sonobuoy.go
@@ -27,7 +27,6 @@ func (k *Sonobuoy) Run(ctx context.Context, contextName string, args ...string) 
 		"--context",
 		contextName,
 		"run",
-		"--mode=certified-conformance",
 		"--wait",
 	}
 	executionArgs = append(executionArgs, args...)

--- a/test/framework/conformance.go
+++ b/test/framework/conformance.go
@@ -61,6 +61,11 @@ func (e *ClusterE2ETest) RunConformanceTests() {
 	// 3. https://github.com/cncf/k8s-conformance/pull/3049
 	if k8s129Compare != -1 {
 		args = append(args, fmt.Sprintf("--e2e-skip='%s'", skippedTestName))
+	} else {
+		// Only mode or --e2e-skip can be used at a time. Because we are using --e2e-skip
+		// for k8s 1.29 and higher, we need to skip --mode=certified-conformance for those versions.
+		// Once we stop skipping e2e, we can add the mode back to k8s 1.29 and higher.
+		args = append(args, "--mode=certified-conformance")
 	}
 	e.T.Logf("Running k8s conformance tests with Image: %s", kubeConformanceImageTagged)
 	output, err := conformance.RunTests(ctx, contextName, args...)


### PR DESCRIPTION
*Description of changes:*
The 129 and 130 conformance tests are failing currently because we are using the `e2e-skip` flag along with `--mode` flag, which is disallowed. 
This is from the test logs
```
conformance.go:68: Error running k8s conformance tests: executing sonobuoy: Error: mode flag and e2e-focus/skip flags both provided and may cause unintended behavior
```
To get around it and get the conformance tests passing, we are going to run 129 and 130 in the default mode so the validation doesn't fail. We can change this behavior to run with `--mode=certified-conformance` once we stop using `e2e-skip` for these versions.

*Testing (if applicable):*
Ran and verified the tests locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

