### PR TITLE
Add versions page for v0.19

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -190,3 +190,9 @@ fullversion = "v0.20"
 version = "v0.20"
 docsbranch = "release-0.20"
 url = "https://release-0-20.anywhere.eks.amazonaws.com"
+
+[[params.versions]]
+fullversion = "v0.19"
+version = "v0.19"
+docsbranch = "release-0.19"
+url = "https://release-0-19.anywhere.eks.amazonaws.com"


### PR DESCRIPTION
*Description of changes:*
Add versions page for v0.19 so that it can still be referred later.

*Testing (if applicable):*
`make build`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

