### PR TITLE
Use specified bundles-override file to validate extended kubernetes version support

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,4 @@ jobs:
         with:
           version: v1.56.2
           only-new-issues: true
-          # Disable package caching to avoid a double cache with setup-go.
-          skip-pkg-cache: true
           args: --timeout 10m

--- a/cmd/eksctl-anywhere/cmd/createcluster.go
+++ b/cmd/eksctl-anywhere/cmd/createcluster.go
@@ -224,6 +224,7 @@ func (cc *createClusterOptions) createCluster(cmd *cobra.Command, _ []string) er
 		SkippedValidations: skippedValidations,
 		KubeClient:         deps.UnAuthKubeClient.KubeconfigClient(mgmt.KubeconfigFile),
 		ManifestReader:     deps.ManifestReader,
+		BundlesOverride:    cc.bundlesOverride,
 	}
 	createValidations := createvalidations.New(validationOpts)
 

--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -200,6 +200,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command, args []strin
 		SkippedValidations: skippedValidations,
 		KubeClient:         deps.UnAuthKubeClient.KubeconfigClient(managementCluster.KubeconfigFile),
 		ManifestReader:     deps.ManifestReader,
+		BundlesOverride:    cc.bundlesOverride,
 	}
 
 	upgradeValidations := upgradevalidations.New(validationOpts)

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbelldatacenterconfigs.yaml
@@ -41,15 +41,16 @@ spec:
                 description: HookImagesURLPath can be used to override the default
                   Hook images path to pull from a local server.
                 type: string
+              hookIsoURL:
+                description: HookIsoURL is the URL of ISO image that will be used
+                  to provision the hardware during one time boot process. It can be
+                  used to override the default Hook OS ISO image to pull from a local
+                  server.
+                type: string
               isoBoot:
-                description: IsoBoot can be used to indicate that the hardware must
+                description: IsoBoot can be used to indicate that the hardware should
                   boot using an ISO.
                 type: boolean
-              hookIsoURL:
-                description: HookIsoURL is the URL of ISO image that will one time boot.
-                  It can be used to override the default Hook OS ISO image to pull
-                  from a local server.
-                type: string
               loadBalancerInterface:
                 description: LoadBalancerInterface can be used to configure a load
                   balancer interface for the Tinkerbell stack.

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -6923,15 +6923,16 @@ spec:
                 description: HookImagesURLPath can be used to override the default
                   Hook images path to pull from a local server.
                 type: string
+              hookIsoURL:
+                description: HookIsoURL is the URL of ISO image that will be used
+                  to provision the hardware during one time boot process. It can be
+                  used to override the default Hook OS ISO image to pull from a local
+                  server.
+                type: string
               isoBoot:
-                description: IsoBoot can be used to indicate that the hardware must
+                description: IsoBoot can be used to indicate that the hardware should
                   boot using an ISO.
                 type: boolean
-              hookIsoURL:
-                description: HookIsoURL is the URL of ISO image that will one time boot.
-                  It can be used to override the default Hook OS ISO image to pull
-                  from a local server.
-                type: string
               loadBalancerInterface:
                 description: LoadBalancerInterface can be used to configure a load
                   balancer interface for the Tinkerbell stack.

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -873,7 +873,7 @@ func TestValidateExtendedKubernetesVersionSupportCLINoError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	reader := internalmocks.NewMockReader(ctrl)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient)
+	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
 	if err != nil {
 		t.Errorf("got = %v, \nwant nil", err)
 	}
@@ -897,9 +897,9 @@ func TestValidateExtendedKubernetesVersionSupportCLIError(t *testing.T) {
 	releasesURL := releases.ManifestURL()
 	reader.EXPECT().ReadFile(releasesURL)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient)
+	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
 	if err == nil {
-		t.Errorf("got = nil, \nwant error: getting bundle for existing cluster")
+		t.Errorf("got = nil, \nwant error: getting bundle for cluster")
 	}
 }
 
@@ -945,7 +945,7 @@ spec:
 
 	reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient)
+	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
 	if err != nil {
 		t.Errorf("got = %v, \nwant nil", err)
 	}

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/aws/eks-anywhere/internal/test"
 	internalmocks "github.com/aws/eks-anywhere/internal/test/mocks"
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/features"
@@ -27,6 +26,23 @@ import (
 	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/validations/mocks"
 )
+
+type fakeFileReader struct {
+	content string
+}
+
+func (f *fakeFileReader) ReadFile(url string) ([]byte, error) {
+	if url == "bundles-override.yaml" {
+		return []byte(f.content), nil
+	}
+	return nil, fmt.Errorf("unexpected url: %s", url)
+}
+
+type fakeFileReaderError struct{}
+
+func (f *fakeFileReaderError) ReadFile(_ string) ([]byte, error) {
+	return nil, fmt.Errorf("failed to read file")
+}
 
 type clusterTest struct {
 	*WithT
@@ -861,8 +877,8 @@ func TestValidateK8s132SupportActive(t *testing.T) {
 func TestValidateExtendedKubernetesVersionSupportCLINoError(t *testing.T) {
 	ctx := context.Background()
 
-	cluster := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
 			EksaVersion: nil,
 		},
 	}
@@ -882,8 +898,8 @@ func TestValidateExtendedKubernetesVersionSupportCLINoError(t *testing.T) {
 func TestValidateExtendedKubernetesVersionSupportCLIError(t *testing.T) {
 	ctx := context.Background()
 	version := test.DevEksaVersion()
-	cluster := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
 			EksaVersion: &version,
 		},
 	}
@@ -906,8 +922,8 @@ func TestValidateExtendedKubernetesVersionSupportCLIError(t *testing.T) {
 func TestValidateExtendedKubernetesVersionSupportCLICheckExtendedSupport(t *testing.T) {
 	ctx := context.Background()
 	version := test.DevEksaVersion()
-	cluster := &v1alpha1.Cluster{
-		Spec: v1alpha1.ClusterSpec{
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
 			EksaVersion:       &version,
 			KubernetesVersion: anywherev1.Kube130,
 		},
@@ -949,4 +965,56 @@ spec:
 	if err != nil {
 		t.Errorf("got = %v, \nwant nil", err)
 	}
+}
+
+func TestValidateExtendedKubernetesSupportWithBundlesOverrideSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := test.DevEksaVersion()
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube130,
+		},
+	}
+
+	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeversion: "1.30"
+    endOfStandardSupport: "2026-12-31"`
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+	bundlesOverride := "bundles-override.yaml"
+
+	fakeClient := test.NewFakeKubeClient(cluster)
+
+	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, reader, fakeClient, bundlesOverride)
+	g.Expect(err).To(BeNil())
+}
+
+func TestValidateExtendedKubernetesSupportWithBundlesOverrideError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := test.DevEksaVersion()
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion: &version,
+		},
+	}
+
+	reader := manifests.NewReader(&fakeFileReaderError{})
+	bundlesOverride := "bundles-override.yaml"
+	fakeClient := test.NewFakeKubeClient(cluster)
+
+	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, reader, fakeClient, bundlesOverride)
+	g.Expect(err).To(MatchError(ContainSubstring("getting bundle for cluster:")))
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -63,7 +63,7 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 			return &validations.ValidationResult{
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
-				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient),
+				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient, v.Opts.BundlesOverride),
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -135,7 +135,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 			return &validations.ValidationResult{
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
-				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient),
+				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient, u.Opts.BundlesOverride),
 			}
 		},
 	}

--- a/pkg/validations/validation_options.go
+++ b/pkg/validations/validation_options.go
@@ -23,6 +23,7 @@ type Opts struct {
 	CliVersion         string
 	KubeClient         kubernetes.Client
 	ManifestReader     *manifests.Reader
+	BundlesOverride    string
 }
 
 func (o *Opts) SetDefaults() {


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
**Commit 1**
This commit updates the extended kubernetes version support validation to use the specified bundles file when a cluster is created or upgraded with `--bundles-override` CLI flag.

**Commit 2**
This commit removes the `skip-pkg-cache` option from the golangci-lint action as it has been removed in v5.0.0+ ([compatibility](https://github.com/golangci/golangci-lint-action/blob/master/README.md#compatibility)). This option was added in [#3888](https://github.com/aws/eks-anywhere/pull/3888) to avoid double cache with setup-go. The action throws the following error now with v6.0.0:
```
Warning: Unexpected input(s) 'skip-pkg-cache', valid inputs are ['version', 'install-mode', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-save-cache', 'problem-matchers', 'args', 'cache-invalidation-interval']
```

**Commit 3**
This commit adds unit tests to improve coverage and also runs `make generate-manifests` and `make release-manifests` to update the manifests files.

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
```
Created docker cluster locally with the changes and verified that the specified bundles-override file is being used for verification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

