### PR TITLE
Use correct Go version in E2E test JUnit files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ ARTIFACTS_BUCKET?=my-s3-bucket
 GIT_VERSION?=$(shell git describe --tag)
 GIT_TAG?=$(shell git tag -l "v*.*.*" --sort -v:refname | head -1)
 GOLANG_VERSION?="1.21"
-GO_VERSION ?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))
-GO ?= $(GO_VERSION)/go
+GO_PATH?= $(shell source ./scripts/common.sh && build::common::get_go_path $(GOLANG_VERSION))
+GO ?= $(GO_PATH)/go
 GO_TEST ?= $(GO) test
 # A regular expression defining what packages to exclude from the unit-test recipe.
 UNIT_TEST_PACKAGE_EXCLUSION_REGEX ?=mocks$
@@ -545,7 +545,7 @@ packages-e2e-test: build-all-test-binaries ## Run Curated Packages tests
 	./bin/e2e.test -test.v -test.run $(PACKAGES_E2E_TESTS)
 
 .PHONY: mocks
-mocks: export PATH := $(GO_VERSION):$(PATH)
+mocks: export PATH := $(GO_PATH):$(PATH)
 mocks: MOCKGEN := ${GOPATH}/bin/mockgen --build_flags=--mod=mod
 mocks: ## Generate mocks
 	$(GO) install github.com/golang/mock/mockgen@v1.6.0

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -290,7 +291,8 @@ func RunTests(conf instanceRunConf, inventoryCatalogue map[string]*hardwareCatal
 
 func (e *E2ESession) runTests(regex string) (testCommandResult *testCommandResult, err error) {
 	e.logger.V(1).Info("Running e2e tests", "regex", regex)
-	command := "GOVERSION=go1.16.6 gotestsum --junitfile=junit-testing.xml --raw-command --format=standard-verbose --hide-summary=all --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v"
+	goVersion := runtime.Version()
+	command := fmt.Sprintf("GOVERSION=%s gotestsum --junitfile=junit-testing.xml --raw-command --format=standard-verbose --hide-summary=all --ignore-non-json-output-lines -- test2json -t -p e2e ./bin/e2e.test -test.v", goVersion)
 
 	if regex != "" {
 		command = fmt.Sprintf("%s -test.run \"^(%s)$\" -test.timeout %s", command, regex, e2eTimeout)


### PR DESCRIPTION
Use correct Go version instead of old hardcoded Go version in E2E test JUnit files by dynamically retrieving the version from the `runtime` package in the Go standard library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

