### PR TITLE
Add license token in the cluster spec for all E2E tests

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -40,6 +40,13 @@ func WithKubernetesVersion(v anywherev1.KubernetesVersion) ClusterFiller {
 	}
 }
 
+// WithLicenseToken sets LicenseToken with the provided token value to use.
+func WithLicenseToken(licenseToken string) ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		c.Spec.LicenseToken = licenseToken
+	}
+}
+
 // WithBundlesRef sets BundlesRef with the provided name to use.
 func WithBundlesRef(name string, namespace string, apiVersion string) ClusterFiller {
 	return func(c *anywherev1.Cluster) {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -67,6 +67,7 @@ const (
 	hardwareCsvPath                        = "hardware.csv"
 	EksaPackagesInstallation               = "eks-anywhere-packages"
 	bundleReleasePathFromArtifacts         = "./eks-anywhere-downloads/bundle-release.yaml"
+	licenseToken                           = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJsaWNlbnNlSWQiOiJsLWJkMmYxZDNkNDhmOTRiYzU4M2QyZDkwNDAxN2NkM2M5IiwibGljZW5zZVZlcnNpb24iOiIxIiwiYmVnaW5WYWxpZGl0eSI6IjIwMjQtMDMtMjBUMjA6NDc6MTMuMDAwWiIsImVuZFZhbGlkaXR5IjoiMjAyNS0wMy0yMVQyMDo0NzoxMy4wMDBaIiwic3Vic2NyaXB0aW9uSWQiOiI5ZjhhMDdhYS1hNTZiLTQ4OWQtYWQwNS1jMmIzMGM1MzljMDU6ZGNiYjE5NTQiLCJzdWJzY3JpcHRpb25OYW1lIjoiSW50ZWdyYXRpb24tVGVzdC05MWYzY2UzYi1jMGVlLTQzOGMtODEwMS1lODdhNDg5MTIwNDAiLCJhY2NvdW50SWQiOiI0MTI2ODc5NDgzOTgiLCJyZWdpb24iOiJ1cy13ZXN0LTIifQ.AiheXFAjEe5NdumVOcGKsJhRthpny_Lnjpotqvghb2Qq8QS-_iZRnVG146uVyQlzX99sLvDtVE5V48x9xAxMGA"
 )
 
 //go:embed testdata/oidc-roles.yaml
@@ -141,6 +142,8 @@ func NewClusterE2ETest(t T, provider Provider, opts ...ClusterE2ETestOpt) *Clust
 	}
 
 	e.ClusterConfigLocation = filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a.yaml")
+
+	e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
 
 	if err := os.MkdirAll(e.ClusterConfigFolder, os.ModePerm); err != nil {
 		t.Fatalf("Failed creating cluster config folder for test: %s", err)


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR updates all the E2E tests to include a valid and unexpired license token in the cluster spec by default. Before this change, all the 1.28 tests failed with the following error:
```
2025-02-11T16:42:49.120-0800    V0      ❌ Validation failed    {"validation": "validate extended kubernetes version support is supported", "error": "getting licenseToken: licenseToken is required for extended kubernetes support", "remediation": "ensure you have a valid license for extended Kubernetes version support"}
```
This is because kubernetes version `v1.28` is already under extended support so a valid and unexpired license token is required to create 1.28 clusters. Eventually, all the kubernetes versions would go under extended support period so it is best to have a valid and unexpired license token being used for all the tests.

*NOTE:*
The license token being used here is obtained from the [739425988811](https://isengard.amazon.com/manage-accounts/739425988811) `beta-pdx` build account. It has the following claims:
```
{
  "licenseId": "l-bd2f1d3d48f94bc583d2d904017cd3c9",
  "licenseVersion": "1",
  "beginValidity": "2024-03-20T20:47:13.000Z",
  "endValidity": "2025-03-21T20:47:13.000Z",
  "subscriptionId": "9f8a07aa-a56b-489d-ad05-c2b30c539c05:dcbb1954",
  "subscriptionName": "Integration-Test-91f3ce3b-c0ee-438c-8101-e87a48912040",
  "accountId": "412687948398",
  "region": "us-west-2"
}
```
The corresponding subscription has `autoRenew` set to True so the license will never expire.

*Testing (if applicable):*
```
make eks-a
make build-e2e-test-binary
./bin/e2e.test -test.v -test.run TestDockerKubernetes128SimpleFlow
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

