### PR TITLE
Fix resolve syntax error in parsing EKS_ANYWHERE_TARBALL_URL

### DIFF
--- a/docs/content/en/docs/getting-started/docker/_index.md
+++ b/docs/content/en/docs/getting-started/docker/_index.md
@@ -61,8 +61,9 @@ sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
 Install the `eksctl-anywhere` plugin
 
 ```bash
+OS_NAME=$(uname -s | tr A-Z a-z)
 RELEASE_VERSION=$(curl https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml --silent --location | yq ".spec.latestVersion")
-EKS_ANYWHERE_TARBALL_URL=$(curl https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml --silent --location | yq ".spec.releases[] | select(.version==\"$RELEASE_VERSION\").eksABinary.$(uname -s | tr A-Z a-z).uri")
+EKS_ANYWHERE_TARBALL_URL=$(curl https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml --silent --location | yq ".spec.releases[] | select(.version==$RELEASE_VERSION).eksABinary.$OS_NAME.uri")
 curl $EKS_ANYWHERE_TARBALL_URL \
     --silent --location \
     | tar xz ./eksctl-anywhere


### PR DESCRIPTION
*Description of changes:*

1. remove quote escaping for RELEASE_VRESION (causing duplicated quote)
2. resolve OS name before parsing tarball url (since yq wont resolve $(uname -s | tr A-Z a-z))

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

