### PR TITLE
Use ECR Public source client for image checks in prod bundle release

### DIFF
--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -163,7 +163,12 @@ func handleImageUpload(_ context.Context, r *releasetypes.ReleaseConfig, package
 		releaseImageUri := artifact.Image.ReleaseImageURI
 		sourceEcrAuthConfig := defaultSourceEcrAuthConfig
 		sourceContainerRegistry := r.SourceContainerRegistry
-		sourceEcrClient := r.SourceClients.ECR.EcrClient
+		var sourceEcrClient interface{}
+		if r.ReleaseEnvironment == "production" && r.BundleRelease {
+			sourceEcrClient = r.SourceClients.ECR.EcrPublicClient
+		} else {
+			sourceEcrClient = r.SourceClients.ECR.EcrClient
+		}
 		if packagesutils.NeedsPackagesAccountArtifacts(r) && (strings.Contains(sourceImageUri, "eks-anywhere-packages") || strings.Contains(sourceImageUri, "ecr-token-refresher") || strings.Contains(sourceImageUri, "credential-provider-package")) {
 			sourceEcrAuthConfig = packagesSourceEcrAuthConfig
 			sourceContainerRegistry = r.PackagesSourceContainerRegistry


### PR DESCRIPTION
This PR fixes the image count verification for the prod bundle release by using the ECR Public source client instead of the ECR source client, which would be `nil` for prod bundle releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

