### PR TITLE
Print output of Git checkout command

### DIFF
--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -351,7 +351,8 @@ func ReadGitTag(projectPath, gitRootPath, branch string) (string, error) {
 		return "", fmt.Errorf("error getting current branch: %v", err)
 	}
 	if currentBranch != branch {
-		_, err = git.CheckoutRepo(gitRootPath, branch)
+		out, err := git.CheckoutRepo(gitRootPath, branch)
+		fmt.Println(out)
 		if err != nil {
 			return "", fmt.Errorf("error checking out repo: %v", err)
 		}


### PR DESCRIPTION
Print output of Git checkout command instead of swallowing it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

