### PR TITLE
Skip cleaning up the instance if cleanup-resources is set to false

### DIFF
--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -249,9 +249,13 @@ func RunTests(conf instanceRunConf, inventoryCatalogue map[string]*hardwareCatal
 	conf.Logger.Info("TestRunner instance has been created")
 
 	defer func() {
-		err := testRunner.decommInstance(conf)
-		if err != nil {
-			conf.Logger.V(1).Info("WARN: Failed to decomm e2e test runner instance", "error", err)
+		if conf.CleanupResources {
+			err := testRunner.decommInstance(conf)
+			if err != nil {
+				conf.Logger.V(1).Info("WARN: Failed to decomm e2e test runner instance", "error", err)
+			}
+		} else {
+			conf.Logger.V(1).Info("Skipping to terminate instance. cleanup-resources set to false")
 		}
 	}()
 


### PR DESCRIPTION
*Description of changes:*
At the end of test, even if cleanup-resources was set to false, the test would decommision the instance. With this change, the instance would not be deleted, leaving the environment in place for debugging. The instance should be manually deleted afterwards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

