### PR TITLE
Document manual certificate renewal requirement for Emissary

### DIFF
--- a/docs/content/en/docs/packages/emissary/addemissary.md
+++ b/docs/content/en/docs/packages/emissary/addemissary.md
@@ -13,6 +13,7 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
   {{% alert title="Important" color="warning" %}}
    * Starting at `eksctl anywhere` version `v0.12.0`, packages on workload clusters are remotely managed by the management cluster.
    * While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster. The only exception is the `kubectl create namespace` command below, which should be run with `kubeconfig` pointing to the workload cluster.
+   * The `emissary-apiext` service has a known issue where its TLS certificate expires after one year and does not auto-renew. To resolve this, manually renew the certificate by running `kubectl delete --all secrets --namespace=emissary-system` followed by `kubectl rollout restart deploy/emissary-apiext -n emissary-system`.
    {{% /alert %}}
 
 ## Install

--- a/docs/content/en/docs/packages/emissary/addemissary.md
+++ b/docs/content/en/docs/packages/emissary/addemissary.md
@@ -13,7 +13,7 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
   {{% alert title="Important" color="warning" %}}
    * Starting at `eksctl anywhere` version `v0.12.0`, packages on workload clusters are remotely managed by the management cluster.
    * While following this guide to install packages on a workload cluster, please make sure the `kubeconfig` is pointing to the management cluster that was used to create the workload cluster. The only exception is the `kubectl create namespace` command below, which should be run with `kubeconfig` pointing to the workload cluster.
-   * The `emissary-apiext` service has a known issue where its TLS certificate expires after one year and does not auto-renew. To resolve this, manually renew the certificate by running `kubectl delete --all secrets --namespace=emissary-system` followed by `kubectl rollout restart deploy/emissary-apiext -n emissary-system`.
+   * The `emissary-apiext` service has a known issue where its TLS certificate expires after one year and does not auto-renew. To resolve this, manually renew the certificate by running `kubectl delete --all secrets --namespace=emissary-system` followed by `kubectl rollout restart deploy/emissary-apiext -n emissary-system` prior to certificate expiry.
    {{% /alert %}}
 
 ## Install


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* customers have encountered emissary certificate expiring issue. The issue is fixed in their 4.0 release, but before that version, users have to manually rotate the certificate

*Testing (if applicable):* Manually tested the renewal steps in my dev environment

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

