### PR TITLE
Get rid of FIQL in Nutanix API list methods

### DIFF
--- a/internal/pkg/nutanix/prismclient.go
+++ b/internal/pkg/nutanix/prismclient.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
-	"github.com/nutanix-cloud-native/prism-go-client/utils"
 	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 
 	"github.com/aws/eks-anywhere/pkg/providers/nutanix"
@@ -44,30 +43,39 @@ func NewPrismClient(endpoint, port string, insecure bool) (PrismClient, error) {
 
 // GetImageUUIDFromName retrieves the image uuid from the given image name.
 func (c *client) GetImageUUIDFromName(ctx context.Context, imageName string) (*string, error) {
-	res, err := c.V3.ListImage(ctx, &v3.DSMetadata{
-		Filter: utils.StringPtr(fmt.Sprintf("name==%s", imageName)),
-	})
-	if err != nil || len(res.Entities) == 0 {
+	res, err := c.V3.ListAllImage(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list images: %v", err)
+	}
+
+	images := make([]*v3.ImageIntentResponse, 0)
+
+	for _, image := range res.Entities {
+		if image.Spec.Name != nil && *image.Spec.Name == imageName {
+			images = append(images, image)
+		}
+	}
+
+	if len(images) == 0 {
 		return nil, fmt.Errorf("failed to find image by name %q: %v", imageName, err)
 	}
 
-	if len(res.Entities) > 1 {
-		return nil, fmt.Errorf("found more than one (%v) image with name %q", len(res.Entities), imageName)
+	if len(images) > 1 {
+		return nil, fmt.Errorf("found more than one (%v) image with name %q", len(images), imageName)
 	}
 
-	return res.Entities[0].Metadata.UUID, nil
+	return images[0].Metadata.UUID, nil
 }
 
 // GetClusterUUIDFromName retrieves the cluster uuid from the given cluster name.
 //
 //nolint:gocyclo
 func (c *client) GetClusterUUIDFromName(ctx context.Context, clusterName string) (*string, error) {
-	res, err := c.V3.ListCluster(ctx, &v3.DSMetadata{
-		Filter: utils.StringPtr(fmt.Sprintf("name==%s", clusterName)),
-	})
+	res, err := c.V3.ListAllCluster(ctx, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to find cluster by name %q: %v", clusterName, err)
+		return nil, fmt.Errorf("failed to list clusters: %v", err)
 	}
+
 	entities := make([]*v3.ClusterIntentResponse, 0)
 	for _, entity := range res.Entities {
 		if entity.Status != nil && entity.Status.Resources != nil && entity.Status.Resources.Config != nil {
@@ -97,16 +105,26 @@ func (c *client) GetClusterUUIDFromName(ctx context.Context, clusterName string)
 
 // GetSubnetUUIDFromName retrieves the subnet uuid from the given subnet name.
 func (c *client) GetSubnetUUIDFromName(ctx context.Context, subnetName string) (*string, error) {
-	res, err := c.V3.ListSubnet(ctx, &v3.DSMetadata{
-		Filter: utils.StringPtr(fmt.Sprintf("name==%s", subnetName)),
-	})
-	if err != nil || len(res.Entities) == 0 {
+	res, err := c.V3.ListAllSubnet(ctx, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list subnets: %v", err)
+	}
+
+	subnets := make([]*v3.SubnetIntentResponse, 0)
+
+	for _, subnet := range res.Entities {
+		if subnet.Spec.Name != nil && *subnet.Spec.Name == subnetName {
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	if len(subnets) == 0 {
 		return nil, fmt.Errorf("failed to find subnet by name %q: %v", subnetName, err)
 	}
 
-	if len(res.Entities) > 1 {
-		return nil, fmt.Errorf("found more than one (%v) subnet with name %q", len(res.Entities), subnetName)
+	if len(subnets) > 1 {
+		return nil, fmt.Errorf("found more than one (%v) subnet with name %q", len(subnets), subnetName)
 	}
 
-	return res.Entities[0].Metadata.UUID, nil
+	return subnets[0].Metadata.UUID, nil
 }

--- a/pkg/providers/nutanix/client.go
+++ b/pkg/providers/nutanix/client.go
@@ -3,19 +3,20 @@ package nutanix
 import (
 	"context"
 
+	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 )
 
 type Client interface {
 	GetSubnet(ctx context.Context, uuid string) (*v3.SubnetIntentResponse, error)
 	ListAllHost(ctx context.Context) (*v3.HostListResponse, error)
-	ListSubnet(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.SubnetListIntentResponse, error)
+	ListAllSubnet(ctx context.Context, filter string, clientSideFilters []*prismgoclient.AdditionalFilter) (*v3.SubnetListIntentResponse, error)
 	GetImage(ctx context.Context, uuid string) (*v3.ImageIntentResponse, error)
-	ListImage(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ImageListIntentResponse, error)
+	ListAllImage(ctx context.Context, filter string) (*v3.ImageListIntentResponse, error)
 	GetCluster(ctx context.Context, uuid string) (*v3.ClusterIntentResponse, error)
-	ListCluster(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ClusterListIntentResponse, error)
+	ListAllCluster(ctx context.Context, filter string) (*v3.ClusterListIntentResponse, error)
 	GetProject(ctx context.Context, uuid string) (*v3.Project, error)
-	ListProject(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ProjectListResponse, error)
+	ListAllProject(ctx context.Context, filter string) (*v3.ProjectListResponse, error)
 	GetCurrentLoggedInUser(ctx context.Context) (*v3.UserIntentResponse, error)
 	ListCategories(ctx context.Context, getEntitiesRequest *v3.CategoryListMetadata) (*v3.CategoryKeyListResponse, error)
 	GetCategoryKey(ctx context.Context, name string) (*v3.CategoryKeyStatus, error)

--- a/pkg/providers/nutanix/mocks/client.go
+++ b/pkg/providers/nutanix/mocks/client.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 )
 
@@ -155,6 +156,21 @@ func (mr *MockClientMockRecorder) GetSubnet(ctx, uuid interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockClient)(nil).GetSubnet), ctx, uuid)
 }
 
+// ListAllCluster mocks base method.
+func (m *MockClient) ListAllCluster(ctx context.Context, filter string) (*v3.ClusterListIntentResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllCluster", ctx, filter)
+	ret0, _ := ret[0].(*v3.ClusterListIntentResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllCluster indicates an expected call of ListAllCluster.
+func (mr *MockClientMockRecorder) ListAllCluster(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllCluster", reflect.TypeOf((*MockClient)(nil).ListAllCluster), ctx, filter)
+}
+
 // ListAllHost mocks base method.
 func (m *MockClient) ListAllHost(ctx context.Context) (*v3.HostListResponse, error) {
 	m.ctrl.T.Helper()
@@ -168,6 +184,51 @@ func (m *MockClient) ListAllHost(ctx context.Context) (*v3.HostListResponse, err
 func (mr *MockClientMockRecorder) ListAllHost(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllHost", reflect.TypeOf((*MockClient)(nil).ListAllHost), ctx)
+}
+
+// ListAllImage mocks base method.
+func (m *MockClient) ListAllImage(ctx context.Context, filter string) (*v3.ImageListIntentResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllImage", ctx, filter)
+	ret0, _ := ret[0].(*v3.ImageListIntentResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllImage indicates an expected call of ListAllImage.
+func (mr *MockClientMockRecorder) ListAllImage(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllImage", reflect.TypeOf((*MockClient)(nil).ListAllImage), ctx, filter)
+}
+
+// ListAllProject mocks base method.
+func (m *MockClient) ListAllProject(ctx context.Context, filter string) (*v3.ProjectListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllProject", ctx, filter)
+	ret0, _ := ret[0].(*v3.ProjectListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllProject indicates an expected call of ListAllProject.
+func (mr *MockClientMockRecorder) ListAllProject(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllProject", reflect.TypeOf((*MockClient)(nil).ListAllProject), ctx, filter)
+}
+
+// ListAllSubnet mocks base method.
+func (m *MockClient) ListAllSubnet(ctx context.Context, filter string, clientSideFilters []*prismgoclient.AdditionalFilter) (*v3.SubnetListIntentResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllSubnet", ctx, filter, clientSideFilters)
+	ret0, _ := ret[0].(*v3.SubnetListIntentResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllSubnet indicates an expected call of ListAllSubnet.
+func (mr *MockClientMockRecorder) ListAllSubnet(ctx, filter, clientSideFilters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllSubnet", reflect.TypeOf((*MockClient)(nil).ListAllSubnet), ctx, filter, clientSideFilters)
 }
 
 // ListCategories mocks base method.
@@ -198,64 +259,4 @@ func (m *MockClient) ListCategoryValues(ctx context.Context, name string, getEnt
 func (mr *MockClientMockRecorder) ListCategoryValues(ctx, name, getEntitiesRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCategoryValues", reflect.TypeOf((*MockClient)(nil).ListCategoryValues), ctx, name, getEntitiesRequest)
-}
-
-// ListCluster mocks base method.
-func (m *MockClient) ListCluster(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ClusterListIntentResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCluster", ctx, getEntitiesRequest)
-	ret0, _ := ret[0].(*v3.ClusterListIntentResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCluster indicates an expected call of ListCluster.
-func (mr *MockClientMockRecorder) ListCluster(ctx, getEntitiesRequest interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCluster", reflect.TypeOf((*MockClient)(nil).ListCluster), ctx, getEntitiesRequest)
-}
-
-// ListImage mocks base method.
-func (m *MockClient) ListImage(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ImageListIntentResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListImage", ctx, getEntitiesRequest)
-	ret0, _ := ret[0].(*v3.ImageListIntentResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListImage indicates an expected call of ListImage.
-func (mr *MockClientMockRecorder) ListImage(ctx, getEntitiesRequest interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImage", reflect.TypeOf((*MockClient)(nil).ListImage), ctx, getEntitiesRequest)
-}
-
-// ListProject mocks base method.
-func (m *MockClient) ListProject(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.ProjectListResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListProject", ctx, getEntitiesRequest)
-	ret0, _ := ret[0].(*v3.ProjectListResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListProject indicates an expected call of ListProject.
-func (mr *MockClientMockRecorder) ListProject(ctx, getEntitiesRequest interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProject", reflect.TypeOf((*MockClient)(nil).ListProject), ctx, getEntitiesRequest)
-}
-
-// ListSubnet mocks base method.
-func (m *MockClient) ListSubnet(ctx context.Context, getEntitiesRequest *v3.DSMetadata) (*v3.SubnetListIntentResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSubnet", ctx, getEntitiesRequest)
-	ret0, _ := ret[0].(*v3.SubnetListIntentResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSubnet indicates an expected call of ListSubnet.
-func (mr *MockClientMockRecorder) ListSubnet(ctx, getEntitiesRequest interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubnet", reflect.TypeOf((*MockClient)(nil).ListSubnet), ctx, getEntitiesRequest)
 }

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -391,7 +391,7 @@ func TestNutanixProviderSetupAndValidateCreate(t *testing.T) {
 			},
 		},
 	}
-	mockClient.EXPECT().ListCluster(gomock.Any(), gomock.Any()).Return(clusters, nil).AnyTimes()
+	mockClient.EXPECT().ListAllCluster(gomock.Any(), gomock.Any()).Return(clusters, nil).AnyTimes()
 	subnets := &v3.SubnetListIntentResponse{
 		Entities: []*v3.SubnetIntentResponse{
 			{
@@ -400,11 +400,16 @@ func TestNutanixProviderSetupAndValidateCreate(t *testing.T) {
 				},
 				Spec: &v3.Subnet{
 					Name: utils.StringPtr("prism-subnet"),
+					ClusterReference: &v3.Reference{
+						Kind: utils.StringPtr("cluster"),
+						UUID: utils.StringPtr("a15f6966-bfc7-4d1e-8575-224096fc1cda"),
+						Name: utils.StringPtr("prism-cluster"),
+					},
 				},
 			},
 		},
 	}
-	mockClient.EXPECT().ListSubnet(gomock.Any(), gomock.Any()).Return(subnets, nil).AnyTimes()
+	mockClient.EXPECT().ListAllSubnet(gomock.Any(), gomock.Any(), nil).Return(subnets, nil).AnyTimes()
 	images := &v3.ImageListIntentResponse{
 		Entities: []*v3.ImageIntentResponse{
 			{
@@ -415,9 +420,17 @@ func TestNutanixProviderSetupAndValidateCreate(t *testing.T) {
 					Name: utils.StringPtr("prism-image"),
 				},
 			},
+			{
+				Metadata: &v3.Metadata{
+					UUID: utils.StringPtr("a15f6966-bfc7-4d1e-8575-224096fc1cdd"),
+				},
+				Spec: &v3.Image{
+					Name: utils.StringPtr("prism-image-1-19"),
+				},
+			},
 		},
 	}
-	mockClient.EXPECT().ListImage(gomock.Any(), gomock.Any()).Return(images, nil).AnyTimes()
+	mockClient.EXPECT().ListAllImage(gomock.Any(), gomock.Any()).Return(images, nil).AnyTimes()
 	mockClient.EXPECT().ListAllHost(gomock.Any()).Return(fakeHostList(), nil).AnyTimes()
 	mockCertValidator := mockCrypto.NewMockTlsValidator(ctrl)
 	mockCertValidator.EXPECT().ValidateCert(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)


### PR DESCRIPTION
*Description of changes:*
FIQL is deprecated and contains well-known bugs. This patch get rid of FIQL for all list requests to Nutanix PC API.
 
*Testing (if applicable):*
```
$ eksctl anywhere create cluster -f ./cluster-eksa-ntnx-fiql-fix.yaml -v10 --bundles-override ./bin/local-bundle-release.yaml
2024-11-12T17:44:10.824Z	V6	Executing command	{"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2024-11-12T17:44:10.844Z	V6	Executing command	{"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2024-11-12T17:44:10.887Z	V4	Reading bundles manifest	{"url": "./bin/local-bundle-release.yaml"}
2024-11-12T17:44:10.907Z	V4	Using CAPI provider versions	{"Core Cluster API": "v1.8.5+177bb52", "Kubeadm Bootstrap": "v1.8.5+206a28e", "Kubeadm Control Plane": "v1.8.5+68b2668", "External etcd Bootstrap": "v1.0.15+27fba9a", "External etcd Controller": "v1.0.24+048255b", "Cluster API Provider Nutanix": "v1.4.0+9156958"}
2024-11-12T17:44:11.038Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-11-12T17:44:11.038Z	V2	Pulling docker image	{"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.21.0-eks-a-v0.22.0-dev-build.32"}
2024-11-12T17:44:11.038Z	V6	Executing command	{"cmd": "/usr/bin/docker pull public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.21.0-eks-a-v0.22.0-dev-build.32"}
2024-11-12T17:44:11.673Z	V5	Retry execution successful	{"retries": 1, "duration": "635.188522ms"}
2024-11-12T17:44:11.673Z	V3	Initializing long running container	{"name": "eksa_1731433451038317442", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.21.0-eks-a-v0.22.0-dev-build.32"}
2024-11-12T17:44:11.673Z	V6	Executing command	{"cmd": "/usr/bin/docker run -d --name eksa_1731433451038317442 --network host -w /home/ubuntu/eksa-tests/fiql-fix -v /var/run/docker.sock:/var/run/docker.sock -v /home/ubuntu/eksa-tests/fiql-fix:/home/ubuntu/eksa-tests/fiql-fix -v /home/ubuntu/eksa-tests/fiql-fix:/home/ubuntu/eksa-tests/fiql-fix --entrypoint sleep public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.21.0-eks-a-v0.22.0-dev-build.32 infinity"}
2024-11-12T17:44:11.846Z	V1	Using the eksa controller to create the management cluster
2024-11-12T17:44:11.846Z	V4	Task start	{"task_name": "setup-validate"}
2024-11-12T17:44:11.846Z	V0	Performing setup and validations
2024-11-12T17:44:11.846Z	V0	ValidateClusterSpec for Nutanix datacenter	{"NutanixDatacenter": "eksa-ntnx-fiql-fix"}
2024-11-12T17:46:38.021Z	V0	✅ Nutanix Provider setup is valid
2024-11-12T17:46:38.021Z	V0	✅ Validate OS is compatible with registry mirror configuration
2024-11-12T17:46:38.021Z	V0	✅ Validate certificate for registry mirror
2024-11-12T17:46:38.021Z	V0	✅ Validate authentication for git provider
2024-11-12T17:46:38.021Z	V0	✅ Validate cluster's eksaVersion matches EKS-A version
2024-11-12T17:46:38.021Z	V4	Task finished	{"task_name": "setup-validate", "duration": "2m26.175237869s"}
2024-11-12T17:46:38.021Z	V4	----------------------------------
2024-11-12T17:46:38.021Z	V4	Task start	{"task_name": "bootstrap-cluster-init"}
2024-11-12T17:46:38.021Z	V0	Creating new bootstrap cluster
2024-11-12T17:46:38.022Z	V4	Creating kind cluster	{"name": "eksa-ntnx-fiql-fix-eks-a-cluster", "kubeconfig": "eksa-ntnx-fiql-fix/generated/eksa-ntnx-fiql-fix.kind.kubeconfig"}
2024-11-12T17:46:38.022Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1731433451038317442 kind create cluster --name eksa-ntnx-fiql-fix-eks-a-cluster --kubeconfig eksa-ntnx-fiql-fix/generated/eksa-ntnx-fiql-fix.kind.kubeconfig --image public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node:v1.30.5-eks-d-1-30-17-eks-a-v0.22.0-dev-build.32 --config eksa-ntnx-fiql-fix/generated/kind_tmp.yaml"}
2024-11-12T17:46:52.492Z	V5	Retrier:	{"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2024-11-12T17:46:52.492Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1731433451038317442 kubectl get namespace eksa-system --kubeconfig eksa-ntnx-fiql-fix/generated/eksa-ntnx-fiql-fix.kind.kubeconfig"}
2024-11-12T17:46:52.648Z	V9	docker	{"stderr": "Error from server (NotFound): namespaces \"eksa-system\" not found\n"}
2024-11-12T17:46:52.648Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1731433451038317442 kubectl create namespace eksa-system --kubeconfig eksa-ntnx-fiql-fix/generated/eksa-ntnx-fiql-fix.kind.kubeconfig"}
2024-11-12T17:46:52.788Z	V5	Retry execution successful	{"retries": 1, "duration": "296.079829ms"}
2024-11-12T17:46:52.788Z	V4	Task finished	{"task_name": "bootstrap-cluster-init", "duration": "14.766237292s"}
2024-11-12T17:46:52.788Z	V4	----------------------------------
2024-11-12T17:46:52.788Z	V4	Task start	{"task_name": "update-secrets-create"}
2024-11-12T17:46:52.788Z	V4	Task finished	{"task_name": "update-secrets-create", "duration": "1.896µs"}
2024-11-12T17:46:52.788Z	V4	----------------------------------
...
2024-11-12T18:00:05.056Z	V4	Deleting kind cluster	{"name": "eksa-ntnx-fiql-fix-eks-a-cluster"}
2024-11-12T18:00:05.056Z	V6	Executing command	{"cmd": "/usr/bin/docker exec -i eksa_1731433451038317442 kind delete cluster --name eksa-ntnx-fiql-fix-eks-a-cluster"}
2024-11-12T18:00:06.280Z	V5	Retry execution successful	{"retries": 1, "duration": "1.224249457s"}
2024-11-12T18:00:06.280Z	V0	🎉 Cluster created!
2024-11-12T18:00:06.280Z	V4	Task finished	{"task_name": "delete-kind-cluster", "duration": "1.620903207s"}
2024-11-12T18:00:06.280Z	V4	----------------------------------
2024-11-12T18:00:06.280Z	V4	Task start	{"task_name": "install-curated-packages"}
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
...
```
*Documentation added/planned (if applicable):*
Not required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
