### PR TITLE
Add license token string to cluster spec

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -383,6 +383,8 @@ spec:
                 type: array
               kubernetesVersion:
                 type: string
+              licenseToken:
+                type: string
               machineHealthCheck:
                 description: MachineHealthCheck allows to configure timeouts for machine
                   health checks. Machine Health Checks are responsible for remediating

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4273,6 +4273,8 @@ spec:
                 type: array
               kubernetesVersion:
                 type: string
+              licenseToken:
+                type: string
               machineHealthCheck:
                 description: MachineHealthCheck allows to configure timeouts for machine
                   health checks. Machine Health Checks are responsible for remediating
@@ -5680,6 +5682,13 @@ spec:
                   bundle for users that configured their Prism Central with certificates
                   from non-publicly trusted CAs
                 type: string
+              ccmExcludeNodeIPs:
+                description: CcmExcludeIPs is the optional list of IP addresses that
+                  should be excluded from the CCM IP pool for nodes. List should be
+                  valid IP addresses and IP address ranges.
+                items:
+                  type: string
+                type: array
               credentialRef:
                 description: CredentialRef is the reference to the secret name that
                   contains the credentials for the Nutanix Prism Central. The namespace

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -87,6 +87,7 @@ type ClusterSpec struct {
 	EksaVersion        *EksaVersion        `json:"eksaVersion,omitempty"`
 	MachineHealthCheck *MachineHealthCheck `json:"machineHealthCheck,omitempty"`
 	EtcdEncryption     *[]EtcdEncryption   `json:"etcdEncryption,omitempty"`
+	LicenseToken       string              `json:"licenseToken,omitempty"`
 }
 
 // EksaVersion is the semver identifying the release of eks-a used to populate the cluster components.
@@ -183,6 +184,9 @@ func (n *Cluster) Equal(o *Cluster) bool {
 		return false
 	}
 	if !reflect.DeepEqual(n.Spec.EtcdEncryption, o.Spec.EtcdEncryption) {
+		return false
+	}
+	if n.Spec.LicenseToken != o.Spec.LicenseToken {
 		return false
 	}
 

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -1494,6 +1494,56 @@ func TestClusterEqualDifferentBundlesRef(t *testing.T) {
 	g.Expect(cluster1.Equal(cluster2)).To(BeFalse())
 }
 
+func TestClusterEqualLicenseToken(t *testing.T) {
+	testCases := []struct {
+		testName                                   string
+		cluster1LicenseToken, cluster2LicenseToken string
+		want                                       bool
+	}{
+		{
+			testName:             "both empty",
+			cluster1LicenseToken: "",
+			cluster2LicenseToken: "",
+			want:                 true,
+		},
+		{
+			testName:             "one empty, one exists",
+			cluster1LicenseToken: "",
+			cluster2LicenseToken: "test-token",
+			want:                 false,
+		},
+		{
+			testName:             "both exists, diff",
+			cluster1LicenseToken: "test-token1",
+			cluster2LicenseToken: "test-token2",
+			want:                 false,
+		},
+		{
+			testName:             "both exists, same",
+			cluster1LicenseToken: "test-token",
+			cluster2LicenseToken: "test-token",
+			want:                 true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			cluster1 := &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					LicenseToken: tt.cluster1LicenseToken,
+				},
+			}
+			cluster2 := &v1alpha1.Cluster{
+				Spec: v1alpha1.ClusterSpec{
+					LicenseToken: tt.cluster2LicenseToken,
+				},
+			}
+
+			g := NewWithT(t)
+			g.Expect(cluster1.Equal(cluster2)).To(Equal(tt.want))
+		})
+	}
+}
+
 func TestControlPlaneConfigurationEqual(t *testing.T) {
 	var emptyTaints []corev1.Taint
 	taint1 := corev1.Taint{Key: "key1"}


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR adds a new optional `licenseToken` string to the cluster spec for extended kubernetes version support.

*Testing (if applicable):*
```
make eks-a
make build-all-test-binaries
make lint
make unit-test
make generate
make generate-manifests
make release-manifests
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

