### PR TITLE
Skip generating AWS IAM kubeconfig on cluster upgrade.

### DIFF
--- a/pkg/workflows/workload/writeclusterconfig.go
+++ b/pkg/workflows/workload/writeclusterconfig.go
@@ -20,7 +20,7 @@ func (s *writeClusterConfig) Run(ctx context.Context, commandContext *task.Comma
 
 	}
 
-	if commandContext.ClusterSpec.AWSIamConfig != nil {
+	if commandContext.CurrentClusterSpec == nil && commandContext.ClusterSpec.AWSIamConfig != nil {
 		logger.Info("Generating the aws iam kubeconfig file")
 		err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.ManagementCluster)
 		if err != nil {

--- a/pkg/workflows/workload/writeclusterconfig.go
+++ b/pkg/workflows/workload/writeclusterconfig.go
@@ -20,6 +20,7 @@ func (s *writeClusterConfig) Run(ctx context.Context, commandContext *task.Comma
 
 	}
 
+	// Generate AWS IAM kubeconfig only for cluster creation step
 	if commandContext.CurrentClusterSpec == nil && commandContext.ClusterSpec.AWSIamConfig != nil {
 		logger.Info("Generating the aws iam kubeconfig file")
 		err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.ManagementCluster)


### PR DESCRIPTION
#### Issue
Workload cluster upgrade fails while upgrading from release-0.18 to release-0.19, on `write-cluster-config` step it is trying to look for secret for management Kubeconfig (`<mgmt-cluster>-aws-iam-kubeconfig`). 

In release-0.18, secret `<mgmt-cluster>-aws-iam-kubeconfig` is not created, there is precondition for creating secret it looks for AWS IAM configmap if it is not found it creates the secret, but in case of release-0.18 since clusterManager was CLI, it most probably created the configmap and secret was never created.

On workload cluster upgrade, this secret is required to generate the management cluster's AWS IAM Kubeconfig which is written to disk, this particular step can be skipped as there is no change to AWS IAM Kubeconfig on the cluster upgrade.

#### Description of changes
* Skipped generating AWS IAM Kubeconfig on cluster upgrade.

#### Testing:
* Validated cluster upgrade by building eksacli locally and using that to upgrade the cluster( 0.18-6 -> 019.11 dev)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

