### PR TITLE
Adding oci namespaces for registry mirror packages tests

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2519,6 +2519,11 @@ func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube129),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  "857151390494.dkr.ecr.us-west-2.amazonaws.com",
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }
@@ -2536,6 +2541,11 @@ func TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube130),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  "857151390494.dkr.ecr.us-west-2.amazonaws.com",
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }

--- a/test/framework/registry_mirror.go
+++ b/test/framework/registry_mirror.go
@@ -65,7 +65,7 @@ func WithRegistryMirrorEndpointAndCert(providerName string) ClusterE2ETestOpt {
 }
 
 // WithRegistryMirrorOciNamespaces sets up e2e for registry mirrors with ocinamespaces.
-func WithRegistryMirrorOciNamespaces(providerName string) ClusterE2ETestOpt {
+func WithRegistryMirrorOciNamespaces(providerName string, optNamespaces ...v1alpha1.OCINamespace) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		var ociNamespaces []v1alpha1.OCINamespace
 
@@ -83,6 +83,8 @@ func WithRegistryMirrorOciNamespaces(providerName string) ClusterE2ETestOpt {
 				Namespace: ns2val,
 			})
 		}
+
+		ociNamespaces = append(ociNamespaces, optNamespaces...)
 
 		setupRegistryMirrorEndpointAndCert(e, providerName, false, ociNamespaces...)
 	}


### PR DESCRIPTION
*Description of changes:*
For testing curated packages with registry mirrors we need to add OCI namespaces to setup mirrors for packages.

/hold

*Testing (if applicable):*
```
./e2e.test -test.v -test.run "TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSimpleFlow"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

