### PR TITLE
Add bootOptions to control plane tinkerbellmachinetemplate

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -560,6 +560,8 @@ spec:
             matchLabels: {{ range $key, $value := .hardwareSelector}}
               {{ $key }}: {{ $value}}
             {{- end }}
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
 {{.controlPlanetemplateOverride | indent 8}}
     {{- end }}

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
@@ -323,6 +323,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: node
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 0
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
@@ -323,6 +323,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: node
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 0
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
@@ -332,6 +332,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: node
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 0
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
@@ -403,6 +403,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -369,6 +369,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -349,6 +349,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
@@ -361,6 +361,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
@@ -347,6 +347,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -383,6 +383,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -383,6 +383,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
@@ -360,6 +360,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -316,6 +316,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
@@ -323,6 +323,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
@@ -318,6 +318,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
@@ -326,6 +326,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
@@ -318,6 +318,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
@@ -336,6 +336,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
@@ -326,6 +326,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
@@ -348,6 +348,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -350,6 +350,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -324,6 +324,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
@@ -323,6 +323,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
@@ -315,6 +315,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -316,6 +316,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
@@ -261,6 +261,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -316,6 +316,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
@@ -316,6 +316,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_pod_iam_config.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_pod_iam_config.yaml
@@ -361,6 +361,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -322,6 +322,8 @@ spec:
         - labelSelector:
             matchLabels: 
               type: cp
+      bootOptions:
+        bootMode: netboot
       templateOverride: |
         global_timeout: 6000
         id: ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
#9094 missed adding Bootoptions to the control plane TinkerbellMachineTemplate which is responsible for creating the necessary Tink workflows to boot the hardware. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

