### PR TITLE
Add end of standard support field to EKS-A bundle

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1384,6 +1384,8 @@ spec:
                       - components
                       - diagnosticCollector
                       type: object
+                    endOfStandardSupport:
+                      type: string
                     etcdadmBootstrap:
                       properties:
                         components:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -1553,6 +1553,8 @@ spec:
                       - components
                       - diagnosticCollector
                       type: object
+                    endOfStandardSupport:
+                      type: string
                     etcdadmBootstrap:
                       properties:
                         components:
@@ -3453,6 +3455,7 @@ spec:
                   - docker
                   - eksD
                   - eksa
+                  - endOfStandardSupport
                   - etcdadmBootstrap
                   - etcdadmController
                   - flux

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -61,6 +61,7 @@ func init() {
 
 type VersionsBundle struct {
 	KubeVersion                string                           `json:"kubeVersion"`
+	EndOfStandardSupport       string                           `json:"endOfStandardSupport,omitempty"`
 	EksD                       EksDRelease                      `json:"eksD"`
 	CertManager                CertManagerBundle                `json:"certManager"`
 	ClusterAPI                 CoreClusterAPI                   `json:"clusterAPI"`

--- a/release/cli/pkg/bundles/bundles.go
+++ b/release/cli/pkg/bundles/bundles.go
@@ -151,6 +151,7 @@ func GetVersionsBundles(r *releasetypes.ReleaseConfig, imageDigests releasetypes
 		number := strconv.Itoa(release.Number)
 		dev := release.Dev
 		kubeVersion := release.KubeVersion
+		endOfStandardSupport := release.EndOfStandardSupport
 		shortKubeVersion := strings.Join(strings.SplitN(kubeVersion[1:], ".", 3)[:2], ".")
 
 		if !slices.Contains(supportedK8sVersions, channel) {
@@ -205,6 +206,9 @@ func GetVersionsBundles(r *releasetypes.ReleaseConfig, imageDigests releasetypes
 			Snow:                       snowBundle,
 			Nutanix:                    nutanixBundle,
 			Upgrader:                   upgraderBundle,
+		}
+		if endOfStandardSupport != "" {
+			versionsBundle.EndOfStandardSupport = endOfStandardSupport
 		}
 		versionsBundles = append(versionsBundles, versionsBundle)
 	}

--- a/release/cli/pkg/filereader/file_reader.go
+++ b/release/cli/pkg/filereader/file_reader.go
@@ -37,10 +37,11 @@ import (
 )
 
 type EksDLatestRelease struct {
-	Branch      string `json:"branch"`
-	KubeVersion string `json:"kubeVersion"`
-	Number      int    `json:"number"`
-	Dev         bool   `json:"dev,omitempty"`
+	Branch               string `json:"branch"`
+	KubeVersion          string `json:"kubeVersion"`
+	Number               int    `json:"number"`
+	Dev                  bool   `json:"dev,omitempty"`
+	EndOfStandardSupport string `json:"endOfStandardSupport,omitempty"`
 }
 
 type EksDLatestReleases struct {

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -1143,6 +1143,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.21.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
+    endOfStandardSupport: "2024-12-31"
     etcdadmBootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.15/bootstrap-components.yaml
@@ -1958,6 +1959,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.21.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
+    endOfStandardSupport: "2025-04-30"
     etcdadmBootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.15/bootstrap-components.yaml
@@ -2773,6 +2775,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.21.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
+    endOfStandardSupport: "2025-08-31"
     etcdadmBootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.15/bootstrap-components.yaml
@@ -3588,6 +3591,7 @@ spec:
         os: linux
         uri: public.ecr.aws/release-container-registry/eks-anywhere-diagnostic-collector:v0.21.3-eks-a-v0.0.0-dev-build.1
       version: v0.0.0-dev+build.0+abcdef1
+    endOfStandardSupport: "2025-12-31"
     etcdadmBootstrap:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.15/bootstrap-components.yaml

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -1384,6 +1384,8 @@ spec:
                       - components
                       - diagnosticCollector
                       type: object
+                    endOfStandardSupport:
+                      type: string
                     etcdadmBootstrap:
                       properties:
                         components:


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR adds the new `endOfStandardSupport` date to the EKS-A bundle for extended kubernetes version support. This date is fetched from the [EKSD_LATEST_RELEASES](https://github.com/aws/eks-anywhere-build-tooling/blob/main/EKSD_LATEST_RELEASES) file which was updated in [#4174](https://github.com/aws/eks-anywhere-build-tooling/pull/4174).

**NOTE:** The [testdata](https://github.com/aws/eks-anywhere/blob/main/release/cli/pkg/operations/testdata/main-bundle-release.yaml) file is not updated yet in this PR as [#4174](https://github.com/aws/eks-anywhere-build-tooling/pull/4174) is not merged yet. Once that is merged, I will re-run the `make -C release update-bundle-golden-files` target to update the testdata file with the field.

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
make generate
make generate-manifests
make release-manifests
make -C release build
make -C release manifests
make -C release update-bundle-golden-files
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

