### PR TITLE
Add feature flag for Kubernetes v1.31 support

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -832,6 +832,7 @@ const (
 	Kube128 KubernetesVersion = "1.28"
 	Kube129 KubernetesVersion = "1.29"
 	Kube130 KubernetesVersion = "1.30"
+	Kube131 KubernetesVersion = "1.31"
 )
 
 // KubeVersionToSemver converts kube version to semver for comparisons.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -8,6 +8,7 @@ const (
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
 	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 	APIServerExtraArgsEnabledEnvVar = "API_SERVER_EXTRA_ARGS_ENABLED"
+	K8s131SupportEnvVar             = "K8S_1_31_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -62,5 +63,13 @@ func APIServerExtraArgsEnabled() Feature {
 	return Feature{
 		Name:     "Configure api server extra args",
 		IsActive: globalFeatures.isActiveForEnvVar(APIServerExtraArgsEnabledEnvVar),
+	}
+}
+
+// K8s131Support is the feature flag for Kubernetes 1.31 support.
+func K8s131Support() Feature {
+	return Feature{
+		Name:     "Kubernetes version 1.31 support",
+		IsActive: globalFeatures.isActiveForEnvVar(K8s131SupportEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -85,3 +85,11 @@ func TestAPIServerExtraArgsEnabledFeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(APIServerExtraArgsEnabledEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(APIServerExtraArgsEnabled())).To(BeTrue())
 }
+
+func TestWithK8s131FeatureFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(K8s131SupportEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(K8s131Support())).To(BeTrue())
+}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
@@ -284,5 +285,15 @@ func ValidateBottlerocketKubeletConfig(spec *cluster.Spec) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateK8s131Support checks if the 1.31 feature flag is set when using k8s 1.31.
+func ValidateK8s131Support(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.K8s131Support()) {
+		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube131 {
+			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube131, features.K8s131SupportEnvVar)
+		}
+	}
 	return nil
 }

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	providermocks "github.com/aws/eks-anywhere/pkg/providers/mocks"
 	"github.com/aws/eks-anywhere/pkg/types"
@@ -836,4 +837,19 @@ func TestValidateBottlerocketKC(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateK8s131Support(t *testing.T) {
+	tt := newTest(t)
+	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube131
+	tt.Expect(validations.ValidateK8s131Support(tt.clusterSpec)).To(
+		MatchError(ContainSubstring("kubernetes version 1.31 is not enabled. Please set the env variable K8S_1_31_SUPPORT")))
+}
+
+func TestValidateK8s131SupportActive(t *testing.T) {
+	tt := newTest(t)
+	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube131
+	features.ClearCache()
+	os.Setenv(features.K8s131SupportEnvVar, "true")
+	tt.Expect(validations.ValidateK8s131Support(tt.clusterSpec)).To(Succeed())
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -8,6 +8,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -48,6 +49,14 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate cluster's eksaVersion matches EKS-A version",
 				Remediation: "ensure EksaVersion matches the EKS-A release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, v.Opts.CliVersion, v.Opts.Spec),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.31 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s131SupportEnvVar),
+				Err:         validations.ValidateK8s131Support(v.Opts.Spec),
+				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,6 +9,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -120,6 +121,14 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate eksa controller is not paused",
 				Remediation: fmt.Sprintf("remove cluster controller reconciler pause annotation %s before upgrading the cluster %s", u.Opts.Spec.Cluster.PausedAnnotation(), targetCluster.Name),
 				Err:         validations.ValidatePauseAnnotation(ctx, k, targetCluster, targetCluster.Name),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.31 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s131SupportEnvVar),
+				Err:         validations.ValidateK8s131Support(u.Opts.Spec),
+				Silent:      true,
 			}
 		},
 	}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -2202,11 +2203,12 @@ func dumpFile(description, path string, t T) {
 func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
 	// Update this variable to equal the feature flagged k8s version when applicable.
 	// For example, if k8s 1.26 is under a feature flag, we would set this to v1alpha1.Kube126
-	var unreleasedK8sVersion v1alpha1.KubernetesVersion
+	unreleasedK8sVersion := v1alpha1.Kube131
 
 	if version == unreleasedK8sVersion {
 		// Set feature flag for the unreleased k8s version when applicable
 		e.T.Logf("Setting k8s version support feature flag...")
+		os.Setenv(features.K8s131SupportEnvVar, "true")
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
[#2399](https://github.com/aws/eks-anywhere-internal/issues/2399)

*Description of changes:*
Add feature flag for Kubernetes v1.31 support in EKS-A.

*Testing (if applicable):*
make eks-a
make unit-test
make build-all-test-binaries
make lint

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

