### PR TITLE
include LicenseToken and EtcdEncryption in cluster config marshaling

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -1561,6 +1561,8 @@ func (c *Cluster) ConvertConfigToConfigGenerateStruct() *ClusterGenerate {
 			BundlesRef:                    c.Spec.BundlesRef,
 			EksaVersion:                   c.Spec.EksaVersion,
 			MachineHealthCheck:            c.Spec.MachineHealthCheck,
+			EtcdEncryption:                c.Spec.EtcdEncryption,
+			LicenseToken:                  c.Spec.LicenseToken,
 		},
 	}
 

--- a/pkg/clustermarshaller/clustermarshaller_test.go
+++ b/pkg/clustermarshaller/clustermarshaller_test.go
@@ -22,8 +22,22 @@ func TestWriteClusterConfigWithOIDCAndGitOps(t *testing.T) {
 		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
 		s.Cluster.Name = "mycluster"
 		s.Cluster.Spec.KubernetesVersion = ""
+		s.Cluster.Spec.LicenseToken = "test-token"
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 			Count: 3,
+		}
+		s.Cluster.Spec.EtcdEncryption = &[]v1alpha1.EtcdEncryption{
+			{
+				Providers: []v1alpha1.EtcdEncryptionProvider{
+					{
+						KMS: &v1alpha1.KMS{
+							Name:                "test-config",
+							SocketListenAddress: "unix:///kms/socket/path",
+						},
+					},
+				},
+				Resources: []string{"secrets"},
+			},
 		}
 		s.Cluster.Spec.GitOpsRef = &v1alpha1.Ref{
 			Kind: v1alpha1.GitOpsConfigKind,
@@ -131,6 +145,7 @@ func TestWriteClusterConfigWithFluxAndGitOpsConfigs(t *testing.T) {
 		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
 		s.Cluster.Name = "mycluster"
 		s.Cluster.Spec.KubernetesVersion = ""
+		s.Cluster.Spec.LicenseToken = "test-token"
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 			Count: 3,
 		}
@@ -238,6 +253,7 @@ func TestWriteClusterConfigWithFluxConfig(t *testing.T) {
 		s.Cluster.CreationTimestamp = v1.Time{Time: time.Now()}
 		s.Cluster.Name = "mycluster"
 		s.Cluster.Spec.KubernetesVersion = ""
+		s.Cluster.Spec.LicenseToken = "test-token"
 		s.Cluster.Spec.ExternalEtcdConfiguration = &v1alpha1.ExternalEtcdConfiguration{
 			Count: 3,
 		}

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster.yaml
@@ -10,6 +10,13 @@ spec:
   controlPlaneConfiguration: {}
   datacenterRef: {}
   eksaVersion: v0.19.0-dev+latest
+  etcdEncryption:
+  - providers:
+    - kms:
+        name: test-config
+        socketListenAddress: unix:///kms/socket/path
+    resources:
+    - secrets
   externalEtcdConfiguration:
     count: 3
   gitOpsRef:
@@ -18,6 +25,7 @@ spec:
   identityProviderRefs:
   - kind: OIDCConfig
     name: config
+  licenseToken: test-token
   managementCluster:
     name: mycluster
   workerNodeGroupConfigurations:

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_and_gitops.yaml
@@ -15,6 +15,7 @@ spec:
   gitOpsRef:
     kind: GitOpsConfig
     name: config
+  licenseToken: test-token
   managementCluster:
     name: mycluster
   workerNodeGroupConfigurations:

--- a/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
+++ b/pkg/clustermarshaller/testdata/expected_marshalled_cluster_flux_config.yaml
@@ -15,6 +15,7 @@ spec:
   gitOpsRef:
     kind: FluxConfig
     name: config
+  licenseToken: test-token
   managementCluster:
     name: mycluster
   workerNodeGroupConfigurations:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/pull/9112 added licenseToken to cluster spec. The ConvertConfigToConfigGenerateStruct() function, which handles cluster marshalling, was not updated to include the LicenseToken field. This meant for some specific flows such as flux, local cluster spec written to disk, spec outputted in CLI during create - this field was always being dropped. 

*Description of changes:*

- Add LicenseToken and EtcdEncryption fields to ClusterGenerate struct
- Ensure these fields are included when converting Cluster to ClusterConfig which is then written to disk
- Fix issue where license token was not persisting in Git config

*Testing (if applicable):*
Ran a local-e2e and verified that the flux tests passed. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

