### PR TITLE
Remove k8s 1.32 feature flag and make 1.32 the default version

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -229,7 +229,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster.
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube131
+	return Kube132
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -4032,7 +4032,7 @@ func TestValidateEksaVersion(t *testing.T) {
 
 func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
-	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube131))
+	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube132))
 }
 
 func TestClusterWorkerNodeConfigCount(t *testing.T) {

--- a/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
@@ -17,7 +17,7 @@ spec:
     upgradeRolloutStrategy:
       type: InPlace
   datacenterRef: {}
-  kubernetesVersion: "1.31"
+  kubernetesVersion: "1.32"
   managementCluster:
     name: test-cluster
   workerNodeGroupConfigurations:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -8,7 +8,6 @@ const (
 	UseControllerForCli               = "USE_CONTROLLER_FOR_CLI"
 	VSphereInPlaceEnvVar              = "VSPHERE_IN_PLACE_UPGRADE"
 	APIServerExtraArgsEnabledEnvVar   = "API_SERVER_EXTRA_ARGS_ENABLED"
-	K8s132SupportEnvVar               = "K8S_1_32_SUPPORT"
 	VSphereFailureDomainEnabledEnvVar = "VSPHERE_FAILURE_DOMAIN_ENABLED"
 )
 
@@ -64,14 +63,6 @@ func APIServerExtraArgsEnabled() Feature {
 	return Feature{
 		Name:     "Configure api server extra args",
 		IsActive: globalFeatures.isActiveForEnvVar(APIServerExtraArgsEnabledEnvVar),
-	}
-}
-
-// K8s132Support is the feature flag for Kubernetes 1.32 support.
-func K8s132Support() Feature {
-	return Feature{
-		Name:     "Kubernetes version 1.32 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s132SupportEnvVar),
 	}
 }
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -86,14 +86,6 @@ func TestAPIServerExtraArgsEnabledFeatureFlag(t *testing.T) {
 	g.Expect(IsActive(APIServerExtraArgsEnabled())).To(BeTrue())
 }
 
-func TestWithK8s132FeatureFlag(t *testing.T) {
-	g := NewWithT(t)
-	setupContext(t)
-
-	g.Expect(os.Setenv(K8s132SupportEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(K8s132Support())).To(BeTrue())
-}
-
 func TestWithVsphereFailureDomainsFeatureFlag(t *testing.T) {
 	g := NewWithT(t)
 	setupContext(t)

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
@@ -287,16 +286,6 @@ func ValidateBottlerocketKubeletConfig(spec *cluster.Spec) error {
 		}
 	}
 
-	return nil
-}
-
-// ValidateK8s132Support checks if the 1.32 feature flag is set when using k8s 1.32.
-func ValidateK8s132Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s132Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube132 {
-			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube132, features.K8s132SupportEnvVar)
-		}
-	}
 	return nil
 }
 

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -17,7 +17,6 @@ import (
 	internalmocks "github.com/aws/eks-anywhere/internal/test/mocks"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/releases"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -857,21 +856,6 @@ func TestValidateBottlerocketKC(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateK8s132Support(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube132
-	tt.Expect(validations.ValidateK8s132Support(tt.clusterSpec)).To(
-		MatchError(ContainSubstring("kubernetes version 1.32 is not enabled. Please set the env variable K8S_1_32_SUPPORT")))
-}
-
-func TestValidateK8s132SupportActive(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube132
-	features.ClearCache()
-	os.Setenv(features.K8s132SupportEnvVar, "true")
-	tt.Expect(validations.ValidateK8s132Support(tt.clusterSpec)).To(Succeed())
 }
 
 func TestValidateExtendedKubernetesVersionSupportCLINoError(t *testing.T) {

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -8,7 +8,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -49,14 +48,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate cluster's eksaVersion matches EKS-A version",
 				Remediation: "ensure EksaVersion matches the EKS-A release or omit the value from the cluster config",
 				Err:         validations.ValidateEksaVersion(ctx, v.Opts.CliVersion, v.Opts.Spec),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.32 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s132SupportEnvVar),
-				Err:         validations.ValidateK8s132Support(v.Opts.Spec),
-				Silent:      true,
 			}
 		},
 		func() *validations.ValidationResult {

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,7 +9,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -121,14 +120,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate eksa controller is not paused",
 				Remediation: fmt.Sprintf("remove cluster controller reconciler pause annotation %s before upgrading the cluster %s", u.Opts.Spec.Cluster.PausedAnnotation(), targetCluster.Name),
 				Err:         validations.ValidatePauseAnnotation(ctx, k, targetCluster, targetCluster.Name),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.32 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s132SupportEnvVar),
-				Err:         validations.ValidateK8s132Support(u.Opts.Spec),
-				Silent:      true,
 			}
 		},
 		func() *validations.ValidationResult {

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -36,7 +36,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -2233,12 +2232,11 @@ func dumpFile(description, path string, t T) {
 func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
 	// Update this variable to equal the feature flagged k8s version when applicable.
 	// For example, if k8s 1.31 is under a feature flag, we would set this to v1alpha1.Kube131
-	unreleasedK8sVersion := v1alpha1.Kube132
+	var unreleasedK8sVersion v1alpha1.KubernetesVersion
 
 	if version == unreleasedK8sVersion {
 		// Set feature flag for the unreleased k8s version when applicable
 		e.T.Logf("Setting k8s version support feature flag...")
-		os.Setenv(features.K8s132SupportEnvVar, "true")
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

