### PR TITLE
For etcd metrics, specify explictily proxy steps are only for stacked etcd

### DIFF
--- a/docs/content/en/docs/clustermgmt/observability/expose-metrics.md
+++ b/docs/content/en/docs/clustermgmt/observability/expose-metrics.md
@@ -9,7 +9,7 @@ description: >
 
 Some Kubernetes system components like kube-controller-manager, kube-scheduler, kube-proxy and etcd (Stacked) expose metrics only on the localhost by default. In order to expose metrics for these components so that other monitoring systems like Prometheus can scrape them, you can deploy a proxy as a Daemonset on the host network of the nodes. The proxy pods also need to be configured with control plane tolerations so that they can be scheduled on the control plane nodes. 
 
-For etcd metrics, the steps outlined below are applicable only for stacked etcd setup. For Unstacked/External etcd, metrics are already exposed on `https://<etcd-machine-ip>:2379/metrics` endpoint and can be scraped by Prometheus directly without deploying proxy.
+For etcd metrics, the steps outlined below are applicable only for stacked etcd setup. For Unstacked/External etcd, metrics are already exposed on `https://<etcd-machine-ip>:2379/metrics` endpoint and can be scraped by Prometheus directly without deploying a proxy.
 
 ### Configure Proxy
 

--- a/docs/content/en/docs/clustermgmt/observability/expose-metrics.md
+++ b/docs/content/en/docs/clustermgmt/observability/expose-metrics.md
@@ -7,7 +7,9 @@ description: >
   Expose metrics for EKS Anywhere components
 ---
 
-Some Kubernetes system components like kube-controller-manager, kube-scheduler, kube-proxy and etcd (Stacked) expose metrics only on the localhost by default. In order to expose metrics for these components so that other monitoring systems like Prometheus can scrape them, you can deploy a proxy as a Daemonset on the host network of the nodes. The proxy pods also need to be configured with control plane tolerations so that they can be scheduled on the control plane nodes. For Unstacked/External etcd, metrics are already exposed on `https://<etcd-machine-ip>:2379/metrics` endpoint and can be scraped by Prometheus directly without deploying anything.
+Some Kubernetes system components like kube-controller-manager, kube-scheduler, kube-proxy and etcd (Stacked) expose metrics only on the localhost by default. In order to expose metrics for these components so that other monitoring systems like Prometheus can scrape them, you can deploy a proxy as a Daemonset on the host network of the nodes. The proxy pods also need to be configured with control plane tolerations so that they can be scheduled on the control plane nodes. 
+
+For etcd metrics, the steps outlined below are applicable only for stacked etcd setup. For Unstacked/External etcd, metrics are already exposed on `https://<etcd-machine-ip>:2379/metrics` endpoint and can be scraped by Prometheus directly without deploying proxy.
 
 ### Configure Proxy
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the metrics doc for etcd metrics to specify explictily that proxy steps are only for stacked setup


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

