### PR TITLE
Get a random subnet id from a list of subnet ids

### DIFF
--- a/internal/pkg/ec2/create.go
+++ b/internal/pkg/ec2/create.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -61,7 +62,7 @@ func CreateInstance(session *session.Session, amiId, key, tag, instanceProfileNa
 			IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
 				Name: aws.String(instanceProfileName),
 			},
-			SubnetId: aws.String(subnetId),
+			SubnetId: aws.String(getRandomSubnetID(subnetId)),
 			TagSpecifications: []*ec2.TagSpecification{
 				{
 					ResourceType: aws.String("instance"),
@@ -110,4 +111,9 @@ func isThrottleError(err error) bool {
 	}
 
 	return false
+}
+
+func getRandomSubnetID(subnetIDsStr string) string {
+	subnetIDs := strings.Split(subnetIDsStr, ",")
+	return subnetIDs[rand.Intn(len(subnetIDs))]
 }


### PR DESCRIPTION
*Description of changes:*

Our e2e tests are failing with the below error,
```
InsufficientInstanceCapacity: We currently do not have sufficient t3.2xlarge capacity in the Availability Zone you requested (***a). Our system will be working on provisioning additional capacity. You can currently get t3.2xlarge capacity by not specifying an Availability Zone in your request or choosing ***b, ***c, ***d.
```
Getting a random subnet id from the string containing multiple subnet ids to fix the above issue.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

