### PR TITLE
Remove AWS Outposts section from validated partners list

### DIFF
--- a/docs/content/en/docs/overview/partner/_index.md
+++ b/docs/content/en/docs/overview/partner/_index.md
@@ -166,28 +166,3 @@ tetrate.io       tetrate-istio-distribution   1.18.1
 hashicorp        vault                        0.25.0
 STCLab           wave-autoscale               1.10.0
 ```
-
-## AWS Outpost provider validated partners
-
-```
-Kubernetes Version :  1.27 
-Date of Conformance Test : 2024-05-02
- 
-Following ISV Partners have Validated their Conformance : 
- 
-VENDOR_PRODUCT   VENDOR_PRODUCT_TYPE          VENDOR_PRODUCT_VERSION
-aqua             aqua-enforcer                2022.4.20
-dynatrace        dynatrace                    0.10.1
-komodor          k8s-watcher                  1.15.5
-kong             kong-enterprise              2.27.0
-accuknox         kubearmor                    v1.3.2
-kubecost         cost-analyzer                2.1.0
-nirmata          enterprise-kyverno           1.6.10
-lacework         polygraph                    6.11.0
-perfectscale     perfectscale                 v0.0.38
-pulumi           pulumi-kubernetes-operator   0.3.0
-solo.io          solo-istiod                  1.18.3-eks-a
-sysdig           sysdig-agent                 1.6.3
-tetrate.io       tetrate-istio-distribution   1.18.1
-hashicorp        vault                        0.25.0
-```


### PR DESCRIPTION
Remove AWS Outposts section from validated partners list since EKS-A doesn't run on Outposts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

