### PR TITLE
Rollout new nodes for OSImageURL change on spec without changing K8s version

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -301,7 +301,6 @@ func (r *Reconciler) ValidateHardware(ctx context.Context, log logr.Logger, tink
 		return controller.ResultWithReturn(), nil
 	}
 
-	// var hwReq tinkerbell.MinimumHardwareRequirements
 	var v tinkerbell.ClusterSpecValidator
 	v.Register(tinkerbell.HardwareSatisfiesOnlyOneSelectorAssertion(kubeReader.GetCatalogue()))
 
@@ -417,7 +416,7 @@ func (r *Reconciler) validateHardwareReqForKCP(validatableCAPI *tinkerbell.Valid
 // validateHardwareReqForMachineDeployments returns minium hardware requirements for the md's to rollout new worker nodes
 // CAPI rolls out a new worker node only whenever the associated MachineTemplate changes in the md object
 // A single cluster can have multiple MachineDeployment objects and in case of modular upgrades
-// only few of those worker groups might need a rollout
+// only few of those worker groups might need a rollout.
 func (r *Reconciler) validateHardwareReqForMachineDeployments(ctx context.Context, tinkerbellScope *Scope) (requirements tinkerbell.MinimumHardwareRequirements, err error) {
 	newWorkers := tinkerbellScope.Workers
 

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -547,6 +547,12 @@ func TestReconcilerValidateHardwareControlPlaneOSImageChangeError(t *testing.T) 
 	logger := test.NewNullLogger()
 	scope := tt.buildScope()
 	cpRef := scope.ClusterSpec.Config.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	scope.ClusterSpec.Config.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy = &anywherev1.ControlPlaneUpgradeRolloutStrategy{
+		Type: anywherev1.RollingUpdateStrategyType,
+		RollingUpdate: &anywherev1.ControlPlaneRollingUpdateParams{
+			MaxSurge: 1,
+		},
+	}
 	scope.ClusterSpec.Config.TinkerbellMachineConfigs[cpRef].Spec.OSImageURL = "new-os-image"
 
 	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
@@ -573,6 +579,12 @@ func TestReconcilerValidateHardwareControlPlaneOSImageChangeSuccess(t *testing.T
 	logger := test.NewNullLogger()
 	scope := tt.buildScope()
 	cpRef := scope.ClusterSpec.Config.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
+	scope.ClusterSpec.Config.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy = &anywherev1.ControlPlaneUpgradeRolloutStrategy{
+		Type: anywherev1.RollingUpdateStrategyType,
+		RollingUpdate: &anywherev1.ControlPlaneRollingUpdateParams{
+			MaxSurge: 1,
+		},
+	}
 	scope.ClusterSpec.Config.TinkerbellMachineConfigs[cpRef].Spec.OSImageURL = "new-os-image"
 
 	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
@@ -595,6 +607,13 @@ func TestReconcilerValidateHardwareWorkerNodeGroupOSImageChangeError(t *testing.
 	logger := test.NewNullLogger()
 	scope := tt.buildScope()
 	wngRef := scope.ClusterSpec.Config.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	scope.ClusterSpec.Config.Cluster.Spec.WorkerNodeGroupConfigurations[0].UpgradeRolloutStrategy = &anywherev1.WorkerNodesUpgradeRolloutStrategy{
+		Type: anywherev1.RollingUpdateStrategyType,
+		RollingUpdate: &anywherev1.WorkerNodesRollingUpdateParams{
+			MaxSurge:       1,
+			MaxUnavailable: 0,
+		},
+	}
 	scope.ClusterSpec.Config.TinkerbellMachineConfigs[wngRef].Spec.OSImageURL = "new-os-image"
 	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
 	tt.Expect(err).NotTo(HaveOccurred())
@@ -617,6 +636,13 @@ func TestReconcilerValidateHardwareWorkerNodeGroupOSImageChangeSuccess(t *testin
 	logger := test.NewNullLogger()
 	scope := tt.buildScope()
 	wngRef := scope.ClusterSpec.Config.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	scope.ClusterSpec.Config.Cluster.Spec.WorkerNodeGroupConfigurations[0].UpgradeRolloutStrategy = &anywherev1.WorkerNodesUpgradeRolloutStrategy{
+		Type: anywherev1.RollingUpdateStrategyType,
+		RollingUpdate: &anywherev1.WorkerNodesRollingUpdateParams{
+			MaxSurge:       1,
+			MaxUnavailable: 0,
+		},
+	}
 	scope.ClusterSpec.Config.TinkerbellMachineConfigs[wngRef].Spec.OSImageURL = "new-os-image"
 	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
 	tt.Expect(err).NotTo(HaveOccurred())

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -314,16 +314,16 @@ func (p *Provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 }
 
 func (p *Provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, clusterSpec)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
-	}
-	return controlPlaneSpec, workersSpec, nil
+	// controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, clusterSpec)
+	// if err != nil {
+	// 	return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+	// }
+	// return controlPlaneSpec, workersSpec, nil
+	return nil, nil, nil
 }
 
 func (p *Provider) GenerateCAPISpecForCreate(ctx context.Context, _ *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
 	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForCreate(ctx, clusterSpec)
-
 	if err != nil {
 		return nil, nil, fmt.Errorf("generating cluster api spec contents: %v", err)
 	}

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -314,12 +314,11 @@ func (p *Provider) generateCAPISpecForUpgrade(ctx context.Context, bootstrapClus
 }
 
 func (p *Provider) GenerateCAPISpecForUpgrade(ctx context.Context, bootstrapCluster, workloadCluster *types.Cluster, currentSpec, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {
-	// controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, clusterSpec)
-	// if err != nil {
-	// 	return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
-	// }
-	// return controlPlaneSpec, workersSpec, nil
-	return nil, nil, nil
+	controlPlaneSpec, workersSpec, err = p.generateCAPISpecForUpgrade(ctx, bootstrapCluster, workloadCluster, currentSpec, clusterSpec)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error generating cluster api spec contents: %v", err)
+	}
+	return controlPlaneSpec, workersSpec, nil
 }
 
 func (p *Provider) GenerateCAPISpecForCreate(ctx context.Context, _ *types.Cluster, clusterSpec *cluster.Spec) (controlPlaneSpec, workersSpec []byte, err error) {

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -27,8 +27,7 @@ func needsNewControlPlaneTemplate(oldSpec, newSpec *cluster.Spec) bool {
 	// Another option is to generate MachineTemplates based on the old and new eksa spec,
 	// remove the name field and compare them with DeepEqual
 	// We plan to approach this way since it's more flexible to add/remove fields and test out for validation
-	if oldSpec.Cluster.Spec.KubernetesVersion != newSpec.Cluster.Spec.KubernetesVersion ||
-		oldSpec.TinkerbellDatacenter.Spec.OSImageURL != newSpec.TinkerbellDatacenter.Spec.OSImageURL {
+	if oldSpec.Cluster.Spec.KubernetesVersion != newSpec.Cluster.Spec.KubernetesVersion {
 		return true
 	}
 
@@ -36,11 +35,7 @@ func needsNewControlPlaneTemplate(oldSpec, newSpec *cluster.Spec) bool {
 		return true
 	}
 
-	// Check if OSImageURL changed without a eks-a/kube version change.
-	oldCPImageURL := oldSpec.TinkerbellMachineConfigs[oldSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name].Spec.OSImageURL
-	newCPImageURL := newSpec.TinkerbellMachineConfigs[newSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name].Spec.OSImageURL
-
-	return oldCPImageURL != newCPImageURL
+	return false
 }
 
 func needsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldWorker, newWorker v1alpha1.WorkerNodeGroupConfiguration) bool {
@@ -54,13 +49,7 @@ func needsNewWorkloadTemplate(oldSpec, newSpec *cluster.Spec, oldWorker, newWork
 		return true
 	}
 
-	// Check if OSImageURL changed without a eks-a/kube version change.
-	oldWorkerNodeGroupName := fmt.Sprintf("%s-%s", oldWorker.MachineGroupRef.Name, oldWorker.Name)
-	newWorkerNodeGroupName := fmt.Sprintf("%s-%s", newWorker.MachineGroupRef.Name, newWorker.Name)
-	oldWorkerImageURL := oldSpec.TinkerbellMachineConfigs[oldWorkerNodeGroupName].Spec.OSImageURL
-	newWorkerImageURL := newSpec.TinkerbellMachineConfigs[newWorkerNodeGroupName].Spec.OSImageURL
-
-	return oldWorkerImageURL != newWorkerImageURL
+	return false
 }
 
 func needsNewKubeadmConfigTemplate(newWorkerNodeGroup, oldWorkerNodeGroup *v1alpha1.WorkerNodeGroupConfiguration) bool {

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -259,13 +259,13 @@ type minimumHardwareRequirement struct {
 	count int
 }
 
-// minimumHardwareRequirements is a collection of minimumHardwareRequirement instances.
+// MinimumHardwareRequirements is a collection of minimumHardwareRequirement instances.
 // it stores requirements in a map where the key is derived from selectors. This ensures selectors
 // specifying the same key-value pairs are combined.
-type minimumHardwareRequirements map[string]*minimumHardwareRequirement
+type MinimumHardwareRequirements map[string]*minimumHardwareRequirement
 
 // Add a minimumHardwareRequirement to r.
-func (r *minimumHardwareRequirements) Add(selector v1alpha1.HardwareSelector, min int) error {
+func (r *MinimumHardwareRequirements) Add(selector v1alpha1.HardwareSelector, min int) error {
 	name, err := selector.ToString()
 	if err != nil {
 		return err
@@ -281,7 +281,7 @@ func (r *minimumHardwareRequirements) Add(selector v1alpha1.HardwareSelector, mi
 
 // validateMinimumHardwareRequirements validates all requirements can be satisfied using hardware
 // registered with catalogue.
-func validateMinimumHardwareRequirements(requirements minimumHardwareRequirements, catalogue *hardware.Catalogue) error {
+func validateMinimumHardwareRequirements(requirements MinimumHardwareRequirements, catalogue *hardware.Catalogue) error {
 	// Count all hardware that meets the selector requirements for each requirement.
 	// This does not consider whether or not a piece of hardware is selectable by multiple
 	// selectors. That requires a different validation ideally run before this one.


### PR DESCRIPTION
*Issue #, if available:*
For Baremetal user might want to patch the nodes with updated OSImage while without upgrading the K8s version. Consequently user might also want to rollout nodes with any specific config change that doesn't involve a K8s version upgrade but warrants a node rollout. Ex. API server flags update. Issue: https://github.com/aws/eks-anywhere-internal/issues/2443

*Description of changes:*

The upgrade flow only rolls out node on Tinkerbell provider for a K8s version change or when there's scale up of Control Plane or Workers. This is primarily due to the fact that there are hardware requirements for  node rollout on Tinkerbell and if EKS-A misses any of those validations during the upgrade and doesn't set an error message on the corresponding object like KCP/MD, once the spec is applied CAPT would just get stuck waiting for additional hardware to be available for the rollout. This would be much later in the stack and would be inconvenient to debug. Currently we perform a bunch of hardware validations on the CLI and controller. This cover cases like RollingUpgrades, ModularUpgrades and Scaling operations on Control Plane and Worker Node groups. 

The existing validations are implemented in a common place for CLI and controller and this is achieved by using a common [interface](https://github.com/aws/eks-anywhere/blob/e0fafe07dfd1bb6ff98df5c09efb765fbd086110/pkg/providers/tinkerbell/assert.go#L275)  `ValidatableCluster`. As we open up more flags/features for ControlPlane/Worker Groups, the existing method of validating won't be scalable as we would require this interface to implement more customized methods depending on the field of interest. This change Introduces a new Hardware Validation method that `ExtraHardwareAvailableAssertionForNodeRollOut` that could be used to validate any node rollout between ControlPlane and Workers. As we open up more feature gates through our spec more validations could be added ControlPlane or Worker Specific changes from CLI. On the controller side, only time CAPI rollsout a new node is when the underlying machine template `Spec.MachineTemplate.InfrastructureRef` changes for KCP or MD object. This change adds validation for that condition. 

Tinkerbell reconciler overrides any generated template during an upgrade by using the `omitTinkerbellMachineTemplates` method which is called in every reconcile by fetching the existing machine templates from KCP and MD objects when the version on KCP and MD doesn't change. This has caused problems when users try to just update the `TinkerbellTemplateConfig` object on the cluster spec and expect a node to be upgraded. As this change adds hardware validations on controller for a node rollout, it is safe to remove this function and the controller would fail early. 


*Testing (if applicable):*
Tested upgrades for control plane and worker node groups separately using both CLI and controller workflows.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

