### PR TITLE
Add missing ENV var in quick e2e buildspec

### DIFF
--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -163,6 +163,7 @@ env:
     T_TINKERBELL_IMAGE_UBUNTU_2204_1_28: "tinkerbell_ci:image_ubuntu_2204_1_28"
     T_TINKERBELL_IMAGE_UBUNTU_2204_1_29: "tinkerbell_ci:image_ubuntu_2204_1_29"
     T_TINKERBELL_IMAGE_UBUNTU_2204_1_29_RTOS: "tinkerbell_ci:image_ubuntu_2204_1_29_rtos"
+    T_TINKERBELL_IMAGE_UBUNTU_2204_1_29_GENERIC: "tinkerbell_ci:image_ubuntu_2204_1_29_generic"
     T_TINKERBELL_IMAGE_UBUNTU_2204_1_30: "tinkerbell_ci:image_ubuntu_2204_1_30"
     T_TINKERBELL_IMAGE_UBUNTU_2204_1_31: "tinkerbell_ci:image_ubuntu_2204_1_31"
     T_TINKERBELL_IMAGE_REDHAT_1_26: "tinkerbell_ci:image_redhat_1_26"


### PR DESCRIPTION
*Description of changes:*
- Added missing ENV variable in quick e2e build spec


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

