### PR TITLE
[release-0.19] Skip bundles override for e2e-test when upgrade is from latest minor release

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3213,11 +3213,12 @@ func TestVSphereKubernetes127UbuntuTo128UpgradeWithCheckpoint(t *testing.T) {
 
 func TestVSphereKubernetes127RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.RedHat8, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.RedHat8, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3244,11 +3245,12 @@ func TestVSphereKubernetes126WithOIDCManagementClusterUpgradeFromLatestSideEffec
 
 func TestVSphereKubernetes125UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPolicy(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube125, framework.Ubuntu2004, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube125, framework.Ubuntu2004, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3271,11 +3273,12 @@ func TestVSphereKubernetes125UbuntuUpgradeFromLatestMinorReleaseAlwaysNetworkPol
 
 func TestVSphereKubernetes125To126UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube125, framework.Ubuntu2004, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube125, framework.Ubuntu2004, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3298,11 +3301,12 @@ func TestVSphereKubernetes125To126UbuntuUpgradeFromLatestMinorRelease(t *testing
 
 func TestVSphereKubernetes126To127UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube126, framework.Ubuntu2004, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube126, framework.Ubuntu2004, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3325,11 +3329,12 @@ func TestVSphereKubernetes126To127UbuntuUpgradeFromLatestMinorRelease(t *testing
 
 func TestVSphereKubernetes127To128UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.Ubuntu2004, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.Ubuntu2004, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3352,11 +3357,12 @@ func TestVSphereKubernetes127To128UbuntuUpgradeFromLatestMinorRelease(t *testing
 
 func TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.Ubuntu2004, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.Ubuntu2004, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3379,12 +3385,13 @@ func TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease(t *testing
 
 func TestVSphereKubernetes128To129UbuntuInPlaceUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(
 		t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.Ubuntu2004, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.Ubuntu2004, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3454,11 +3461,12 @@ func TestVSphereKubernetes128BottlerocketAndRemoveWorkerNodeGroups(t *testing.T)
 
 func TestVSphereKubernetes127To128RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.RedHat8, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.RedHat8, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3481,11 +3489,12 @@ func TestVSphereKubernetes127To128RedhatUpgradeFromLatestMinorRelease(t *testing
 
 func TestVSphereKubernetes128To129RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
 	release := latestMinorRelease(t)
+	useBundlesOverride := false
 	provider := framework.NewVSphere(t,
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.RedHat8, release),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.RedHat8, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3539,6 +3548,7 @@ func TestVSphereKubernetes125UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testin
 func TestVSphereKubernetes127to128UpgradeFromLatestMinorReleaseBottleRocketAPI(t *testing.T) {
 	release := latestMinorRelease(t)
 	provider := framework.NewVSphere(t)
+	useBundlesOverride := false
 	managementCluster := framework.NewClusterE2ETest(
 		t, provider,
 	)
@@ -3550,7 +3560,7 @@ func TestVSphereKubernetes127to128UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 		api.VSphereToConfigFiller(
 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
 		),
-		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.Bottlerocket1, release),
+		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.Bottlerocket1, release, useBundlesOverride),
 	)
 
 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
@@ -3566,7 +3576,7 @@ func TestVSphereKubernetes127to128UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 		api.VSphereToConfigFiller(
 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
 		),
-		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.Bottlerocket1, release),
+		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube127, framework.Bottlerocket1, release, useBundlesOverride),
 	)
 
 	test.WithWorkloadClusters(wc)

--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -331,10 +331,11 @@ func cloudStackMachineConfig(name string, fillers ...api.CloudStackMachineConfig
 // templateForKubeVersionAndOS returns a CloudStack filler for the given OS and Kubernetes version.
 func (c *CloudStack) templateForKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) api.CloudStackFiller {
 	var template string
+	useBundlesOverride := getBundlesOverride() == "true"
 	if release == nil {
-		template = c.templateForDevRelease(kubeVersion, os)
+		template = c.templateForDevRelease(kubeVersion, os, useBundlesOverride)
 	} else {
-		template = c.templatesRegistry.templateForRelease(c.t, release, kubeVersion, os)
+		template = c.templatesRegistry.templateForRelease(c.t, release, kubeVersion, os, useBundlesOverride)
 	}
 
 	return api.WithCloudStackTemplateForAllMachines(template)
@@ -510,9 +511,9 @@ func (c *CloudStack) getDevRelease() *releasev1.EksARelease {
 	return c.devRelease
 }
 
-func (c *CloudStack) templateForDevRelease(kubeVersion anywherev1.KubernetesVersion, os OS) string {
+func (c *CloudStack) templateForDevRelease(kubeVersion anywherev1.KubernetesVersion, os OS, useBundlesOverride bool) string {
 	c.t.Helper()
-	return c.templatesRegistry.templateForRelease(c.t, c.getDevRelease(), kubeVersion, os)
+	return c.templatesRegistry.templateForRelease(c.t, c.getDevRelease(), kubeVersion, os, useBundlesOverride)
 }
 
 // envVarForTemplate Looks for explicit configuration through an env var: "T_CLOUDSTACK_TEMPLATE_{osFamily}_{eks-d version}"

--- a/test/framework/nutanix.go
+++ b/test/framework/nutanix.go
@@ -316,7 +316,8 @@ func WithRedHat9Kubernetes129Nutanix() NutanixOpt {
 // to use this OS family.
 func withNutanixKubeVersionAndOSForUUID(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) NutanixOpt {
 	return func(n *Nutanix) {
-		name := n.templateForDevRelease(kubeVersion, os)
+		useBundlesOverride := getBundlesOverride() == "true"
+		name := n.templateForDevRelease(kubeVersion, os, useBundlesOverride)
 		n.fillers = append(n.fillers, n.withNutanixUUID(name, osFamiliesForOS[os])...)
 	}
 }
@@ -449,10 +450,11 @@ func WithNutanixSubnetUUID() NutanixOpt {
 // templateForKubeVersionAndOS returns a Nutanix filler for the given OS and Kubernetes version.
 func (n *Nutanix) templateForKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) api.NutanixFiller {
 	var template string
+	useBundlesOverride := getBundlesOverride() == "true"
 	if release == nil {
-		template = n.templateForDevRelease(kubeVersion, os)
+		template = n.templateForDevRelease(kubeVersion, os, useBundlesOverride)
 	} else {
-		template = n.templatesRegistry.templateForRelease(n.t, release, kubeVersion, os)
+		template = n.templatesRegistry.templateForRelease(n.t, release, kubeVersion, os, useBundlesOverride)
 	}
 	return api.WithNutanixMachineTemplateImageName(template)
 }
@@ -566,9 +568,9 @@ func (n *Nutanix) getDevRelease() *releasev1.EksARelease {
 	return n.devRelease
 }
 
-func (n *Nutanix) templateForDevRelease(kubeVersion anywherev1.KubernetesVersion, os OS) string {
+func (n *Nutanix) templateForDevRelease(kubeVersion anywherev1.KubernetesVersion, os OS, useBundlesOverride bool) string {
 	n.t.Helper()
-	return n.templatesRegistry.templateForRelease(n.t, n.getDevRelease(), kubeVersion, os)
+	return n.templatesRegistry.templateForRelease(n.t, n.getDevRelease(), kubeVersion, os, useBundlesOverride)
 }
 
 // envVarForTemplate looks for explicit configuration through an env var: "T_NUTANIX_TEMPLATE_{osFamily}_{eks-d version}"

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -38,9 +38,9 @@ type templateRegistry struct {
 // 3. If the template doesn't exist, default to the value of the default template env vars: eg. "T_CLOUDSTACK_TEMPLATE_REDHAT_1_23".
 // This is a catch all condition. Mostly for edge cases where the bundle has been updated with a new eks-d version, but the
 // the new template hasn't been imported yet. It also preserves backwards compatibility.
-func (tc *templateRegistry) templateForRelease(t *testing.T, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion, operatingSystem OS) string {
+func (tc *templateRegistry) templateForRelease(t *testing.T, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion, operatingSystem OS, useBundlesOverride bool) string {
 	t.Helper()
-	versionsBundle := readVersionsBundles(t, release, kubeVersion)
+	versionsBundle := readVersionsBundles(t, release, kubeVersion, useBundlesOverride)
 	eksDName := versionsBundle.EksD.Name
 
 	templateEnvVarName := tc.generator.envVarForTemplate(operatingSystem, eksDName)

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -454,17 +454,19 @@ func (v *VSphere) WithNewVSphereWorkerNodeGroup(name string, workerNodeGroup *Wo
 // templateForKubeVersionAndOS returns a vSphere filler for the given OS and Kubernetes version.
 func (v *VSphere) templateForKubeVersionAndOS(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) api.VSphereFiller {
 	var template string
+	useBundlesOverride := getBundlesOverride() == "true"
 	if release == nil {
-		template = v.templateForDevRelease(kubeVersion, os)
+		template = v.templateForDevRelease(kubeVersion, os, useBundlesOverride)
 	} else {
-		template = v.templatesRegistry.templateForRelease(v.t, release, kubeVersion, os)
+		template = v.templatesRegistry.templateForRelease(v.t, release, kubeVersion, os, useBundlesOverride)
 	}
 	return api.WithTemplateForAllMachines(template)
 }
 
 // templateForKubeVersionAndOSMachineConfig returns a vSphere filler for the given OS and Kubernetes version for a specific machine config.
 func (v *VSphere) templateForKubeVersionAndOSMachineConfig(name string, kubeVersion anywherev1.KubernetesVersion, os OS) api.VSphereFiller {
-	template := v.templateForDevRelease(kubeVersion, os)
+	useBundlesOverride := getBundlesOverride() == "true"
+	template := v.templateForDevRelease(kubeVersion, os, useBundlesOverride)
 	return api.WithMachineTemplate(name, template)
 }
 
@@ -572,9 +574,9 @@ func (v *VSphere) getDevRelease() *releasev1.EksARelease {
 	return v.devRelease
 }
 
-func (v *VSphere) templateForDevRelease(kubeVersion anywherev1.KubernetesVersion, os OS) string {
+func (v *VSphere) templateForDevRelease(kubeVersion anywherev1.KubernetesVersion, os OS, useBundlesOverride bool) string {
 	v.t.Helper()
-	return v.templatesRegistry.templateForRelease(v.t, v.getDevRelease(), kubeVersion, os)
+	return v.templatesRegistry.templateForRelease(v.t, v.getDevRelease(), kubeVersion, os, useBundlesOverride)
 }
 
 func RequiredVsphereEnvVars() []string {
@@ -615,22 +617,22 @@ func buildVSphereWorkerNodeGroupClusterFiller(machineConfigName string, workerNo
 
 // WithKubeVersionAndOSForRelease returns a vSphereOpt that sets the cluster kube version and the right template for all
 // vsphere machine configs based on the EKS-A release.
-func WithKubeVersionAndOSForRelease(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) VSphereOpt {
-	return optionToSetTemplateForRelease(kubeVersion, os, release)
+func WithKubeVersionAndOSForRelease(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease, useBundlesOverride bool) VSphereOpt {
+	return optionToSetTemplateForRelease(kubeVersion, os, release, useBundlesOverride)
 }
 
 // WithKubeVersionAndOSForRelease returns a cluster config filler that sets the cluster kube version and the right template for all
 // vsphere machine configs based on the EKS-A release.
-func (v *VSphere) WithKubeVersionAndOSForRelease(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) api.ClusterConfigFiller {
+func (v *VSphere) WithKubeVersionAndOSForRelease(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease, useBundlesOverride bool) api.ClusterConfigFiller {
 	return api.VSphereToConfigFiller(
-		api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, release, kubeVersion, os)),
+		api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, release, kubeVersion, os, useBundlesOverride)),
 	)
 }
 
-func optionToSetTemplateForRelease(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease) VSphereOpt {
+func optionToSetTemplateForRelease(kubeVersion anywherev1.KubernetesVersion, os OS, release *releasev1.EksARelease, useBundlesOverride bool) VSphereOpt {
 	return func(v *VSphere) {
 		v.fillers = append(v.fillers,
-			api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, release, kubeVersion, os)),
+			api.WithTemplateForAllMachines(v.templatesRegistry.templateForRelease(v.t, release, kubeVersion, os, useBundlesOverride)),
 		)
 	}
 }
@@ -670,11 +672,11 @@ func (v *VSphere) searchTemplate(ctx context.Context, template string) (string, 
 	return foundTemplate, nil
 }
 
-func readVersionsBundles(t testing.TB, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion) *releasev1.VersionsBundle {
+func readVersionsBundles(t testing.TB, release *releasev1.EksARelease, kubeVersion anywherev1.KubernetesVersion, useBundlesOverride bool) *releasev1.VersionsBundle {
 	reader := newFileReader()
 	var allBundles *releasev1.Bundles
 	var err error
-	if getBundlesOverride() == "true" {
+	if useBundlesOverride {
 		allBundles, err = bundles.Read(reader, defaultBundleReleaseManifestFile)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/eks-anywhere/pull/8807


