### PR TITLE
Fix wrong k8s version in VSphere131UbuntuTo132InPlaceUpgradeWorker

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -4483,7 +4483,7 @@ func TestVSphereKubernetes130UbuntuTo131InPlaceUpgradeWorkerOnly(t *testing.T) {
 
 func TestVSphereKubernetes131UbuntuTo132InPlaceUpgradeWorkerOnly(t *testing.T) {
 	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+	provider := framework.NewVSphere(t, framework.WithUbuntu131())
 	kube131 := v1alpha1.Kube131
 	kube132 := v1alpha1.Kube132
 	test := framework.NewClusterE2ETest(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the wrong k8s version in VSphere131UbuntuTo132InPlaceUpgradeWorker
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

