### PR TITLE
Ensure Kubernetes version is always parsed as string

### DIFF
--- a/pkg/api/v1alpha1/testdata/cluster_1_20.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_20.yaml
@@ -10,7 +10,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_1_20_cloudstack.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_20_cloudstack.yaml
@@ -21,7 +21,7 @@ spec:
   datacenterRef:
     kind: CloudStackDatacenterConfig
     name: eksa-unit-test
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_1_20_namespace_mismatch_between_cluster_and_datacenter.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_20_namespace_mismatch_between_cluster_and_datacenter.yaml
@@ -11,7 +11,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_1_20_namespace_mismatch_between_cluster_and_machineconfigs.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_20_namespace_mismatch_between_cluster_and_machineconfigs.yaml
@@ -11,7 +11,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_1_20_with_non_eksa_resources.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_1_20_with_non_eksa_resources.yaml
@@ -17,7 +17,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_cluster_name.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_cluster_name.yaml
@@ -10,7 +10,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_invalid_worker_node_count.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_invalid_worker_node_count.yaml
@@ -10,7 +10,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 0
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/cluster_package_configuration.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_package_configuration.yaml
@@ -10,7 +10,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/api/v1alpha1/testdata/incorrect_indentation.yaml
+++ b/pkg/api/v1alpha1/testdata/incorrect_indentation.yaml
@@ -10,7 +10,7 @@ spec:
     machineGroupRef:
       name: eksa-unit-test
       kind: VSphereMachineConfig
- kubernetesVersion: "1.20"
+ kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/cluster/config_manager.go
+++ b/pkg/cluster/config_manager.go
@@ -122,9 +122,9 @@ func (c *ConfigManager) unmarshal(yamlManifest []byte) (*parsed, error) {
 	yamlObjs := separatorRegex.Split(string(yamlManifest), -1)
 
 	for _, yamlObj := range yamlObjs {
-		trimmedYamlObj := strings.TrimSuffix(yamlObj, "\n")
+		normalizedYamlObj := anywherev1.NormalizeKubernetesVersion(strings.TrimSuffix(yamlObj, "\n"))
 		k := &basicAPIObject{}
-		err := yaml.Unmarshal([]byte(trimmedYamlObj), k)
+		err := yaml.Unmarshal([]byte(normalizedYamlObj), k)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +154,7 @@ func (c *ConfigManager) unmarshal(yamlManifest []byte) (*parsed, error) {
 			continue
 		}
 
-		if err := yaml.Unmarshal([]byte(trimmedYamlObj), obj); err != nil {
+		if err := yaml.Unmarshal([]byte(normalizedYamlObj), obj); err != nil {
 			return nil, err
 		}
 		parsed.objects.add(obj)

--- a/pkg/cluster/testdata/cluster_1_19.yaml
+++ b/pkg/cluster/testdata/cluster_1_19.yaml
@@ -30,7 +30,7 @@ spec:
         kind: VSphereMachineConfig
         name: eksa-unit-test
     - name: workers-2
-      kubernetesVersion: "1.20"
+      kubernetesVersion: 1.20
       count: 1
       machineGroupRef:
         kind: VSphereMachineConfig

--- a/pkg/cluster/testdata/cluster_1_20_cloudstack.yaml
+++ b/pkg/cluster/testdata/cluster_1_20_cloudstack.yaml
@@ -21,7 +21,7 @@ spec:
   datacenterRef:
     kind: CloudStackDatacenterConfig
     name: eksa-unit-test
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/cluster/testdata/cluster_cloudstack_missing_datacenter.yaml
+++ b/pkg/cluster/testdata/cluster_cloudstack_missing_datacenter.yaml
@@ -21,7 +21,7 @@ spec:
   datacenterRef:
     kind: CloudStackDatacenterConfig
     name: eksa-unit-test
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   workerNodeGroupConfigurations:
     - count: 3
       machineGroupRef:

--- a/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
+++ b/pkg/cluster/testdata/docker_cluster_oidc_awsiam_flux.yaml
@@ -21,7 +21,7 @@ spec:
     name: m-docker
   workerNodeGroupConfigurations:
   - name: workers-1
-    kubernetesVersion: "1.20"
+    kubernetesVersion: 1.20
     count: 1
   identityProviderRefs:
   - kind: OIDCConfig

--- a/pkg/dependencies/testdata/cluster_tinkerbell.yaml
+++ b/pkg/dependencies/testdata/cluster_tinkerbell.yaml
@@ -22,7 +22,7 @@ spec:
   datacenterRef:
     kind: TinkerbellDatacenterConfig
     name: eksa-unit-test
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   managementCluster:
     name: eksa-unit-test
   workerNodeGroupConfigurations:

--- a/pkg/providers/cloudstack/testdata/cluster_main_worker_node_group_kubernetes_version.yaml
+++ b/pkg/providers/cloudstack/testdata/cluster_main_worker_node_group_kubernetes_version.yaml
@@ -31,7 +31,7 @@ spec:
   workerNodeGroupConfigurations:
   - count: 3
     name: md-0
-    kubernetesVersion: "1.20"
+    kubernetesVersion: 1.20
     machineGroupRef:
       kind: CloudStackMachineConfig
       name: test-md-0

--- a/pkg/providers/nutanix/testdata/eksa-cluster-external-etcd-k8s-1-20.yaml
+++ b/pkg/providers/nutanix/testdata/eksa-cluster-external-etcd-k8s-1-20.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eksa-unit-test
   namespace: default
 spec:
-  kubernetesVersion: "1.20"
+  kubernetesVersion: 1.20
   controlPlaneConfiguration:
     name: eksa-unit-test-cp
     count: 3

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_worker_version.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_worker_version.yaml
@@ -35,7 +35,7 @@ spec:
     name: test
   workerNodeGroupConfigurations:
   - count: 1
-    kubernetesVersion: "1.20"
+    kubernetesVersion: 1.20
     name: md-0
     machineGroupRef:
       name: test-md

--- a/pkg/utils/yaml/yaml.go
+++ b/pkg/utils/yaml/yaml.go
@@ -1,12 +1,9 @@
 package yaml
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
-	"io"
 
-	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -27,24 +24,4 @@ func Serialize[T any](objs ...T) ([][]byte, error) {
 		r = append(r, b)
 	}
 	return r, nil
-}
-
-// SplitDocuments function splits content into individual document parts represented as byte slices.
-func SplitDocuments(r io.Reader) ([][]byte, error) {
-	resources := make([][]byte, 0)
-
-	yr := apiyaml.NewYAMLReader(bufio.NewReader(r))
-	for {
-		d, err := yr.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		resources = append(resources, d)
-	}
-
-	return resources, nil
 }

--- a/pkg/utils/yaml/yaml_test.go
+++ b/pkg/utils/yaml/yaml_test.go
@@ -1,99 +1,70 @@
 package yaml_test
 
 import (
-	"bufio"
-	"errors"
-	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	yamlutil "github.com/aws/eks-anywhere/pkg/utils/yaml"
 )
 
-func TestSplitDocuments(t *testing.T) {
+func TestJoin(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        string
-		expectedDocs [][]byte
-		expectedErr  error
+		name   string
+		input  [][]byte
+		output []byte
 	}{
 		{
-			name:         "Empty input",
-			input:        "",
-			expectedDocs: [][]byte{},
-			expectedErr:  nil,
+			name:   "Empty input",
+			input:  [][]byte{},
+			output: []byte{},
 		},
 		{
 			name: "Single document",
-			input: `apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-1
-`,
-			expectedDocs: [][]byte{
+			input: [][]byte{
 				[]byte(`apiVersion: v1
 kind: Pod
 metadata:
   name: pod-1
 `),
 			},
-			expectedErr: nil,
-		},
-		{
-			name: "Multiple documents",
-			input: `apiVersion: v1
+			output: []byte(`apiVersion: v1
 kind: Pod
 metadata:
   name: pod-1
+`),
+		},
+		{
+			name: "Multiple documents",
+			input: [][]byte{
+				[]byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+`),
+				[]byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: service-1
+`),
+			},
+			output: []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: service-1
-`,
-			expectedDocs: [][]byte{
-				[]byte(`apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-1
 `),
-				[]byte(`apiVersion: v1
-kind: Service
-metadata:
-  name: service-1
-`),
-			},
-			expectedErr: nil,
-		},
-		{
-			name:         "Error reading input 2",
-			input:        `---\nkey: value\ninvalid_separator\n`,
-			expectedDocs: nil,
-			expectedErr:  errors.New("invalid Yaml document separator: \\nkey: value\\ninvalid_separator\\n"),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			r := strings.NewReader(test.input)
-
-			docs, err := yamlutil.SplitDocuments(bufio.NewReader(r))
-			if test.expectedErr != nil {
-				assert.Equal(t, test.expectedErr.Error(), err.Error())
-				assert.Equal(t, len(test.expectedDocs), len(docs))
-			} else {
-				require.NoError(t, err)
-				if len(docs) != len(test.expectedDocs) {
-					t.Errorf("Expected %d documents, but got %d", len(test.expectedDocs), len(docs))
-				}
-
-				for i, doc := range docs {
-					if string(doc) != string(test.expectedDocs[i]) {
-						t.Errorf("Document %d mismatch.\nExpected:\n%s\nGot:\n%s", i+1, string(test.expectedDocs[i]), string(doc))
-					}
-				}
+			joinedDoc := yamlutil.Join(test.input)
+			if string(joinedDoc) != string(test.output) {
+				t.Errorf("Document mismatch.\nExpected:\n%s\nGot:\n%s", string(test.output), string(joinedDoc))
 			}
 		})
 	}

--- a/pkg/yamlutil/parser.go
+++ b/pkg/yamlutil/parser.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 )
 
 type (
@@ -95,7 +97,8 @@ type Builder interface {
 // Parse reads yaml manifest content with the registered mappings and passes
 // the result to the Builder for further processing.
 func (p *Parser) Parse(yamlManifest []byte, b Builder) error {
-	return p.Read(bytes.NewReader(yamlManifest), b)
+	normalizedYamlManifest := v1alpha1.NormalizeKubernetesVersion(string(yamlManifest))
+	return p.Read(bytes.NewReader([]byte(normalizedYamlManifest)), b)
 }
 
 // Read reads yaml manifest content with the registered mappings and passes

--- a/pkg/yamlutil/parser_test.go
+++ b/pkg/yamlutil/parser_test.go
@@ -45,6 +45,7 @@ func TestParserParse(t *testing.T) {
 apiVersion: v1
 data:
   Corefile: "d"
+  kubernetesVersion: 1.30
 kind: ConfigMap
 metadata:
   name: aws-iam-authenticator 
@@ -77,6 +78,7 @@ data:
 	g.Expect(parser.Parse([]byte(yaml), holder)).To(Succeed())
 	g.Expect(holder).NotTo(BeNil())
 	g.Expect(holder.configMap.Data).To(HaveKeyWithValue("Corefile", "d"))
+	g.Expect(holder.configMap.Data).To(HaveKeyWithValue("kubernetesVersion", "1.30"))
 	g.Expect(holder.secret.Data["username"]).To(Equal([]byte("admin")))
 }
 

--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -17,9 +17,9 @@ package archives
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/pkg/errors"
-	"slices"
 
 	assettypes "github.com/aws/eks-anywhere/release/cli/pkg/assets/types"
 	"github.com/aws/eks-anywhere/release/cli/pkg/filereader"

--- a/release/cli/pkg/assets/assets.go
+++ b/release/cli/pkg/assets/assets.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-	"slices"
 
 	"github.com/aws/eks-anywhere/release/cli/pkg/assets/archives"
 	assetconfig "github.com/aws/eks-anywhere/release/cli/pkg/assets/config"

--- a/release/cli/pkg/bundles/bundles.go
+++ b/release/cli/pkg/bundles/bundles.go
@@ -16,12 +16,12 @@ package bundles
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"slices"
 
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/release/cli/pkg/constants"


### PR DESCRIPTION
Ensure Kubernetes version in cluster config is always parsed as string regardless of whether it is quoted or not. Ref: #9184.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

