### PR TITLE
Fix "Committer identity unknown" when patching:

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,7 +30,7 @@ submodule: ## Initialize the docsy theme submodule
 	git submodule update --init --recursive
 
 submodule-apply-patches: submodule ## Apply submodule patches
-	cd themes/docsy; git am < ../../patches/0001-Security-update.patch && cd ../..
+	cd themes/docsy; git -c user.name="none" -c user.email="none@none.org" am ../../patches/0001-Security-update.patch && cd ../..
 
 submodule-reset: ## Reset submodules to tracked commit
 	git submodule update --init --recursive --force

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,7 +30,7 @@ submodule: ## Initialize the docsy theme submodule
 	git submodule update --init --recursive
 
 submodule-apply-patches: submodule ## Apply submodule patches
-	cd themes/docsy; git am < ../../patches/0001-Security-update.patch; cd ../..
+	cd themes/docsy; git am < ../../patches/0001-Security-update.patch && cd ../..
 
 submodule-reset: ## Reset submodules to tracked commit
 	git submodule update --init --recursive --force

--- a/docs/amplify.yml
+++ b/docs/amplify.yml
@@ -4,7 +4,7 @@ applications:
       phases:
         build:
           commands:
-            - git config --global user.email "none@none.com"; git config --global user.name "none"; make release
+            - make release
         postBuild:
           commands:
             - make upload-checksum invalidate-docs-cdn

--- a/docs/amplify.yml
+++ b/docs/amplify.yml
@@ -4,7 +4,7 @@ applications:
       phases:
         build:
           commands:
-            - make release
+            - git config --global user.email "none@none.com"; git config --global user.name "none"; make release
         postBuild:
           commands:
             - make upload-checksum invalidate-docs-cdn

--- a/docs/patches/0001-Security-update.patch
+++ b/docs/patches/0001-Security-update.patch
@@ -1,4 +1,3 @@
-From f97e20029a8b34b66eb5356764b268fc527741f7 Mon Sep 17 00:00:00 2001
 From: Jacob Weinstock <jakobweinstock@gmail.com>
 Date: Thu, 31 Oct 2024 10:24:12 -0600
 Subject: [PATCH] Security update:


### PR DESCRIPTION
*Issue #, if available:*

git am is failing to apply the theme patch because amplify doesn't have a git user and email configured. This configures a user and email so the git am doesn't fail.

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

