### PR TITLE
Remove release logic for RTOS images

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -145,65 +145,6 @@ func KernelArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettype
 	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil
 }
 
-func RTOSArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.Archive, projectPath, gitTag, eksDReleaseChannel, eksDReleaseNumber, kubeVersion, latestPath, arch string) (string, string, string, string, error) {
-	var sourceS3Key string
-	var sourceS3Prefix string
-	var releaseS3Path string
-	var releaseName string
-	releaseDate := gitTag
-	eksDReleaseChannel = "1-29" // hardcoding because we vend RTOS artifacts only for 1-29 release branch
-
-	imageExtensions := map[string]string{
-		"ami": "gz",
-		"ova": "ova",
-		"raw": "gz",
-	}
-	imageExtension := imageExtensions[archive.Format]
-
-	if rc.DevRelease || rc.ReleaseEnvironment == "development" {
-		sourceS3Key = fmt.Sprintf("%s.%s", archive.OSName, imageExtension)
-		sourceS3Prefix = fmt.Sprintf("%s/%s", projectPath, latestPath)
-	} else {
-		sourceS3Key = fmt.Sprintf("%s-%s-%s-eks-a-%d-%s.%s",
-			archive.OSName,
-			eksDReleaseChannel,
-			releaseDate,
-			rc.BundleNumber,
-			arch,
-			imageExtension,
-		)
-		sourceS3Prefix = fmt.Sprintf("releases/canonical/%s/artifacts/rtos/%s", releaseDate, eksDReleaseChannel)
-	}
-
-	if rc.DevRelease {
-		releaseName = fmt.Sprintf("%s-%s-%s-eks-a-%s-%s.%s",
-			archive.OSName,
-			eksDReleaseChannel,
-			releaseDate,
-			rc.DevReleaseUriVersion,
-			arch,
-			imageExtension,
-		)
-		releaseS3Path = fmt.Sprintf("artifacts/%s/rtos/%s/%s",
-			rc.DevReleaseUriVersion,
-			archive.Format,
-			eksDReleaseChannel,
-		)
-	} else {
-		releaseName = fmt.Sprintf("%s-%s-%s-eks-a-%d-%s.%s",
-			archive.OSName,
-			eksDReleaseChannel,
-			releaseDate,
-			rc.BundleNumber,
-			arch,
-			imageExtension,
-		)
-		releaseS3Path = fmt.Sprintf("releases/canonical/%s/artifacts/rtos/%s", releaseDate, eksDReleaseChannel)
-	}
-
-	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil
-}
-
 func GetArchiveAssets(rc *releasetypes.ReleaseConfig, archive *assettypes.Archive, projectPath, gitTag, eksDReleaseChannel, eksDReleaseNumber, kubeVersion string) (*releasetypes.ArchiveArtifact, error) {
 	os := "linux"
 	arch := "amd64"
@@ -227,21 +168,20 @@ func GetArchiveAssets(rc *releasetypes.ReleaseConfig, archive *assettypes.Archiv
 	}
 
 	archiveArtifact := &releasetypes.ArchiveArtifact{
-		SourceS3Key:        sourceS3Key,
-		SourceS3Prefix:     sourceS3Prefix,
-		ArtifactPath:       filepath.Join(rc.ArtifactDir, fmt.Sprintf("%s-%s", archive.Name, archive.Format), eksDReleaseChannel, rc.BuildRepoHead),
-		ReleaseName:        releaseName,
-		ReleaseS3Path:      releaseS3Path,
-		ReleaseCdnURI:      cdnURI,
-		OS:                 os,
-		OSName:             archive.OSName,
-		Arch:               []string{arch},
-		GitTag:             gitTag,
-		ProjectPath:        projectPath,
-		SourcedFromBranch:  sourcedFromBranch,
-		ImageFormat:        archive.Format,
-		Private:            archive.Private,
-		UploadToRTOSBucket: archive.UploadToRTOSBucket,
+		SourceS3Key:       sourceS3Key,
+		SourceS3Prefix:    sourceS3Prefix,
+		ArtifactPath:      filepath.Join(rc.ArtifactDir, fmt.Sprintf("%s-%s", archive.Name, archive.Format), eksDReleaseChannel, rc.BuildRepoHead),
+		ReleaseName:       releaseName,
+		ReleaseS3Path:     releaseS3Path,
+		ReleaseCdnURI:     cdnURI,
+		OS:                os,
+		OSName:            archive.OSName,
+		Arch:              []string{arch},
+		GitTag:            gitTag,
+		ProjectPath:       projectPath,
+		SourcedFromBranch: sourcedFromBranch,
+		ImageFormat:       archive.Format,
+		Private:           archive.Private,
 	}
 
 	return archiveArtifact, nil

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -66,23 +66,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		},
 		HasReleaseBranches: true,
 	},
-	// Canonical Ubuntu RTOS artifacts
-	{
-		ProjectName:    "ubuntu-rtos",
-		ProjectPath:    "projects/canonical/ubuntu",
-		GitTagAssigner: tagger.RTOSReleaseDateAssigner,
-		Archives: []*assettypes.Archive{
-			{
-				Name:                "rtos",
-				Format:              "raw",
-				OSName:              "ubuntu",
-				OSVersion:           "22.04",
-				ArchiveS3PathGetter: archives.RTOSArtifactPathGetter,
-				Private:             true,
-				UploadToRTOSBucket:  true,
-			},
-		},
-	},
 	// Cert-manager artifacts
 	{
 		ProjectName: "cert-manager",

--- a/release/cli/pkg/assets/tagger/tagger.go
+++ b/release/cli/pkg/assets/tagger/tagger.go
@@ -54,19 +54,6 @@ func CliGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranc
 	return gitTag, nil
 }
 
-func RTOSReleaseDateAssigner(rc *releasetypes.ReleaseConfig, rtosImageDatePath, overrideBranch string) (string, error) {
-	branchName := rc.BuildRepoBranchName
-	if overrideBranch != "" {
-		branchName = overrideBranch
-	}
-	releaseDate, err := filereader.ReadRTOSImageDate(rtosImageDatePath, rc.BuildRepoSource, branchName)
-	if err != nil {
-		return "", errors.Cause(err)
-	}
-
-	return releaseDate, nil
-}
-
 func NonExistentTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranch string) (string, error) {
 	return "non-existent", nil
 }

--- a/release/cli/pkg/assets/types/types.go
+++ b/release/cli/pkg/assets/types/types.go
@@ -49,7 +49,6 @@ type Archive struct {
 	ArchitectureOverride string
 	ArchiveS3PathGetter  ArchiveS3PathGenerator
 	Private              bool
-	UploadToRTOSBucket   bool
 }
 
 type AssetConfig struct {

--- a/release/cli/pkg/constants/constants.go
+++ b/release/cli/pkg/constants/constants.go
@@ -52,6 +52,5 @@ const (
 	//	01/02 03:04:05PM '06 -0700
 	//
 	// (January 2, 15:04:05, 2006, in time zone seven hours west of GMT).
-	YYYYMMDD                  = "2006-01-02"
-	RTOSArtifactsBucketEnvvar = "RTOS_ARTIFACTS_BUCKET"
+	YYYYMMDD = "2006-01-02"
 )

--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -365,24 +365,3 @@ func ReadGitTag(projectPath, gitRootPath, branch string) (string, error) {
 
 	return gitTag, nil
 }
-
-func ReadRTOSImageDate(projectPath, gitRootPath, branch string) (string, error) {
-	currentBranch, err := git.GetCurrentBranch(gitRootPath)
-	if err != nil {
-		return "", fmt.Errorf("error getting current branch: %v", err)
-	}
-	if currentBranch != branch {
-		_, err = git.CheckoutRepo(gitRootPath, branch)
-		if err != nil {
-			return "", fmt.Errorf("error checking out repo: %v", err)
-		}
-	}
-
-	dateFile := filepath.Join(gitRootPath, projectPath, "RTOS_IMAGE_DATE")
-	releaseDate, err := ReadFileContentsTrimmed(dateFile)
-	if err != nil {
-		return "", fmt.Errorf("error reading RTOS image date: %v", err)
-	}
-
-	return releaseDate, nil
-}

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -112,26 +112,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:d13453a013480c568b6640c3536f978e855b89c8f5eec31df1036a368ba78363
+        imageDigest: sha256:cfa08cb82ca8b01955d544745d093694fb8f55f648faabebc21f40eb017acbaf
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.13.18-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:e6719b1e2761b65066d5eba1f43159a495cbd0b159cb1282d18622ff944d55a3
+        imageDigest: sha256:b736e114add07ba2bbd3b2b3c2a9dfaed2324fcbc8911ffb541c868d52041c28
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.13.18-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.17-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.18-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:583b8934a58f762ec7564a057fa0e8b3e648938a1818b17f5ea1e201ddeb8798
+        imageDigest: sha256:8762be81f0fba2295fb2345cc55505b394b28846a60bf7d91187fad944f7d819
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.13.17-eksa.1
-      version: v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.13.18-eksa.1
+      version: v1.13.18-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -161,7 +161,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.10-rc1/metadata.yaml
       version: v0.4.10-rc1+abcdef1
@@ -261,7 +261,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.30.1/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.31.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -438,7 +438,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -460,7 +460,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.5/metadata.yaml
       version: v1.3.5+abcdef1
@@ -518,7 +518,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -562,7 +562,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.5.3/metadata.yaml
       tinkerbellStack:
@@ -810,7 +810,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -927,26 +927,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:d13453a013480c568b6640c3536f978e855b89c8f5eec31df1036a368ba78363
+        imageDigest: sha256:cfa08cb82ca8b01955d544745d093694fb8f55f648faabebc21f40eb017acbaf
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.13.18-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:e6719b1e2761b65066d5eba1f43159a495cbd0b159cb1282d18622ff944d55a3
+        imageDigest: sha256:b736e114add07ba2bbd3b2b3c2a9dfaed2324fcbc8911ffb541c868d52041c28
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.13.18-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.17-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.18-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:583b8934a58f762ec7564a057fa0e8b3e648938a1818b17f5ea1e201ddeb8798
+        imageDigest: sha256:8762be81f0fba2295fb2345cc55505b394b28846a60bf7d91187fad944f7d819
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.13.17-eksa.1
-      version: v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.13.18-eksa.1
+      version: v1.13.18-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -976,7 +976,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.10-rc1/metadata.yaml
       version: v0.4.10-rc1+abcdef1
@@ -1076,7 +1076,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.30.1/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.31.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1253,7 +1253,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -1275,7 +1275,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.5/metadata.yaml
       version: v1.3.5+abcdef1
@@ -1333,7 +1333,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1377,7 +1377,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.5.3/metadata.yaml
       tinkerbellStack:
@@ -1625,7 +1625,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1742,26 +1742,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:d13453a013480c568b6640c3536f978e855b89c8f5eec31df1036a368ba78363
+        imageDigest: sha256:cfa08cb82ca8b01955d544745d093694fb8f55f648faabebc21f40eb017acbaf
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.13.18-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:e6719b1e2761b65066d5eba1f43159a495cbd0b159cb1282d18622ff944d55a3
+        imageDigest: sha256:b736e114add07ba2bbd3b2b3c2a9dfaed2324fcbc8911ffb541c868d52041c28
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.13.18-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.17-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.18-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:583b8934a58f762ec7564a057fa0e8b3e648938a1818b17f5ea1e201ddeb8798
+        imageDigest: sha256:8762be81f0fba2295fb2345cc55505b394b28846a60bf7d91187fad944f7d819
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.13.17-eksa.1
-      version: v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.13.18-eksa.1
+      version: v1.13.18-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -1791,7 +1791,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.10-rc1/metadata.yaml
       version: v0.4.10-rc1+abcdef1
@@ -1891,7 +1891,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.30.1/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.31.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -2068,7 +2068,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -2090,7 +2090,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.5/metadata.yaml
       version: v1.3.5+abcdef1
@@ -2148,7 +2148,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2192,7 +2192,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.5.3/metadata.yaml
       tinkerbellStack:
@@ -2440,7 +2440,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2557,26 +2557,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:d13453a013480c568b6640c3536f978e855b89c8f5eec31df1036a368ba78363
+        imageDigest: sha256:cfa08cb82ca8b01955d544745d093694fb8f55f648faabebc21f40eb017acbaf
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.13.18-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:e6719b1e2761b65066d5eba1f43159a495cbd0b159cb1282d18622ff944d55a3
+        imageDigest: sha256:b736e114add07ba2bbd3b2b3c2a9dfaed2324fcbc8911ffb541c868d52041c28
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.13.18-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.17-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.18-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:583b8934a58f762ec7564a057fa0e8b3e648938a1818b17f5ea1e201ddeb8798
+        imageDigest: sha256:8762be81f0fba2295fb2345cc55505b394b28846a60bf7d91187fad944f7d819
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.13.17-eksa.1
-      version: v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.13.18-eksa.1
+      version: v1.13.18-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -2606,7 +2606,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.10-rc1/metadata.yaml
       version: v0.4.10-rc1+abcdef1
@@ -2706,7 +2706,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.30.1/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.31.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -2883,7 +2883,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -2905,7 +2905,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.5/metadata.yaml
       version: v1.3.5+abcdef1
@@ -2963,7 +2963,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3007,7 +3007,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.5.3/metadata.yaml
       tinkerbellStack:
@@ -3255,7 +3255,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3372,26 +3372,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:d13453a013480c568b6640c3536f978e855b89c8f5eec31df1036a368ba78363
+        imageDigest: sha256:cfa08cb82ca8b01955d544745d093694fb8f55f648faabebc21f40eb017acbaf
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:v1.13.18-eksa.1
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:e6719b1e2761b65066d5eba1f43159a495cbd0b159cb1282d18622ff944d55a3
+        imageDigest: sha256:b736e114add07ba2bbd3b2b3c2a9dfaed2324fcbc8911ffb541c868d52041c28
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/cilium:1.13.18-eksa.1
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.17-eksa.1/cilium.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.13.18-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:583b8934a58f762ec7564a057fa0e8b3e648938a1818b17f5ea1e201ddeb8798
+        imageDigest: sha256:8762be81f0fba2295fb2345cc55505b394b28846a60bf7d91187fad944f7d819
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.13.17-eksa.1
-      version: v1.13.17-eksa.1
+        uri: public.ecr.aws/isovalent/operator-generic:v1.13.18-eksa.1
+      version: v1.13.18-eksa.1
     cloudStack:
       clusterAPIController:
         arch:
@@ -3421,7 +3421,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.4.10-rc1/metadata.yaml
       version: v0.4.10-rc1+abcdef1
@@ -3521,7 +3521,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.30.1/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.31.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -3698,7 +3698,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.3.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -3720,7 +3720,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.3.5/metadata.yaml
       version: v1.3.5+abcdef1
@@ -3778,7 +3778,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3822,7 +3822,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.5.3/metadata.yaml
       tinkerbellStack:
@@ -4070,7 +4070,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v0.8.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -17,7 +17,6 @@ package operations
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -89,14 +88,10 @@ func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArt
 }
 
 func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artifact releasetypes.Artifact) error {
-	releaseBucket := r.ReleaseBucket
-	if artifact.Archive.UploadToRTOSBucket && r.ReleaseEnvironment == "production" {
-		releaseBucket = os.Getenv(constants.RTOSArtifactsBucketEnvvar)
-	}
 	archiveFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName)
 	fmt.Printf("Archive - %s\n", archiveFile)
 	key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName)
-	err := s3.UploadFile(archiveFile, aws.String(releaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
+	err := s3.UploadFile(archiveFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
 	if err != nil {
 		return fmt.Errorf("uploading archive file [%s] to S3: %v", key, err)
 	}
@@ -113,7 +108,7 @@ func handleArchiveUpload(_ context.Context, r *releasetypes.ReleaseConfig, artif
 		checksumFile := filepath.Join(artifact.Archive.ArtifactPath, artifact.Archive.ReleaseName) + extension
 		fmt.Printf("Checksum - %s\n", checksumFile)
 		key := filepath.Join(artifact.Archive.ReleaseS3Path, artifact.Archive.ReleaseName) + extension
-		err := s3.UploadFile(checksumFile, aws.String(releaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
+		err := s3.UploadFile(checksumFile, aws.String(r.ReleaseBucket), aws.String(key), r.ReleaseClients.S3.Uploader, artifact.Archive.Private)
 		if err != nil {
 			return fmt.Errorf("uploading checksum file [%s] to S3: %v", key, err)
 		}

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -64,21 +64,20 @@ type ImageTagOverride struct {
 }
 
 type ArchiveArtifact struct {
-	SourceS3Key        string
-	SourceS3Prefix     string
-	ArtifactPath       string
-	ReleaseName        string
-	ReleaseS3Path      string
-	ReleaseCdnURI      string
-	OS                 string
-	OSName             string
-	Arch               []string
-	GitTag             string
-	ProjectPath        string
-	SourcedFromBranch  string
-	ImageFormat        string
-	Private            bool
-	UploadToRTOSBucket bool
+	SourceS3Key       string
+	SourceS3Prefix    string
+	ArtifactPath      string
+	ReleaseName       string
+	ReleaseS3Path     string
+	ReleaseCdnURI     string
+	OS                string
+	OSName            string
+	Arch              []string
+	GitTag            string
+	ProjectPath       string
+	SourcedFromBranch string
+	ImageFormat       string
+	Private           bool
 }
 
 type ImageArtifact struct {


### PR DESCRIPTION
Remove release logic for RTOS images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

