### PR TITLE
Fix latest EKS-A version assignment in announcement script

### DIFF
--- a/release/scripts/announce_eksa_release.sh
+++ b/release/scripts/announce_eksa_release.sh
@@ -24,7 +24,7 @@ set_aws_config "production"
 
 EKSA_RELEASE_MANIFEST_URL="${1?Specify first argument - EKS-A release manifest URL}"
 
-LATEST_EKSA_VERSION=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.latestVersion')
+LATEST_EKSA_VERSION=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[-1].version')
 LATEST_EKSA_RELEASE_NUMBER=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[] | select(.version == '\"$LATEST_EKSA_VERSION\"') | .number')
 LATEST_BUNDLE_RELEASE_MANIFEST_URI=$(curl $EKSA_RELEASE_MANIFEST_URL | yq e '.spec.releases[] | select(.version == '\"$LATEST_EKSA_VERSION\"') | .bundleManifestUrl')
 LATEST_EKSA_ADMIN_AMI_URI="https://anywhere-assets.eks.amazonaws.com/releases/eks-a/$LATEST_EKSA_RELEASE_NUMBER/artifacts/eks-a-admin-ami/$LATEST_EKSA_VERSION/eks-anywhere-admin-ami-$LATEST_EKSA_VERSION-eks-a-$LATEST_EKSA_RELEASE_NUMBER.raw"


### PR DESCRIPTION
Because the latest version field does not change unless there's an update to the latest minor version, this script will send out announcements with the latest EKS-A minor release for patch releases for the `n-1` minor version. We fix this by getting the latest version based on the release that was last added to the list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

