### PR TITLE
Unskip upgrade from latest minor tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -16,21 +16,6 @@ skipped_tests:
 
 # Nutanix
 
-# UpgradeFromLatestTests for new K8s version (expected to work only after the release is out)
-- TestDockerKubernetes130to131UpgradeFromLatestMinorRelease
-- TestDockerKubernetes130to131UpgradeFromLatestMinorReleaseAPI
-- TestDockerKubernetes131AirgappedUpgradeFromLatestRegistryMirrorAndCert
-- TestDockerKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects
-
-- TestVSphereKubernetes130To131UbuntuUpgradeFromLatestMinorRelease
-- TestVSphereKubernetes131RedhatUpgradeFromLatestMinorRelease
-- TestVSphereKubernetes130To131RedhatUpgradeFromLatestMinorRelease
-- TestVSphereKubernetes130To131UbuntuInPlaceUpgradeFromLatestMinorRelease
-- TestVSphereKubernetes130to131UpgradeFromLatestMinorReleaseBottleRocketAPI
-- TestVSphereKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects
-
-- TestCloudStackKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects
-
 # Snow
 - TestSnowKubernetes127SimpleFlow
 - TestSnowKubernetes128SimpleFlow


### PR DESCRIPTION
*Issue #, if available:*
[#2402](https://github.com/aws/eks-anywhere-internal/issues/2402)

*Description of changes:*
Unskip upgrade from latest minor tests now that the EKS-A latest minor release [v0.21.0](https://github.com/aws/eks-anywhere/releases/tag/v0.21.0) is out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

