### PR TITLE
Use packages-related clients and methods conditionally

### DIFF
--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -115,6 +115,7 @@ var releaseCmd = &cobra.Command{
 			ReleaseDate:                     releaseDate,
 			ReleaseTime:                     releaseTime,
 			DevRelease:                      devRelease,
+			BundleRelease:                   bundleRelease,
 			DryRun:                          dryRun,
 			Weekly:                          weekly,
 			ReleaseEnvironment:              releaseEnvironment,

--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
 	commandutils "github.com/aws/eks-anywhere/release/cli/pkg/util/command"
+	packagesutils "github.com/aws/eks-anywhere/release/cli/pkg/util/packages"
 )
 
 var HelmLog = ctrl.Log.WithName("HelmLog")
@@ -71,7 +72,7 @@ func GetHelmDest(d *helmDriver, r *releasetypes.ReleaseConfig, sourceImageURI, a
 	var chartPath string
 
 	sourceRemoteType := "source"
-	if assetName == "eks-anywhere-packages" || assetName == "ecr-token-refresher" || assetName == "credential-provider-package" {
+	if packagesutils.NeedsPackagesAccountArtifacts(r) && (assetName == "eks-anywhere-packages" || assetName == "ecr-token-refresher" || assetName == "credential-provider-package") {
 		sourceRemoteType = "packages"
 	}
 	err := d.HelmRegistryLogin(r, sourceRemoteType)

--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -40,6 +40,7 @@ import (
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
 	artifactutils "github.com/aws/eks-anywhere/release/cli/pkg/util/artifacts"
 	commandutils "github.com/aws/eks-anywhere/release/cli/pkg/util/command"
+	packagesutils "github.com/aws/eks-anywhere/release/cli/pkg/util/packages"
 )
 
 func PollForExistence(devRelease bool, authConfig *docker.AuthConfiguration, imageUri, imageContainerRegistry, releaseEnvironment, branchName string) error {
@@ -129,7 +130,7 @@ func GetSourceImageURI(r *releasetypes.ReleaseConfig, name, repoName string, tag
 	var latestTag string
 	sourcedFromBranch := r.BuildRepoBranchName
 	sourceContainerRegistry := r.SourceContainerRegistry
-	if repoName == "eks-anywhere-packages" || repoName == "ecr-token-refresher" || repoName == "credential-provider-package" {
+	if packagesutils.NeedsPackagesAccountArtifacts(r) && (repoName == "eks-anywhere-packages" || repoName == "ecr-token-refresher" || repoName == "credential-provider-package") {
 		sourceContainerRegistry = r.PackagesSourceContainerRegistry
 	}
 	if r.DevRelease || r.ReleaseEnvironment == "development" {
@@ -157,7 +158,7 @@ func GetSourceImageURI(r *releasetypes.ReleaseConfig, name, repoName string, tag
 		}
 		if !r.DryRun {
 			sourceEcrAuthConfig := r.SourceClients.ECR.AuthConfig
-			if repoName == "eks-anywhere-packages" || repoName == "ecr-token-refresher" || repoName == "credential-provider-package" {
+			if packagesutils.NeedsPackagesAccountArtifacts(r) && (repoName == "eks-anywhere-packages" || repoName == "ecr-token-refresher" || repoName == "credential-provider-package") {
 				sourceEcrAuthConfig = r.SourceClients.Packages.AuthConfig
 			}
 			err := PollForExistence(r.DevRelease, sourceEcrAuthConfig, sourceImageUri, sourceContainerRegistry, r.ReleaseEnvironment, r.BuildRepoBranchName)

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/eks-anywhere/release/cli/pkg/helm"
 	"github.com/aws/eks-anywhere/release/cli/pkg/images"
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
+	packagesutils "github.com/aws/eks-anywhere/release/cli/pkg/util/packages"
 )
 
 func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArtifacts releasetypes.ArtifactsTable, isBundleRelease bool) error {
@@ -43,8 +44,11 @@ func UploadArtifacts(ctx context.Context, r *releasetypes.ReleaseConfig, eksaArt
 	errGroup, ctx := errgroup.WithContext(ctx)
 
 	sourceEcrAuthConfig := r.SourceClients.ECR.AuthConfig
-	packagesSourceEcrAuthConfig := r.SourceClients.Packages.AuthConfig
 	releaseEcrAuthConfig := r.ReleaseClients.ECRPublic.AuthConfig
+	var packagesSourceEcrAuthConfig *docker.AuthConfiguration
+	if packagesutils.NeedsPackagesAccountArtifacts(r) {
+		packagesSourceEcrAuthConfig = r.SourceClients.Packages.AuthConfig
+	}
 
 	packagesArtifacts := map[string][]releasetypes.Artifact{}
 	if isBundleRelease {
@@ -158,7 +162,7 @@ func handleImageUpload(_ context.Context, r *releasetypes.ReleaseConfig, package
 		sourceImageUri := artifact.Image.SourceImageURI
 		releaseImageUri := artifact.Image.ReleaseImageURI
 		sourceEcrAuthConfig := defaultSourceEcrAuthConfig
-		if strings.Contains(sourceImageUri, "eks-anywhere-packages") || strings.Contains(sourceImageUri, "ecr-token-refresher") || strings.Contains(sourceImageUri, "credential-provider-package") {
+		if packagesutils.NeedsPackagesAccountArtifacts(r) && strings.Contains(sourceImageUri, "eks-anywhere-packages") || strings.Contains(sourceImageUri, "ecr-token-refresher") || strings.Contains(sourceImageUri, "credential-provider-package") {
 			sourceEcrAuthConfig = packagesSourceEcrAuthConfig
 		}
 		fmt.Printf("Source Image - %s\n", sourceImageUri)

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -48,6 +48,7 @@ type ReleaseConfig struct {
 	ReleaseDate                     string
 	ReleaseTime                     time.Time
 	DevRelease                      bool
+	BundleRelease                   bool
 	DryRun                          bool
 	Weekly                          bool
 	ReleaseEnvironment              string

--- a/release/cli/pkg/util/packages/packages.go
+++ b/release/cli/pkg/util/packages/packages.go
@@ -1,0 +1,23 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packages
+
+import (
+	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
+)
+
+func NeedsPackagesAccountArtifacts(r *releasetypes.ReleaseConfig) bool {
+	return r.DevRelease || (r.ReleaseEnvironment == "development" && r.BundleRelease)
+}


### PR DESCRIPTION
This PR adds logic to use packages-related clients and methods conditionally, only if the type of release is dev release or staging bundle release, and in other cases, using the default clients. We do this in order to prevent nil pointer errors when using a packages client when it's not defined in the first place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

