### PR TITLE
Check image pushability based on image/tag count limits prior to push

### DIFF
--- a/release/cli/pkg/constants/constants.go
+++ b/release/cli/pkg/constants/constants.go
@@ -53,4 +53,7 @@ const (
 	//
 	// (January 2, 15:04:05, 2006, in time zone seven hours west of GMT).
 	YYYYMMDD = "2006-01-02"
+
+	MAX_IMAGES_PER_REPOSITORY = 10000
+	MAX_TAGS_PER_IMAGE        = 1000
 )

--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	ecrsdk "github.com/aws/aws-sdk-go/service/ecr"
 	ecrpublicsdk "github.com/aws/aws-sdk-go/service/ecrpublic"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
@@ -35,6 +36,7 @@ import (
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/ecr"
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/ecrpublic"
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/s3"
+	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
 	"github.com/aws/eks-anywhere/release/cli/pkg/filereader"
 	"github.com/aws/eks-anywhere/release/cli/pkg/retrier"
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
@@ -384,4 +386,33 @@ func ComputeImageDigestFromManifest(ecrPublicClient *ecrpublicsdk.ECRPublic, reg
 	digest := h.Sum(nil)
 
 	return fmt.Sprintf("%x", digest), nil
+}
+
+func CheckRepositoryImagesAndTagsCountLimit(sourceImageUri, releaseImageUri, sourceContainerRegistry, releaseContainerRegistry string, ecrClient *ecrsdk.ECR, ecrPublicClient *ecrpublicsdk.ECRPublic) error {
+	repository, _ := artifactutils.SplitImageUri(releaseImageUri, releaseContainerRegistry)
+
+	fmt.Printf("Checking if image %s can be pushed to repository %s\n", releaseImageUri, repository)
+
+	sourceImageDigest, err := ecr.GetImageDigest(sourceImageUri, sourceContainerRegistry, ecrClient)
+	if err != nil {
+		return errors.Cause(err)
+	}
+
+	allImagesCount, err := ecrpublic.GetAllImagesCount(repository, ecrPublicClient)
+	if err != nil {
+		return errors.Cause(err)
+	}
+	if allImagesCount >= constants.MAX_IMAGES_PER_REPOSITORY {
+		return fmt.Errorf("cannot push image [%s] since the repository %s already has the maximum allowed number of images which is '%d'", releaseImageUri, repository, constants.MAX_IMAGES_PER_REPOSITORY)
+	}
+
+	tagsForImageCount, err := ecrpublic.GetTagsCountForImage(repository, sourceImageDigest, ecrPublicClient)
+	if err != nil {
+		return errors.Cause(err)
+	}
+	if tagsForImageCount >= constants.MAX_TAGS_PER_IMAGE {
+		return fmt.Errorf("cannot push image [%s] since the image with digest [%s] in repository %s already has the maximum allowed number of tags per image which is '%d'", releaseImageUri, sourceImageDigest, repository, constants.MAX_TAGS_PER_IMAGE)
+	}
+
+	return nil
 }

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -162,12 +162,24 @@ func handleImageUpload(_ context.Context, r *releasetypes.ReleaseConfig, package
 		sourceImageUri := artifact.Image.SourceImageURI
 		releaseImageUri := artifact.Image.ReleaseImageURI
 		sourceEcrAuthConfig := defaultSourceEcrAuthConfig
+		sourceContainerRegistry := r.SourceContainerRegistry
+		sourceEcrClient := r.SourceClients.ECR.EcrClient
 		if packagesutils.NeedsPackagesAccountArtifacts(r) && (strings.Contains(sourceImageUri, "eks-anywhere-packages") || strings.Contains(sourceImageUri, "ecr-token-refresher") || strings.Contains(sourceImageUri, "credential-provider-package")) {
 			sourceEcrAuthConfig = packagesSourceEcrAuthConfig
+			sourceContainerRegistry = r.PackagesSourceContainerRegistry
+			sourceEcrClient = r.SourceClients.Packages.EcrClient
 		}
+		releaseContainerRegistry := r.ReleaseContainerRegistry
+		releaseEcrPublicClient := r.ReleaseClients.ECRPublic.Client
 		fmt.Printf("Source Image - %s\n", sourceImageUri)
 		fmt.Printf("Destination Image - %s\n", releaseImageUri)
-		err := images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri)
+
+		err := images.CheckRepositoryImagesAndTagsCountLimit(sourceImageUri, releaseImageUri, sourceContainerRegistry, releaseContainerRegistry, sourceEcrClient, releaseEcrPublicClient)
+		if err != nil {
+			return fmt.Errorf("checking pushability of image [%s] based on destination repository images or tags limits: %v", releaseImageUri, err)
+		}
+
+		err = images.CopyToDestination(sourceEcrAuthConfig, releaseEcrAuthConfig, sourceImageUri, releaseImageUri)
 		if err != nil {
 			return fmt.Errorf("copying image from source [%s] to destination [%s]: %v", sourceImageUri, releaseImageUri, err)
 		}


### PR DESCRIPTION
We have noticed that the image copy through Skopeo errors out when the destination repo has already hit the 10000 images mark or the 1000 tags per image mark, since these are the default limits set by ECR Public. In these cases, we should fail fast instead of retrying the image copy.
This PR adds logic to perform the check for images-per-repo and tags-per-repo on the destination ECR and fail early.

I tested this by building a small program with the actual ECR public bits (with credentials provided by my local AWS config file) and the checker method that returns the error. I created a repository and pushed 10000 images to it and tested the code against it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

