### PR TITLE
Removed trailing comma (,) from json

### DIFF
--- a/docs/content/en/docs/osmgmt/artifacts.md
+++ b/docs/content/en/docs/osmgmt/artifacts.md
@@ -450,7 +450,7 @@ These steps use `image-builder` to create an Ubuntu-based or RHEL-based image fo
      "password": "",
      "resource_pool": "",
      "username": "",
-     "vcenter_server": "",
+     "vcenter_server": ""
    }
    ```
    ##### **[cluster](https://developer.hashicorp.com/packer/integrations/hashicorp/vsphere/latest/components/builder/vsphere-iso#location-configuration)**


### PR DESCRIPTION
*Issue #, if available:*
There is a trailing comma in the example provided that invalidates the json formating

*Description of changes:*
removed the trailing comma (,)

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

