### PR TITLE
Add new license token to the workload cluster e2e tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -69,6 +69,7 @@ env:
     T_CLOUDSTACK_SSH_AUTHORIZED_KEY: "vsphere_ci_beta_connection:ssh_authorized_key"
     T_SSH_PRIVATE_KEY: "vsphere_ci_beta_connection:base64_encoded_ssh_private_key"
     LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -144,6 +144,8 @@ env:
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_29: "nutanix_ci:nutanix_template_rhel_9_1_29"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_30: "nutanix_ci:nutanix_template_rhel_9_1_30"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_31: "nutanix_ci:nutanix_template_rhel_9_1_31"
+    LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 
 phases:
   pre_build:

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -25,6 +25,7 @@ env:
     T_REGISTRY_MIRROR_AIRGAPPED_SECURITY_GROUP: "harbor-registry-data:airgapped_sg_id"
     T_AWS_IAM_ROLE_ARN: "aws-iam-auth-role:ec2_role_arn"
     LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -48,6 +48,7 @@ env:
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_30: "nutanix_ci:nutanix_template_rhel_9_1_30"
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_31: "nutanix_ci:nutanix_template_rhel_9_1_31"
     LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -183,6 +183,9 @@ env:
     TEST_RUNNER_GOVC_RESOURCE_POOL: "tinkerbell_ci:govc_resource_pool"
     TEST_RUNNER_GOVC_NETWORK: "tinkerbell_ci:govc_network"
     TEST_RUNNER_GOVC_FOLDER: "tinkerbell_ci:govc_folder"
+    # Extended kubernetes version support secrets
+    LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -73,6 +73,7 @@ env:
     T_TINKERBELL_BMC_INCLUDED_PAYLOAD_HEADERS: "tinkerbell_ci:bmc_included_payload_headers"
     T_TINKERBELL_HOOK_ISO_URL: "tinkerbell_ci:hook_iso_url"
     LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 phases:
   pre_build:
     commands:

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -88,6 +88,7 @@ env:
     T_KMS_SOCKET: "etcd-encryption:socket"
     T_SSH_PRIVATE_KEY: "vsphere_ci_beta_connection:base64_encoded_ssh_private_key"
     LICENSE_TOKEN: "extended_support:license_token"
+    LICENSE_TOKEN2: "extended_support:license_token2"
 phases:
   pre_build:
     commands:

--- a/pkg/validations/extendedversion.go
+++ b/pkg/validations/extendedversion.go
@@ -122,7 +122,7 @@ func validateLicenseKeyIsUnique(ctx context.Context, clusterName string, license
 	}
 	for _, eksaCluster := range eksaClusters.Items {
 		if eksaCluster.Name != clusterName && eksaCluster.Spec.LicenseToken == licenseToken {
-			return fmt.Errorf("license key %s is already in use by cluster %s", licenseToken, eksaCluster.Name)
+			return fmt.Errorf("license token %s is already in use by cluster %s", licenseToken, eksaCluster.Name)
 		}
 	}
 	return nil

--- a/pkg/validations/extendedversion_test.go
+++ b/pkg/validations/extendedversion_test.go
@@ -160,7 +160,7 @@ func TestValidateLicenseKeyIsUnique(t *testing.T) {
 					LicenseToken: "valid-token",
 				},
 			},
-			wantErr: fmt.Errorf("license key valid-token is already in use by cluster"),
+			wantErr: fmt.Errorf("license token valid-token is already in use by cluster"),
 		},
 	}
 	for _, tc := range tests {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -64,6 +64,7 @@ const (
 	ClusterIPEnvVar                        = "T_CLUSTER_IP"
 	CleanupResourcesVar                    = "T_CLEANUP_RESOURCES"
 	LicenseTokenEnvVar                     = "LICENSE_TOKEN"
+	LicenseToken2EnvVar                    = "LICENSE_TOKEN2"
 	hardwareYamlPath                       = "hardware.yaml"
 	hardwareCsvPath                        = "hardware.csv"
 	EksaPackagesInstallation               = "eks-anywhere-packages"
@@ -1082,6 +1083,10 @@ func getBundlesOverride() string {
 
 func getLicenseToken() string {
 	return os.Getenv(LicenseTokenEnvVar)
+}
+
+func getLicenseToken2() string {
+	return os.Getenv(LicenseToken2EnvVar)
 }
 
 func getCleanupResourcesVar() (bool, error) {

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -28,8 +28,10 @@ func NewMulticlusterE2ETest(t *testing.T, managementCluster *ClusterE2ETest, wor
 	}
 
 	m.WorkloadClusters = make(WorkloadClusters, len(workloadClusters))
+	licenseToken2 := getLicenseToken2()
 	for _, c := range workloadClusters {
 		c.clusterFillers = append(c.clusterFillers, api.WithManagementCluster(managementCluster.ClusterName))
+		c.clusterFillers = append(c.clusterFillers, api.WithLicenseToken(licenseToken2))
 		c.UpdateClusterName(m.NewWorkloadClusterName())
 		m.WithWorkloadClusters(c)
 	}


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR adds a new license token to the workload cluster E2E tests to have unique tokens for each cluster. Before this change, the workload cluster E2E tests failed with the following error:
```
2025-02-18T05:20:00.146Z	V0	❌ Validation failed	{"validation": "validate extended kubernetes version support is supported", "error": "validating licenseToken is unique for cluster <workload-cluster-name>: license key <license-token-string> is already in use by cluster <other-cluster-name>", "remediation": "ensure you have a valid license for extended Kubernetes version support"}
```

It also updates the error message to say license "token" instead of license "key" to be consistent with the extended support terminology.

NOTE:
The new license token being used here is also obtained from the [739425988811](https://tiny.amazon.com/1hut4ldhl/IsenLink) beta-pdx build account and it is valid till 21st March 2025.

*Testing (if applicable):*
```
make eks-a
make build-all-test-binaries
make lint
make unit-test
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

