### PR TITLE
Remove Bottlerocket AMI from release artifacts list

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -627,13 +627,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				Name:                "eks-distro",
 				OSName:              "bottlerocket",
 				OSVersion:           "1",
-				Format:              "ami",
-				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
-			},
-			{
-				Name:                "eks-distro",
-				OSName:              "bottlerocket",
-				OSVersion:           "1",
 				Format:              "ova",
 				ArchiveS3PathGetter: archives.EksDistroArtifactPathGetter,
 			},

--- a/release/cli/pkg/bundles/eksd.go
+++ b/release/cli/pkg/bundles/eksd.go
@@ -147,9 +147,6 @@ func GetEksDReleaseBundle(r *releasetypes.ReleaseConfig, eksDReleaseChannel, kub
 		Crictl:         bundleArchiveArtifacts["cri-tools"],
 		Containerd:     bundleArchiveArtifacts["containerd"],
 		ImageBuilder:   bundleArchiveArtifacts["image-builder"],
-		Ami: anywherev1alpha1.OSImageBundle{
-			Bottlerocket: bundleArchiveArtifacts["bottlerocket-ami"],
-		},
 		Ova: anywherev1alpha1.OSImageBundle{
 			Bottlerocket: bundleArchiveArtifacts["bottlerocket-ova"],
 		},


### PR DESCRIPTION
Remove Bottlerocket AMI from release artifacts list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

