### PR TITLE
Remove 1.26 E2E tests for Docker and Snow

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -30,7 +30,6 @@ skipped_tests:
 - TestCloudStackKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects
 
 # Snow
-- TestSnowKubernetes126SimpleFlow
 - TestSnowKubernetes127SimpleFlow
 - TestSnowKubernetes128SimpleFlow
 - TestSnowKubernetes128StackedEtcdSimpleFlow
@@ -42,11 +41,8 @@ skipped_tests:
 - TestSnowKubernetes128OIDC
 - TestSnowKubernetes128UbuntuProxyConfig
 - TestSnowKubernetes127UbuntuTo128Upgrade
-- TestSnowKubernetes126UbuntuTo127Upgrade
 - TestSnowKubernetes127BottlerocketTo128Upgrade
-- TestSnowKubernetes126BottlerocketTo127Upgrade
 - TestSnowKubernetes127To128BottlerocketStaticIPUpgrade
-- TestSnowKubernetes126To127BottlerocketStaticIPUpgrade
 - TestSnowMulticlusterWorkloadClusterAPI
 - TestSnowKubernetes128UbuntuTaintsUpgradeFlow
 - TestSnowKubernetes127To128UbuntuMultipleFieldsUpgrade

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -48,5 +48,5 @@ const (
 
 var (
 	EksaPackageControllerHelmValues = []string{"sourceRegistry=public.ecr.aws/l0g8r8j6"}
-	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube126, v1alpha1.Kube127, v1alpha1.Kube128, v1alpha1.Kube129, v1alpha1.Kube130, v1alpha1.Kube131}
+	KubeVersions                    = []v1alpha1.KubernetesVersion{v1alpha1.Kube127, v1alpha1.Kube128, v1alpha1.Kube129, v1alpha1.Kube130, v1alpha1.Kube131}
 )

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -133,18 +133,6 @@ func TestDockerKubernetes131UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
 }
 
 // Curated Packages
-func TestDockerKubernetes126CuratedPackagesSimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube126),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
-	)
-	runCuratedPackageInstallSimpleFlow(test)
-}
-
 func TestDockerKubernetes127CuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
@@ -206,18 +194,6 @@ func TestDockerKubernetes131CuratedPackagesSimpleFlow(t *testing.T) {
 }
 
 // Emissary
-func TestDockerKubernetes126CuratedPackagesEmissarySimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube126),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
-	)
-	runCuratedPackageEmissaryInstallSimpleFlow(test)
-}
-
 func TestDockerKubernetes127CuratedPackagesEmissarySimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
@@ -279,18 +255,6 @@ func TestDockerKubernetes131CuratedPackagesEmissarySimpleFlow(t *testing.T) {
 }
 
 // Harbor
-func TestDockerKubernetes126CuratedPackagesHarborSimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube126),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
-	)
-	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
-}
-
 func TestDockerKubernetes127CuratedPackagesHarborSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,
@@ -352,17 +316,6 @@ func TestDockerKubernetes131CuratedPackagesHarborSimpleFlow(t *testing.T) {
 }
 
 // ADOT
-func TestDockerKubernetes126CuratedPackagesAdotSimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube126),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
-	)
-	runCuratedPackagesAdotInstallSimpleFlow(test) // other args as necessary
-}
-
 func TestDockerKubernetes127CuratedPackagesAdotSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
@@ -419,17 +372,6 @@ func TestDockerKubernetes131CuratedPackagesAdotSimpleFlow(t *testing.T) {
 }
 
 // Prometheus
-func TestDockerKubernetes126CuratedPackagesPrometheusSimpleFlow(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube126),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
-	)
-	runCuratedPackagesPrometheusInstallSimpleFlow(test)
-}
-
 func TestDockerKubernetes127CuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
@@ -486,18 +428,6 @@ func TestDockerKubernetes131CuratedPackagesPrometheusSimpleFlow(t *testing.T) {
 }
 
 // Curated Packages Disabled
-func TestDockerKubernetes126CuratedPackagesDisabled(t *testing.T) {
-	framework.CheckCuratedPackagesCredentials(t)
-	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube126),
-			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
-			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues,
-			&v1alpha1.PackageConfiguration{Disable: true}),
-	)
-	runDisabledCuratedPackageInstallSimpleFlow(test) // other args as necessary
-}
-
 func TestDockerKubernetes127CuratedPackagesDisabled(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t, framework.NewDocker(t),
@@ -559,10 +489,6 @@ func TestDockerKubernetes131CuratedPackagesDisabled(t *testing.T) {
 }
 
 // MetalLB
-func TestDockerKubernetes126CuratedPackagesMetalLB(t *testing.T) {
-	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube126)
-}
-
 func TestDockerKubernetes127CuratedPackagesMetalLB(t *testing.T) {
 	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube127)
 }
@@ -584,15 +510,6 @@ func TestDockerKubernetes131CuratedPackagesMetalLB(t *testing.T) {
 }
 
 // AWS IAM Auth
-func TestDockerKubernetes126AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
 func TestDockerKubernetes127AWSIamAuth(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
@@ -639,15 +556,6 @@ func TestDockerKubernetes131AWSIamAuth(t *testing.T) {
 }
 
 // OIDC
-func TestDockerKubernetes126OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-	)
-	runOIDCFlow(test)
-}
-
 func TestDockerKubernetes127OIDC(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewDocker(t),
@@ -744,15 +652,6 @@ func TestDockerKubernetes131RegistryMirrorInsecureSkipVerify(t *testing.T) {
 }
 
 // Simple Flow
-func TestDockerKubernetes126SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-	)
-	runSimpleFlow(test)
-}
-
 func TestDockerKubernetes127SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -933,25 +832,6 @@ func TestDockerKubernetes130To131ExternalEtcdUpgrade(t *testing.T) {
 }
 
 // Upgrade From Latest Minor Release
-func TestDockerKubernetes126to127UpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube127,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube127)),
-	)
-}
-
 func TestDockerKubernetes127to128UpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
 	provider := framework.NewDocker(t)

--- a/test/e2e/snow_test.go
+++ b/test/e2e/snow_test.go
@@ -109,7 +109,7 @@ func TestSnowKubernetes128OIDC(t *testing.T) {
 	runOIDCFlow(test)
 }
 
-// Proxy config
+// Proxy Config
 func TestSnowKubernetes128UbuntuProxyConfig(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -123,16 +123,7 @@ func TestSnowKubernetes128UbuntuProxyConfig(t *testing.T) {
 	runProxyConfigFlow(test)
 }
 
-// Simpleflow
-func TestSnowKubernetes126SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewSnow(t, framework.WithSnowUbuntu126()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube126)),
-	)
-	runSimpleFlow(test)
-}
-
+// Simple Flow
 func TestSnowKubernetes127SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -274,13 +265,6 @@ func TestSnowKubernetes127UbuntuTo128Upgrade(t *testing.T) {
 	runSnowUpgradeTest(test, snow, snow.WithUbuntu127(), snow.WithUbuntu128())
 }
 
-func TestSnowKubernetes126UbuntuTo127Upgrade(t *testing.T) {
-	snow := framework.NewSnow(t)
-	test := framework.NewClusterE2ETest(t, snow)
-
-	runSnowUpgradeTest(test, snow, snow.WithUbuntu126(), snow.WithUbuntu127())
-}
-
 func TestSnowKubernetes127BottlerocketTo128Upgrade(t *testing.T) {
 	snow := framework.NewSnow(t)
 	test := framework.NewClusterE2ETest(t, snow)
@@ -288,81 +272,9 @@ func TestSnowKubernetes127BottlerocketTo128Upgrade(t *testing.T) {
 	runSnowUpgradeTest(test, snow, snow.WithBottlerocket127(), snow.WithBottlerocket128())
 }
 
-func TestSnowKubernetes126BottlerocketTo127Upgrade(t *testing.T) {
-	snow := framework.NewSnow(t)
-	test := framework.NewClusterE2ETest(t, snow)
-
-	runSnowUpgradeTest(test, snow, snow.WithBottlerocket126(), snow.WithBottlerocket127())
-}
-
 func TestSnowKubernetes127To128BottlerocketStaticIPUpgrade(t *testing.T) {
 	snow := framework.NewSnow(t)
 	test := framework.NewClusterE2ETest(t, snow)
 
 	runSnowUpgradeTest(test, snow, snow.WithBottlerocketStaticIP127(), snow.WithBottlerocketStaticIP128())
-}
-
-func TestSnowKubernetes126To127BottlerocketStaticIPUpgrade(t *testing.T) {
-	snow := framework.NewSnow(t)
-	test := framework.NewClusterE2ETest(t, snow)
-
-	runSnowUpgradeTest(test, snow, snow.WithBottlerocketStaticIP126(), snow.WithBottlerocketStaticIP127())
-}
-
-// Workload API
-func TestSnowMulticlusterWorkloadClusterAPI(t *testing.T) {
-	snow := framework.NewSnow(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, snow,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		snow.WithBottlerocket126(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, snow, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			snow.WithBottlerocket126(),
-		),
-		framework.NewClusterE2ETest(
-			t, snow, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			snow.WithBottlerocket127(),
-		),
-		framework.NewClusterE2ETest(
-			t, snow, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			snow.WithBottlerocket128(),
-		),
-	)
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.DeleteClusterWithKubectl()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
 }

--- a/test/framework/snow.go
+++ b/test/framework/snow.go
@@ -19,10 +19,6 @@ import (
 )
 
 const (
-	snowAMIIDUbuntu123   = "T_SNOW_AMIID_UBUNTU_1_23"
-	snowAMIIDUbuntu124   = "T_SNOW_AMIID_UBUNTU_1_24"
-	snowAMIIDUbuntu125   = "T_SNOW_AMIID_UBUNTU_1_25"
-	snowAMIIDUbuntu126   = "T_SNOW_AMIID_UBUNTU_1_26"
 	snowAMIIDUbuntu127   = "T_SNOW_AMIID_UBUNTU_1_27"
 	snowAMIIDUbuntu128   = "T_SNOW_AMIID_UBUNTU_1_28"
 	snowDevices          = "T_SNOW_DEVICES"
@@ -211,15 +207,6 @@ func (s *Snow) WithProviderUpgrade(fillers ...api.SnowFiller) ClusterE2ETestOpt 
 	}
 }
 
-// WithBottlerocket126 returns a cluster config filler that sets the kubernetes version of the cluster to 1.26
-// as well as the right devices and osFamily for all SnowMachineConfigs. It also sets any
-// necessary machine config default required for BR, like the container volume size. If the env var is set, this will
-// also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
-func (s *Snow) WithBottlerocket126() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.withBottlerocketForKubeVersion(anywherev1.Kube126)
-}
-
 // WithBottlerocket127 returns a cluster config filler that sets the kubernetes version of the cluster to 1.27
 // as well as the right devices and osFamily for all SnowMachineConfigs. It also sets any
 // necessary machine config default required for BR, like the container volume size. If the env var is set, this will
@@ -238,14 +225,6 @@ func (s *Snow) WithBottlerocket128() api.ClusterConfigFiller {
 	return s.withBottlerocketForKubeVersion(anywherev1.Kube128)
 }
 
-// WithBottlerocketStaticIP126 returns a cluster config filler that sets the kubernetes version of the cluster to 1.26
-// as well as the right devices, osFamily and static ip config for all SnowMachineConfigs. Comparing to WithBottlerocket126,
-// this method also adds a snow ip pool to support static ip configuration.
-func (s *Snow) WithBottlerocketStaticIP126() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.withBottlerocketStaticIPForKubeVersion(anywherev1.Kube126)
-}
-
 // WithBottlerocketStaticIP127 returns a cluster config filler that sets the kubernetes version of the cluster to 1.27
 // as well as the right devices, osFamily and static ip config for all SnowMachineConfigs. Comparing to WithBottlerocket127,
 // this method also adds a snow ip pool to support static ip configuration.
@@ -260,14 +239,6 @@ func (s *Snow) WithBottlerocketStaticIP127() api.ClusterConfigFiller {
 func (s *Snow) WithBottlerocketStaticIP128() api.ClusterConfigFiller {
 	s.t.Helper()
 	return s.withBottlerocketStaticIPForKubeVersion(anywherev1.Kube128)
-}
-
-// WithUbuntu126 returns a cluster config filler that sets the kubernetes version of the cluster to 1.26
-// as well as the right devices and osFamily for all SnowMachineConfigs. If the env var is set, this will
-// also set the AMI ID. Otherwise, it will leave it empty and let CAPAS select one.
-func (s *Snow) WithUbuntu126() api.ClusterConfigFiller {
-	s.t.Helper()
-	return s.WithKubeVersionAndOS(anywherev1.Kube126, Ubuntu2004, nil)
 }
 
 // WithUbuntu127 returns a cluster config filler that sets the kubernetes version of the cluster to 1.27
@@ -332,42 +303,6 @@ func (s *Snow) withIPPoolFromEnvVar(name string) api.SnowFiller {
 	envVars := []string{snowIPPoolIPStart, snowIPPoolIPEnd, snowIPPoolGateway, snowIPPoolSubnet}
 	checkRequiredEnvVars(s.t, envVars)
 	return api.WithSnowIPPool(name, os.Getenv(snowIPPoolIPStart), os.Getenv(snowIPPoolIPEnd), os.Getenv(snowIPPoolGateway), os.Getenv(snowIPPoolSubnet))
-}
-
-func WithSnowUbuntu123() SnowOpt {
-	return func(s *Snow) {
-		s.fillers = append(s.fillers,
-			api.WithSnowStringFromEnvVar(snowAMIIDUbuntu123, api.WithSnowAMIIDForAllMachines),
-			api.WithSnowStringFromEnvVar(snowDevices, api.WithSnowDevicesForAllMachines),
-			api.WithOsFamilyForAllSnowMachines(anywherev1.Ubuntu),
-		)
-	}
-}
-
-// WithSnowUbuntu124 returns SnowOpt that sets the right devices and osFamily for all SnowMachineConfigs.
-// If the env var is set, this will also set the AMI ID.
-// Otherwise, it will leave it empty and let CAPAS select one.
-func WithSnowUbuntu124() SnowOpt {
-	return func(s *Snow) {
-		s.fillers = append(s.fillers,
-			s.withAMIIDFromEnvVar(snowAMIIDUbuntu124),
-			api.WithSnowStringFromEnvVar(snowDevices, api.WithSnowDevicesForAllMachines),
-			api.WithOsFamilyForAllSnowMachines(anywherev1.Ubuntu),
-		)
-	}
-}
-
-// WithSnowUbuntu126 returns SnowOpt that sets the right devices and osFamily for all SnowMachineConfigs.
-// If the env var is set, this will also set the AMI ID.
-// Otherwise, it will leave it empty and let CAPAS select one.
-func WithSnowUbuntu126() SnowOpt {
-	return func(s *Snow) {
-		s.fillers = append(s.fillers,
-			api.WithSnowStringFromEnvVar(snowAMIIDUbuntu126, api.WithSnowAMIIDForAllMachines),
-			api.WithSnowStringFromEnvVar(snowDevices, api.WithSnowDevicesForAllMachines),
-			api.WithOsFamilyForAllSnowMachines(anywherev1.Ubuntu),
-		)
-	}
 }
 
 // WithSnowUbuntu127 returns SnowOpt that sets the right devices and osFamily for all SnowMachineConfigs.
@@ -449,10 +384,6 @@ func buildSnowWorkerNodeGroupClusterFiller(machineConfigName string, workerNodeG
 	workerNodeGroup.MachineConfigKind = anywherev1.SnowMachineConfigKind
 	workerNodeGroup.MachineConfigName = machineConfigName
 	return workerNodeGroup.ClusterFiller()
-}
-
-func UpdateSnowUbuntuTemplate123Var() api.SnowFiller {
-	return api.WithSnowStringFromEnvVar(snowAMIIDUbuntu123, api.WithSnowAMIIDForAllMachines)
 }
 
 // ClusterStateValidations returns a list of provider specific validations.


### PR DESCRIPTION
*Issue #, if available:*
[#2399](https://github.com/aws/eks-anywhere-internal/issues/2399)

*Description of changes:*
Remove kubernetes v1.26 E2E tests for Docker and Snow providers.

*Testing (if applicable):*
make build-all-test-binaries
make lint

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

