### PR TITLE
Fix K8s version for Tinkerbell E2E test

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -416,7 +416,7 @@ func TestTinkerbellKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
 }
 
 func TestTinkerbellKubernetes131UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell())
+	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,


### PR DESCRIPTION
*Description of changes:*
'TestTinkerbellKubernetes131UbuntuWorkerNodeUpgrade' was using the wrong K8s version during init. Fix the test to use the template form the expected K8s version which 1.31.  

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

