### PR TITLE
Update docs to add k8s 1.31 support

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -180,13 +180,13 @@ icon = "fab fa-github"
 desc = "Development takes place here!"
 
 [[params.versions]]
-fullversion = "v0.20"
-version = "v0.20"
+fullversion = "v0.21"
+version = "v0.21"
 docsbranch = "main"
 url = "https://anywhere.eks.amazonaws.com"
 
 [[params.versions]]
-fullversion = "v0.19"
-version = "v0.19"
-docsbranch = "release-0.19"
-url = "https://release-0-19.anywhere.eks.amazonaws.com"
+fullversion = "v0.20"
+version = "v0.20"
+docsbranch = "release-0.20"
+url = "https://release-0-20.anywhere.eks.amazonaws.com"

--- a/docs/content/en/docs/concepts/support-versions.md
+++ b/docs/content/en/docs/concepts/support-versions.md
@@ -56,7 +56,9 @@ Bottlerocket, Ubuntu, and Red Hat Enterprise Linux (RHEL) can be used as operati
 |------------|------------------------------|---------------------------------|
 | Ubuntu        | 22.04     | 0.17 and above
 |               | 20.04     | 0.5 and above
-| Bottlerocket  | 1.19.1    | 0.19
+| Bottlerocket  | 1.22.0    | 0.21
+|               | 1.20.0    | 0.20
+|               | 1.19.1    | 0.19
 |               | 1.15.1    | 0.18
 |               | 1.13.1    | 0.15-0.17
 |               | 1.12.0    | 0.14

--- a/docs/content/en/docs/getting-started/baremetal/bare-spec.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-spec.md
@@ -50,7 +50,7 @@ spec:
   datacenterRef:
     kind: TinkerbellDatacenterConfig
     name: my-cluster-name
-  kubernetesVersion: "1.28"
+  kubernetesVersion: "1.31"
   managementCluster:
     name: my-cluster-name
   workerNodeGroupConfigurations:
@@ -172,7 +172,7 @@ Optional field to skip deploying the control plane load balancer. Make sure your
 Refers to the Kubernetes object with Tinkerbell-specific configuration. See `TinkerbellDatacenterConfig Fields` below.
 
 ### kubernetesVersion (required)
-The Kubernetes version you want to use for your cluster. Supported values: `1.28`, `1.27`, `1.26`, `1.25`, `1.24`
+The Kubernetes version you want to use for your cluster. Supported values: `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 ### managementCluster (required)
 Identifies the name of the management cluster.
@@ -222,7 +222,7 @@ Modifying the labels associated with a worker node group configuration will caus
 the existing nodes associated with the configuration.
 
 ### workerNodeGroupConfigurations[*].kubernetesVersion (optional)
-The Kubernetes version you want to use for this worker node group. [Supported values]({{< relref "../../concepts/support-versions/#kubernetes-versions" >}}): `1.28`, `1.27`, `1.26`, `1.25`, `1.24`
+The Kubernetes version you want to use for this worker node group. [Supported values]({{< relref "../../concepts/support-versions/#kubernetes-versions" >}}): `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 Must be less than or equal to the cluster `kubernetesVersion` defined at the root level of the cluster spec. The worker node kubernetesVersion must be no more than two minor Kubernetes versions lower than the cluster control plane's Kubernetes version. Removing `workerNodeGroupConfiguration.kubernetesVersion` will trigger an upgrade of the node group to the `kubernetesVersion` defined at the root level of the cluster spec.
 
@@ -269,7 +269,7 @@ When separate management and workload clusters are supported in Bare Metal, the 
 
 ### osImageURL (required)
 Required field to set the operating system. In order to use Ubuntu or RHEL see [building baremetal node images]({{< relref "../../osmgmt/artifacts/#build-bare-metal-node-images" >}}). This field is also useful if you want to provide a customized operating system image or simply host the standard image locally. To upgrade a node or group of nodes to a new operating system version (ie. RHEL 8.7 to RHEL 8.8), modify this field to point to the new operating system image URL and run [upgrade cluster command]({{< relref "../../clustermgmt/cluster-upgrades/baremetal-upgrades/#upgrade-cluster-command" >}}).
-The `osImageURL` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, the `osImageURL` name should include 1.24, 1_24, 1-24 or 124.
+The `osImageURL` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, the `osImageURL` name should include 1.31, 1_31, 1-31 or 131.
 
 >**_NOTE:_** osImageURL field cannot be set both in the `TinkerbellDatacenterConfig` and `TinkerbellMachineConfig` objects. If this value is set for `TinkerbellDatacenterConfig`, osImageURL has to be set to empty string `""` for all the `TinkerbellMachineConfigs`.
 
@@ -324,7 +324,7 @@ spec:
 Operating system on the machine. Permitted values: `bottlerocket`, `ubuntu`, `redhat` (Default: `bottlerocket`).
 
 ### osImageURL (required)
-Required field to set the operating system. In order to use Ubuntu or RHEL see [building baremetal node images]({{< relref "../../osmgmt/artifacts/#build-bare-metal-node-images" >}}). This field is also useful if you want to provide a customized operating system image or simply host the standard image locally. To upgrade a node or group of nodes to a new operating system version (ie. RHEL 8.7 to RHEL 8.8), modify this field to point to the new operating system image URL and run [upgrade cluster command]({{< relref "../../clustermgmt/cluster-upgrades/baremetal-upgrades/#upgrade-cluster-command" >}}). The `osImageURL` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, the `osImageURL` name should include 1.24, 1_24, 1-24 or 124.
+Required field to set the operating system. In order to use Ubuntu or RHEL see [building baremetal node images]({{< relref "../../osmgmt/artifacts/#build-bare-metal-node-images" >}}). This field is also useful if you want to provide a customized operating system image or simply host the standard image locally. To upgrade a node or group of nodes to a new operating system version (ie. RHEL 8.7 to RHEL 8.8), modify this field to point to the new operating system image URL and run [upgrade cluster command]({{< relref "../../clustermgmt/cluster-upgrades/baremetal-upgrades/#upgrade-cluster-command" >}}). The `osImageURL` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, the `osImageURL` name should include 1.31, 1_31, 1-31 or 131.
 
 >**_NOTE:_** If this value is set for a single `TinkerbellMachineConfig`, osImageURL has to be set for all the `TinkerbellMachineConfigs`. osImageURL field cannot be set both in the `TinkerbellDatacenterConfig` and `TinkerbellMachineConfig` objects. If set for `TinkerbellMachineConfig`, the value must be set to empty string `""` for `TinkerbellDatacenterConfig`
 

--- a/docs/content/en/docs/getting-started/cloudstack/cloud-spec.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloud-spec.md
@@ -225,7 +225,7 @@ Number of etcd members
 Refers to the Kubernetes object with CloudStack specific configuration for your etcd members. See `CloudStackMachineConfig Fields` below.
 
 ### kubernetesVersion (required)
-The Kubernetes version you want to use for your cluster. Supported values: `1.28`, `1.27`, `1.26`, `1.25`, `1.24`
+The Kubernetes version you want to use for your cluster. Supported values: `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 ### managementCluster (required)
 Identifies the name of the management cluster.
@@ -274,7 +274,7 @@ Modifying the labels associated with a worker node group configuration will caus
 the existing nodes associated with the configuration.
 
 ### workerNodeGroupConfigurations[*].kubernetesVersion (optional)
-The Kubernetes version you want to use for this worker node group. Supported values: 1.28, 1.27, 1.26, 1.25, 1.24
+The Kubernetes version you want to use for this worker node group. Supported values: 1.31, 1.30, 1.29, 1.28, 1.27
 
 ## CloudStackDatacenterConfig
 
@@ -327,7 +327,7 @@ The default is generating a key in your `$(pwd)/<cluster-name>` folder when not 
 ### template.{id,name} (required)
 The VM template to use for your EKS Anywhere cluster. Currently, a VM based on RHEL 8.6 is required.
 This can be a name or ID.
-The `template.name` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, the `template.name` field name should include 1.24, 1_24, 1-24 or 124.
+The `template.name` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, the `template.name` field name should include 1.31, 1_31, 1-31 or 131.
 See the [Artifacts]({{< relref "../../osmgmt/artifacts" >}}) page for instructions for building RHEL-based images.
 
 ### diskOffering (optional)

--- a/docs/content/en/docs/getting-started/cloudstack/cloudstack-getstarted.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloudstack-getstarted.md
@@ -171,7 +171,7 @@ Follow these steps to create an EKS Anywhere cluster that can be used either as 
    Example command output
    ```
    ...
-   kubernetesVersion: "1.28"
+   kubernetesVersion: "1.31"
    managementCluster:
      name: mgmt
    workerNodeGroupConfigurations:

--- a/docs/content/en/docs/getting-started/cloudstack/cloudstack-preparation.md
+++ b/docs/content/en/docs/getting-started/cloudstack/cloudstack-preparation.md
@@ -112,7 +112,7 @@ spec:
   computeOffering:
     name: "Medium Instance"
   template:
-    name: "rhel8-kube-1.28-eksa"
+    name: "rhel8-kube-1.31-eksa"
   diskOffering:
     name: "Small"
     mountPath: "/data-small"

--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -116,7 +116,7 @@ sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
          name: mgmt
       externalEtcdConfiguration:
          count: 1
-      kubernetesVersion: "1.28"
+      kubernetesVersion: "1.31"
       managementCluster:
          name: mgmt
       workerNodeGroupConfigurations:

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-getstarted.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-getstarted.md
@@ -159,7 +159,7 @@ Make sure you use single quotes around the values so that your shell does not in
    Example command output
    ```
    ...
-   kubernetesVersion: "1.28"
+   kubernetesVersion: "1.31"
    managementCluster:
      name: mgmt
    workerNodeGroupConfigurations:

--- a/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
+++ b/docs/content/en/docs/getting-started/nutanix/nutanix-spec.md
@@ -53,7 +53,7 @@ spec:
    machineGroupRef:
      kind: NutanixMachineConfig
      name: mgmt-etcd
- kubernetesVersion: "1.28"
+ kubernetesVersion: "1.31"
  workerNodeGroupConfigurations:
    - count: 1
      machineGroupRef:
@@ -85,7 +85,7 @@ spec:
    name: nx-cluster-01
    type: name
  image:
-   name: eksa-ubuntu-2004-kube-v1.28
+   name: eksa-ubuntu-2004-kube-v1.31
    type: name
  memorySize: 4Gi
  osFamily: ubuntu
@@ -116,7 +116,7 @@ spec:
    name: nx-cluster-01
    type: name
  image:
-   name: eksa-ubuntu-2004-kube-v1.28
+   name: eksa-ubuntu-2004-kube-v1.31
    type: name
  memorySize: 4Gi
  osFamily: ubuntu
@@ -144,7 +144,7 @@ spec:
    name: nx-cluster-01
    type: name
  image:
-   name: eksa-ubuntu-2004-kube-v1.28
+   name: eksa-ubuntu-2004-kube-v1.31
    type: name
  memorySize: 4Gi
  osFamily: ubuntu
@@ -208,7 +208,7 @@ Minimum number of nodes for this node group's autoscaling configuration.
 Maximum number of nodes for this node group's autoscaling configuration.
 
 ### workerNodeGroupConfigurations[*].kubernetesVersion (optional)
-The Kubernetes version you want to use for this worker node group. Supported values: 1.28, 1.27, 1.26, 1.25, 1.24
+The Kubernetes version you want to use for this worker node group. Supported values: `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 ### externalEtcdConfiguration.count (optional)
 Number of etcd members
@@ -220,7 +220,7 @@ Refers to the Kubernetes object with Nutanix specific configuration for your etc
 Refers to the Kubernetes object with Nutanix environment specific configuration. See `NutanixDatacenterConfig` fields below.
 
 ### kubernetesVersion (required)
-The Kubernetes version you want to use for your cluster. Supported values: `1.28`, `1.27`, `1.26`, `1.25`, `1.24`
+The Kubernetes version you want to use for your cluster. Supported values: `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 ## NutanixDatacenterConfig Fields
 
@@ -274,11 +274,11 @@ Type to identify the OS image. (Permitted values: `name` or `uuid`)
 
 ### image.name (`name` or `UUID` required)
 Name of the image
-The `image.name` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, `image.name` must include 1.24, 1_24, 1-24 or 124.
+The `image.name` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, `image.name` must include 1.31, 1_31, 1-31 or 131.
 
 ### image.uuid (`name` or `UUID` required)
 UUID of the image
-The name of the image associated with the `uuid` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, the name associated with `image.uuid` field must include 1.24, 1_24, 1-24 or 124.
+The name of the image associated with the `uuid` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, the name associated with `image.uuid` field must include 1.31, 1_31, 1-31 or 131.
 
 ### memorySize (optional)
 Size of RAM on virtual machines (Default: `4Gi`)

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-getstarted.md
@@ -162,7 +162,7 @@ Make sure you use single quotes around the values so that your shell does not in
    Example command output
    ```
    ...
-   kubernetesVersion: "1.28"
+   kubernetesVersion: "1.31"
    managementCluster:
      name: mgmt
    workerNodeGroupConfigurations:

--- a/docs/content/en/docs/getting-started/vsphere/vsphere-spec.md
+++ b/docs/content/en/docs/getting-started/vsphere/vsphere-spec.md
@@ -49,7 +49,7 @@ spec:
      machineGroupRef:                <a href="#externaletcdconfigurationmachinegroupref-optional"># vSphere-specific Kubernetes etcd config</a>
         kind: VSphereMachineConfig
         name: my-cluster-machines
-   kubernetesVersion: <span>"1.25"</span>         <a href="#kubernetesversion-required"># Kubernetes version to use for the cluster (required)</a>
+   kubernetesVersion: <span>"1.31"</span>         <a href="#kubernetesversion-required"># Kubernetes version to use for the cluster (required)</a>
    workerNodeGroupConfigurations:    <a href="#workernodegroupconfigurations-required"># List of node groups you can define for workers (required) </a>
    - count: <span style="color:green">2</span>                        <a href="#workernodegroupconfigurationscount-optional"># Number of worker nodes </a>
      machineGroupRef:                <a href="#workernodegroupconfigurationsmachinegroupref-required"># vSphere-specific Kubernetes node objects (required) </a>
@@ -89,7 +89,7 @@ spec:
   osFamily: <span>"bottlerocket"</span>             <a href="#osfamily-optional"># Operating system on VMs</a>
   resourcePool: <span>"resourcePool1"</span>        <a href="#resourcepool-required"># vSphere resource pool for EKS Anywhere VMs (required)</a>
   storagePolicyName: <span>"storagePolicy1"</span>  <a href="#storagepolicyname-optional"># Storage policy name associated with VMs</a>
-  template: <span>"bottlerocket-kube-v1-25"</span>  <a href="#template-optional"># VM template for EKS Anywhere (required for RHEL/Ubuntu-based OVAs)</a>
+  template: <span>"bottlerocket-kube-v1-31"</span>  <a href="#template-optional"># VM template for EKS Anywhere (required for RHEL/Ubuntu-based OVAs)</a>
   cloneMode: <span>"fullClone"</span>               <a href="#clonemode-optional"># Clone mode to use when cloning VMs from the template</a>
   users:                               <a href="#users-optional"># Add users to access VMs via SSH</a>
   - name: <span>"ec2-user"</span>                   <a href="#users0name-optional"># Name of each user set to access VMs</a>
@@ -191,7 +191,7 @@ Modifying the labels associated with a worker node group configuration will caus
 the existing nodes associated with the configuration.
 
 ### workerNodeGroupConfigurations[*].kubernetesVersion (optional)
-The Kubernetes version you want to use for this worker node group. [Supported values]({{< relref "../../concepts/support-versions/#kubernetes-versions" >}}): `1.28`, `1.27`, `1.26`, `1.25`, `1.24`
+The Kubernetes version you want to use for this worker node group. [Supported values]({{< relref "../../concepts/support-versions/#kubernetes-versions" >}}): `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 Must be less than or equal to the cluster `kubernetesVersion` defined at the root level of the cluster spec. The worker node kubernetesVersion must be no more than two minor Kubernetes versions lower than the cluster control plane's Kubernetes version. Removing `workerNodeGroupConfiguration.kubernetesVersion` will trigger an upgrade of the node group to the `kubernetesVersion` defined at the root level of the cluster spec.
 
@@ -205,7 +205,7 @@ Refers to the Kubernetes object with vsphere specific configuration for your etc
 Refers to the Kubernetes object with vsphere environment specific configuration.  See [VSphereDatacenterConfig Fields](#vspheredatacenterconfig-fields) below.
 
 ### kubernetesVersion (required)
-The Kubernetes version you want to use for your cluster. [Supported values]({{< relref "../../concepts/support-versions/#kubernetes-versions" >}}): `1.28`, `1.27`, `1.26`, `1.25`, `1.24`
+The Kubernetes version you want to use for your cluster. [Supported values]({{< relref "../../concepts/support-versions/#kubernetes-versions" >}}): `1.31`, `1.30`, `1.29`, `1.28`, `1.27`
 
 ## VSphereDatacenterConfig Fields
 
@@ -285,7 +285,7 @@ The default is generating a key in your `$(pwd)/<cluster-name>` folder when not 
 The VM template to use for your EKS Anywhere cluster. This template was created when you
 [imported the OVA file into vSphere]({{< relref "../vsphere/customize/vsphere-ovas.md" >}}).
 This is a required field if you are using Ubuntu-based or RHEL-based OVAs.
-The `template` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.24, `template` must include 1.24, 1_24, 1-24 or 124.
+The `template` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, `template` must include 1.31, 1_31, 1-31 or 131.
 
 ### cloneMode (optional)
 `cloneMode` defines the clone mode to use when creating the cluster VMs from the template. Allowed values are:

--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -49,7 +49,7 @@ EKSA_RELEASE_VERSION=<EKS-A version>
 ```
 
 ```bash
-KUBEVERSION=1.30 # Replace this with the Kubernetes version you wish to use
+KUBEVERSION=1.31 # Replace this with the Kubernetes version you wish to use
 
 BUNDLE_MANIFEST_URL=$(curl -sL https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.releases[] | select(.version==\"$EKSA_RELEASE_VERSION\").bundleManifestUrl")
 curl -s $BUNDLE_MANIFEST_URL | yq ".spec.versionsBundles[] | select(.kubeVersion==\"$KUBEVERSION\").eksD.raw.bottlerocket.uri"
@@ -99,7 +99,7 @@ EKSA_RELEASE_VERSION=<EKS-A version>
 ```
 
 ```bash
-KUBEVERSION=1.30 # Replace this with the Kubernetes version you wish to use
+KUBEVERSION=1.31 # Replace this with the Kubernetes version you wish to use
 
 BUNDLE_MANIFEST_URL=$(curl -sL https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.releases[] | select(.version==\"$EKSA_RELEASE_VERSION\").bundleManifestUrl")
 curl -s $BUNDLE_MANIFEST_URL | yq ".spec.versionsBundles[] | select(.kubeVersion==\"$KUBEVERSION\").eksD.ova.bottlerocket.uri"
@@ -130,7 +130,7 @@ EKSA_RELEASE_VERSION=<EKS-A version>
 ```
 
 ```bash
-KUBEVERSION=1.30 # Replace this with the Kubernetes version you wish to use
+KUBEVERSION=1.31 # Replace this with the Kubernetes version you wish to use
 
 BUNDLE_MANIFEST_URL=$(curl -sL https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.releases[] | select(.version==\"$EKSA_RELEASE_VERSION\").bundleManifestUrl")
 curl -sL $BUNDLE_MANIFEST_URL | yq ".spec.versionsBundles[] | select(.kubeVersion==\"$KUBEVERSION\").eksD.name"
@@ -152,9 +152,9 @@ CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install --force tuftool
 curl -O "https://cache.bottlerocket.aws/root.json"
 sha512sum -c <<<"a3c58bc73999264f6f28f3ed9bfcb325a5be943a782852c7d53e803881968e0a4698bd54c2f125493f4669610a9da83a1787eb58a8303b2ee488fa2a3f7d802f  root.json"
 ```
-4. Export the desired Kubernetes version. EKS Anywhere currently supports 1.23, 1.24, 1.25, 1.26, 1.27, and 1.28.
+4. Export the desired Kubernetes version. EKS Anywhere currently supports 1.27, 1.28, 1.29, 1.30, and 1.31.
 ```bash
-export KUBEVERSION="1.27"
+export KUBEVERSION="1.31"
 ```
 5. Programmatically retrieve the Bottlerocket version corresponding to this release of EKS-A and Kubernetes version and export it.
 
@@ -483,11 +483,11 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
       * `--os`: `ubuntu`
       * `--os-version`: `20.04` or `22.04` (default: `20.04`)
       * `--hypervisor`: For vSphere use `vsphere`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--vsphere-config`: vSphere configuration file (`vsphere.json` in this example)
 
       ```bash
-      image-builder build --os ubuntu --hypervisor vsphere --release-channel 1-29 --vsphere-config vsphere.json
+      image-builder build --os ubuntu --hypervisor vsphere --release-channel 1-31 --vsphere-config vsphere.json
       ```
 
    **Red Hat Enterprise Linux**
@@ -497,11 +497,11 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
       * `--os`: `redhat`
       * `--os-version`: `8` (default: `8`)
       * `--hypervisor`: For vSphere use `vsphere`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--vsphere-config`: vSphere configuration file (`vsphere.json` in this example)
 
       ```bash
-      image-builder build --os redhat --hypervisor vsphere --release-channel 1-29 --vsphere-config vsphere.json
+      image-builder build --os redhat --hypervisor vsphere --release-channel 1-31 --vsphere-config vsphere.json
       ```
 
 ### Build Bare Metal node images
@@ -576,11 +576,11 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
       * `--os`: `ubuntu`
       * `--os-version`: `20.04` or `22.04` (default: `20.04`)
       * `--hypervisor`: `baremetal`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--baremetal-config`: baremetal config file if using proxy
 
       ```bash
-      image-builder build --os ubuntu --hypervisor baremetal --release-channel 1-29
+      image-builder build --os ubuntu --hypervisor baremetal --release-channel 1-31
       ```
 
    **Red Hat Enterprise Linux (RHEL)**
@@ -605,14 +605,14 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
       * `--os`: `redhat`
       * `--os-version`: `8` or `9` (default: `8`)
       * `--hypervisor`: `baremetal`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--baremetal-config`: Bare metal config file
 
 
    Image builder only supports building RHEL 9 raw images with EFI firmware. Refer to [UEFI Support]({{< relref "#uefi-support">}}) to enable image builds with EFI firmware.
 
       ```bash
-      image-builder build --os redhat --hypervisor baremetal --release-channel 1-29 --baremetal-config baremetal.json
+      image-builder build --os redhat --hypervisor baremetal --release-channel 1-31 --baremetal-config baremetal.json
       ```
 1. To consume the image, serve it from an accessible web server, then create the [bare metal cluster spec]({{< relref "../getting-started/baremetal/bare-spec/" >}})
    configuring the `osImageURL` field URL of the image. For example:
@@ -703,11 +703,11 @@ These steps use `image-builder` to create a RHEL-based image for CloudStack. Bef
       * `--os`: `redhat`
       * `--os-version`: `8` (default: `8`)
       * `--hypervisor`: For CloudStack use `cloudstack`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--cloudstack-config`: CloudStack configuration file (`cloudstack.json` in this example)
 
       ```bash
-      image-builder build --os redhat --hypervisor cloudstack --release-channel 1-29 --cloudstack-config cloudstack.json
+      image-builder build --os redhat --hypervisor cloudstack --release-channel 1-31 --cloudstack-config cloudstack.json
       ```
 1. To consume the resulting RHEL-based image, add it as a template to your CloudStack setup as described in [Preparing CloudStack]({{< relref "../getting-started/cloudstack/cloudstack-preparation" >}}).
 
@@ -826,11 +826,11 @@ These steps use `image-builder` to create an Ubuntu-based Amazon Machine Image (
    * `--os`: `ubuntu`
    * `--os-version`: `20.04` or `22.04` (default: `20.04`)
    * `--hypervisor`: For AMI, use `ami`
-   * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+   * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
    * `--ami-config`: AMI configuration file (`ami.json` in this example)
 
    ```bash
-   image-builder build --os ubuntu --hypervisor ami --release-channel 1-29 --ami-config ami.json
+   image-builder build --os ubuntu --hypervisor ami --release-channel 1-31 --ami-config ami.json
    ```
 1. After the build, the Ubuntu AMI will be available in your AWS account in the AWS region specified in your AMI configuration file. If you wish to export it as a raw image, you can achieve this using the AWS CLI.
    ```
@@ -933,11 +933,11 @@ These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV a
       * `--os`: `ubuntu`
       * `--os-version`: `20.04` or `22.04` (default: `20.04`)
       * `--hypervisor`: For Nutanix use `nutanix`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--nutanix-config`: Nutanix configuration file (`nutanix.json` in this example)
 
       ```bash
-      image-builder build --os ubuntu --hypervisor nutanix --release-channel 1-29 --nutanix-config nutanix.json
+      image-builder build --os ubuntu --hypervisor nutanix --release-channel 1-31 --nutanix-config nutanix.json
       ```
 
    **Red Hat Enterprise Linux**
@@ -947,11 +947,11 @@ These steps use `image-builder` to create a Ubuntu-based image for Nutanix AHV a
       * `--os`: `redhat`
       * `--os-version`: `8` or `9` (default: `8`)
       * `--hypervisor`: For Nutanix use `nutanix`
-      * `--release-channel`: Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29.
+      * `--release-channel`: Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31.
       * `--nutanix-config`: Nutanix configuration file (`nutanix.json` in this example)
 
       ```bash
-      image-builder build --os redhat --hypervisor nutanix --release-channel 1-29 --nutanix-config nutanix.json
+      image-builder build --os redhat --hypervisor nutanix --release-channel 1-31 --nutanix-config nutanix.json
       ```
 
 ### Configuring OS version
@@ -1039,9 +1039,9 @@ In both these above approaches, the artifacts embedded into the images will be o
 
 `image-builder` supports UEFI-enabled images for Ubuntu OVA, Ubuntu Raw and RHEL 9 Raw images. UEFI is turned on by default for Ubuntu Raw image builds, but the default firmware for Ubuntu OVAs and RHEL Raw images is BIOS. This can be toggled with the `firmware` option.
 
-For example, to build a Kubernetes v1.27 Ubuntu 22.04 OVA with UEFI enabled, you can run the following command.
+For example, to build a Kubernetes v1.31 Ubuntu 22.04 OVA with UEFI enabled, you can run the following command.
    ```bash
-   image-builder build --os ubuntu --hypervisor vsphere --os-version 22.04 --release-channel 1.27 --vsphere-config config.json --firmware efi
+   image-builder build --os ubuntu --hypervisor vsphere --os-version 22.04 --release-channel 1.31 --vsphere-config config.json --firmware efi
    ```
 
 The table below shows the possible firmware options for the hypervisor and OS combinations that `image-builder` supports.
@@ -1143,7 +1143,7 @@ In order to use Red Hat Satellite in the image build process follow the steps be
 4. Artifacts server should have the ability to host and serve, standalone artifacts and Ubuntu OS packages 
 
 #### Building node images in an air-gapped environment
-1. Identify the EKS-D release channel (generally aligning with Kubernetes version) to build. For example, 1.27 or 1.28
+1. Identify the EKS-D release channel (generally aligning with Kubernetes version) to build. For example, 1.30 or 1.31
 2. Identify the latest release of EKS-A from [changelog]({{< ref "/docs/whatsnew/changelog" >}}). For example, <EKS-A version>
 3. Run `image-builder` CLI to download manifests in an environment with internet connectivity
    ```bash
@@ -1174,7 +1174,7 @@ In order to use Red Hat Satellite in the image build process follow the steps be
       fi
 
       if [ -z "${RELEASE_CHANNEL}" ]; then
-         echo "RELEASE_CHANNEL not set. Supported EKS Distro releases include 1-25, 1-26, 1-27, 1-28 and 1-29"
+         echo "RELEASE_CHANNEL not set. Supported EKS Distro releases include 1-27, 1-28, 1-29, 1-30 and 1-31"
          exit 1
       fi
 
@@ -1243,7 +1243,7 @@ In order to use Red Hat Satellite in the image build process follow the steps be
    ```
 5. Set EKS-A release version and EKS-D release channel as environment variables and execute the script
    ```bash
-   EKSA_RELEASE_VERSION=<EKS-A version> RELEASE_CHANNEL=1-28 ./download-airgapped-artifacts.sh
+   EKSA_RELEASE_VERSION=<EKS-A version> RELEASE_CHANNEL=1-31 ./download-airgapped-artifacts.sh
    ```
    Executing this script will create a local directory `eks-a-d-artifacts` and download the required EKS-A and EKS-D artifacts.
 6. Create two repositories, one for EKS-A and one for EKS-D on the private artifacts server.

--- a/docs/content/en/docs/reference/eksctl/anywhere_list_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_list_packages.md
@@ -17,7 +17,7 @@ anywhere list packages [flags]
       --bundles-override string   Override default Bundles manifest (not recommended)
       --cluster string            Name of cluster for package list.
   -h, --help                      help for packages
-      --kube-version string       Kubernetes version <major>.<minor> of the packages to list, for example: "1.28".
+      --kube-version string       Kubernetes version <major>.<minor> of the packages to list, for example: "1.31".
       --kubeconfig string         Path to a kubeconfig file to use when source is a cluster.
       --registry string           Specifies an alternative registry for packages discovery.
 ```

--- a/docs/data/version_support.yml
+++ b/docs/data/version_support.yml
@@ -20,6 +20,11 @@
 #
 # receiving_patches: Whether or not the release is receiving patches.
 eksa:
+- version: '0.21'
+  released: 2024-10-31
+  kube_versions: ['1.31', '1.30', '1.29', '1.28', '1.27']
+  receiving_patches: true
+
 - version: '0.20'
   released: 2024-06-28
   kube_versions: ['1.30', '1.29', '1.28', '1.27', '1.26']
@@ -28,7 +33,7 @@ eksa:
 - version: '0.19'
   released: 2024-02-29
   kube_versions: ['1.29', '1.28', '1.27', '1.26', '1.25']
-  receiving_patches: true
+  receiving_patches: false
 
 - version: '0.18'
   released: 2023-10-30
@@ -114,6 +119,10 @@ eksa:
 #                        when there is no EKS-A release in the eksa array above. Mutually exclusive
 #                        with `endOfLifeIn`.
 kube:
+- version: '1.31'
+  releasedIn: '0.21'
+  expectedEndOfLifeDate: 2025-10-23
+
 - version: '1.30'
   releasedIn: '0.20'
   expectedEndOfLifeDate: 2025-06-23


### PR DESCRIPTION
*Issue #, if available:*
[#2399](https://github.com/aws/eks-anywhere-internal/issues/2399)

*Description of changes:*
This PR updates the docs to include k8s 1.31 support and also EKS-A v0.21.0 release.

*Testing (if applicable):*
make build

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

