### PR TITLE
Fix kubernetes version in vSphere inplace E2E test

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3918,7 +3918,7 @@ func TestVSphereKubernetes129UbuntuTo130InPlaceUpgradeWorkerOnly(t *testing.T) {
 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
 	).WithClusterConfig(
 		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(kube129),
+			api.WithKubernetesVersion(kube130),
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
 			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube129),


### PR DESCRIPTION
*Description of changes:*
`TestVSphereKubernetes129UbuntuTo130InPlaceUpgradeWorkerOnly` E2E test is failing with the following error:
```
2024-09-09T07:03:49.183Z	V0	❌ Validation failed	{"validation": "vsphere Provider setup is valid", "error": "template /SDDC-Datacenter/vm/Templates/kubernetes-1-30-eks-13-ubuntu is missing tag eksdRelease:kubernetes-1-29-eks-20", "remediation": ""}
```
This is due to an incorrect version configured in the test. This PR updates the kubernetes version in the test to fix the failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

