### PR TITLE
Unskip tinkerbell multiple upgrades test

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -82,8 +82,6 @@ skipped_tests:
 - TestTinkerbellKubernetes127UbuntuTo128Upgrade
 - TestTinkerbellKubernetes128UbuntuTo129Upgrade
 
-#Skip single upgrade all the way test until debugging upgrade as they have been failing consistently 
-- TestTinkerbellKubernetes126UbuntuTo130MultipleUpgrade
 
 # Tinkerbell Packages
 # Skip test cases for packages other than hello-eks-anywhere and not for K 1.28.


### PR DESCRIPTION
*Description of changes:*

*Testing (if applicable):*
`TestTinkerbellKubernetes125UbuntuTo129MultipleUpgrade` was skipped as the test failed consitently on CI runs. on checking the logs from the runs the test consistently failed while upgrading to K8s version 1.28. Suspect this is due to a `KubeletCredentialProviders` being set in Kubelet extra args when a 1.25 cluster is created which is deprecated in version 1.28. Ran the test locally and verified that the test passes and is able to upgrade all the way upto 1.30. Also triggered a quick E2E against my local branch to verify that the test can pass on CI: https://tiny.amazon.com/1970e4lq7/IsenLink

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

