### PR TITLE
Update cert manager image in the EKS-A bundle with new image

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: bundles.anywhere.eks.amazonaws.com
 spec:
@@ -400,6 +399,7 @@ spec:
                               type: string
                           type: object
                         ctl:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -432,6 +432,35 @@ spec:
                           properties:
                             uri:
                               description: URI points to the manifest yaml file
+                              type: string
+                          type: object
+                        startupapicheck:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
                               type: string
                           type: object
                         version:
@@ -469,8 +498,8 @@ spec:
                       - acmesolver
                       - cainjector
                       - controller
-                      - ctl
                       - manifest
+                      - startupapicheck
                       - webhook
                       type: object
                     cilium:

--- a/config/crd/bases/anywhere.eks.amazonaws.com_eksareleases.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_eksareleases.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: eksareleases.anywhere.eks.amazonaws.com
 spec:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -172,7 +172,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: bundles.anywhere.eks.amazonaws.com
 spec:
@@ -567,7 +567,13 @@ spec:
                               description: The image repository, name, and tag
                               type: string
                           type: object
-                        ctl:
+                        manifest:
+                          properties:
+                            uri:
+                              description: URI points to the manifest yaml file
+                              type: string
+                          type: object
+                        startupapicheck:
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -594,12 +600,6 @@ spec:
                               type: string
                             uri:
                               description: The image repository, name, and tag
-                              type: string
-                          type: object
-                        manifest:
-                          properties:
-                            uri:
-                              description: URI points to the manifest yaml file
                               type: string
                           type: object
                         version:
@@ -637,8 +637,8 @@ spec:
                       - acmesolver
                       - cainjector
                       - controller
-                      - ctl
                       - manifest
+                      - startupapicheck
                       - webhook
                       type: object
                     cilium:
@@ -4943,7 +4943,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: eksareleases.anywhere.eks.amazonaws.com
 spec:

--- a/internal/test/testdata/bundles.yaml
+++ b/internal/test/testdata/bundles.yaml
@@ -37,6 +37,8 @@ spec:
         uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-cainjector:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       controller:
         uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-controller:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
+      startupapicheck:
+        uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-startupapicheck:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
       webhook:
         uri: public.ecr.aws/l0g8r8j6/cert-manager/cert-manager-webhook:v1.1.0-17655eca4c3db6708da08de4e04ea646d1cfd0c9
     cilium:

--- a/release/Makefile
+++ b/release/Makefile
@@ -35,8 +35,6 @@ WEEKLY_RELEASES_URL_PREFIX=https://dev-release-assets.eks-anywhere.model-rocket.
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -84,7 +82,7 @@ clean: ## Cleanup resources created by make targets
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	## Copy only the bundles crd to root config kustomization folder
 	cp -f config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml ../config/crd/bases/
 	cp -f config/crd/bases/anywhere.eks.amazonaws.com_eksareleases.yaml ../config/crd/bases/

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -177,7 +177,7 @@ func (vb *VersionsBundle) SharedImages() []Image {
 		vb.CertManager.Acmesolver,
 		vb.CertManager.Cainjector,
 		vb.CertManager.Controller,
-		vb.CertManager.Ctl,
+		vb.CertManager.Startupapicheck,
 		vb.CertManager.Webhook,
 		vb.Cilium.Cilium,
 		vb.Cilium.Operator,

--- a/release/api/v1alpha1/artifacts_test.go
+++ b/release/api/v1alpha1/artifacts_test.go
@@ -125,3 +125,80 @@ func TestVersionsBundleSnowImages(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionsBundleSharedImages(t *testing.T) {
+	expectedSharedImages := make([]v1alpha1.Image, 27)
+	expectedSharedImages = append(
+		expectedSharedImages[:5],
+		append(
+			[]v1alpha1.Image{
+				{
+					Name: "acmesolver",
+					URI:  "uri1",
+				},
+				{
+					Name: "cainjector",
+					URI:  "uri2",
+				},
+				{
+					Name: "controller",
+					URI:  "uri3",
+				},
+				{
+					Name: "startupapicheck",
+					URI:  "uri4",
+				},
+				{
+					Name: "webhook",
+					URI:  "uri5",
+				},
+			},
+			expectedSharedImages[5:]...,
+		)...,
+	)
+	tests := []struct {
+		name           string
+		versionsBundle *v1alpha1.VersionsBundle
+		want           []v1alpha1.Image
+	}{
+		{
+			name:           "no images",
+			versionsBundle: &v1alpha1.VersionsBundle{},
+			want:           make([]v1alpha1.Image, 32),
+		},
+		{
+			name: "cert-manager images",
+			versionsBundle: &v1alpha1.VersionsBundle{
+				CertManager: v1alpha1.CertManagerBundle{
+					Acmesolver: v1alpha1.Image{
+						Name: "acmesolver",
+						URI:  "uri1",
+					},
+					Cainjector: v1alpha1.Image{
+						Name: "cainjector",
+						URI:  "uri2",
+					},
+					Controller: v1alpha1.Image{
+						Name: "controller",
+						URI:  "uri3",
+					},
+					Startupapicheck: v1alpha1.Image{
+						Name: "startupapicheck",
+						URI:  "uri4",
+					},
+					Webhook: v1alpha1.Image{
+						Name: "webhook",
+						URI:  "uri5",
+					},
+				},
+			},
+			want: expectedSharedImages,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.versionsBundle.SharedImages()).To(Equal(tt.want))
+		})
+	}
+}

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -151,13 +151,15 @@ type BottlerocketHostContainersBundle struct {
 }
 
 type CertManagerBundle struct {
-	Version    string   `json:"version,omitempty"`
-	Acmesolver Image    `json:"acmesolver"`
-	Cainjector Image    `json:"cainjector"`
-	Controller Image    `json:"controller"`
-	Ctl        Image    `json:"ctl"`
-	Webhook    Image    `json:"webhook"`
-	Manifest   Manifest `json:"manifest"`
+	Version    string `json:"version,omitempty"`
+	Acmesolver Image  `json:"acmesolver"`
+	Cainjector Image  `json:"cainjector"`
+	Controller Image  `json:"controller"`
+	// This field has been deprecated
+	Ctl             *Image   `json:"ctl,omitempty"`
+	Startupapicheck Image    `json:"startupapicheck"`
+	Webhook         Image    `json:"webhook"`
+	Manifest        Manifest `json:"manifest"`
 }
 
 type CoreClusterAPI struct {

--- a/release/api/v1alpha1/zz_generated.deepcopy.go
+++ b/release/api/v1alpha1/zz_generated.deepcopy.go
@@ -253,7 +253,12 @@ func (in *CertManagerBundle) DeepCopyInto(out *CertManagerBundle) {
 	in.Acmesolver.DeepCopyInto(&out.Acmesolver)
 	in.Cainjector.DeepCopyInto(&out.Cainjector)
 	in.Controller.DeepCopyInto(&out.Controller)
-	in.Ctl.DeepCopyInto(&out.Ctl)
+	if in.Ctl != nil {
+		in, out := &in.Ctl, &out.Ctl
+		*out = new(Image)
+		(*in).DeepCopyInto(*out)
+	}
+	in.Startupapicheck.DeepCopyInto(&out.Startupapicheck)
 	in.Webhook.DeepCopyInto(&out.Webhook)
 	out.Manifest = in.Manifest
 }

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -81,7 +81,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				RepoName: "cert-manager-controller",
 			},
 			{
-				RepoName: "cert-manager-ctl",
+				RepoName: "cert-manager-startupapicheck",
 			},
 			{
 				RepoName: "cert-manager-webhook",

--- a/release/cli/pkg/bundles/certmanager.go
+++ b/release/cli/pkg/bundles/certmanager.go
@@ -88,13 +88,13 @@ func GetCertManagerBundle(r *releasetypes.ReleaseConfig, imageDigests releasetyp
 	}
 
 	bundle := anywherev1alpha1.CertManagerBundle{
-		Version:    version,
-		Acmesolver: bundleImageArtifacts["cert-manager-acmesolver"],
-		Cainjector: bundleImageArtifacts["cert-manager-cainjector"],
-		Controller: bundleImageArtifacts["cert-manager-controller"],
-		Ctl:        bundleImageArtifacts["cert-manager-ctl"],
-		Webhook:    bundleImageArtifacts["cert-manager-webhook"],
-		Manifest:   bundleManifestArtifacts["cert-manager.yaml"],
+		Version:         version,
+		Acmesolver:      bundleImageArtifacts["cert-manager-acmesolver"],
+		Cainjector:      bundleImageArtifacts["cert-manager-cainjector"],
+		Controller:      bundleImageArtifacts["cert-manager-controller"],
+		Startupapicheck: bundleImageArtifacts["cert-manager-startupapicheck"],
+		Webhook:         bundleImageArtifacts["cert-manager-webhook"],
+		Manifest:        bundleManifestArtifacts["cert-manager.yaml"],
 	}
 
 	return bundle, nil

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -67,7 +67,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.15.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -76,7 +76,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.15.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -85,19 +85,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.14.7-eks-a-v0.0.0-dev-build.1
-      ctl:
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.15.3-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.15.3/cert-manager.yaml
+      startupapicheck:
         arch:
         - amd64
         - arm64
-        description: Container image for cert-manager-ctl image
+        description: Container image for cert-manager-startupapicheck image
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
+        name: cert-manager-startupapicheck
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.14.7-eks-a-v0.0.0-dev-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.14.7/cert-manager.yaml
-      version: v1.14.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-startupapicheck:v1.15.3-eks-a-v0.0.0-dev-build.1
+      version: v1.15.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -106,7 +106,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.15.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -882,7 +882,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.15.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -891,7 +891,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.15.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -900,19 +900,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.14.7-eks-a-v0.0.0-dev-build.1
-      ctl:
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.15.3-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.15.3/cert-manager.yaml
+      startupapicheck:
         arch:
         - amd64
         - arm64
-        description: Container image for cert-manager-ctl image
+        description: Container image for cert-manager-startupapicheck image
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
+        name: cert-manager-startupapicheck
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.14.7-eks-a-v0.0.0-dev-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.14.7/cert-manager.yaml
-      version: v1.14.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-startupapicheck:v1.15.3-eks-a-v0.0.0-dev-build.1
+      version: v1.15.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -921,7 +921,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.15.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -1697,7 +1697,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.15.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -1706,7 +1706,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.15.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -1715,19 +1715,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.14.7-eks-a-v0.0.0-dev-build.1
-      ctl:
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.15.3-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.15.3/cert-manager.yaml
+      startupapicheck:
         arch:
         - amd64
         - arm64
-        description: Container image for cert-manager-ctl image
+        description: Container image for cert-manager-startupapicheck image
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
+        name: cert-manager-startupapicheck
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.14.7-eks-a-v0.0.0-dev-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.14.7/cert-manager.yaml
-      version: v1.14.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-startupapicheck:v1.15.3-eks-a-v0.0.0-dev-build.1
+      version: v1.15.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -1736,7 +1736,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.15.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -2512,7 +2512,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.15.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -2521,7 +2521,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.15.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -2530,19 +2530,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.14.7-eks-a-v0.0.0-dev-build.1
-      ctl:
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.15.3-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.15.3/cert-manager.yaml
+      startupapicheck:
         arch:
         - amd64
         - arm64
-        description: Container image for cert-manager-ctl image
+        description: Container image for cert-manager-startupapicheck image
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
+        name: cert-manager-startupapicheck
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.14.7-eks-a-v0.0.0-dev-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.14.7/cert-manager.yaml
-      version: v1.14.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-startupapicheck:v1.15.3-eks-a-v0.0.0-dev-build.1
+      version: v1.15.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -2551,7 +2551,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.15.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:
@@ -3327,7 +3327,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-acmesolver
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-acmesolver:v1.15.3-eks-a-v0.0.0-dev-build.1
       cainjector:
         arch:
         - amd64
@@ -3336,7 +3336,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-cainjector
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-cainjector:v1.15.3-eks-a-v0.0.0-dev-build.1
       controller:
         arch:
         - amd64
@@ -3345,19 +3345,19 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.14.7-eks-a-v0.0.0-dev-build.1
-      ctl:
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-controller:v1.15.3-eks-a-v0.0.0-dev-build.1
+      manifest:
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.15.3/cert-manager.yaml
+      startupapicheck:
         arch:
         - amd64
         - arm64
-        description: Container image for cert-manager-ctl image
+        description: Container image for cert-manager-startupapicheck image
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        name: cert-manager-ctl
+        name: cert-manager-startupapicheck
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-ctl:v1.14.7-eks-a-v0.0.0-dev-build.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cert-manager/manifests/v1.14.7/cert-manager.yaml
-      version: v1.14.7+abcdef1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-startupapicheck:v1.15.3-eks-a-v0.0.0-dev-build.1
+      version: v1.15.3+abcdef1
       webhook:
         arch:
         - amd64
@@ -3366,7 +3366,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cert-manager-webhook
         os: linux
-        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.14.7-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/cert-manager/cert-manager-webhook:v1.15.3-eks-a-v0.0.0-dev-build.1
     cilium:
       cilium:
         arch:

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: bundles.anywhere.eks.amazonaws.com
 spec:
@@ -400,6 +399,7 @@ spec:
                               type: string
                           type: object
                         ctl:
+                          description: This field has been deprecated
                           properties:
                             arch:
                               description: Architectures of the asset
@@ -432,6 +432,35 @@ spec:
                           properties:
                             uri:
                               description: URI points to the manifest yaml file
+                              type: string
+                          type: object
+                        startupapicheck:
+                          properties:
+                            arch:
+                              description: Architectures of the asset
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            imageDigest:
+                              description: The SHA256 digest of the image manifest
+                              type: string
+                            name:
+                              description: The asset name
+                              type: string
+                            os:
+                              description: Operating system of the asset
+                              enum:
+                              - linux
+                              - darwin
+                              - windows
+                              type: string
+                            osName:
+                              description: Name of the OS like ubuntu, bottlerocket
+                              type: string
+                            uri:
+                              description: The image repository, name, and tag
                               type: string
                           type: object
                         version:
@@ -469,8 +498,8 @@ spec:
                       - acmesolver
                       - cainjector
                       - controller
-                      - ctl
                       - manifest
+                      - startupapicheck
                       - webhook
                       type: object
                     cilium:

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_eksareleases.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_eksareleases.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: eksareleases.anywhere.eks.amazonaws.com
 spec:

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_releases.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_releases.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: releases.anywhere.eks.amazonaws.com
 spec:


### PR DESCRIPTION
*Description of changes:*
The `cert-manager-ctl` image was replaced with `cert-manager-startupapicheck` image in [#3790](https://github.com/aws/eks-anywhere-build-tooling/pull/3790) when cert-manager was bumped to v1.15.3. This PR updates the corresponding field in the EKS-A bundle to match the upstream image.

This PR also removes the `crd:trivialVersions=true,preserveUnknownFields=false` [CRD options](https://github.com/aws/eks-anywhere/blob/c7c5e480f1d0537abf7836b09cf26d0234d17e60/release/Makefile#L39) for controller-gen v0.8.0 as we bumped controller-gen from v0.6.1 to v0.8.0 in [#8531](https://github.com/aws/eks-anywhere/pull/8531) and controller-gen [v0.7.0](https://github.com/kubernetes-sigs/controller-tools/releases/tag/v0.7.0) introduced a breaking change in [#607](https://github.com/kubernetes-sigs/controller-tools/pull/607) that removed support for legacy v1beta1 CRDs and webhooks.

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
make generate
make generate-manifests
make release-manifests
make build-all-test-binaries
make -C release manifests
make -C release update-bundle-golden-files
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

