### PR TITLE
Fix release version assignment for main and release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ BUNDLE_MANIFEST_URL?=$(shell curl $(RELEASE_MANIFEST_URL) | yq ".spec.releases[-
 ifneq ($(PULL_BASE_REF),)
 # PULL_BASE_REF originates from prow
 # If prow presubmit, ping to the latest available version
-	DEV_GIT_VERSION ?= $(shell source ./scripts/eksa_version.sh && eksa-version::latest_release_verison_in_manifest "$(RELEASE_MANIFEST_URL)")
+	DEV_GIT_VERSION ?= $(shell source ./scripts/eksa_version.sh && eksa-version::latest_release_version_in_manifest "$(RELEASE_MANIFEST_URL)")
 else ifeq ($(CODEBUILD_CI),true)
 # If codebuild e2e tests, ping to the latest available version
-	DEV_GIT_VERSION ?= $(shell source ./scripts/eksa_version.sh && eksa-version::latest_release_verison_in_manifest "$(RELEASE_MANIFEST_URL)")
+	DEV_GIT_VERSION ?= $(shell source ./scripts/eksa_version.sh && eksa-version::latest_release_version_in_manifest "$(RELEASE_MANIFEST_URL)")
 else
 # Else, this is a local buid, so use "dev+latest" to always select the latest
 # version in the manifest in runtime.
@@ -674,7 +674,7 @@ build-eks-a-for-e2e:
 
 .PHONY: eks-a-for-dev-e2e
 eks-a-for-dev-e2e:
-	DEV_GIT_VERSION=$(shell source ./scripts/eksa_version.sh && eksa-version::latest_release_verison_in_manifest "$(RELEASE_MANIFEST_URL)") $(MAKE) eks-a;
+	DEV_GIT_VERSION=$(shell source ./scripts/eksa_version.sh && eksa-version::latest_release_version_in_manifest "$(RELEASE_MANIFEST_URL)") $(MAKE) eks-a;
 
 .PHONY: e2e-tests-binary
 e2e-tests-binary: E2E_TAGS ?= e2e

--- a/scripts/eksa_version.sh
+++ b/scripts/eksa_version.sh
@@ -30,9 +30,16 @@ function eksa-version::get_closest_ancestor_branch() {
             continue
         fi
 
+        # When running the script locally, filter remotes to get the remote corresponding to the primary repo
+        # aws/eks-anywhere, otherwise the local fork's default origin remote will be used, which could potentially
+        # be out of date and produce incorrect versions
+        if ! [[ $CI == true || $CODEBUILD_CI == true ]]; then
+            upstream_remote=$(git remote -v | grep "aws/eks-anywhere.git" | awk '{print $1}' | uniq)
+            branch="$upstream_remote/$branch"
+        fi
         # Find the common ancestor of the current branch and the iterated branch
         local merge_base=$(git merge-base "$current_branch" "$branch" 2>/dev/null)
-        
+
         # Get the commit date of the common ancestor
         local merge_base_date=$(git show -s --format=%ci "$merge_base" 2>/dev/null)
 
@@ -57,21 +64,22 @@ function eksa-version::get_next_eksa_version_for_ancestor() {
     local ancestor_branch=$1
     local release_version
     local latest_tag
-    # This checks if main in the ancestors of the current branch.
+    # This checks if main or upstream/main are the ancestors of the current branch.
     # If it is, then it is either main or a branch off main.
     # If it is not, then it is a release branch or a branch off a release branch.
-    if [[ "$ancestor_branch" == "main" ]]; then
-        #  If the branch is main, then get the latest tag by date and
-        # bump one minor version and use patch 0
-        
-        latest_tag=$(git describe --tags "$(git rev-list --tags='v*.*.*' --max-count=1)")
-        
+    if [[ "$ancestor_branch" =~ "main" ]]; then
+        #  If the branch is main, then get the latest release tag from the releases manifest and
+        # bump one minor version and using 0 as the patch
+
+        latest_tag=$(curl https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.latestVersion")
+
         release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$2++; $3=0; print}')
     else
         # For a release branch, get the latest tag for the release minor version and bump the patch version
         # If there is not tag yet, use latest tag by date but bumping the minor version and using 0 as the patch
-        # Silence stdeer as the command will fail if there are no tags
-        latest_tag=$(git tag -l "v${ancestor_branch#release-}.*" | sort -V | tail -n 1)
+        # Silence stderr as the command will fail if there are no tags
+        minor_release=$(echo $ancestor_branch | grep -Eo "[[:digit:]]+.[[:digit:]]+")
+        latest_tag=$(git tag -l "v${minor_release}.*" | sort -V | tail -n 1)
         if [[ -z "$latest_tag" ]]; then
             latest_tag=$(git describe --tags "$(git rev-list --tags='v*.*.*' --max-count=1)")
             release_version=$(echo "${latest_tag}" | awk -F. -v OFS=. '{$2++; $3=0; print}')
@@ -89,7 +97,7 @@ function eksa-version::get_next_eksa_version() {
     eksa-version::get_next_eksa_version_for_ancestor "$ancestor_branch"
 }
 
-function eksa-version::latest_release_verison_in_manifest() {
+function eksa-version::latest_release_version_in_manifest() {
     local manifest_file=$1
     local release_version
     release_version=$(curl -s -L "$manifest_file" | yq '.spec.latestVersion')


### PR DESCRIPTION
This PR adds some fixes to the EKS-A version assignment script:
1. Ensure checks are done on upstream remote when running locally to avoid out-of-date origin remote
2. Get latest tag for main builds from release manifest instead of Git tag chronological listing because if the latest release is an `n-1` release, it would provide an incorrect version
3. Extract minor release info from ancestor branch instead of using it directly.
4. Typo fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

