### PR TITLE
Fix tink-relay and tink-relay-init images

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -584,8 +584,8 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 			},
 			relay: map[string]interface{}{
 				enabled:     s.dhcpRelay,
-				image:       bundle.TinkerbellStack.Tink.TinkRelay,
-				"initImage": bundle.TinkerbellStack.Tink.TinkRelayInit,
+				image:       bundle.TinkerbellStack.Tink.TinkRelay.URI,
+				"initImage": bundle.TinkerbellStack.Tink.TinkRelayInit.URI,
 			},
 			"loadBalancerIP": tinkerbellIP,
 			"hostNetwork":    s.hostNetwork,

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -42,10 +42,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -40,10 +40,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -40,10 +40,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -39,10 +39,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -42,10 +42,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -42,10 +42,8 @@ stack:
   loadBalancerIP: 1.2.3.4
   relay:
     enabled: false
-    image:
-      uri: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage:
-      uri: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    image: public.ecr.aws/eks-anywhere/tink-relay:latest
+    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
 tink:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tink-relay and relay-init images did not reference the URI in the bundle properly.
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


