### PR TITLE
Check against regional public ECR for getting registry

### DIFF
--- a/pkg/curatedpackages/regional_registry.go
+++ b/pkg/curatedpackages/regional_registry.go
@@ -65,7 +65,7 @@ func TestRegistryWithAuthToken(authToken, registry string, do Do) error {
 
 // GetRegionalRegistry get the regional registry corresponding to defaultRegistry in a specific region.
 func GetRegionalRegistry(defaultRegistry, region string) string {
-	if strings.Contains(defaultRegistry, devNonRegionalPublicRegistryAlias) {
+	if strings.Contains(defaultRegistry, devRegionalPublicRegistryAlias) {
 		return devRegionalPrivateRegistryURI
 	}
 	if strings.Contains(defaultRegistry, stagingPublicRegistryAlias) {


### PR DESCRIPTION
*Description of changes:*
Check against regional public ECR for getting registry since we are using the same registry for testing regional and non-regional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

