### PR TITLE
Allow user to generate support bundle in Airgap environment

### DIFF
--- a/docs/content/en/docs/clustermgmt/support/supportbundle.md
+++ b/docs/content/en/docs/clustermgmt/support/supportbundle.md
@@ -39,6 +39,8 @@ If you provide a support bundle configuration file using the `--bundle-config` f
 for example one generated with `generate support-bundle-config`, 
 `generate support-bundle` will use the provided configuration when collecting information from your cluster and analyzing the results.
 
+If you want to generate support bundle in an airgapped environment, the `--bundles-manifest` flag must be set to the local path
+of your eks-a bundles manifest yaml file.
 ```
 Flags:
       --bundle-config string   Bundle Config file to use when generating support bundle
@@ -47,6 +49,7 @@ Flags:
       --since string           Collect pod logs in the latest duration like 5s, 2m, or 3h.
       --since-time string      Collect pod logs after a specific datetime(RFC3339) like 2021-06-28T15:04:05Z
   -w, --w-config string        Kubeconfig file to use when creating support bundle for a workload cluster
+      --bundles-manifest       Bundles manifest to use when generating support bundle (required for generating support bundle in airgap environment)
 ```
 
 ### Collecting and analyzing a bundle

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle.md
@@ -24,6 +24,7 @@ anywhere generate support-bundle -f my-cluster.yaml [flags]
       --since string           Collect pod logs in the latest duration like 5s, 2m, or 3h.
       --since-time string      Collect pod logs after a specific datetime(RFC3339) like 2021-06-28T15:04:05Z
   -w, --w-config string        Kubeconfig file to use when creating support bundle for a workload cluster
+      --bundles-manifest       Bundles manifest to use when generating support bundle (required for generating support bundle in airgap environment)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
*Issue #, if available: 5783

*Description of changes:
Currently eks-anywhere cannot generate support bundle in Airgap environment because eks-a needs to read bundle manifest from remote URL.

This PR fixed the issue by allowing user to specify path of local bundle manifest file so that eks-a does not need to read it from remote URL.

*Testing (if applicable):
Run eksctl to generate support bundle with bundle-manifest flag specified in the command, bundle can be generated successfully.
`eksctl-anywhere generate support-bundle -f eks-a-cluster.yaml --bundle-manifest eks-anywhere-downloads/bundle-release.yaml`

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

