### PR TITLE
Increase vSphere max EC2 count to 220

### DIFF
--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    INTEGRATION_TEST_MAX_EC2_COUNT: 200
+    INTEGRATION_TEST_MAX_EC2_COUNT: 220
     INTEGRATION_TEST_MAX_CONCURRENT_TEST_COUNT: 80
     EKSA_GIT_KNOWN_HOSTS: "/tmp/known_hosts"
     EKSA_GIT_PRIVATE_KEY: "/tmp/private-key"


### PR DESCRIPTION
*Description of changes:*
The max ec2 count is used to determine how many tests are to be run per instance
```
testPerInstance := len(testsList) / conf.MaxInstances
if testPerInstance == 0 {
	testPerInstance = 1
}
```
Until few days ago, we only had ~380 vSphere tests so tests per instance was 380/200 = 1 after rounding off. After un-skipping bottlerocket 1.31 tests in [#8768](https://github.com/aws/eks-anywhere/pull/8768), CAPI 1.31 tests in [#8819](https://github.com/aws/eks-anywhere/pull/8819) and packages 1.31 tests in [#8825](https://github.com/aws/eks-anywhere/pull/8825), the total vSphere tests count went above 400 which caused the tests per instance to be 412/200 = 2 after rounding off so we run two tests per instance on 200 EC2 instances which can only run sequentially.

This PR increases the max EC2 count to 220 in order to run only 1 test per instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

