### PR TITLE
Change tinkerbell e2e run algorithm to schedule longer/smaller tests concurrently

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -436,23 +436,25 @@ func splitTests(testsList []string, conf ParallelRunConf) ([]instanceRunConf, er
 //nolint:gocyclo // This legacy function is complex but the team too busy to simplify it
 func appendNonAirgappedTinkerbellRunConfs(awsSession *session.Session, testsList []string, conf ParallelRunConf, testRunnerConfig *TestInfraConfig, runConfs []instanceRunConf, ipManager *E2EIPManager) ([]instanceRunConf, error) {
 	nonAirgappedTinkerbellTests := getTinkerbellNonAirgappedTests(testsList)
-	conf.Logger.V(1).Info("INFO:", "tinkerbellTests", len(nonAirgappedTinkerbellTests))
+	conf.Logger.V(1).Info("INFO:", "tinkerbellTests", len(nonAirgappedTinkerbellTests), "MaxInstances", conf.MaxInstances, "ConcurrentInstances", conf.MaxConcurrentTests)
 
-	testPerInstance := len(nonAirgappedTinkerbellTests) / conf.MaxInstances
-	if testPerInstance == 0 {
-		testPerInstance = 1
-	}
-	testsInVSphereInstance := make([]string, 0, testPerInstance)
 	nonAirgappedTinkerbellTestsWithCount, err := getTinkerbellTestsWithCount(nonAirgappedTinkerbellTests, conf)
 	if err != nil {
 		return nil, err
 	}
-	for i, test := range nonAirgappedTinkerbellTestsWithCount {
-		testsInVSphereInstance = append(testsInVSphereInstance, test.Name)
+	end := len(nonAirgappedTinkerbellTestsWithCount) - 1
+	for start := range nonAirgappedTinkerbellTestsWithCount {
+		if start > end/2 {
+			break
+		}
 		ipPool := ipManager.reserveIPPool(tinkerbellIPPoolSize)
-		if len(testsInVSphereInstance) == testPerInstance || (len(testsList)-1) == i {
-			runConfs = append(runConfs, newInstanceRunConf(awsSession, conf, len(runConfs), strings.Join(testsInVSphereInstance, "|"), ipPool, []*api.Hardware{}, test.Count, false, VSphereTestRunnerType, testRunnerConfig))
-			testsInVSphereInstance = make([]string, 0, testPerInstance)
+		runConfs = append(runConfs, newInstanceRunConf(awsSession, conf, len(runConfs), nonAirgappedTinkerbellTestsWithCount[start].Name, ipPool, []*api.Hardware{}, nonAirgappedTinkerbellTestsWithCount[start].Count, false, VSphereTestRunnerType, testRunnerConfig))
+
+		// Pop from both ends to run a longer count tests and shorter count tests together
+		// to efficiently use the available hardware.
+		if end-start > start {
+			ipPool := ipManager.reserveIPPool(tinkerbellIPPoolSize)
+			runConfs = append(runConfs, newInstanceRunConf(awsSession, conf, len(runConfs), nonAirgappedTinkerbellTestsWithCount[end-start].Name, ipPool, []*api.Hardware{}, nonAirgappedTinkerbellTestsWithCount[end-start].Count, false, VSphereTestRunnerType, testRunnerConfig))
 		}
 	}
 


### PR DESCRIPTION
*Description of changes:*
Tinkerbell E2E tests runner algorithm sorts the tests based on the hardware count and prioritize running the tests that require more hardware which typically take more duration to run first. Our test runners run concurrently and reserve the hardware from the available pool. The concurrent count is set to 20 as we have issues with VCenter environment when we bump this count to higher number. In current setup, the longer tests reserve the required hardware first and run for a really long time. So the first few runners that reserve the hardware do not free them up until the first couple of hours of the runtime. We do not know if this is the best way to use up the hardware as smaller tests like single node tests take 20-30% of the runtime as that of longer tests. We have earlier also tried running all the smaller tests first which did take same amount of time like longer tests or even a little longer. Change the algorithm to prioritize tests that require lesser and more hardware count at the same time by popping from the tests queue at both ends.  Experimentally check if this helps in using the hardware efficiently and helps in reducing the test run time.  

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

