### PR TITLE
Setup AWS profile for packages account only for bundle releases

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -139,7 +139,7 @@ var releaseCmd = &cobra.Command{
 			fmt.Printf("%s Successfully created dev release clients\n", constants.SuccessIcon)
 		}
 		if releaseEnvironment == "development" {
-			sourceClients, releaseClients, err = clients.CreateStagingReleaseClients()
+			sourceClients, releaseClients, err = clients.CreateStagingReleaseClients(bundleRelease)
 			if err != nil {
 				fmt.Printf("Error creating clients: %v\n", err)
 				os.Exit(1)

--- a/release/scripts/bundle-release.sh
+++ b/release/scripts/bundle-release.sh
@@ -38,7 +38,7 @@ CLI_REPO_BRANCH_NAME="${13?Specify thirteenth argument - CLI repo branch name}"
 BUILD_REPO_URL="${14?Specify fourteenth argument - Build repo URL}"
 CLI_REPO_URL="${15?Specify fifteenth argument - CLI repo URL}"
 
-set_aws_config "$RELEASE_ENVIRONMENT"
+set_aws_config "$RELEASE_ENVIRONMENT" "bundle"
 
 mkdir -p "${ARTIFACTS_DIR}"
 

--- a/release/scripts/eks-a-release.sh
+++ b/release/scripts/eks-a-release.sh
@@ -34,7 +34,7 @@ CLI_REPO_BRANCH_NAME="${9?Specify ninth argument - Branch name}"
 BUILD_REPO_URL="${10?Specify tenth argument - Build repo URL}"
 CLI_REPO_URL="${11?Specify eleventh argument - CLI repo URL}"
 
-set_aws_config "$RELEASE_ENVIRONMENT"
+set_aws_config "$RELEASE_ENVIRONMENT" "cli"
 
 mkdir -p "${ARTIFACTS_DIR}"
 

--- a/release/scripts/setup-aws-config.sh
+++ b/release/scripts/setup-aws-config.sh
@@ -20,7 +20,8 @@ set -o pipefail
 
 function set_aws_config() {
     release_environment="$1"
-    if [ "$release_environment" = "" ] || [ "$release_environment" = "development" ]; then
+    release_type="$2"
+    if [ "$release_environment" = "" ] || ([ "$release_environment" = "development" ] && [ "$release_type" = "bundle" ]); then
         cat << EOF > awscliconfig
 [profile packages-beta]
 role_arn=$PACKAGES_ECR_ROLE


### PR DESCRIPTION
PR #8628 added logic to setup the AWS profile for packages beta account in order to pull the dev private packages images, but we actually need to do this only for the dev release and staging bundle release. Other types of releases don't need this profile setup as we don't need to pull images from the packages beta account. So this PR adds checks to ensure the profile setup and clients creation for packages happens only where necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

