### PR TITLE
Add extended kubernetes version support validations for create and upgrade CLI operations

### DIFF
--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -223,6 +223,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		CliConfig:          cliConfig,
 		SkippedValidations: skippedValidations,
 		KubeClient:         deps.UnAuthKubeClient.KubeconfigClient(mgmt.KubeconfigFile),
+		ManifestReader:     deps.ManifestReader,
 	}
 	createValidations := createvalidations.New(validationOpts)
 

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -199,6 +199,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command, args []strin
 		CliConfig:          cliConfig,
 		SkippedValidations: skippedValidations,
 		KubeClient:         deps.UnAuthKubeClient.KubeconfigClient(managementCluster.KubeconfigFile),
+		ManifestReader:     deps.ManifestReader,
 	}
 
 	upgradeValidations := upgradevalidations.New(validationOpts)

--- a/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
+++ b/cmd/eksctl-anywhere/cmd/validatecreatecluster.go
@@ -88,6 +88,7 @@ func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []str
 		WithGitOpsFlux(clusterSpec.Cluster, clusterSpec.FluxConfig, cliConfig).
 		WithUnAuthKubeClient().
 		WithValidatorClients().
+		WithManifestReader().
 		Build(ctx)
 	if err != nil {
 		cleanupDirectory(tmpPath)
@@ -105,8 +106,8 @@ func (valOpt *validateOptions) validateCreateCluster(cmd *cobra.Command, _ []str
 		ManagementCluster: getManagementCluster(clusterSpec),
 		Provider:          deps.Provider,
 		CliConfig:         cliConfig,
+		ManifestReader:    deps.ManifestReader,
 	}
-
 	createValidations := createvalidations.New(validationOpts)
 
 	commandVal := createcluster.NewValidations(clusterSpec, deps.Provider, deps.GitOpsFlux, createValidations, deps.DockerClient)

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -341,7 +341,7 @@ func (p *Provider) ValidateNewSpec(ctx context.Context, cluster *types.Cluster, 
 	// for any operation other than k8s version change, hookImageURL is immutable
 	if currentClstr.Spec.KubernetesVersion == desiredClstrSpec.Cluster.Spec.KubernetesVersion {
 		if desiredDCCfgSpec.HookImagesURLPath != currentDCCfg.Spec.HookImagesURLPath {
-			return fmt.Errorf("spec.hookImagesURLPath is immutable. previoius = %s, new = %s",
+			return fmt.Errorf("spec.hookImagesURLPath is immutable. previous = %s, new = %s",
 				currentDCCfg.Spec.HookImagesURLPath, desiredDCCfgSpec.HookImagesURLPath)
 		}
 	}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/providers/common"
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -296,4 +297,18 @@ func ValidateK8s132Support(clusterSpec *cluster.Spec) error {
 		}
 	}
 	return nil
+}
+
+// ValidateExtendedKubernetesSupport validates the extended kubernetes version support for create and upgrade operations.
+func ValidateExtendedKubernetesSupport(ctx context.Context, clusterSpec v1alpha1.Cluster, reader *manifests.Reader, k kubernetes.Client) error {
+	eksaVersion := clusterSpec.Spec.EksaVersion
+	if eksaVersion == nil {
+		return nil
+	}
+
+	bundles, err := reader.ReadBundlesForVersion(string(*eksaVersion))
+	if err != nil {
+		return fmt.Errorf("getting bundle for existing cluster : %w", err)
+	}
+	return ValidateExtendedK8sVersionSupport(ctx, clusterSpec, bundles, k)
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -59,6 +59,13 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Silent:      true,
 			}
 		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate extended kubernetes version support is supported",
+				Remediation: "ensure you have a valid license for extended Kubernetes version support",
+				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient),
+			}
+		},
 	}
 
 	if len(v.Opts.Spec.VSphereMachineConfigs) != 0 {

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -2,6 +2,7 @@ package createvalidations_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -11,9 +12,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/internal/test"
+	internalmocks "github.com/aws/eks-anywhere/internal/test/mocks"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/manifests"
+	"github.com/aws/eks-anywhere/pkg/manifests/releases"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/createvalidations"
@@ -30,22 +34,32 @@ type preflightValidationsTest struct {
 func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 	ctrl := gomock.NewController(t)
 	k := mocks.NewMockKubectlClient(ctrl)
+
+	version := test.DevEksaVersion()
+
 	c := &types.Cluster{
 		KubeconfigFile: "kubeconfig",
 	}
+
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
-		s.Cluster.Spec.GitOpsRef = &anywherev1.Ref{
-			Name: "gitops",
+		s.Cluster = &anywherev1.Cluster{
+			Spec: anywherev1.ClusterSpec{
+				KubernetesVersion: "1.30",
+				GitOpsRef: &anywherev1.Ref{
+					Name: "gitops",
+				},
+				EksaVersion: &version,
+			},
 		}
 	})
-	version := "v0.19.0-dev+latest"
+
 	objects := []client.Object{test.EKSARelease()}
 	opts := &validations.Opts{
 		Kubectl:           k,
 		Spec:              clusterSpec,
 		WorkloadCluster:   c,
 		ManagementCluster: c,
-		CliVersion:        version,
+		CliVersion:        string(version),
 		KubeClient:        test.NewFakeKubeClient(objects...),
 	}
 	return &preflightValidationsTest{
@@ -56,8 +70,42 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 	}
 }
 
+func addManifestReaderMock(t *testing.T, version anywherev1.EksaVersion) *manifests.Reader {
+	ctrl := gomock.NewController(t)
+	reader := internalmocks.NewMockReader(ctrl)
+	releasesURL := releases.ManifestURL()
+
+	releasesManifest := fmt.Sprintf(`apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Release
+metadata:
+  name: release-1
+spec:
+  releases:
+  - bundleManifestUrl: "https://bundles/bundles.yaml"
+    version: %s`, string(version))
+	reader.EXPECT().ReadFile(releasesURL).Return([]byte(releasesManifest), nil)
+
+	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeversion: "1.30"
+    endOfStandardSupport: "2026-12-31"`
+
+	reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
+
+	return manifests.NewReader(reader)
+}
+
 func TestPreFlightValidationsGitProvider(t *testing.T) {
 	tt := newPreflightValidationsTest(t)
+	tt.c.Opts.ManifestReader = addManifestReaderMock(t, anywherev1.EksaVersion(tt.c.Opts.CliVersion))
 	tt.Expect(validations.ProcessValidationResults(tt.c.PreflightValidations(tt.ctx))).To(Succeed())
 }
 
@@ -67,13 +115,15 @@ func TestPreFlightValidationsWorkloadCluster(t *testing.T) {
 	tt.c.Opts.Spec.Cluster.SetManagedBy(mgmtClusterName)
 	tt.c.Opts.Spec.Cluster.Spec.ManagementCluster.Name = mgmtClusterName
 	tt.c.Opts.ManagementCluster.Name = mgmtClusterName
-	version := test.DevEksaVersion()
+	version := anywherev1.EksaVersion(tt.c.Opts.CliVersion)
+	tt.c.Opts.ManifestReader = addManifestReaderMock(t, version)
 
 	mgmt := &anywherev1.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "mgmt-cluster",
 		},
 		Spec: anywherev1.ClusterSpec{
+			KubernetesVersion: "1.30",
 			ManagementCluster: anywherev1.ManagementCluster{
 				Name: "mgmt-cluster",
 			},

--- a/pkg/validations/extendedversion.go
+++ b/pkg/validations/extendedversion.go
@@ -50,7 +50,7 @@ func validateBundleSignature(bundle *v1alpha1.Bundles) error {
 		return err
 	}
 	if !valid {
-		return fmt.Errorf("signature on the bundle is invalid, error: %w", err)
+		return errors.New("signature on the bundle is invalid")
 	}
 	return nil
 }

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -131,6 +131,13 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Silent:      true,
 			}
 		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate extended kubernetes version support is supported",
+				Remediation: "ensure you have a valid license for extended Kubernetes version support",
+				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient),
+			}
+		},
 	}
 
 	if len(u.Opts.Spec.VSphereMachineConfigs) != 0 {

--- a/pkg/validations/validation_options.go
+++ b/pkg/validations/validation_options.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/crypto"
+	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/version"
@@ -21,6 +22,7 @@ type Opts struct {
 	SkippedValidations map[string]bool
 	CliVersion         string
 	KubeClient         kubernetes.Client
+	ManifestReader     *manifests.Reader
 }
 
 func (o *Opts) SetDefaults() {


### PR DESCRIPTION
*Issue #, if available:*
#6793 

*Description of changes:*
Validate extended kubernetes version support for eks-a create and upgrade CLI operations.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

