### PR TITLE
Display Cilium upgrade skipped status in upgrade plan command

### DIFF
--- a/pkg/networking/cilium/upgrade_plan.go
+++ b/pkg/networking/cilium/upgrade_plan.go
@@ -259,6 +259,20 @@ func ChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 
 func ciliumChangeDiff(currentSpec, newSpec *cluster.Spec) *types.ChangeDiff {
 	currentVersionsBundle := currentSpec.RootVersionsBundle()
+
+	newCiliumCfg := newSpec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium
+	if !newCiliumCfg.IsManaged() {
+		return &types.ChangeDiff{
+			ComponentReports: []types.ComponentChangeDiff{
+				{
+					ComponentName: "cilium",
+					OldVersion:    currentVersionsBundle.Cilium.Version,
+					NewVersion:    "Upgrade skipped (skipUpgrade: true)",
+				},
+			},
+		}
+	}
+
 	newVersionsBundle := newSpec.RootVersionsBundle()
 	if currentVersionsBundle.Cilium.Version == newVersionsBundle.Cilium.Version {
 		return nil


### PR DESCRIPTION
Display Cilium upgrade skipped status in `upgrade plan` command

Fixes: https://github.com/aws/eks-anywhere/issues/8853

```console
> ./eksctl-anywhere upgrade plan cluster -f $CLUSTER_NAME.yaml
Checking new release availability...
NAME                 CURRENT VERSION       NEXT VERSION
EKS-A Management     v0.20.5+edd7640       v0.21.0-dev+build.291+294dfde
cert-manager         v1.14.7+fe09cef       v1.16.1+5d8f23c
cluster-api          v1.7.2+9efc12c        v1.8.4+ab49b25
kubeadm              v1.7.2+d36e661        v1.8.4+d751002
docker               v1.7.2+b91f85f        v1.8.4+94e333f
kubeadm              v1.7.2+302c0db        v1.8.4+236f530
etcdadm-bootstrap    v1.0.13+fcf0999       v1.0.14+4bacd57
etcdadm-controller   v1.0.22+d178343       v1.0.24+a1c69ab
cilium               v1.13.18-eksa.1       Upgrade skipped (skipUpgrade: true)
kubernetes           v1.30.3-eks-1-30-13   v1.31.1-eks-1-31-6
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

