### PR TITLE
Fix skip hardware validation logic for InPlace upgrades

### DIFF
--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -114,7 +114,7 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 		return err
 	}
 
-	upgradeStrategy := currentClusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy
+	upgradeStrategy := clusterSpec.Cluster.Spec.ControlPlaneConfiguration.UpgradeRolloutStrategy
 	// skip extra hardware validation for InPlace upgrades
 	if upgradeStrategy == nil || upgradeStrategy.Type != v1alpha1.InPlaceStrategyType {
 		if err := p.validateAvailableHardwareForUpgrade(ctx, currentClusterSpec, clusterSpec); err != nil {


### PR DESCRIPTION
*Issue #, if available:*
When an existing cluster configured with `rollingUpdate` as the upgrade strategy is upgraded to `InPlace`, CLI validates for additional hardware to rollout nodes. 

```
2024-09-16T16:53:43.181Z        V0      ❌ Validation failed    {"validation": "tinkerbell provider validation", "error": "for rolling upgrade, minimum hardware count not met for selector '{\"type\":\"control-plane\"}': have 0, require 1", "remediation": ""}
```

*Description of changes:*
Fix the validation logic to factor in the updated strategy type instead of picking from the previous cluster spec. 

*Testing (if applicable):*
Tested manually with an updated cluster spec with strategy set to InPlace and didn't run into the hardware validation error.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

