### PR TITLE
Remove curated package list from concepts page

### DIFF
--- a/docs/content/en/docs/concepts/packages.md
+++ b/docs/content/en/docs/concepts/packages.md
@@ -36,17 +36,3 @@ Please check out [curated package list]({{< relref "../packages/packagelist/" >}
 
     If, for example, you deploy a Harbor image that is not built and signed by Amazon, Amazon will not provide testing or customer support to your self-built images.
 
-### Curated package list
-
-| Name                       | Description                | Versions                  | GitHub                      |
-|----------------------------|----------------------------|---------------------------|-----------------------------|
-| [ADOT]({{< relref "../packages/adot" >}}) | ADOT Collector is an AWS distribution of the OpenTelemetry Collector, which provides a vendor-agnostic solution to receive, process and export telemetry data. | [v0.25.0]({{< relref "../packages/adot/v0.25.0.md" >}}) | https://github.com/aws-observability/aws-otel-collector |
-| [Cert-manager]({{< relref "../packages/cert-manager" >}}) | Cert-manager is a certificate manager for Kubernetes clusters. | [v1.9.1]({{< relref "../packages/cert-manager/v1.9.1.md" >}}) | https://github.com/cert-manager/cert-manager |
-| [Cluster Autoscaler]({{< relref "../packages/cluster-autoscaler" >}}) | Cluster Autoscaler is a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes. | [v9.21.0]({{< relref "../packages/cluster-autoscaler/v9.21.0.md" >}}) | https://github.com/kubernetes/autoscaler |
-| [Emissary Ingress]({{< relref "../packages/emissary" >}}) | Emissary Ingress is an open source `Ingress` supporting API Gateway + Layer 7 load balancer built on Envoy Proxy. | [v3.3.0]({{< relref "../packages/emissary/v3.3.0.md" >}}) | https://github.com/emissary-ingress/emissary/ |
-| [Harbor]({{< relref "../packages/harbor" >}}) | Harbor is an open source trusted cloud native registry project that stores, signs, and scans content. | [v2.7.1]({{< relref "../packages/harbor/v2.7.1.md" >}})<br> [v2.5.1]({{< relref "../packages/harbor/v2.7.1.md" >}}) | https://github.com/goharbor/harbor<br>https://github.com/goharbor/harbor-helm |
-| [MetalLB]({{< relref "../packages/metallb" >}}) | MetalLB is a virtual IP provider for services of type `LoadBalancer` supporting ARP and BGP. | [v0.13.7]({{< relref "../packages/metallb/v0.13.7.md" >}}) | https://github.com/metallb/metallb/ |
-| [Metrics Server]({{< relref "../packages/metrics-server" >}}) | Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines. | [v3.8.2]({{< relref "../packages/metrics-server/v3.8.2.md" >}}) | https://github.com/kubernetes-sigs/metrics-server |
-| [Prometheus]({{< relref "../packages/prometheus" >}}) | Prometheus is an open-source systems monitoring and alerting toolkit that collects and stores metrics as time series data. | [v2.41.0]({{< relref "../packages/prometheus/v2.41.0.md" >}}) | https://github.com/prometheus/prometheus |
-
-

--- a/docs/content/en/docs/concepts/support-scope.md
+++ b/docs/content/en/docs/concepts/support-scope.md
@@ -16,9 +16,9 @@ You can purchase EKS Anywhere Enterprise Subscriptions for 24/7 support from AWS
 
 EKS Anywhere Enterprise Subscriptions include support for the following components:
 
-- EKS Distro (see [documentation](https://distro.eks.aws.com/) for components)
+- EKS Distro (see [documentation](https://distro.eks.amazonaws.com/) for components)
 - EKS Anywhere core components such as the Cilium CNI, Flux GitOps controller, kube-vip, EKS Anywhere CLI, EKS Anywhere controllers, image builder, and EKS Connector
-- EKS Anywhere Curated Packages (see [curated packages list]({{< relref "../concepts/packages/#curated-package-list" >}}) for list of packages) 
+- EKS Anywhere Curated Packages (see [curated packages list]({{< relref "../packages/packagelist/" >}}) for list of packages) 
 - EKS Anywhere cluster lifecycle operations such as creating, scaling, and upgrading
 - EKS Anywhere troubleshooting, general guidance, and best practices
 - Bottlerocket node operating system


### PR DESCRIPTION
*Description of changes:*
This PR removes the curated package list from concepts page as it is already being referenced on the same page above as a hyperlink to the updated list in the package management section. It makes sense to have a single source of truth for the updated list of curated packages. The PR also fixes the link for the EKS Distro documentation page.

*Testing (if applicable):*
`make build`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

