### PR TITLE
Add bootOptions to cp/md tinkerbellmachine template, fix unit-tests

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -535,6 +535,8 @@ spec:
             matchLabels: {{ range $key, $value := .etcdHardwareSelector}}
               {{ $key }}: {{ $value}}
             {{- end }}
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
 {{.etcdTemplateOverride | indent 8}}
     {{- end }}

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -61,6 +61,8 @@ spec:
             matchLabels: {{ range $key, $value := .hardwareSelector}}
               {{ $key }}: {{ $value}}
             {{- end }}
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
 {{.workertemplateOverride | indent 8}}
     {{- end}}

--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -241,8 +241,7 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 		"-e", fmt.Sprintf("SMEE_DHCP_TFTP_IP=%s", tinkServerIP),
 		"-e", fmt.Sprintf("SMEE_DHCP_HTTP_IPXE_BINARY_HOST=%s", tinkServerIP),
 		"-e", fmt.Sprintf("SMEE_DHCP_HTTP_IPXE_SCRIPT_HOST=%s", tinkServerIP),
-		"-e", fmt.Sprintf("PUBLIC_SYSLOG_IP=%s", tinkServerIP),
-		"-e", fmt.Sprintf("BOOTS_KUBE_NAMESPACE=%v", s.namespace),
+		"-e", fmt.Sprintf("SMEE_BACKEND_KUBE_NAMESPACE=%v", s.namespace),
 	}
 
 	extraKernelArgList := s.getSmeeKernelArgs(bundle)

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -239,7 +239,6 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 					"-e", gomock.Any(),
 					"-e", gomock.Any(),
 					"-e", gomock.Any(),
-					"-e", gomock.Any(),
 				)
 			}
 

--- a/pkg/providers/tinkerbell/testdata/expected_kct.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kct.yaml
@@ -41,6 +41,8 @@ spec:
         required:
         - labelSelector:
             matchLabels: 
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_md.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_md.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_md.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_md.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_autoscaler_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_autoscaler_md.yaml
@@ -48,6 +48,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_taints.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""
@@ -217,6 +219,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
@@ -42,6 +42,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_md_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_md_template.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""
@@ -216,6 +218,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_md.yaml
@@ -46,6 +46,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: worker
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Latest release of CAPT, supports `bootOptions` in the `TinkerbellMachineSpec`. In EKS-A this translates to `tinkerbellMachineTemplate` having those fields configurable for Control-Plane and MachineDeployment. Default `bootMode` to `netboot` in this change. I will follow up with the conditional logic to toggle between netboot and isoboot in a different PR that'll introduce L3 provisioning changes to EKS-A. 
Also, update Smee flags as all smee flags start with `SMEE_` prefix and the previous  `BOOTS_KUBE_NAMESPACE` was invalid. Remove `PUBLIC_SYSLOG_IP ` as it is not a valid flag in the latest [version](https://github.com/tinkerbell/smee/blob/main/README.md).

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

