### PR TITLE
Update docker test name for e2e presubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ EKS_A_CROSS_PLATFORMS := $(foreach platform,$(EKS_A_PLATFORMS),eks-a-cross-platf
 E2E_CROSS_PLATFORMS := $(foreach platform,$(EKS_A_PLATFORMS),e2e-cross-platform-$(platform))
 EKS_A_RELEASE_CROSS_PLATFORMS := $(foreach platform,$(EKS_A_PLATFORMS),eks-a-release-cross-platform-$(platform))
 
-DOCKER_E2E_TEST := TestDockerKubernetes130SimpleFlow
+DOCKER_E2E_TEST := TestDockerKubernetes131SimpleFlow
 LOCAL_E2E_TESTS ?= $(DOCKER_E2E_TEST)
 
 EMBED_CONFIG_FOLDER = pkg/files/config

--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -36,7 +36,7 @@ fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 BIN_FOLDER=$REPO_ROOT/bin
-TEST_REGEX="${1:-TestDockerKubernetes130SimpleFlow}"
+TEST_REGEX="${1:-TestDockerKubernetes131SimpleFlow}"
 BRANCH_NAME="${2:-main}"
 source $REPO_ROOT/test/e2e/E2E_AMI_FILTER_VARS
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -11,8 +11,8 @@ or
 #
 # The makefile will include the .env file and export all the vars to the environment for you
 #
-# By default the local-e2e target will run TestDockerKubernetes130SimpleFlow. You can either 
-#   override LOCAL_E2E_TESTS in your .env file or pass it on the cli every time (i.e LOCAL_E2E_TESTS=TestDockerKubernetes130SimpleFlow)
+# By default the local-e2e target will run TestDockerKubernetes131SimpleFlow. You can either 
+#   override LOCAL_E2E_TESTS in your .env file or pass it on the cli every time (i.e LOCAL_E2E_TESTS=TestDockerKubernetes131SimpleFlow)
 make local-e2e
 ```
 or


### PR DESCRIPTION
*Issue #, if available:*
[#2402](https://github.com/aws/eks-anywhere-internal/issues/2402)

*Description of changes:*
Update docker test name for e2e presubmit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

