### PR TITLE
Remove old comment related to the tinkerbell e2e skip power action

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -63,7 +63,6 @@ skipped_tests:
 - TestTinkerbellUpgrade128MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI
 # Skipping ETCD tests
 - TestTinkerbellKubernetes126UbuntuExternalEtcdSimpleFlow
-# Skipping skip power action tests - Not going to work because e2e test powers on CP and worker node at the same time and worker node times out early waiting for ipxe
 # Skipping a few redundant tests
 - TestTinkerbellKubernetes126RedHatSimpleFlow
 - TestTinkerbellKubernetes127RedHatSimpleFlow


### PR DESCRIPTION
*Description of changes:*
We do not need this comment to skip power action related Tinkerbell e2e tests as we have decided to remove power action related tests with this PR 
https://github.com/aws/eks-anywhere/pull/7512

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

