### PR TITLE
Add workload cluster license token env variable to required common env vars

### DIFF
--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -2,6 +2,7 @@ package framework
 
 var requiredCommonEnvVars = []string{
 	LicenseTokenEnvVar,
+	LicenseToken2EnvVar,
 }
 
 // RequiredCommonEnvVars returns the list of env variables required for all tests.


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR adds the workload cluster license token env variable to required common env vars. The new token was added in [#9262](https://github.com/aws/eks-anywhere/pull/9262) to fix the workload cluster e2e tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

