### PR TITLE
Remove kubebuilder annotations from local copy of CAPT APIs

### DIFF
--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/groupversion_info.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/groupversion_info.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kubebuilder:object:generate=true
-// +groupName=infrastructure.cluster.x-k8s.io
-
 package v1beta1
 
 import (

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellcluster_types.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellcluster_types.go
@@ -33,8 +33,6 @@ type TinkerbellClusterSpec struct {
 	//
 	// See https://cluster-api.sigs.k8s.io/developer/architecture/controllers/cluster.html
 	// for more details.
-	//
-	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
 
 	// ImageLookupFormat is the URL naming format to use for machine images when
@@ -49,24 +47,18 @@ type TinkerbellClusterSpec struct {
 	// kubernetes/release: v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default
 	// image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz will
 	// attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/
-	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
 	// ImageLookupBaseRegistry is the base Registry URL that is used for pulling images,
 	// if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
-	// +optional
-	// +kubebuilder:default=ghcr.io/tinkerbell/cluster-api-provider-tinkerbell
 	ImageLookupBaseRegistry string `json:"imageLookupBaseRegistry,omitempty"`
 
 	// ImageLookupOSDistro is the name of the OS distro to use when fetching machine images,
 	// if not set it will default to ubuntu.
-	// +optional
-	// +kubebuilder:default=ubuntu
 	ImageLookupOSDistro string `json:"imageLookupOSDistro,omitempty"`
 
 	// ImageLookupOSVersion is the version of the OS distribution to use when fetching machine
 	// images. If not set it will default based on ImageLookupOSDistro.
-	// +optional
 	ImageLookupOSVersion string `json:"imageLookupOSVersion,omitempty"`
 }
 
@@ -76,15 +68,8 @@ type TinkerbellClusterStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file.
 
 	// Ready denotes that the cluster (infrastructure) is ready.
-	// +optional
 	Ready bool `json:"ready"`
 }
-
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:path=tinkerbellclusters,scope=Namespaced,categories=cluster-api
-// +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this TinkerbellCluster belongs"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="TinkerbellCluster ready status"
 
 // TinkerbellCluster is the Schema for the tinkerbellclusters API.
 type TinkerbellCluster struct {
@@ -94,8 +79,6 @@ type TinkerbellCluster struct {
 	Spec   TinkerbellClusterSpec   `json:"spec,omitempty"`
 	Status TinkerbellClusterStatus `json:"status,omitempty"`
 }
-
-// +kubebuilder:object:root=true
 
 // TinkerbellClusterList contains a list of TinkerbellCluster.
 type TinkerbellClusterList struct {

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellcluster_webhook.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellcluster_webhook.go
@@ -36,9 +36,6 @@ func (c *TinkerbellCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(c).Complete() //nolint:wrapcheck
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-tinkerbellcluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=tinkerbellclusters,versions=v1beta1,name=validation.tinkerbellcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1beta1-tinkerbellcluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=tinkerbellclusters,versions=v1beta1,name=default.tinkerbellcluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (c *TinkerbellCluster) ValidateCreate() (admission.Warnings, error) {
 	return nil, nil

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachine_types.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachine_types.go
@@ -45,35 +45,28 @@ type TinkerbellMachineSpec struct {
 	// kubernetes/release: v1.13.0, v1.12.5-mybuild.1, or v1.17.3. For example, the default
 	// image format of {{.BaseRegistry}}/{{.OSDistro}}-{{.OSVersion}}:{{.KubernetesVersion}}.gz will
 	// attempt to pull the image from that location. See also: https://golang.org/pkg/text/template/
-	// +optional
 	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
 
 	// ImageLookupBaseRegistry is the base Registry URL that is used for pulling images,
 	// if not set, the default will be to use ghcr.io/tinkerbell/cluster-api-provider-tinkerbell.
-	// +optional
 	ImageLookupBaseRegistry string `json:"imageLookupBaseRegistry,omitempty"`
 
 	// ImageLookupOSDistro is the name of the OS distro to use when fetching machine images,
 	// if not set it will default to ubuntu.
-	// +optional
 	ImageLookupOSDistro string `json:"imageLookupOSDistro,omitempty"`
 
 	// ImageLookupOSVersion is the version of the OS distribution to use when fetching machine
 	// images. If not set it will default based on ImageLookupOSDistro.
-	// +optional
 	ImageLookupOSVersion string `json:"imageLookupOSVersion,omitempty"`
 
 	// TemplateOverride overrides the default Tinkerbell template used by CAPT.
 	// You can learn more about Tinkerbell templates here: https://tinkerbell.org/docs/concepts/templates/
-	// +optional
 	TemplateOverride string `json:"templateOverride,omitempty"`
 
 	// HardwareAffinity allows filtering for hardware.
-	// +optional
 	HardwareAffinity *HardwareAffinity `json:"hardwareAffinity,omitempty"`
 
 	// BootOptions are options that control the booting of Hardware.
-	// +optional
 	BootOptions BootOptions `json:"bootOptions,omitempty"`
 
 	// Those fields are set programmatically, but they cannot be re-constructed from "state of the world", so
@@ -95,14 +88,10 @@ type BootOptions struct {
 	// as this is where the ISO patching endpoint lives.
 	// The ":macAddress" is a placeholder for the MAC address of the hardware and
 	// should be provided exactly as is: ":macAddress".
-	// +optional
-	// +kubebuilder:validation:Format=url
 	ISOURL string `json:"isoURL,omitempty"`
 
 	// BootMode is the type of booting that will be done.
 	// Must be one of "none", "netboot", or "iso".
-	// +optional
-	// +kubebuilder:validation:Enum=none;netboot;iso
 	BootMode BootMode `json:"bootMode,omitempty"`
 }
 
@@ -110,11 +99,9 @@ type BootOptions struct {
 type HardwareAffinity struct {
 	// Required are the required hardware affinity terms.  The terms are OR'd together, hardware must match one term to
 	// be considered.
-	// +optional
 	Required []HardwareAffinityTerm `json:"required,omitempty"`
 	// Preferred are the preferred hardware affinity terms. Hardware matching these terms are preferred according to the
 	// weights provided, but are not required.
-	// +optional
 	Preferred []WeightedHardwareAffinityTerm `json:"preferred,omitempty"`
 }
 
@@ -128,8 +115,6 @@ type HardwareAffinityTerm struct {
 // WeightedHardwareAffinityTerm fields are added per-hardware to find the most preferred hardware.
 type WeightedHardwareAffinityTerm struct {
 	// Weight associated with matching the corresponding hardwareAffinityTerm, in the range 1-100.
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=100
 	Weight int32 `json:"weight"`
 	// HardwareAffinityTerm is the term associated with the corresponding weight.
 	HardwareAffinityTerm HardwareAffinityTerm `json:"hardwareAffinityTerm"`
@@ -141,20 +126,17 @@ type TinkerbellMachineStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Ready is true when the provider resource is ready.
-	// +optional
 	Ready bool `json:"ready"`
 
 	// Addresses contains the Tinkerbell device associated addresses.
 	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
 
 	// InstanceStatus is the status of the Tinkerbell device instance for this machine.
-	// +optional
 	InstanceStatus *TinkerbellResourceStatus `json:"instanceStatus,omitempty"`
 
 	// Any transient errors that occur during the reconciliation of Machines
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
-	// +optional
 	ErrorReason *capierrors.MachineStatusError `json:"errorReason,omitempty"`
 
 	// ErrorMessage will be set in the event that there is a terminal problem
@@ -173,19 +155,8 @@ type TinkerbellMachineStatus struct {
 	// Any transient errors that occur during the reconciliation of Machines
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
-	// +optional
 	ErrorMessage *string `json:"errorMessage,omitempty"`
 }
-
-// +kubebuilder:subresource:status
-// +kubebuilder:object:root=true
-// +kubebuilder:resource:path=tinkerbellmachines,scope=Namespaced,categories=cluster-api
-// +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this TinkerbellMachine belongs"
-// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="Tinkerbell instance state"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
-// +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="Tinkerbell instance ID"
-// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this TinkerbellMachine"
 
 // TinkerbellMachine is the Schema for the tinkerbellmachines API.
 type TinkerbellMachine struct {
@@ -195,8 +166,6 @@ type TinkerbellMachine struct {
 	Spec   TinkerbellMachineSpec   `json:"spec,omitempty"`
 	Status TinkerbellMachineStatus `json:"status,omitempty"`
 }
-
-// +kubebuilder:object:root=true
 
 // TinkerbellMachineList contains a list of TinkerbellMachine.
 type TinkerbellMachineList struct {

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachine_webhook.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachine_webhook.go
@@ -30,8 +30,6 @@ func (m *TinkerbellMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(m).Complete() //nolint:wrapcheck
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-tinkerbellmachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=tinkerbellmachines,versions=v1beta1,name=validation.tinkerbellmachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (m *TinkerbellMachine) ValidateCreate() (admission.Warnings, error) {
 	allErrs := m.validateSpec()

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachinetemplate_types.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachinetemplate_types.go
@@ -25,10 +25,6 @@ type TinkerbellMachineTemplateSpec struct {
 	Template TinkerbellMachineTemplateResource `json:"template"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:resource:path=tinkerbellmachinetemplates,scope=Namespaced,categories=cluster-api
-// +kubebuilder:storageversion
-
 // TinkerbellMachineTemplate is the Schema for the tinkerbellmachinetemplates API.
 type TinkerbellMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -36,8 +32,6 @@ type TinkerbellMachineTemplate struct {
 
 	Spec TinkerbellMachineTemplateSpec `json:"spec,omitempty"`
 }
-
-// +kubebuilder:object:root=true
 
 // TinkerbellMachineTemplateList contains a list of TinkerbellMachineTemplate.
 type TinkerbellMachineTemplateList struct {

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachinetemplate_webhook.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachinetemplate_webhook.go
@@ -33,8 +33,6 @@ func (m *TinkerbellMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) er
 	return ctrl.NewWebhookManagedBy(mgr).For(m).Complete() //nolint:wrapcheck
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-tinkerbellmachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=tinkerbellmachinetemplates,versions=v1beta1,name=validation.tinkerbellmachinetemplate.infrastructure.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (m *TinkerbellMachineTemplate) ValidateCreate() (admission.Warnings, error) {
 	var allErrs field.ErrorList


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We added CAPT crds to a local package in #9114. The upstream CRDs contained kubebuilder annotations that was making EKS-A register additional webhooks for CAPT objects which shouldn't be there at first place. Here's reference to the [eksa-components.yaml](https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.22.0-dev-build.105/eks-anywhere/manifests/cluster-controller/v0.21.3/eksa-components.yaml) post that change that has webhooks for tinkerbellcluster, tinkerbellmachine and tinkerbellmachinetemplate crds. 
This causes cluster creation process to fail when applying the spec for CAPT objects with the below error:

```
Internal error occurred: failed calling webhook "[default.tinkerbellcluster.infrastructure.cluster.x-k8s.io](http://default.tinkerbellcluster.infrastructure.cluster.x-k8s.io/)": failed to call webhook: the server could not find the requested resource
```

Ideally we do not want any kubebuilder annotations as we don't want to include anything related to CAPT CRDs in the eksa-components spec. This change removes all kubebuilder annotations in the local CAPT package. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

