### PR TITLE
Skip generating AWS IAM Kubeconfig on cluster upgrade

### DIFF
--- a/pkg/workflows/workload/upgrade_test.go
+++ b/pkg/workflows/workload/upgrade_test.go
@@ -207,7 +207,7 @@ func TestUpgradeRunWithAWSIAMSuccess(t *testing.T) {
 	test.expectUpgradeWorkloadCluster(nil)
 	test.expectBuildClientFromKubeconfig(nil)
 	test.expectWriteWorkloadClusterConfig(nil)
-	test.expectAWSIAMAuthKubeconfig(nil)
+	test.expectWithoutAWSIAMAuthKubeconfig(nil)
 	err := test.run()
 	if err != nil {
 		t.Fatalf("Upgrade.Run() err = %v, want err = nil", err)

--- a/pkg/workflows/workload/upgrade_test.go
+++ b/pkg/workflows/workload/upgrade_test.go
@@ -135,7 +135,7 @@ func (c *upgradeTestSetup) expectWriteWorkloadClusterConfig(err error) {
 	)
 }
 
-func (c *upgradeTestSetup) expectAWSIAMAuthKubeconfig(err error) {
+func (c *upgradeTestSetup) expectWithoutAWSIAMAuthKubeconfig(err error) {
 	c.clusterManager.EXPECT().GenerateAWSIAMKubeconfig(
 		c.ctx, c.clusterSpec.ManagementCluster).Return(err).Times(0)
 }

--- a/pkg/workflows/workload/upgrade_test.go
+++ b/pkg/workflows/workload/upgrade_test.go
@@ -135,6 +135,11 @@ func (c *upgradeTestSetup) expectWriteWorkloadClusterConfig(err error) {
 	)
 }
 
+func (c *upgradeTestSetup) expectAWSIAMAuthKubeconfig(err error) {
+	c.clusterManager.EXPECT().GenerateAWSIAMKubeconfig(
+		c.ctx, c.clusterSpec.ManagementCluster).Return(err).Times(0)
+}
+
 func (c *upgradeTestSetup) expectDatacenterConfig() {
 	gomock.InOrder(
 		c.provider.EXPECT().DatacenterConfig(c.clusterSpec).Return(c.datacenterConfig).AnyTimes(),
@@ -183,6 +188,26 @@ func TestUpgradeRunSuccess(t *testing.T) {
 	test.expectBuildClientFromKubeconfig(nil)
 	test.expectWriteWorkloadClusterConfig(nil)
 
+	err := test.run()
+	if err != nil {
+		t.Fatalf("Upgrade.Run() err = %v, want err = nil", err)
+	}
+}
+
+func TestUpgradeRunWithAWSIAMSuccess(t *testing.T) {
+	features.ClearCache()
+	os.Setenv(features.UseControllerForCli, "true")
+	test := newUpgradeTest(t)
+	test.clusterSpec.AWSIamConfig = &v1alpha1.AWSIamConfig{}
+	test.expectSetup()
+	test.expectPreflightValidationsToPass()
+	test.expectDatacenterConfig()
+	test.expectMachineConfigs()
+	test.expectBackupWorkloadFromCluster(nil)
+	test.expectUpgradeWorkloadCluster(nil)
+	test.expectBuildClientFromKubeconfig(nil)
+	test.expectWriteWorkloadClusterConfig(nil)
+	test.expectAWSIAMAuthKubeconfig(nil)
 	err := test.run()
 	if err != nil {
 		t.Fatalf("Upgrade.Run() err = %v, want err = nil", err)

--- a/pkg/workflows/workload/writeclusterconfig.go
+++ b/pkg/workflows/workload/writeclusterconfig.go
@@ -20,7 +20,8 @@ func (s *writeClusterConfig) Run(ctx context.Context, commandContext *task.Comma
 
 	}
 
-	if commandContext.ClusterSpec.AWSIamConfig != nil {
+	// Generate AWS IAM kubeconfig only for cluster creation step
+	if commandContext.CurrentClusterSpec == nil && commandContext.ClusterSpec.AWSIamConfig != nil {
 		logger.Info("Generating the aws iam kubeconfig file")
 		err = commandContext.ClusterManager.GenerateAWSIAMKubeconfig(ctx, commandContext.ManagementCluster)
 		if err != nil {


### PR DESCRIPTION
*Description of changes:*

This PR introduces a change to the write-cluster-config step of the upgrade workflow. Specifically, it adds a check to skip writing the AWS IAM Kubeconfig to disk during this step. During a cluster upgrade, the AWS IAM Kubeconfig is not updated. As a result, the step to write the Kubeconfig to disk can be safely skipped without any impact on the upgrade process.

*Testing:*
Built eksa binary locally and tested upgrade workflow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

