### PR TITLE
Fix docker upgrade from latest tests

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1259,7 +1259,7 @@ func TestDockerUpgradeFromLatestMinorReleaseCiliumSkipUpgrade_CLIUpgrade(t *test
 
 	test.ValidateCiliumCLIAvailable()
 
-	test.GenerateClusterConfig(framework.ExecuteWithEksaRelease(release))
+	test.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
 	test.CreateCluster(framework.ExecuteWithEksaRelease(release))
 	test.ReplaceCiliumWithOSSCilium()
 

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -494,11 +494,11 @@ func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opt
 		// We will need the conditional check as long as the latest minor is 'v0.21.*'.
 		currentSemver, err := semver.New(eksaVersion)
 		if err != nil {
-			e.T.Fatal("parsing esk-a version", err)
+			e.T.Fatalf("parsing eks-a version:", err)
 		}
 		semverV022, err := semver.New(releaseV022)
 		if err != nil {
-			e.T.Fatal("parsing esk-a version", err)
+			e.T.Fatalf("parsing eks-a version:", err)
 		}
 
 		if currentSemver.Compare(semverV022) != -1 {


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR fixes the `TestDockerUpgradeFromLatestMinorReleaseCiliumSkipUpgrade_CLIUpgrade` test. It was failing with the following error:
```
Error: the cluster config file provided is invalid: unable to parse main-i-0ee7f-9546b4b/main-i-0ee7f-9546b4b-eks-a.yaml file: error unmarshaling JSON: while decoding JSON: json: unknown field "licenseToken"
```
This is because the test creates cluster with the latest minor release which is v0.21 and the license token field is only supported from v0.22.0 onwards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

