### PR TITLE
Retrieve license token from secrets manager

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -68,6 +68,7 @@ env:
     T_KMS_SOCKET: "etcd-encryption:socket"
     T_CLOUDSTACK_SSH_AUTHORIZED_KEY: "vsphere_ci_beta_connection:ssh_authorized_key"
     T_SSH_PRIVATE_KEY: "vsphere_ci_beta_connection:base64_encoded_ssh_private_key"
+    LICENSE_TOKEN: "extended_support:license_token"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -24,6 +24,7 @@ env:
     T_REGISTRY_MIRROR_DEFAULT_SECURITY_GROUP: "harbor-registry-data:default_sg_id"
     T_REGISTRY_MIRROR_AIRGAPPED_SECURITY_GROUP: "harbor-registry-data:airgapped_sg_id"
     T_AWS_IAM_ROLE_ARN: "aws-iam-auth-role:ec2_role_arn"
+    LICENSE_TOKEN: "extended_support:license_token"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -47,7 +47,7 @@ env:
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_29: "nutanix_ci:nutanix_template_rhel_9_1_29"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_30: "nutanix_ci:nutanix_template_rhel_9_1_30"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_31: "nutanix_ci:nutanix_template_rhel_9_1_31"
-
+    LICENSE_TOKEN: "extended_support:license_token"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -72,6 +72,7 @@ env:
     T_TINKERBELL_BMC_TIMESTAMP_HEADER: "tinkerbell_ci:bmc_timestamp_header"
     T_TINKERBELL_BMC_INCLUDED_PAYLOAD_HEADERS: "tinkerbell_ci:bmc_included_payload_headers"
     T_TINKERBELL_HOOK_ISO_URL: "tinkerbell_ci:hook_iso_url"
+    LICENSE_TOKEN: "extended_support:license_token"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -87,6 +87,7 @@ env:
     T_KMS_KEY_REGION: "etcd-encryption:region"
     T_KMS_SOCKET: "etcd-encryption:socket"
     T_SSH_PRIVATE_KEY: "vsphere_ci_beta_connection:base64_encoded_ssh_private_key"
+    LICENSE_TOKEN: "extended_support:license_token"
 phases:
   pre_build:
     commands:

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -63,11 +63,11 @@ const (
 	ClusterIPPoolEnvVar                    = "T_CLUSTER_IP_POOL"
 	ClusterIPEnvVar                        = "T_CLUSTER_IP"
 	CleanupResourcesVar                    = "T_CLEANUP_RESOURCES"
+	LicenseTokenEnvVar                     = "LICENSE_TOKEN"
 	hardwareYamlPath                       = "hardware.yaml"
 	hardwareCsvPath                        = "hardware.csv"
 	EksaPackagesInstallation               = "eks-anywhere-packages"
 	bundleReleasePathFromArtifacts         = "./eks-anywhere-downloads/bundle-release.yaml"
-	licenseToken                           = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJsaWNlbnNlSWQiOiJsLWJkMmYxZDNkNDhmOTRiYzU4M2QyZDkwNDAxN2NkM2M5IiwibGljZW5zZVZlcnNpb24iOiIxIiwiYmVnaW5WYWxpZGl0eSI6IjIwMjQtMDMtMjBUMjA6NDc6MTMuMDAwWiIsImVuZFZhbGlkaXR5IjoiMjAyNS0wMy0yMVQyMDo0NzoxMy4wMDBaIiwic3Vic2NyaXB0aW9uSWQiOiI5ZjhhMDdhYS1hNTZiLTQ4OWQtYWQwNS1jMmIzMGM1MzljMDU6ZGNiYjE5NTQiLCJzdWJzY3JpcHRpb25OYW1lIjoiSW50ZWdyYXRpb24tVGVzdC05MWYzY2UzYi1jMGVlLTQzOGMtODEwMS1lODdhNDg5MTIwNDAiLCJhY2NvdW50SWQiOiI0MTI2ODc5NDgzOTgiLCJyZWdpb24iOiJ1cy13ZXN0LTIifQ.AiheXFAjEe5NdumVOcGKsJhRthpny_Lnjpotqvghb2Qq8QS-_iZRnVG146uVyQlzX99sLvDtVE5V48x9xAxMGA"
 )
 
 //go:embed testdata/oidc-roles.yaml
@@ -143,7 +143,10 @@ func NewClusterE2ETest(t T, provider Provider, opts ...ClusterE2ETestOpt) *Clust
 
 	e.ClusterConfigLocation = filepath.Join(e.ClusterConfigFolder, e.ClusterName+"-eks-a.yaml")
 
-	e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
+	licenseToken := getLicenseToken()
+	if licenseToken != "" {
+		e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
+	}
 
 	if err := os.MkdirAll(e.ClusterConfigFolder, os.ModePerm); err != nil {
 		t.Fatalf("Failed creating cluster config folder for test: %s", err)
@@ -1075,6 +1078,10 @@ func getClusterName(t T) string {
 
 func getBundlesOverride() string {
 	return os.Getenv(BundlesOverrideVar)
+}
+
+func getLicenseToken() string {
+	return os.Getenv(LicenseTokenEnvVar)
 }
 
 func getCleanupResourcesVar() (bool, error) {


### PR DESCRIPTION
*Issue:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR retrieves the license token from secrets manager.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

