### PR TITLE
Use HookOS embedded images in Tinkerbell Templates:

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generate_tinkerbell_template_config.go
+++ b/cmd/eksctl-anywhere/cmd/generate_tinkerbell_template_config.go
@@ -94,16 +94,10 @@ func NewGenerateTinkerbellTemplateConfig() *cobra.Command {
 			controlPlaneMachineConfigName := cs.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name
 			controlPlaneMachineConfig := cs.TinkerbellMachineConfigs[controlPlaneMachineConfigName]
 			osFamily := controlPlaneMachineConfig.OSFamily()
-
-			// For modular upgrades the version bundle is retrieve per worker node group. However,
-			// because Tinkerbell action images are the same for every Kubernetes version within
-			// the same bundle manifest, its OK to just use the root version bundle.
-			bundle := *cs.RootVersionsBundle().VersionsBundle
-
 			osImageURL := cs.TinkerbellDatacenter.Spec.OSImageURL
 			tinkerbellIP := cs.TinkerbellDatacenter.Spec.TinkerbellIP
 
-			cfg := v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(cs.Cluster, bundle, osImageURL,
+			cfg := v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(cs.Cluster, osImageURL,
 				opts.BootstrapTinkerbellIP, tinkerbellIP, osFamily)
 
 			return yaml.NewK8sEncoder(os.Stdout).Encode(cfg)

--- a/internal/pkg/api/tinkerbell.go
+++ b/internal/pkg/api/tinkerbell.go
@@ -96,20 +96,6 @@ func WithOsFamilyForAllTinkerbellMachines(value anywherev1.OSFamily) TinkerbellF
 	}
 }
 
-func WithImageUrlForAllTinkerbellMachines(value string) TinkerbellFiller {
-	return func(config TinkerbellConfig) {
-		for _, t := range config.templateConfigs {
-			for _, task := range t.Spec.Template.Tasks {
-				for _, action := range task.Actions {
-					if action.Name == "stream-image" {
-						action.Environment["IMG_URL"] = value
-					}
-				}
-			}
-		}
-	}
-}
-
 func WithSSHAuthorizedKeyForAllTinkerbellMachines(key string) TinkerbellFiller {
 	return func(config TinkerbellConfig) {
 		for _, m := range config.machineConfigs {

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig.go
@@ -4,7 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1/thirdparty/tinkerbell"
-	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 const TinkerbellTemplateConfigKind = "TinkerbellTemplateConfig"
@@ -12,9 +11,8 @@ const TinkerbellTemplateConfigKind = "TinkerbellTemplateConfig"
 // +kubebuilder:object:generate=false
 type ActionOpt func(action *[]tinkerbell.Action)
 
-// NewDefaultTinkerbellTemplateConfigCreate returns a default TinkerbellTemplateConfig with the
-// required Tasks and Actions.
-func NewDefaultTinkerbellTemplateConfigCreate(clusterSpec *Cluster, versionBundle v1alpha1.VersionsBundle, osImageOverride, tinkerbellLocalIP, tinkerbellLBIP string, osFamily OSFamily) *TinkerbellTemplateConfig {
+// NewDefaultTinkerbellTemplateConfigCreate returns a default TinkerbellTemplateConfig with the required Tasks and Actions.
+func NewDefaultTinkerbellTemplateConfigCreate(clusterSpec *Cluster, osImageOverride, tinkerbellLocalIP, tinkerbellLBIP string, osFamily OSFamily) *TinkerbellTemplateConfig {
 	config := &TinkerbellTemplateConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       TinkerbellTemplateConfigKind,
@@ -41,7 +39,7 @@ func NewDefaultTinkerbellTemplateConfigCreate(clusterSpec *Cluster, versionBundl
 		},
 	}
 
-	defaultActions := GetDefaultActionsFromBundle(clusterSpec, versionBundle, osImageOverride, tinkerbellLocalIP, tinkerbellLBIP, osFamily)
+	defaultActions := DefaultActions(clusterSpec, osImageOverride, tinkerbellLocalIP, tinkerbellLBIP, osFamily)
 	for _, action := range defaultActions {
 		action(&config.Spec.Template.Tasks[0].Actions)
 	}

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -20,7 +20,7 @@ warnings:
 `
 
 	// HookOS embeds container images from the bundle.
-	// The container images are tagged as follows:
+	// The container images are tagged as below.
 	actionImage2Disk = "127.0.0.1/embedded/image2disk"
 	actionWriteFile  = "127.0.0.1/embedded/writefile"
 	actionReboot     = "127.0.0.1/embedded/reboot"

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1/thirdparty/tinkerbell"
-	"github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
 func TestWithDefaultActionsFromBundle(t *testing.T) {
-	vBundle := givenVersionBundle()
 	tinkerbellLocalIp := "127.0.0.1"
 	tinkerbellLBIP := "1.2.3.4"
 	metadataString := fmt.Sprintf("http://%s:50061,http://%s:50061", tinkerbellLocalIp, tinkerbellLBIP)
@@ -38,8 +36,8 @@ warnings:
 			clusterSpec:     &Cluster{},
 			wantActions: []tinkerbell.Action{
 				{
-					Name:    "stream-image",
-					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
+					Name:    "stream image to disk",
+					Image:   "127.0.0.1/embedded/image2disk",
 					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
@@ -48,8 +46,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-bootconfig",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write Bottlerocket bootconfig",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Pid:     "host",
 					Environment: map[string]string{
@@ -64,8 +62,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-user-data",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write Bottlerocket user data",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Pid:     "host",
 					Environment: map[string]string{
@@ -80,8 +78,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-netplan",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write netplan config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Pid:     "host",
 					Environment: map[string]string{
@@ -97,8 +95,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "reboot-image",
-					Image:   "public.ecr.aws/eks-anywhere/reboot:latest",
+					Name:    "reboot",
+					Image:   "127.0.0.1/embedded/reboot",
 					Timeout: 90,
 					Volumes: []string{"/worker:/worker"},
 					Pid:     "host",
@@ -112,8 +110,8 @@ warnings:
 			clusterSpec:     &Cluster{},
 			wantActions: []tinkerbell.Action{
 				{
-					Name:    "stream-image",
-					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
+					Name:    "stream image to disk",
+					Image:   "127.0.0.1/embedded/image2disk",
 					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
@@ -122,8 +120,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-bootconfig",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write Bottlerocket bootconfig",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Pid:     "host",
 					Environment: map[string]string{
@@ -138,8 +136,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-user-data",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write Bottlerocket user data",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Pid:     "host",
 					Environment: map[string]string{
@@ -154,8 +152,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-netplan",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write netplan config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Pid:     "host",
 					Environment: map[string]string{
@@ -171,8 +169,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "reboot-image",
-					Image:   "public.ecr.aws/eks-anywhere/reboot:latest",
+					Name:    "reboot",
+					Image:   "127.0.0.1/embedded/reboot",
 					Timeout: 90,
 					Volumes: []string{"/worker:/worker"},
 					Pid:     "host",
@@ -186,8 +184,8 @@ warnings:
 			osImageOverride: "http://tinkerbell-example:8080/redhat-8.4-kube-v1.21.5.gz",
 			wantActions: []tinkerbell.Action{
 				{
-					Name:    "stream-image",
-					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
+					Name:    "stream image to disk",
+					Image:   "127.0.0.1/embedded/image2disk",
 					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/redhat-8.4-kube-v1.21.5.gz",
@@ -196,8 +194,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-netplan",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write netplan config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK":      "{{ formatPartition ( index .Hardware.Disks 0 ) 1 }}",
@@ -212,8 +210,8 @@ warnings:
 					Pid: "host",
 				},
 				{
-					Name:    "disable-cloud-init-network-capabilities",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "disable cloud-init network capabilities",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"CONTENTS":  "network: {config: disabled}",
@@ -227,8 +225,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 1 }}",
@@ -242,8 +240,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-ds-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init ds config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 1 }}",
@@ -257,8 +255,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "reboot-image",
-					Image:   "public.ecr.aws/eks-anywhere/reboot:latest",
+					Name:    "reboot",
+					Image:   "127.0.0.1/embedded/reboot",
 					Timeout: 90,
 					Pid:     "host",
 					Volumes: []string{"/worker:/worker"},
@@ -272,8 +270,8 @@ warnings:
 			osImageOverride: "http://tinkerbell-example:8080/ubuntu-kube-v1.21.5.gz",
 			wantActions: []tinkerbell.Action{
 				{
-					Name:    "stream-image",
-					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
+					Name:    "stream image to disk",
+					Image:   "127.0.0.1/embedded/image2disk",
 					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/ubuntu-kube-v1.21.5.gz",
@@ -282,8 +280,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-netplan",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write netplan config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK":      "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -298,8 +296,8 @@ warnings:
 					Pid: "host",
 				},
 				{
-					Name:    "disable-cloud-init-network-capabilities",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "disable cloud-init network capabilities",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"CONTENTS":  "network: {config: disabled}",
@@ -313,8 +311,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -328,8 +326,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-ds-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init ds config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -343,8 +341,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "reboot-image",
-					Image:   "public.ecr.aws/eks-anywhere/reboot:latest",
+					Name:    "reboot",
+					Image:   "127.0.0.1/embedded/reboot",
 					Timeout: 90,
 					Pid:     "host",
 					Volumes: []string{"/worker:/worker"},
@@ -358,8 +356,8 @@ warnings:
 			osImageOverride: "http://tinkerbell-example:8080/ubuntu-kube-v1.21.5.gz",
 			wantActions: []tinkerbell.Action{
 				{
-					Name:    "stream-image",
-					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
+					Name:    "stream image to disk",
+					Image:   "127.0.0.1/embedded/image2disk",
 					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":    "http://tinkerbell-example:8080/ubuntu-kube-v1.21.5.gz",
@@ -368,8 +366,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-netplan",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write netplan config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK":      "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -384,8 +382,8 @@ warnings:
 					Pid: "host",
 				},
 				{
-					Name:    "disable-cloud-init-network-capabilities",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "disable cloud-init network capabilities",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"CONTENTS":  "network: {config: disabled}",
@@ -399,8 +397,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -414,8 +412,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-ds-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init ds config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -429,8 +427,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "reboot-image",
-					Image:   "public.ecr.aws/eks-anywhere/reboot:latest",
+					Name:    "reboot",
+					Image:   "127.0.0.1/embedded/reboot",
 					Timeout: 90,
 					Pid:     "host",
 					Volumes: []string{"/worker:/worker"},
@@ -456,8 +454,8 @@ warnings:
 			osImageOverride: "http://tinkerbell-example:8080/ubuntu-kube-v1.21.5.gz",
 			wantActions: []tinkerbell.Action{
 				{
-					Name:    "stream-image",
-					Image:   "public.ecr.aws/eks-anywhere/image2disk:latest",
+					Name:    "stream image to disk",
+					Image:   "127.0.0.1/embedded/image2disk",
 					Timeout: 600,
 					Environment: map[string]string{
 						"IMG_URL":     "http://tinkerbell-example:8080/ubuntu-kube-v1.21.5.gz",
@@ -469,8 +467,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "write-netplan",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "write netplan config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK":      "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -485,8 +483,8 @@ warnings:
 					Pid: "host",
 				},
 				{
-					Name:    "disable-cloud-init-network-capabilities",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "disable cloud-init network capabilities",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"CONTENTS":  "network: {config: disabled}",
@@ -500,8 +498,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -515,8 +513,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "add-tink-cloud-init-ds-config",
-					Image:   "public.ecr.aws/eks-anywhere/writefile:latest",
+					Name:    "add cloud-init ds config",
+					Image:   "127.0.0.1/embedded/writefile",
 					Timeout: 90,
 					Environment: map[string]string{
 						"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}",
@@ -530,8 +528,8 @@ warnings:
 					},
 				},
 				{
-					Name:    "reboot-image",
-					Image:   "public.ecr.aws/eks-anywhere/reboot:latest",
+					Name:    "reboot",
+					Image:   "127.0.0.1/embedded/reboot",
 					Timeout: 90,
 					Pid:     "host",
 					Volumes: []string{"/worker:/worker"},
@@ -543,7 +541,7 @@ warnings:
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			givenActions := []tinkerbell.Action{}
-			opts := GetDefaultActionsFromBundle(tt.clusterSpec, vBundle, tt.osImageOverride, tinkerbellLocalIp, tinkerbellLBIP, tt.osFamily)
+			opts := DefaultActions(tt.clusterSpec, tt.osImageOverride, tinkerbellLocalIp, tinkerbellLBIP, tt.osFamily)
 			for _, opt := range opts {
 				opt(&givenActions)
 			}
@@ -551,35 +549,5 @@ warnings:
 				t.Fatalf("Expected file mismatch (-want +got):\n%s", diff)
 			}
 		})
-	}
-}
-
-func givenVersionBundle() v1alpha1.VersionsBundle {
-	return v1alpha1.VersionsBundle{
-		EksD: v1alpha1.EksDRelease{
-			Raw: v1alpha1.OSImageBundle{
-				Bottlerocket: v1alpha1.Archive{
-					URI: "http://tinkerbell-example:8080/bottlerocket-2004-kube-v1.21.5.gz",
-				},
-			},
-		},
-		Tinkerbell: v1alpha1.TinkerbellBundle{
-			TinkerbellStack: v1alpha1.TinkerbellStackBundle{
-				Actions: v1alpha1.ActionsBundle{
-					ImageToDisk: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/image2disk:latest",
-					},
-					WriteFile: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/writefile:latest",
-					},
-					Kexec: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/kexec:latest",
-					},
-					Reboot: v1alpha1.Image{
-						URI: "public.ecr.aws/eks-anywhere/reboot:latest",
-					},
-				},
-			},
-		},
 	}
 }

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -125,7 +125,7 @@ func TestControlPlaneSpecUpdateMachineTemplates(t *testing.T) {
 	expectedKCP.Spec.MachineTemplate.InfrastructureRef.Name = "test-control-plane-1"
 
 	expectedCPTemplate.Name = "test-control-plane-1"
-	expectedCPTemplate.Spec.Template.Spec.TemplateOverride = "global_timeout: 6000\nid: \"\"\nname: tink-test\ntasks:\n- actions:\n  - environment:\n      COMPRESSED: \"true\"\n      DEST_DISK: /dev/sda\n      IMG_URL: \"\"\n    image: image2disk:v1.0.0\n    name: stream-image\n    timeout: 360\n  - environment:\n      BLOCK_DEVICE: /dev/sda2\n      CHROOT: \"y\"\n      CMD_LINE: apt -y update && apt -y install openssl\n      DEFAULT_INTERPRETER: /bin/sh -c\n      FS_TYPE: ext4\n    image: cexec:v1.0.0\n    name: install-openssl\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        network:\n          version: 2\n          renderer: networkd\n          ethernets:\n              eno1:\n                  dhcp4: true\n              eno2:\n                  dhcp4: true\n              eno3:\n                  dhcp4: true\n              eno4:\n                  dhcp4: true\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/netplan/config.yaml\n      DIRMODE: \"0755\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0644\"\n      UID: \"0\"\n    image: writefile:v1.0.0\n    name: write-netplan\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        datasource:\n          Ec2:\n            metadata_urls: []\n            strict_id: false\n        system_info:\n          default_user:\n            name: tink\n            groups: [wheel, adm]\n            sudo: [\"ALL=(ALL) NOPASSWD:ALL\"]\n            shell: /bin/bash\n        manage_etc_hosts: localhost\n        warnings:\n          dsid_missing_source: off\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0600\"\n    image: writefile:v1.0.0\n    name: add-tink-cloud-init-config\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        datasource: Ec2\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/cloud/ds-identify.cfg\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0600\"\n      UID: \"0\"\n    image: writefile:v1.0.0\n    name: add-tink-cloud-init-ds-config\n    timeout: 90\n  - environment:\n      BLOCK_DEVICE: /dev/sda2\n      FS_TYPE: ext4\n    image: kexec:v1.0.0\n    name: kexec-image\n    pid: host\n    timeout: 90\n  name: tink-test\n  volumes:\n  - /dev:/dev\n  - /dev/console:/dev/console\n  - /lib/firmware:/lib/firmware:ro\n  worker: '{{.device_1}}'\nversion: \"0.1\"\n"
+	expectedCPTemplate.Spec.Template.Spec.TemplateOverride = testTemplateOverride
 	expectedCPTemplate.Spec.Template.Spec.HardwareAffinity = &tinkerbellv1.HardwareAffinity{
 		Required: []tinkerbellv1.HardwareAffinityTerm{
 			{
@@ -924,6 +924,104 @@ status:
 	return kcp
 }
 
+var testTemplateOverride = `global_timeout: 6000
+id: ""
+name: tink-test
+tasks:
+- actions:
+  - environment:
+      COMPRESSED: "true"
+      DEST_DISK: /dev/sda
+      IMG_URL: ""
+    image: image2disk:v1.0.0
+    name: stream-image
+    timeout: 360
+  - environment:
+      BLOCK_DEVICE: /dev/sda2
+      CHROOT: "y"
+      CMD_LINE: apt -y update && apt -y install openssl
+      DEFAULT_INTERPRETER: /bin/sh -c
+      FS_TYPE: ext4
+    image: cexec:v1.0.0
+    name: install-openssl
+    timeout: 90
+  - environment:
+      CONTENTS: |
+        network:
+          version: 2
+          renderer: networkd
+          ethernets:
+              eno1:
+                  dhcp4: true
+              eno2:
+                  dhcp4: true
+              eno3:
+                  dhcp4: true
+              eno4:
+                  dhcp4: true
+      DEST_DISK: /dev/sda2
+      DEST_PATH: /etc/netplan/config.yaml
+      DIRMODE: "0755"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0644"
+      UID: "0"
+    image: writefile:v1.0.0
+    name: write-netplan
+    timeout: 90
+  - environment:
+      CONTENTS: |
+        datasource:
+          Ec2:
+            metadata_urls: []
+            strict_id: false
+        system_info:
+          default_user:
+            name: tink
+            groups: [wheel, adm]
+            sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+            shell: /bin/bash
+        manage_etc_hosts: localhost
+        warnings:
+          dsid_missing_source: off
+      DEST_DISK: /dev/sda2
+      DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+      DIRMODE: "0700"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0600"
+    image: writefile:v1.0.0
+    name: add-tink-cloud-init-config
+    timeout: 90
+  - environment:
+      CONTENTS: |
+        datasource: Ec2
+      DEST_DISK: /dev/sda2
+      DEST_PATH: /etc/cloud/ds-identify.cfg
+      DIRMODE: "0700"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0600"
+      UID: "0"
+    image: writefile:v1.0.0
+    name: add-tink-cloud-init-ds-config
+    timeout: 90
+  - environment:
+      BLOCK_DEVICE: /dev/sda2
+      FS_TYPE: ext4
+    image: kexec:v1.0.0
+    name: kexec-image
+    pid: host
+    timeout: 90
+  name: tink-test
+  volumes:
+  - /dev:/dev
+  - /dev/console:/dev/console
+  - /lib/firmware:/lib/firmware:ro
+  worker: '{{.device_1}}'
+version: "0.1"
+`
+
 func tinkerbellMachineTemplate(name string) *tinkerbellv1.TinkerbellMachineTemplate {
 	return &tinkerbellv1.TinkerbellMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
@@ -937,7 +1035,7 @@ func tinkerbellMachineTemplate(name string) *tinkerbellv1.TinkerbellMachineTempl
 		Spec: tinkerbellv1.TinkerbellMachineTemplateSpec{
 			Template: tinkerbellv1.TinkerbellMachineTemplateResource{
 				Spec: tinkerbellv1.TinkerbellMachineSpec{
-					TemplateOverride: "global_timeout: 6000\nid: \"\"\nname: tink-test\ntasks:\n- actions:\n  - environment:\n      COMPRESSED: \"true\"\n      DEST_DISK: /dev/sda\n      IMG_URL: \"\"\n    image: image2disk:v1.0.0\n    name: stream-image\n    timeout: 360\n  - environment:\n      BLOCK_DEVICE: /dev/sda2\n      CHROOT: \"y\"\n      CMD_LINE: apt -y update && apt -y install openssl\n      DEFAULT_INTERPRETER: /bin/sh -c\n      FS_TYPE: ext4\n    image: cexec:v1.0.0\n    name: install-openssl\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        network:\n          version: 2\n          renderer: networkd\n          ethernets:\n              eno1:\n                  dhcp4: true\n              eno2:\n                  dhcp4: true\n              eno3:\n                  dhcp4: true\n              eno4:\n                  dhcp4: true\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/netplan/config.yaml\n      DIRMODE: \"0755\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0644\"\n      UID: \"0\"\n    image: writefile:v1.0.0\n    name: write-netplan\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        datasource:\n          Ec2:\n            metadata_urls: []\n            strict_id: false\n        system_info:\n          default_user:\n            name: tink\n            groups: [wheel, adm]\n            sudo: [\"ALL=(ALL) NOPASSWD:ALL\"]\n            shell: /bin/bash\n        manage_etc_hosts: localhost\n        warnings:\n          dsid_missing_source: off\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0600\"\n    image: writefile:v1.0.0\n    name: add-tink-cloud-init-config\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        datasource: Ec2\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/cloud/ds-identify.cfg\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0600\"\n      UID: \"0\"\n    image: writefile:v1.0.0\n    name: add-tink-cloud-init-ds-config\n    timeout: 90\n  - environment:\n      BLOCK_DEVICE: /dev/sda2\n      FS_TYPE: ext4\n    image: kexec:v1.0.0\n    name: kexec-image\n    pid: host\n    timeout: 90\n  name: tink-test\n  volumes:\n  - /dev:/dev\n  - /dev/console:/dev/console\n  - /lib/firmware:/lib/firmware:ro\n  worker: '{{.device_1}}'\nversion: \"0.1\"\n",
+					TemplateOverride: testTemplateOverride,
 					HardwareAffinity: &tinkerbellv1.HardwareAffinity{
 						Required: []tinkerbellv1.HardwareAffinityTerm{
 							{

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -1073,6 +1073,73 @@ func tinkHardware(hardwareName, labelType string) *tinkv1alpha1.Hardware {
 
 type cpOpt func(plane *tinkerbell.ControlPlane)
 
+var testTemplateOverride = `global_timeout: 6000
+id: ""
+name: workload-cluster
+tasks:
+- actions:
+  - environment:
+      COMPRESSED: "true"
+      DEST_DISK: '{{ index .Hardware.Disks 0 }}'
+      IMG_URL: ""
+    image: 127.0.0.1/embedded/image2disk
+    name: stream image to disk
+    timeout: 600
+  - environment:
+      BOOTCONFIG_CONTENTS: kernel {}
+      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'
+      DEST_PATH: /bootconfig.data
+      DIRMODE: "0700"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0644"
+      UID: "0"
+    image: 127.0.0.1/embedded/writefile
+    name: write Bottlerocket bootconfig
+    pid: host
+    timeout: 90
+  - environment:
+      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'
+      DEST_PATH: /user-data.toml
+      DIRMODE: "0700"
+      FS_TYPE: ext4
+      GID: "0"
+      HEGEL_URLS: http://2.2.2.2:50061,http://2.2.2.2:50061
+      MODE: "0644"
+      UID: "0"
+    image: 127.0.0.1/embedded/writefile
+    name: write Bottlerocket user data
+    pid: host
+    timeout: 90
+  - environment:
+      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'
+      DEST_PATH: /net.toml
+      DIRMODE: "0755"
+      FS_TYPE: ext4
+      GID: "0"
+      IFNAME: eno1
+      MODE: "0644"
+      STATIC_BOTTLEROCKET: "true"
+      UID: "0"
+    image: 127.0.0.1/embedded/writefile
+    name: write netplan config
+    pid: host
+    timeout: 90
+  - image: 127.0.0.1/embedded/reboot
+    name: reboot
+    pid: host
+    timeout: 90
+    volumes:
+    - /worker:/worker
+  name: workload-cluster
+  volumes:
+  - /dev:/dev
+  - /dev/console:/dev/console
+  - /lib/firmware:/lib/firmware:ro
+  worker: '{{.device_1}}'
+version: "0.1"
+`
+
 func tinkerbellCP(clusterName string, opts ...cpOpt) *tinkerbell.ControlPlane {
 	cp := &tinkerbell.ControlPlane{
 		BaseControlPlane: tinkerbell.BaseControlPlane{
@@ -1433,7 +1500,7 @@ rules:
 				Spec: tinkerbellv1.TinkerbellMachineTemplateSpec{
 					Template: tinkerbellv1.TinkerbellMachineTemplateResource{
 						Spec: tinkerbellv1.TinkerbellMachineSpec{
-							TemplateOverride: "global_timeout: 6000\nid: \"\"\nname: workload-cluster\ntasks:\n- actions:\n  - environment:\n      COMPRESSED: \"true\"\n      DEST_DISK: '{{ index .Hardware.Disks 0 }}'\n      IMG_URL: \"\"\n    image: \"\"\n    name: stream-image\n    timeout: 600\n  - environment:\n      BOOTCONFIG_CONTENTS: kernel {}\n      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'\n      DEST_PATH: /bootconfig.data\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0644\"\n      UID: \"0\"\n    image: \"\"\n    name: write-bootconfig\n    pid: host\n    timeout: 90\n  - environment:\n      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'\n      DEST_PATH: /user-data.toml\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      HEGEL_URLS: http://2.2.2.2:50061,http://2.2.2.2:50061\n      MODE: \"0644\"\n      UID: \"0\"\n    image: \"\"\n    name: write-user-data\n    pid: host\n    timeout: 90\n  - environment:\n      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'\n      DEST_PATH: /net.toml\n      DIRMODE: \"0755\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      IFNAME: eno1\n      MODE: \"0644\"\n      STATIC_BOTTLEROCKET: \"true\"\n      UID: \"0\"\n    image: \"\"\n    name: write-netplan\n    pid: host\n    timeout: 90\n  - image: \"\"\n    name: reboot-image\n    pid: host\n    timeout: 90\n    volumes:\n    - /worker:/worker\n  name: workload-cluster\n  volumes:\n  - /dev:/dev\n  - /dev/console:/dev/console\n  - /lib/firmware:/lib/firmware:ro\n  worker: '{{.device_1}}'\nversion: \"0.1\"\n",
+							TemplateOverride: testTemplateOverride,
 							HardwareAffinity: &tinkerbellv1.HardwareAffinity{
 								Required: []tinkerbellv1.HardwareAffinityTerm{
 									{LabelSelector: metav1.LabelSelector{
@@ -1573,7 +1640,7 @@ func tinkWorker(clusterName string, opts ...workerOpt) *tinkerbell.Workers {
 					},
 					Spec: tinkerbellv1.TinkerbellMachineTemplateSpec{
 						Template: tinkerbellv1.TinkerbellMachineTemplateResource{Spec: tinkerbellv1.TinkerbellMachineSpec{
-							TemplateOverride: "global_timeout: 6000\nid: \"\"\nname: " + clusterName + "\ntasks:\n- actions:\n  - environment:\n      COMPRESSED: \"true\"\n      DEST_DISK: '{{ index .Hardware.Disks 0 }}'\n      IMG_URL: \"\"\n    image: \"\"\n    name: stream-image\n    timeout: 600\n  - environment:\n      BOOTCONFIG_CONTENTS: kernel {}\n      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'\n      DEST_PATH: /bootconfig.data\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0644\"\n      UID: \"0\"\n    image: \"\"\n    name: write-bootconfig\n    pid: host\n    timeout: 90\n  - environment:\n      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'\n      DEST_PATH: /user-data.toml\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      HEGEL_URLS: http://2.2.2.2:50061,http://2.2.2.2:50061\n      MODE: \"0644\"\n      UID: \"0\"\n    image: \"\"\n    name: write-user-data\n    pid: host\n    timeout: 90\n  - environment:\n      DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 12 }}'\n      DEST_PATH: /net.toml\n      DIRMODE: \"0755\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      IFNAME: eno1\n      MODE: \"0644\"\n      STATIC_BOTTLEROCKET: \"true\"\n      UID: \"0\"\n    image: \"\"\n    name: write-netplan\n    pid: host\n    timeout: 90\n  - image: \"\"\n    name: reboot-image\n    pid: host\n    timeout: 90\n    volumes:\n    - /worker:/worker\n  name: workload-cluster\n  volumes:\n  - /dev:/dev\n  - /dev/console:/dev/console\n  - /lib/firmware:/lib/firmware:ro\n  worker: '{{.device_1}}'\nversion: \"0.1\"\n",
+							TemplateOverride: testTemplateOverride,
 							HardwareAffinity: &tinkerbellv1.HardwareAffinity{
 								Required: []tinkerbellv1.HardwareAffinityTerm{
 									{

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -66,7 +66,6 @@ func NewTemplateBuilder(datacenterSpec *v1alpha1.TinkerbellDatacenterConfigSpec,
 
 func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spec, buildOptions ...providers.BuildMapOption) (content []byte, err error) {
 	cpTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[tb.controlPlaneMachineSpec.TemplateRef.Name]
-	bundle := clusterSpec.RootVersionsBundle()
 	var OSImageURL string
 
 	if tinkerbellIP := clusterSpec.Cluster.HasTinkerbellIPAnnotation(); tinkerbellIP != "" {
@@ -78,8 +77,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 		if tb.controlPlaneMachineSpec.OSImageURL != "" {
 			OSImageURL = tb.controlPlaneMachineSpec.OSImageURL
 		}
-		versionBundle := bundle.VersionsBundle
-		cpTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, *versionBundle, OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, tb.controlPlaneMachineSpec.OSFamily)
+		cpTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, tb.controlPlaneMachineSpec.OSFamily)
 	}
 
 	cpTemplateString, err := cpTemplateConfig.ToTemplateString()
@@ -97,8 +95,7 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 		}
 		etcdTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[tb.etcdMachineSpec.TemplateRef.Name]
 		if etcdTemplateConfig == nil {
-			versionBundle := bundle.VersionsBundle
-			etcdTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, *versionBundle, OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, tb.etcdMachineSpec.OSFamily)
+			etcdTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, tb.etcdMachineSpec.OSFamily)
 		}
 		etcdTemplateString, err = etcdTemplateConfig.ToTemplateString()
 		if err != nil {
@@ -122,7 +119,6 @@ func (tb *TemplateBuilder) GenerateCAPISpecControlPlane(clusterSpec *cluster.Spe
 
 func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, workloadTemplateNames, kubeadmconfigTemplateNames map[string]string) (content []byte, err error) {
 	workerSpecs := make([][]byte, 0, len(clusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations))
-	bundle := clusterSpec.RootVersionsBundle()
 	OSImageURL := clusterSpec.TinkerbellDatacenter.Spec.OSImageURL
 
 	if tinkerbellIP := clusterSpec.Cluster.HasTinkerbellIPAnnotation(); tinkerbellIP != "" {
@@ -133,11 +129,10 @@ func (tb *TemplateBuilder) GenerateCAPISpecWorkers(clusterSpec *cluster.Spec, wo
 		workerNodeMachineSpec := tb.WorkerNodeGroupMachineSpecs[workerNodeGroupConfiguration.MachineGroupRef.Name]
 		wTemplateConfig := clusterSpec.TinkerbellTemplateConfigs[workerNodeMachineSpec.TemplateRef.Name]
 		if wTemplateConfig == nil {
-			versionBundle := bundle.VersionsBundle
 			if workerNodeMachineSpec.OSImageURL != "" {
 				OSImageURL = workerNodeMachineSpec.OSImageURL
 			}
-			wTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, *versionBundle, OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, workerNodeMachineSpec.OSFamily)
+			wTemplateConfig = v1alpha1.NewDefaultTinkerbellTemplateConfigCreate(clusterSpec.Cluster, OSImageURL, tb.tinkerbellIP, tb.datacenterSpec.TinkerbellIP, workerNodeMachineSpec.OSFamily)
 		}
 
 		wTemplateString, err := wTemplateConfig.ToTemplateString()

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_minimal_registry_mirror.yaml
@@ -179,7 +179,7 @@ spec:
             timeout: 90
           - environment:
             image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_registry_mirror_with_auth.yaml
@@ -195,7 +195,7 @@ spec:
             timeout: 90
           - environment:
             image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_registry_mirror_with_cert.yaml
@@ -194,7 +194,7 @@ spec:
             timeout: 90
           - environment:
             image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_kct.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kct.yaml
@@ -51,8 +51,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -63,8 +63,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -76,8 +76,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -95,8 +95,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -108,11 +108,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
@@ -413,8 +413,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -425,8 +425,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -438,8 +438,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -452,12 +452,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_md.yaml
@@ -56,8 +56,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -68,8 +68,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -81,8 +81,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -95,12 +95,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -379,8 +379,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -391,8 +391,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -404,8 +404,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -418,12 +418,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_md.yaml
@@ -56,8 +56,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -68,8 +68,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -81,8 +81,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -95,12 +95,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -359,8 +359,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -371,8 +371,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -384,8 +384,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -398,12 +398,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_md.yaml
@@ -56,8 +56,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -68,8 +68,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -81,8 +81,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -95,12 +95,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
@@ -371,8 +371,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -383,8 +383,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -396,8 +396,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -410,12 +410,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_md.yaml
@@ -56,8 +56,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://bottlerocket-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               BOOTCONFIG_CONTENTS: kernel {}
@@ -68,8 +68,8 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-bootconfig
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket bootconfig
             pid: host
             timeout: 90
           - environment:
@@ -81,8 +81,8 @@ spec:
               HEGEL_URLS: http://5.6.7.8:50061,http://5.6.7.8:50061
               MODE: "0644"
               UID: "0"
-            image: ""
-            name: write-user-data
+            image: 127.0.0.1/embedded/writefile
+            name: write Bottlerocket user data
             pid: host
             timeout: 90
           - environment:
@@ -95,12 +95,12 @@ spec:
               MODE: "0644"
               STATIC_BOTTLEROCKET: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
@@ -413,7 +413,7 @@ spec:
             name: write-user-data
             timeout: 90
           - image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -449,7 +449,7 @@ spec:
             name: write-user-data
             timeout: 90
           - image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -449,7 +449,7 @@ spec:
             name: write-user-data
             timeout: 90
           - image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
@@ -112,7 +112,7 @@ spec:
             name: write-user-data
             timeout: 90
           - image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
@@ -112,7 +112,7 @@ spec:
             name: write-user-data
             timeout: 90
           - image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
@@ -112,7 +112,7 @@ spec:
             name: write-user-data
             timeout: 90
           - image: reboot:v1.0.0
-            name: reboot-image
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -334,8 +334,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -346,8 +346,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -359,8 +359,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -378,8 +378,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -391,11 +391,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
@@ -333,8 +333,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -345,8 +345,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -358,8 +358,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -377,8 +377,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -390,11 +390,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
@@ -325,8 +325,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -337,8 +337,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -350,8 +350,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -369,8 +369,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -382,11 +382,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
@@ -271,8 +271,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -283,8 +283,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -296,8 +296,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -315,8 +315,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -328,11 +328,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
@@ -326,8 +326,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -338,8 +338,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -351,8 +351,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -370,8 +370,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -383,11 +383,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_md_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_md_template.yaml
@@ -56,8 +56,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -68,8 +68,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -81,8 +81,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -100,8 +100,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -113,11 +113,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -332,8 +332,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -344,8 +344,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -357,8 +357,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -376,8 +376,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -389,11 +389,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_md.yaml
@@ -56,8 +56,8 @@ spec:
               COMPRESSED: "true"
               DEST_DISK: '{{ index .Hardware.Disks 0 }}'
               IMG_URL: https://ubuntu-1-21.gz
-            image: ""
-            name: stream-image
+            image: 127.0.0.1/embedded/image2disk
+            name: stream image to disk
             timeout: 600
           - environment:
               DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
@@ -68,8 +68,8 @@ spec:
               MODE: "0644"
               STATIC_NETPLAN: "true"
               UID: "0"
-            image: ""
-            name: write-netplan
+            image: 127.0.0.1/embedded/writefile
+            name: write netplan config
             pid: host
             timeout: 90
           - environment:
@@ -81,8 +81,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: disable-cloud-init-network-capabilities
+            image: 127.0.0.1/embedded/writefile
+            name: disable cloud-init network capabilities
             timeout: 90
           - environment:
               CONTENTS: |
@@ -100,8 +100,8 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init config
             timeout: 90
           - environment:
               CONTENTS: |
@@ -113,11 +113,11 @@ spec:
               GID: "0"
               MODE: "0600"
               UID: "0"
-            image: ""
-            name: add-tink-cloud-init-ds-config
+            image: 127.0.0.1/embedded/writefile
+            name: add cloud-init ds config
             timeout: 90
-          - image: ""
-            name: reboot-image
+          - image: 127.0.0.1/embedded/reboot
+            name: reboot
             pid: host
             timeout: 90
             volumes:

--- a/pkg/providers/tinkerbell/workers_test.go
+++ b/pkg/providers/tinkerbell/workers_test.go
@@ -389,6 +389,104 @@ func kubeadmConfigTemplate(opts ...func(*bootstrapv1.KubeadmConfigTemplate)) *bo
 	return o
 }
 
+var testTemplateOverride = `global_timeout: 6000
+id: ""
+name: tink-test
+tasks:
+- actions:
+  - environment:
+      COMPRESSED: "true"
+      DEST_DISK: /dev/sda
+      IMG_URL: ""
+    image: image2disk:v1.0.0
+    name: stream-image
+    timeout: 360
+  - environment:
+      BLOCK_DEVICE: /dev/sda2
+      CHROOT: "y"
+      CMD_LINE: apt -y update && apt -y install openssl
+      DEFAULT_INTERPRETER: /bin/sh -c
+      FS_TYPE: ext4
+    image: cexec:v1.0.0
+    name: install-openssl
+    timeout: 90
+  - environment:
+      CONTENTS: |
+        network:
+          version: 2
+          renderer: networkd
+          ethernets:
+              eno1:
+                  dhcp4: true
+              eno2:
+                  dhcp4: true
+              eno3:
+                  dhcp4: true
+              eno4:
+                  dhcp4: true
+      DEST_DISK: /dev/sda2
+      DEST_PATH: /etc/netplan/config.yaml
+      DIRMODE: "0755"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0644"
+      UID: "0"
+    image: writefile:v1.0.0
+    name: write-netplan
+    timeout: 90
+  - environment:
+      CONTENTS: |
+        datasource:
+          Ec2:
+            metadata_urls: []
+            strict_id: false
+        system_info:
+          default_user:
+            name: tink
+            groups: [wheel, adm]
+            sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+            shell: /bin/bash
+        manage_etc_hosts: localhost
+        warnings:
+          dsid_missing_source: off
+      DEST_DISK: /dev/sda2
+      DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
+      DIRMODE: "0700"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0600"
+    image: writefile:v1.0.0
+    name: add-tink-cloud-init-config
+    timeout: 90
+  - environment:
+      CONTENTS: |
+        datasource: Ec2
+      DEST_DISK: /dev/sda2
+      DEST_PATH: /etc/cloud/ds-identify.cfg
+      DIRMODE: "0700"
+      FS_TYPE: ext4
+      GID: "0"
+      MODE: "0600"
+      UID: "0"
+    image: writefile:v1.0.0
+    name: add-tink-cloud-init-ds-config
+    timeout: 90
+  - environment:
+      BLOCK_DEVICE: /dev/sda2
+      FS_TYPE: ext4
+    image: kexec:v1.0.0
+    name: kexec-image
+    pid: host
+    timeout: 90
+  name: tink-test
+  volumes:
+  - /dev:/dev
+  - /dev/console:/dev/console
+  - /lib/firmware:/lib/firmware:ro
+  worker: '{{.device_1}}'
+version: "0.1"
+`
+
 func machineTemplate(opts ...func(*tinkerbellv1.TinkerbellMachineTemplate)) *tinkerbellv1.TinkerbellMachineTemplate {
 	o := &tinkerbellv1.TinkerbellMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
@@ -402,7 +500,7 @@ func machineTemplate(opts ...func(*tinkerbellv1.TinkerbellMachineTemplate)) *tin
 		Spec: tinkerbellv1.TinkerbellMachineTemplateSpec{
 			Template: tinkerbellv1.TinkerbellMachineTemplateResource{
 				Spec: tinkerbellv1.TinkerbellMachineSpec{
-					TemplateOverride: "global_timeout: 6000\nid: \"\"\nname: tink-test\ntasks:\n- actions:\n  - environment:\n      COMPRESSED: \"true\"\n      DEST_DISK: /dev/sda\n      IMG_URL: \"\"\n    image: image2disk:v1.0.0\n    name: stream-image\n    timeout: 360\n  - environment:\n      BLOCK_DEVICE: /dev/sda2\n      CHROOT: \"y\"\n      CMD_LINE: apt -y update && apt -y install openssl\n      DEFAULT_INTERPRETER: /bin/sh -c\n      FS_TYPE: ext4\n    image: cexec:v1.0.0\n    name: install-openssl\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        network:\n          version: 2\n          renderer: networkd\n          ethernets:\n              eno1:\n                  dhcp4: true\n              eno2:\n                  dhcp4: true\n              eno3:\n                  dhcp4: true\n              eno4:\n                  dhcp4: true\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/netplan/config.yaml\n      DIRMODE: \"0755\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0644\"\n      UID: \"0\"\n    image: writefile:v1.0.0\n    name: write-netplan\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        datasource:\n          Ec2:\n            metadata_urls: []\n            strict_id: false\n        system_info:\n          default_user:\n            name: tink\n            groups: [wheel, adm]\n            sudo: [\"ALL=(ALL) NOPASSWD:ALL\"]\n            shell: /bin/bash\n        manage_etc_hosts: localhost\n        warnings:\n          dsid_missing_source: off\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0600\"\n    image: writefile:v1.0.0\n    name: add-tink-cloud-init-config\n    timeout: 90\n  - environment:\n      CONTENTS: |\n        datasource: Ec2\n      DEST_DISK: /dev/sda2\n      DEST_PATH: /etc/cloud/ds-identify.cfg\n      DIRMODE: \"0700\"\n      FS_TYPE: ext4\n      GID: \"0\"\n      MODE: \"0600\"\n      UID: \"0\"\n    image: writefile:v1.0.0\n    name: add-tink-cloud-init-ds-config\n    timeout: 90\n  - environment:\n      BLOCK_DEVICE: /dev/sda2\n      FS_TYPE: ext4\n    image: kexec:v1.0.0\n    name: kexec-image\n    pid: host\n    timeout: 90\n  name: tink-test\n  volumes:\n  - /dev:/dev\n  - /dev/console:/dev/console\n  - /lib/firmware:/lib/firmware:ro\n  worker: '{{.device_1}}'\nversion: \"0.1\"\n",
+					TemplateOverride: testTemplateOverride,
 					HardwareAffinity: &tinkerbellv1.HardwareAffinity{
 						Required: []tinkerbellv1.HardwareAffinityTerm{
 							{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
HookOS now embeds the container images for all Tinkerbell Actions into the HookOS Docker cache. As such, we update all Actions to use the embedded image names.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

