### PR TITLE
Ensure bundles override is used for template generation if available

### DIFF
--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -688,12 +688,21 @@ func (v *VSphere) searchTemplate(ctx context.Context, template string) (string, 
 
 func readVersionsBundles(t testing.TB, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) *releasev1.VersionsBundle {
 	reader := newFileReader()
-	b, err := releases.ReadBundlesForRelease(reader, release)
-	if err != nil {
-		t.Fatal(err)
+	var allBundles *releasev1.Bundles
+	var err error
+	if getBundlesOverride() == "true" {
+		allBundles, err = bundles.Read(reader, defaultBundleReleaseManifestFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		allBundles, err = releases.ReadBundlesForRelease(reader, release)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	return bundles.VersionsBundleForKubernetesVersion(b, string(kubeVersion))
+	return bundles.VersionsBundleForKubernetesVersion(allBundles, string(kubeVersion))
 }
 
 func readVSphereConfig() (vsphereConfig, error) {


### PR DESCRIPTION
We observed that for template generation, the staging E2E tests are not using the staging bundle manifest override (`bin/local-bundle-release.yaml`) but are using the dev-release manifest corresponding to the test EKS-A CLI, and sometimes the dev one has older EKS-D versions than the staging bundle manifest, for example, in case a dev release for the release branch had not been run after an EKS Distro version bump. In this case, CLI preflight tag validations would fail for vSphere because the template was generated using one EKS-D version while another EKS-D version was used for the tag validation. We are fixing this by always using the bundles override for template generation if available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

