### PR TITLE
Remove baremetal-branch flag from the integration test CLI

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -108,7 +108,6 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -57,7 +57,6 @@ phases:
         --bundles-override=${BUNDLES_OVERRIDE}
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -91,7 +91,6 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
   post_build:
     commands:
       - >

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -174,7 +174,6 @@ env:
     T_TINKERBELL_CP_NETWORK_CIDR: "tinkerbell_ci:cp_network_cidr"
     T_TINKERBELL_S3_INVENTORY_CSV_KEY: "tinkerbell_ci:s3_inventory_csv"
     T_TINKERBELL_S3_AG_INVENTORY_CSV_KEY: "tinkerbell_ci:s3_ag_inventory_csv"
-    BAREMETAL_BRANCH: "tinkerbell_ci:baremetal_branch"
     TEST_RUNNER_GOVC_USERNAME: "tinkerbell_ci:govc_username"
     TEST_RUNNER_GOVC_PASSWORD: "tinkerbell_ci:govc_password"
     TEST_RUNNER_GOVC_URL: "tinkerbell_ci:govc_url"
@@ -237,7 +236,6 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
@@ -58,7 +58,6 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -56,7 +56,6 @@ env:
     T_TINKERBELL_CP_NETWORK_CIDR: "tinkerbell_ci:cp_network_cidr"
     T_TINKERBELL_S3_INVENTORY_CSV_KEY: "tinkerbell_ci:s3_inventory_csv"
     T_TINKERBELL_S3_AG_INVENTORY_CSV_KEY: "tinkerbell_ci:s3_ag_inventory_csv"
-    BAREMETAL_BRANCH: "tinkerbell_ci:baremetal_branch"
     TEST_RUNNER_GOVC_USERNAME: "tinkerbell_ci:govc_username"
     TEST_RUNNER_GOVC_PASSWORD: "tinkerbell_ci:govc_password"
     TEST_RUNNER_GOVC_URL: "tinkerbell_ci:govc_url"
@@ -106,7 +105,6 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -126,7 +126,6 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
-        --baremetal-branch=${BAREMETAL_BRANCH}
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/cmd/run.go
+++ b/cmd/integration_test/cmd/run.go
@@ -25,7 +25,6 @@ const (
 	testReportFolderFlagName   = "test-report-folder"
 	branchNameFlagName         = "branch-name"
 	instanceConfigFlagName     = "instance-config"
-	baremetalBranchFlagName    = "baremetal-branch"
 )
 
 var runE2ECmd = &cobra.Command{
@@ -67,7 +66,6 @@ func init() {
 	runE2ECmd.Flags().Bool(cleanupResourcesFlagName, false, "Flag to indicate if test resources should be cleaned up automatically as tests complete")
 	runE2ECmd.Flags().String(testReportFolderFlagName, "", "Folder destination for JUnit tests reports")
 	runE2ECmd.Flags().String(branchNameFlagName, "main", "EKS-A origin branch from where the tests are being run")
-	runE2ECmd.Flags().String(baremetalBranchFlagName, "main", "Branch for baremetal tests to run on")
 
 	for _, flag := range requiredFlags {
 		if err := runE2ECmd.MarkFlagRequired(flag); err != nil {
@@ -88,7 +86,6 @@ func runE2E(ctx context.Context) error {
 	cleanupResources := viper.GetBool(cleanupResourcesFlagName)
 	testReportFolder := viper.GetString(testReportFolderFlagName)
 	branchName := viper.GetString(branchNameFlagName)
-	baremetalBranchName := viper.GetString(baremetalBranchFlagName)
 
 	runConf := e2e.ParallelRunConf{
 		MaxConcurrentTests:     maxConcurrentTests,
@@ -102,7 +99,6 @@ func runE2E(ctx context.Context) error {
 		TestReportFolder:       testReportFolder,
 		BranchName:             branchName,
 		TestInstanceConfigFile: instanceConfigFile,
-		BaremetalBranchName:    baremetalBranchName,
 		Logger:                 logger.Get(),
 	}
 

--- a/scripts/e2e_test_docker.sh
+++ b/scripts/e2e_test_docker.sh
@@ -100,7 +100,6 @@ $BIN_FOLDER/test e2e run \
     -r ${TEST_REGEX} \
     --bundles-override=${BUNDLES_OVERRIDE} \
     --test-report-folder=${TEST_REPORT_FOLDER} \
-    --baremetal-branch="" \
     -v4
 
 # Faking cross-platform versioned folders for dry-run


### PR DESCRIPTION
*Description of changes:*
This PR removes the `--baremetal-branch` flag from the integration test CLI as we no longer run tinkerbell tests simultaneously on multiple branches. This flag was introduced in [#3201](https://github.com/aws/eks-anywhere/pull/3201) more than two years ago to set the branch name for baremetal tests to run on. We now have additional mechanisms to prevent tests from being triggered from different branches at the same time so this flag doesn't add any value anymore. Since we started supporting n-1 EKS-A release branch too, we keep doing patch releases every 3 out of 4 weeks which requires us to run tests on release branches frequently. This change will reduce the headache of changing the secret value every time we do a patch release from main to release branch and then back to main. We also added periodic triggers for release pipelines to run tests on release branches every weekend at 7pm PST. But those pipelines don't have anything to handle changing the secret value before running the tests so this will also help in making sure that even tinkerbell tests run on the release branches every weekend. Overall, removing this flag adds a lot of value to our CI and release process.

*Testing (if applicable):*
```
make eks-a
make build-all-test-binaries
make lint
make unit-test
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

