### PR TITLE
Fix e2e tests failures due to missing license token

### DIFF
--- a/test/e2e/flux.go
+++ b/test/e2e/flux.go
@@ -11,6 +11,7 @@ import (
 func runFluxFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
+	test.GenerateSupportBundleIfTestFailed()
 	test.ValidateFlux()
 	test.StopIfFailed()
 	test.DeleteCluster()
@@ -20,6 +21,7 @@ func runUpgradeFlowWithFlux(test *framework.ClusterE2ETest, updateVersion v1alph
 	test.GenerateClusterConfig()
 	test.CreateCluster()
 	test.UpgradeClusterWithNewConfig(clusterOpts)
+	test.GenerateSupportBundleIfTestFailed()
 	test.ValidateCluster(updateVersion)
 	test.ValidateFlux()
 	test.StopIfFailed()

--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -14,8 +14,9 @@ import (
 
 func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 	test.CreateManagementClusterWithConfig()
+	licenseToken2 := framework.GetLicenseToken2()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.GenerateClusterConfig()
+		w.GenerateClusterConfigWithLicenseToken(licenseToken2)
 		w.CreateCluster()
 		w.DeleteCluster()
 	})

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3948,6 +3948,8 @@ func TestVSphereKubernetes132BottlerocketTaintsUpgradeFlow(t *testing.T) {
 }
 
 func TestVSphereKubernetes128UbuntuWorkloadClusterTaintsFlow(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
+	licenseToken2 := framework.GetLicenseToken2()
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 
 	managementCluster := framework.NewClusterE2ETest(
@@ -3958,6 +3960,7 @@ func TestVSphereKubernetes128UbuntuWorkloadClusterTaintsFlow(t *testing.T) {
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
 			api.WithExternalEtcdTopology(1),
+			api.WithLicenseToken(licenseToken),
 		),
 	)
 
@@ -3973,6 +3976,7 @@ func TestVSphereKubernetes128UbuntuWorkloadClusterTaintsFlow(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
 				api.WithStackedEtcdTopology(),
+				api.WithLicenseToken(licenseToken2),
 			),
 			provider.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
 			provider.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoExecuteTaint()))),
@@ -4044,12 +4048,16 @@ func TestVSphereKubernetes131UbuntuTo132Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes128To129Ubuntu2204Upgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,
@@ -4108,6 +4116,7 @@ func TestVSphereKubernetes131To132Ubuntu2204Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes128To129Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
@@ -4116,6 +4125,7 @@ func TestVSphereKubernetes128To129Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
 		api.ClusterToConfigFiller(
 			api.WithStackedEtcdTopology(),
+			api.WithLicenseToken(licenseToken),
 		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
@@ -4308,12 +4318,16 @@ func TestVSphereKubernetes131To132StackedEtcdRedHatUpgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes128Ubuntu2004To2204Upgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,
@@ -4324,12 +4338,16 @@ func TestVSphereKubernetes128Ubuntu2004To2204Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes129Ubuntu2004To2204Upgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,
@@ -4340,12 +4358,16 @@ func TestVSphereKubernetes129Ubuntu2004To2204Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes130Ubuntu2004To2204Upgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,
@@ -4356,12 +4378,16 @@ func TestVSphereKubernetes130Ubuntu2004To2204Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,
@@ -4372,12 +4398,16 @@ func TestVSphereKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes132Ubuntu2004To2204Upgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
 	).WithClusterConfig(
 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
 		test,
@@ -4388,6 +4418,7 @@ func TestVSphereKubernetes132Ubuntu2004To2204Upgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes128UbuntuTo129InPlaceUpgradeCPOnly(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
 	kube128 := v1alpha1.Kube128
 	kube129 := v1alpha1.Kube129
@@ -4403,6 +4434,7 @@ func TestVSphereKubernetes128UbuntuTo129InPlaceUpgradeCPOnly(t *testing.T) {
 			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube128),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -4417,6 +4449,7 @@ func TestVSphereKubernetes128UbuntuTo129InPlaceUpgradeCPOnly(t *testing.T) {
 }
 
 func TestVSphereKubernetes130UbuntuTo131InPlaceUpgradeWorkerOnly(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
 	kube130 := v1alpha1.Kube130
 	kube131 := v1alpha1.Kube131
@@ -4432,6 +4465,7 @@ func TestVSphereKubernetes130UbuntuTo131InPlaceUpgradeWorkerOnly(t *testing.T) {
 			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube130),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -4448,6 +4482,7 @@ func TestVSphereKubernetes130UbuntuTo131InPlaceUpgradeWorkerOnly(t *testing.T) {
 }
 
 func TestVSphereKubernetes131UbuntuTo132InPlaceUpgradeWorkerOnly(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
 	kube131 := v1alpha1.Kube131
 	kube132 := v1alpha1.Kube132
@@ -4463,6 +4498,7 @@ func TestVSphereKubernetes131UbuntuTo132InPlaceUpgradeWorkerOnly(t *testing.T) {
 			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -5626,6 +5662,7 @@ func TestVSphereKubernetes131to132UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 }
 
 func TestVSphereKubernetes128UbuntuTo129InPlaceUpgrade_1CP_3Worker(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5637,6 +5674,7 @@ func TestVSphereKubernetes128UbuntuTo129InPlaceUpgrade_1CP_3Worker(t *testing.T)
 			api.WithWorkerNodeCount(3),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
@@ -5650,6 +5688,7 @@ func TestVSphereKubernetes128UbuntuTo129InPlaceUpgrade_1CP_3Worker(t *testing.T)
 }
 
 func TestVSphereKubernetes129UbuntuTo130InPlaceUpgrade_3CP_3Worker(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5661,6 +5700,7 @@ func TestVSphereKubernetes129UbuntuTo130InPlaceUpgrade_3CP_3Worker(t *testing.T)
 			api.WithWorkerNodeCount(3),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
@@ -5674,6 +5714,7 @@ func TestVSphereKubernetes129UbuntuTo130InPlaceUpgrade_3CP_3Worker(t *testing.T)
 }
 
 func TestVSphereKubernetes130UbuntuTo131InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5685,6 +5726,7 @@ func TestVSphereKubernetes130UbuntuTo131InPlaceUpgrade_1CP_1Worker(t *testing.T)
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
@@ -5698,6 +5740,7 @@ func TestVSphereKubernetes130UbuntuTo131InPlaceUpgrade_1CP_1Worker(t *testing.T)
 }
 
 func TestVSphereKubernetes131UbuntuTo132InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5709,6 +5752,7 @@ func TestVSphereKubernetes131UbuntuTo132InPlaceUpgrade_1CP_1Worker(t *testing.T)
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
@@ -5722,6 +5766,7 @@ func TestVSphereKubernetes131UbuntuTo132InPlaceUpgrade_1CP_1Worker(t *testing.T)
 }
 
 func TestVSphereKubernetes128UbuntuTo132InPlaceUpgrade(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	var kube129clusterOpts []framework.ClusterE2ETestOpt
 	var kube130clusterOpts []framework.ClusterE2ETestOpt
 	var kube131clusterOpts []framework.ClusterE2ETestOpt
@@ -5736,6 +5781,7 @@ func TestVSphereKubernetes128UbuntuTo132InPlaceUpgrade(t *testing.T) {
 			api.WithKubernetesVersion(v1alpha1.Kube128),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -5784,6 +5830,7 @@ func TestVSphereKubernetes128UbuntuTo132InPlaceUpgrade(t *testing.T) {
 }
 
 func TestVSphereKubernetes132UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5796,6 +5843,7 @@ func TestVSphereKubernetes132UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -5812,6 +5860,7 @@ func TestVSphereKubernetes132UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
 }
 
 func TestVSphereKubernetes132UbuntuInPlaceCPScaleDown3To1(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5824,6 +5873,7 @@ func TestVSphereKubernetes132UbuntuInPlaceCPScaleDown3To1(t *testing.T) {
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -5840,6 +5890,7 @@ func TestVSphereKubernetes132UbuntuInPlaceCPScaleDown3To1(t *testing.T) {
 }
 
 func TestVSphereKubernetes132UbuntuInPlaceWorkerScaleUp1To2(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5852,6 +5903,7 @@ func TestVSphereKubernetes132UbuntuInPlaceWorkerScaleUp1To2(t *testing.T) {
 			api.WithWorkerNodeCount(1),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),
@@ -5868,6 +5920,7 @@ func TestVSphereKubernetes132UbuntuInPlaceWorkerScaleUp1To2(t *testing.T) {
 }
 
 func TestVSphereKubernetes132UbuntuInPlaceWorkerScaleDown2To1(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
 	test := framework.NewClusterE2ETest(
 		t,
@@ -5880,6 +5933,7 @@ func TestVSphereKubernetes132UbuntuInPlaceWorkerScaleDown2To1(t *testing.T) {
 			api.WithWorkerNodeCount(2),
 			api.WithStackedEtcdTopology(),
 			api.WithInPlaceUpgradeStrategy(),
+			api.WithLicenseToken(licenseToken),
 		),
 		api.VSphereToConfigFiller(
 			api.RemoveEtcdVsphereMachineConfig(),

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -351,8 +351,17 @@ type Provider interface {
 	WithNewWorkerNodeGroup(name string, workerNodeGroup *WorkerNodeGroup) api.ClusterConfigFiller
 }
 
+// GenerateClusterConfig generates a cluster configuration.
 func (e *ClusterE2ETest) GenerateClusterConfig(opts ...CommandOpt) {
-	licenseToken := getLicenseToken()
+	licenseToken := GetLicenseToken()
+	if licenseToken != "" {
+		e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
+	}
+	e.GenerateClusterConfigForVersion("", opts...)
+}
+
+// GenerateClusterConfigWithLicenseToken generates a cluster configuration while setting a specific license token.
+func (e *ClusterE2ETest) GenerateClusterConfigWithLicenseToken(licenseToken string, opts ...CommandOpt) {
 	if licenseToken != "" {
 		e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
 	}
@@ -493,7 +502,7 @@ func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opt
 		}
 
 		if currentSemver.Compare(semverV022) != -1 {
-			licenseToken := getLicenseToken()
+			licenseToken := GetLicenseToken()
 			if licenseToken != "" {
 				e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
 			}
@@ -541,7 +550,7 @@ func (e *ClusterE2ETest) UpdateClusterConfig(fillers ...api.ClusterConfigFiller)
 	e.buildClusterConfigFile()
 }
 
-func (e *ClusterE2ETest) baseClusterConfigUpdates(opts ...CommandOpt) []api.ClusterConfigFiller {
+func (e *ClusterE2ETest) baseClusterConfigUpdates() []api.ClusterConfigFiller {
 	clusterFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+3)
 	// This defaults all tests to a 1:1:1 configuration. Since all the fillers defined on each test are run
 	// after these 3, if the tests is explicit about any of these, the defaults will be overwritten
@@ -1094,11 +1103,13 @@ func getBundlesOverride() string {
 	return os.Getenv(BundlesOverrideVar)
 }
 
-func getLicenseToken() string {
+// GetLicenseToken retrieves the license token from the environment variables.
+func GetLicenseToken() string {
 	return os.Getenv(LicenseTokenEnvVar)
 }
 
-func getLicenseToken2() string {
+// GetLicenseToken2 retrieves the license token 2 from the environment variables.
+func GetLicenseToken2() string {
 	return os.Getenv(LicenseToken2EnvVar)
 }
 
@@ -1719,13 +1730,13 @@ func (e *ClusterE2ETest) VerifyCertManagerPackageInstalled(prefix, namespace, pa
 	}
 
 	e.T.Log("Waiting for Self Signed certificate to be issued")
-	err = e.verifySelfSignedCertificate(mgmtCluster)
+	err = e.verifySelfSignedCertificate()
 	if err != nil {
 		errCh <- err
 	}
 
 	e.T.Log("Waiting for Let's Encrypt certificate to be issued")
-	err = e.verifyLetsEncryptCert(mgmtCluster)
+	err = e.verifyLetsEncryptCert()
 	if err != nil {
 		errCh <- err
 	}
@@ -1749,7 +1760,7 @@ var certManagerSelfSignedIssuer []byte
 //go:embed testdata/certmanager/certmanager_selfsignedcert.yaml
 var certManagerSelfSignedCert []byte
 
-func (e *ClusterE2ETest) verifySelfSignedCertificate(mgmtCluster *types.Cluster) error {
+func (e *ClusterE2ETest) verifySelfSignedCertificate() error {
 	ctx := context.Background()
 	selfsignedCert := "my-selfsigned-ca"
 	err := e.KubectlClient.ApplyKubeSpecFromBytes(ctx, e.Cluster(), certManagerSelfSignedIssuer)
@@ -1779,7 +1790,7 @@ var certManagerLetsEncryptCert []byte
 //go:embed testdata/certmanager/certmanager_secret.yaml
 var certManagerSecret string
 
-func (e *ClusterE2ETest) verifyLetsEncryptCert(mgmtCluster *types.Cluster) error {
+func (e *ClusterE2ETest) verifyLetsEncryptCert() error {
 	ctx := context.Background()
 	letsEncryptCert := "test-cert"
 	accessKey, secretAccess, region, zoneID := GetRoute53Configs()

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -28,7 +28,7 @@ func NewMulticlusterE2ETest(t *testing.T, managementCluster *ClusterE2ETest, wor
 	}
 
 	m.WorkloadClusters = make(WorkloadClusters, len(workloadClusters))
-	licenseToken2 := getLicenseToken2()
+	licenseToken2 := GetLicenseToken2()
 	for _, c := range workloadClusters {
 		c.clusterFillers = append(c.clusterFillers, api.WithManagementCluster(managementCluster.ClusterName))
 		c.clusterFillers = append(c.clusterFillers, api.WithLicenseToken(licenseToken2))


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR fixes the inplace upgrade tests and upgrade tests without cluster config generation failing with the following error:
```
2025-02-22T05:23:13.299Z	V0	❌ Validation failed	{"validation": "validate extended kubernetes version support is supported", "error": "getting licenseToken: licenseToken is required for extended kubernetes support", "remediation": "ensure you have a valid license for extended Kubernetes version support"}
```
It also fixes the workload cluster tests failing with the following error:
```
Error: validations failed: validating licenseToken is unique for cluster main-i-00821-76f2f36-w-0: license token <license-token-string> is already in use by cluster main-i-00821-76f2f36
```
This is because [#9264](https://github.com/aws/eks-anywhere/pull/9264) moved the logic for setting the license token in the cluster config from NewClusterE2ETest() function to GenerateClusterConfig() function. The problem with this is that all tests call the NewClusterE2ETest() function but not every test calls the GenerateClusterConfig() function. Some tests have upgrade flows which do not generate cluster config which led to those tests not having the license token set in the cluster spec. This PR fixes the issue by updating those tests to set the license token in the main test function.

Additionally, this PR also updates the Flux flow tests to generate support bundle if the test fails. This is necessary because currently the GitFlux and GitHubFlux tests are failing but there is no way to root cause the issue since the support bundle is not getting generated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

