### PR TITLE
Skip validating the pbc registry for non-regional curated packages flow

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1174,6 +1175,10 @@ func (e *ClusterE2ETest) InstallCuratedPackageFile(packageFile, kubeconfig strin
 
 // ValidatePackageBundleControllerRegistry checks if the registries for helm charts and images match for curated packages tests.
 func (e *ClusterE2ETest) ValidatePackageBundleControllerRegistry() {
+	nonRegionalPackagesRegex := `^.*NonRegionalCuratedPackages.*$`
+	if regexp.MustCompile(nonRegionalPackagesRegex).MatchString(e.T.Name()) {
+		return
+	}
 	pbc, err := e.KubectlClient.GetPackageBundleController(context.Background(), e.KubeconfigFilePath(), e.ClusterName)
 	if err != nil {
 		e.T.Fatalf("cannot get PackageBundleController: %v", err)


### PR DESCRIPTION
*Description of changes:*
This PR skips validating the pbc registry for non-regional curated packages flow as a follow-up to [#8910](https://github.com/aws/eks-anywhere/pull/8910).

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
make build-all-test-binaries
make generate
make generate-manifests
make release-manifests
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

