### PR TITLE
Fix incorrect template kubernetes versions for etcd scale tests

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -7424,12 +7424,12 @@ func TestVSphereKubernetes128to129BottlerocketEtcdScaleUp(t *testing.T) {
 
 	runSimpleUpgradeFlow(
 		test,
-		v1alpha1.Kube128,
+		v1alpha1.Kube129,
 		framework.WithClusterUpgrade(
 			api.WithKubernetesVersion(v1alpha1.Kube129),
 			api.WithExternalEtcdTopology(3),
 		),
-		provider.WithProviderUpgrade(provider.Bottlerocket128Template()),
+		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
 	)
 }
 
@@ -7439,7 +7439,7 @@ func TestVSphereKubernetes128to129BottlerocketEtcdScaleDown(t *testing.T) {
 		t,
 		provider,
 		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
+			api.WithKubernetesVersion(v1alpha1.Kube128),
 			api.WithExternalEtcdTopology(3),
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
@@ -7448,12 +7448,12 @@ func TestVSphereKubernetes128to129BottlerocketEtcdScaleDown(t *testing.T) {
 
 	runSimpleUpgradeFlow(
 		test,
-		v1alpha1.Kube128,
+		v1alpha1.Kube129,
 		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
+			api.WithKubernetesVersion(v1alpha1.Kube129),
 			api.WithExternalEtcdTopology(1),
 		),
-		provider.WithProviderUpgrade(provider.Bottlerocket128Template()),
+		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
 	)
 }
 


### PR DESCRIPTION
*Description of changes:*
This PR fixes incorrect template kubernetes versions for etcd scale tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

