### PR TITLE
Remove tunnel from cilium template

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -205,7 +205,8 @@ func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) 
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"tunnel":            "geneve",
+		"routing-mode":      "tunnel",
+		"tunnel-protocol":   "geneve",
 		"image": values{
 			"repository": versionsBundle.Cilium.Cilium.Image(),
 			"tag":        versionsBundle.Cilium.Cilium.Tag(),
@@ -236,7 +237,8 @@ func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) 
 	}
 
 	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.RoutingMode == anywherev1.CiliumRoutingModeDirect {
-		val["tunnel"] = "disabled"
+		val["routing-mode"] = "native"
+		delete(val, "tunnel-protocol")
 
 		if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv4NativeRoutingCIDR == "" &&
 			spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv6NativeRoutingCIDR == "" {

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -119,7 +119,8 @@ func TestTemplaterGenerateUpgradePreflightManifestSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"tunnel":            "geneve",
+		"routing-mode":      "tunnel",
+		"tunnel-protocol":   "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -189,7 +190,8 @@ func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"tunnel":            "geneve",
+		"routing-mode":      "tunnel",
+		"tunnel-protocol":   "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -226,7 +228,8 @@ func TestTemplaterGenerateManifestPolicyEnforcementModeSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"tunnel":            "geneve",
+		"routing-mode":      "tunnel",
+		"tunnel-protocol":   "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -268,7 +271,8 @@ func TestTemplaterGenerateManifestEgressMasqueradeInterfacesSuccess(t *testing.T
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"tunnel":            "geneve",
+		"routing-mode":      "tunnel",
+		"tunnel-protocol":   "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -308,7 +312,7 @@ func TestTemplaterGenerateManifestDirectRouteModeSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods":    true,
-		"tunnel":               "disabled",
+		"routing-mode":         "native",
 		"autoDirectNodeRoutes": "true",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
@@ -347,7 +351,7 @@ func TestTemplaterGenerateManifestDirectModeManualIPCIDRSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods":     true,
-		"tunnel":                "disabled",
+		"routing-mode":          "native",
 		"ipv4NativeRoutingCIDR": "192.168.0.0/24",
 		"ipv6NativeRoutingCIDR": "2001:db8::/32",
 		"image": map[string]interface{}{
@@ -455,7 +459,8 @@ func wantUpgradeValues() map[string]interface{} {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"tunnel":            "geneve",
+		"routing-mode":      "tunnel",
+		"tunnel-protocol":   "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",

--- a/pkg/networking/cilium/testdata/cilium_manifest.yaml
+++ b/pkg/networking/cilium/testdata/cilium_manifest.yaml
@@ -109,7 +109,8 @@ data:
   #   - disabled
   #   - vxlan (default)
   #   - geneve
-  tunnel: geneve
+  routing-mode: "tunnel"
+  tunnel-protocol: "geneve"
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: "true"
 


### PR DESCRIPTION
*Description of changes:*
`tunnel` was deprecated in cilium v1.14 and will be removed in v1.15.
For the previous `tunnel: "geneve"`, we now need to use
```
  routing-mode: "tunnel"
  tunnel-protocol: "geneve"
```
And for `tunnel: "disable"`, set `routing-mode `to `native `and remove `tunnel-protocol` entry.

Reference:
https://docs.cilium.io/en/v1.15/operations/upgrade/#removed-options
*Testing (if applicable):*
1. `make test` to run a capd simpleflow test.
2. Created an EKS-A cluster with cilium v1.15 and override eks-a controller with the change in this PR.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

