### PR TITLE
Fix URL for release-0.20 branch docs URL

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -189,7 +189,7 @@ url = "https://anywhere.eks.amazonaws.com"
 fullversion = "v0.20"
 version = "v0.20"
 docsbranch = "release-0.20"
-url = "https://release-0.20.anywhere.eks.amazonaws.com"
+url = "https://release-0-20.anywhere.eks.amazonaws.com"
 
 [[params.versions]]
 fullversion = "v0.19"


### PR DESCRIPTION
Fix URL for release-0.20 branch docs URL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

