### PR TITLE
Update smee flags for the latest version bump

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -236,7 +236,11 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 	flags := []string{
 		"-v", fmt.Sprintf("%s:/kubeconfig", kubeconfig),
 		"--network", "host",
-		"-e", fmt.Sprintf("PUBLIC_IP=%s", tinkServerIP),
+		"-e", fmt.Sprintf("SMEE_DHCP_SYSLOG_IP=%s", tinkServerIP),
+		"-e", fmt.Sprintf("SMEE_DHCP_IP_FOR_PACKET=%s", tinkServerIP),
+		"-e", fmt.Sprintf("SMEE_DHCP_TFTP_IP=%s", tinkServerIP),
+		"-e", fmt.Sprintf("SMEE_DHCP_HTTP_IPXE_BINARY_HOST=%s", tinkServerIP),
+		"-e", fmt.Sprintf("SMEE_DHCP_HTTP_IPXE_SCRIPT_HOST=%s", tinkServerIP),
 		"-e", fmt.Sprintf("PUBLIC_SYSLOG_IP=%s", tinkServerIP),
 		"-e", fmt.Sprintf("BOOTS_KUBE_NAMESPACE=%v", s.namespace),
 	}
@@ -542,8 +546,9 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 			},
 			"http": map[string]interface{}{
 				"tinkServer": map[string]interface{}{
-					"ip": tinkerbellIP,
-					port: grpcPort,
+					"ip":          tinkerbellIP,
+					port:          grpcPort,
+					"insecureTLS": true,
 				},
 				"osieUrl": map[string]interface{}{
 					"scheme": osiePath.Scheme,

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -236,6 +236,10 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 					"-e", gomock.Any(),
 					"-e", gomock.Any(),
 					"-e", gomock.Any(),
+					"-e", gomock.Any(),
+					"-e", gomock.Any(),
+					"-e", gomock.Any(),
+					"-e", gomock.Any(),
 				)
 			}
 

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -21,6 +21,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -19,6 +19,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -19,6 +19,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -18,6 +18,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -21,6 +21,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -21,6 +21,7 @@ smee:
     tinkServer:
       ip: 1.2.3.4
       port: "42113"
+      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   publicIP: 1.2.3.4
   tinkWorkerImage: 1.2.3.4:443/custom/eks-anywhere/tink-worker:latest


### PR DESCRIPTION
*Issue #, if available:*
Fix flags for smee version `v0.15.1` #4115.

*Description of changes:*
Number of flags have changed in smee due to the above version bump. This PR sets the necessary flags to the smee deployment.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

