### PR TITLE
Add K8s version arg to secondary control plane nodes in node upgrader

### DIFF
--- a/controllers/nodeupgrade_controller.go
+++ b/controllers/nodeupgrade_controller.go
@@ -184,7 +184,7 @@ func (r *NodeUpgradeReconciler) reconcile(ctx context.Context, log logr.Logger, 
 		if nodeUpgrade.Spec.FirstNodeToBeUpgraded {
 			upgraderPod = upgrader.UpgradeFirstControlPlanePod(node.Name, upgraderImage, nodeUpgrade.Spec.KubernetesVersion, *nodeUpgrade.Spec.EtcdVersion)
 		} else {
-			upgraderPod = upgrader.UpgradeSecondaryControlPlanePod(node.Name, upgraderImage)
+			upgraderPod = upgrader.UpgradeSecondaryControlPlanePod(node.Name, upgraderImage, nodeUpgrade.Spec.KubernetesVersion)
 		}
 	} else {
 		upgraderPod = upgrader.UpgradeWorkerPod(node.Name, upgraderImage)

--- a/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
+++ b/pkg/nodeupgrader/testdata/expected_rest_control_plane_upgrader_pod.yaml
@@ -86,6 +86,8 @@ spec:
     - node
     - --type
     - RestCP
+    - --k8sVersion
+    - v1.28.3-eks-1-28-9
     command:
     - nsenter
     image: public.ecr.aws/eks-anywhere/node-upgrader:latest

--- a/pkg/nodeupgrader/upgrader.go
+++ b/pkg/nodeupgrader/upgrader.go
@@ -45,9 +45,9 @@ func UpgradeFirstControlPlanePod(nodeName, image, kubernetesVersion, etcdVersion
 }
 
 // UpgradeSecondaryControlPlanePod returns an upgrader pod that can be deployed on the remaining control plane nodes.
-func UpgradeSecondaryControlPlanePod(nodeName, image string) *corev1.Pod {
+func UpgradeSecondaryControlPlanePod(nodeName, image, kubernetesVersion string) *corev1.Pod {
 	p := upgraderPod(nodeName, image, true)
-	p.Spec.InitContainers = containersForUpgrade(true, image, nodeName, "upgrade", "node", "--type", "RestCP")
+	p.Spec.InitContainers = containersForUpgrade(true, image, nodeName, "upgrade", "node", "--type", "RestCP", "--k8sVersion", kubernetesVersion)
 	return p
 }
 

--- a/pkg/nodeupgrader/upgrader_test.go
+++ b/pkg/nodeupgrader/upgrader_test.go
@@ -29,7 +29,7 @@ func TestUpgradeFirstControlPlanePod(t *testing.T) {
 
 func TestUpgradeSecondaryControlPlanePod(t *testing.T) {
 	g := NewWithT(t)
-	pod := nodeupgrader.UpgradeSecondaryControlPlanePod(nodeName, upgraderImage)
+	pod := nodeupgrader.UpgradeSecondaryControlPlanePod(nodeName, upgraderImage, kubernetesVersion)
 	g.Expect(pod).ToNot(BeNil())
 
 	data, err := yaml.Marshal(pod)


### PR DESCRIPTION
From K8s 1.32 node upgrader scheduled in secondary control plane nodes will need the K8s version to add some version specific flags. Upgrader [change](https://github.com/aws/eks-anywhere-build-tooling/pull/4371) post which we need this.

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

