### PR TITLE
Unskip cloudstack proxy config tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -7,10 +7,6 @@ skipped_tests:
 
 # Proxy API tests skipped due to being unable to run in cloudstack CI env. We should probably revisit these and see if we can unskip them now
 # as we have a proxy env set up in the cloudstack CI env now.
-- TestCloudStackKubernetes126RedhatProxyConfigAPI
-- TestCloudStackKubernetes127RedhatProxyConfigAPI
-- TestCloudStackKubernetes128RedhatProxyConfigAPI
-- TestCloudStackKubernetes130RedhatProxyConfigAPI
 
 # MultiEndpoint
 - TestCloudStackKubernetes126MultiEndpointSimpleFlow


### PR DESCRIPTION
*Description of changes:*
Proxy config tests were skipped initially for cloudstack as we moved our Cloudstack env to Colo lab and didn't have proxy setup in the lab. Currently we do have a proxy configured for the lab which runs on the following address: `10.80.148.64:3128`. Updated the secrets manager to point to the given proxy and verified that the tests are pull from the proxy in the lab. Here's a quick test run on Cloudstack for just proxy tests: https://tiny.amazon.com/tm7ntzfv/IsenLink  

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

