### PR TITLE
Retry for transient 'server doesn't have a Resource type errors' after clusterctl move

### DIFF
--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -61,6 +61,7 @@ const (
 var (
 	clusterctlNetworkErrorRegex              = regexp.MustCompile(`.*failed to connect to the management cluster:.*`)
 	clusterctlMoveProvisionedInfraErrorRegex = regexp.MustCompile(`.*failed to check for provisioned infrastructure*`)
+	kubectlResourceNotFoundRegex             = regexp.MustCompile(`.*the server doesn't have a resource type "(.*)".*`)
 	eksaClusterResourceType                  = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 )
 
@@ -211,7 +212,7 @@ func WithNoTimeouts() ClusterManagerOpt {
 func clusterctlMoveWaitForInfrastructureRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
 	// Retry both network and cluster move errors.
 	if match := (clusterctlNetworkErrorRegex.MatchString(err.Error()) || clusterctlMoveProvisionedInfraErrorRegex.MatchString(err.Error())); match {
-		return true, clusterctlMoveRetryWaitTime(totalRetries)
+		return true, exponentialRetryWaitTime(totalRetries)
 	}
 	return false, 0
 }
@@ -219,12 +220,24 @@ func clusterctlMoveWaitForInfrastructureRetryPolicy(totalRetries int, err error)
 func clusterctlMoveRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
 	// Retry only network errors.
 	if match := clusterctlNetworkErrorRegex.MatchString(err.Error()); match {
-		return true, clusterctlMoveRetryWaitTime(totalRetries)
+		return true, exponentialRetryWaitTime(totalRetries)
 	}
 	return false, 0
 }
 
-func clusterctlMoveRetryWaitTime(totalRetries int) time.Duration {
+func kubectlWaitRetryPolicy(totalRetries int, err error) (retry bool, wait time.Duration) {
+	// Sometimes it is possible that the clusterctl move is successful,
+	// but the clusters.cluster.x-k8s.io resource is not available on the cluster yet.
+	//
+	// Retry on transient 'server doesn't have a resource type' errors.
+	// Use existing exponential backoff implementation for retry on these errors.
+	if match := kubectlResourceNotFoundRegex.MatchString(err.Error()); match {
+		return true, exponentialRetryWaitTime(totalRetries)
+	}
+	return false, 0
+}
+
+func exponentialRetryWaitTime(totalRetries int) time.Duration {
 	// Exponential backoff on errors.  Retrier built-in backoff is linear, so implementing here.
 
 	// Retrier first calls the policy before retry #1.  We want it zero-based for exponentiation.
@@ -297,7 +310,10 @@ func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, 
 	}
 
 	logger.V(3).Info("Waiting for workload cluster control plane to be ready after move")
-	err = c.clusterClient.WaitForControlPlaneReady(ctx, to, c.controlPlaneWaitAfterMoveTimeout.String(), clusterName)
+	r = retrier.New(c.clusterctlMoveTimeout, retrier.WithRetryPolicy(kubectlWaitRetryPolicy))
+	err = r.Retry(func() error {
+		return c.clusterClient.WaitForControlPlaneReady(ctx, to, c.controlPlaneWaitAfterMoveTimeout.String(), clusterName)
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*
Sometimes the `clusterctl move` returns successfully, but the actual resource type isn't available in the management cluster until after sometime. During this edge condition, if we run the `kubectl wait` command on the management it throws the following error: 
`executing wait: error: the server doesn't have a resource type \"clusters\"\n",`

*Description of changes:*
If the `clusterctl move` is successful and we still see this error, treat this as a transient error and add retries to make the cluster creation process more resilient. This should not affect the existing flow as the retries would only kick in if the kubectl wait errors out. 

