### PR TITLE
Add instructions for embedded images:

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
+++ b/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
@@ -54,7 +54,7 @@ The result of this step will be a modified kernel configuration file (`./kernel/
     ./build.sh kernel hook-latest-lts-amd64
     ```
 
-1. Add the embedded Action images. This creates the file, `images.txt`, in the `images/hook-embedded` directory and runs the script, `images/hook-embedded/pull-images.sh`, to pull and embedded the images in the HookOS initramfs.
+1. Add the embedded Action images. This creates the file, `images.txt`, in the `images/hook-embedded` directory and runs the script, `images/hook-embedded/pull-images.sh`, to pull and embed the images in the HookOS initramfs.
 The result of this step will be a populated images file: `images/hook-embedded/images.txt` and a Docker directory cache of images: `images/hook-embedded/images/`.
 
     ```bash

--- a/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
+++ b/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
@@ -41,7 +41,8 @@ Be sure to install all the following dependencies.
     cd hook/
     ```
 
-1. Run the Linux kernel [menuconfig](https://en.wikipedia.org/wiki/Menuconfig) TUI and configuring the kernel as needed. Be sure to save the config before exiting. The result of this step will be a modified kernel configuration file (`./kernel/configs/generic-6.6.y-x86_64`).
+1. Run the Linux kernel [menuconfig](https://en.wikipedia.org/wiki/Menuconfig) TUI and configuring the kernel as needed. Be sure to save the config before exiting.
+The result of this step will be a modified kernel configuration file (`./kernel/configs/generic-6.6.y-x86_64`).
 
     ```bash
     ./build.sh kernel-config hook-latest-lts-amd64
@@ -53,10 +54,32 @@ Be sure to install all the following dependencies.
     ./build.sh kernel hook-latest-lts-amd64
     ```
 
-1. Build the HookOS kernel and initramfs artifacts. The result of this step will be the kernel and initramfs. These files are located at `./out/hook/vmlinuz-latest-lts-x86_64` and `./out/hook/initramfs-latest-lts-x86_64` respectively.
+1. Add the embedded Action images. This creates the file, `images.txt`, in the `images/hook-embedded` directory and runs the script, `images/hook-embedded/pull-images.sh`, to pull and embedded the images in the HookOS initramfs.
+The result of this step will be a populated images file: `images/hook-embedded/images.txt` and a Docker directory cache of images: `images/hook-embedded/images/`.
 
     ```bash
-    ./build.sh linuxkit hook-latest-lts-amd64 
+    BUNDLE_URL=$(eksctl anywhere version | grep "https://anywhere-assets.eks.amazonaws.com/releases/bundles" | tr -d ' ' | cut -d":" -f2,3)
+    IMAGES=$(curl -s $BUNDLE_URL | grep "public.ecr.aws/eks-anywhere/tinkerbell/hub/\|public.ecr.aws/eks-anywhere/tinkerbell/tink/tink-worker" | sort | uniq | tr -d ' ' | cut -d":" -f2,3)
+    images_file="images/hook-embedded/images.txt"
+    rm "$images_file"
+    while read -r image; do
+      action_name=$(basename "$image" | cut -d":" -f1)
+      echo "$image 127.0.0.1/embedded/$action_name" >> "$images_file"
+    done <<< "$IMAGES"
+    (cd images/hook-embedded; ./pull-images.sh)
+    ```
+
+1. Build the HookOS kernel and initramfs artifacts. The `sudo` command is needed as the image embedding step uses Docker-in-Docker (DinD) which changes file ownerships to the root user.
+The result of this step will be the kernel and initramfs. These files are located at `./out/hook/vmlinuz-latest-lts-x86_64` and `./out/hook/initramfs-latest-lts-x86_64` respectively.
+
+    ```bash
+    sudo ./build.sh linuxkit hook-latest-lts-amd64
+    ```
+
+    **Note:** If you did not customize the kernel configuration, you can use the latest upstream built kernel by setting the `USE_LATEST_BUILT_KERNEL` to `yes`. Run this command instead of the previous one.
+
+    ```bash
+    sudo ./build.sh linuxkit hook-latest-lts-amd64 USE_LATEST_BUILT_KERNEL=yes
     ```
 
 1. Rename the kernel and initramfs files to `vmlinuz-x86_64` and `initramfs-x86_64` respectively.

--- a/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
+++ b/docs/content/en/docs/getting-started/baremetal/customize/bare-custom-hookos.md
@@ -41,7 +41,7 @@ Be sure to install all the following dependencies.
     cd hook/
     ```
 
-1. Run the Linux kernel [menuconfig](https://en.wikipedia.org/wiki/Menuconfig) TUI and configuring the kernel as needed. Be sure to save the config before exiting.
+1. Run the Linux kernel [menuconfig](https://en.wikipedia.org/wiki/Menuconfig) TUI and configure the kernel as needed. Save the config before you exit.
 The result of this step will be a modified kernel configuration file (`./kernel/configs/generic-6.6.y-x86_64`).
 
     ```bash


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For EKS Anywhere >= v0.21.0 embedded images are required when building HookOS.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

