### PR TITLE
Update docs to mark packages commands as deprecated

### DIFF
--- a/docs/content/en/docs/reference/eksctl/anywhere_apply_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_apply_package(s).md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere apply package(s)"
+title: "(deprecated) anywhere apply package(s)"
 linkTitle: "anywhere apply package(s)"
 ---
 
@@ -9,6 +9,7 @@ Apply curated packages
 
 ### Synopsis
 
+Command "package" is deprecated, use `kubectl apply` instead
 Apply Curated Packages Custom Resources to the cluster
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_create_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_create_package(s).md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere create package(s)"
+title: "(deprecated) anywhere create package(s)"
 linkTitle: "anywhere create package(s)"
 ---
 
@@ -9,6 +9,7 @@ Create curated packages
 
 ### Synopsis
 
+Command "package" is deprecated, use `kubectl apply` instead
 Create Curated Packages Custom Resources to the cluster
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_delete_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_delete_package(s).md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere delete package(s)"
+title: "(deprecated) anywhere delete package(s)"
 linkTitle: "anywhere delete package(s)"
 ---
 
@@ -9,6 +9,7 @@ Delete package(s)
 
 ### Synopsis
 
+Command "package" is deprecated, use `kubectl delete package` instead
 This command is used to delete the curated packages custom resources installed in the cluster
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_describe_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_describe_package(s).md
@@ -1,10 +1,11 @@
 ---
-title: "anywhere describe package(s)"
+title: "(deprecated) anywhere describe package(s)"
 linkTitle: "anywhere describe package(s)"
 ---
 
 ## anywhere describe package(s)
 
+Command "package" is deprecated, use `kubectl describe packages` instead
 Describe curated packages in the cluster
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_package(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_package(s).md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere get package(s)"
+title: "(deprecated) anywhere get package(s)"
 linkTitle: "anywhere get package(s)"
 ---
 
@@ -9,6 +9,7 @@ Get package(s)
 
 ### Synopsis
 
+Command "package" is deprecated, use `kubectl get packages` instead
 This command is used to display the curated packages installed in the cluster
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundle(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundle(s).md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere get packagebundle(s)"
+title: "(deprecated) anywhere get packagebundle(s)"
 linkTitle: "anywhere get packagebundle(s)"
 ---
 
@@ -9,6 +9,7 @@ Get packagebundle(s)
 
 ### Synopsis
 
+Command "packagebundle" is deprecated, use `kubectl get packagebundle` instead
 This command is used to display the currently supported packagebundles
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundlecontroller(s).md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_get_packagebundlecontroller(s).md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere get packagebundlecontroller(s)"
+title: "(deprecated) anywhere get packagebundlecontroller(s)"
 linkTitle: "anywhere get packagebundlecontroller(s)"
 ---
 
@@ -9,6 +9,7 @@ Get packagebundlecontroller(s)
 
 ### Synopsis
 
+Command "packagebundlecontroller" is deprecated, use `kubectl get packagebundlecontroller` instead
 This command is used to display the current packagebundlecontrollers
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_install_package.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_install_package.md
@@ -1,5 +1,5 @@
 ---
-title: "anywhere install package"
+title: "(deprecated) anywhere install package"
 linkTitle: "anywhere install package"
 ---
 
@@ -9,6 +9,7 @@ Install package
 
 ### Synopsis
 
+Command "package" is deprecated, use `kubectl apply` instead
 This command is used to Install a curated package. Use list to discover curated packages
 
 ```

--- a/docs/content/en/docs/reference/eksctl/anywhere_upgrade_packages.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_upgrade_packages.md
@@ -1,10 +1,11 @@
 ---
-title: "anywhere upgrade packages"
+title: "(deprecated) anywhere upgrade packages"
 linkTitle: "anywhere upgrade packages"
 ---
 
 ## anywhere upgrade packages
 
+Command "packages" is deprecated, refer to `https://anywhere.eks.amazonaws.com/docs/packages/packagebundles` for upgrading
 Upgrade all curated packages to the latest version
 
 ```


### PR DESCRIPTION
*Issue #, if available:*
[#2270](https://github.com/aws/eks-anywhere-internal/issues/2270)

*Description of changes:*
Packages commands were deprecated in [#8240](https://github.com/aws/eks-anywhere/pull/8240) from EKS-A v0.20.0 onwards. This PR updates the EKS-A docs to mark packages commands as deprecated.

*Testing (if applicable):*
`make -C docs build`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

