### PR TITLE
Use the prod license tokens for staging tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -70,6 +70,8 @@ env:
     T_SSH_PRIVATE_KEY: "vsphere_ci_beta_connection:base64_encoded_ssh_private_key"
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 phases:
   pre_build:
     commands:
@@ -94,6 +96,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - mv bin/cloudstack/e2e.test bin/e2e.test
       - >
@@ -110,6 +117,7 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
+        --stage=${STAGE}
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -136,6 +136,8 @@ env:
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_32: "nutanix_ci:nutanix_template_rhel_9_1_32"
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 
 phases:
   pre_build:
@@ -152,6 +154,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - >
         ./bin/test e2e run
@@ -166,6 +173,7 @@ phases:
         --bundles-override=${BUNDLES_OVERRIDE}
         --cleanup-resources=true
         --test-report-folder=reports
+        --stage=${STAGE}
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -26,6 +26,8 @@ env:
     T_AWS_IAM_ROLE_ARN: "aws-iam-auth-role:ec2_role_arn"
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 phases:
   pre_build:
     commands:
@@ -44,6 +46,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - mv bin/docker/e2e.test bin/e2e.test
       - >
@@ -59,6 +66,7 @@ phases:
         --bundles-override=${BUNDLES_OVERRIDE}
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
+        --stage=${STAGE}
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -194,6 +194,8 @@ env:
     # Extended kubernetes version support secrets
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 phases:
   pre_build:
     commands:
@@ -229,6 +231,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - |
         if [ -z "$TESTS" ] || [ "$TESTS" == "QUICK" ]; then
@@ -248,6 +255,7 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
+        --stage=${STAGE}
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -74,6 +74,8 @@ env:
     T_TINKERBELL_HOOK_ISO_URL: "tinkerbell_ci:hook_iso_url"
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 phases:
   pre_build:
     commands:
@@ -92,6 +94,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - mv bin/tinkerbell/e2e.test bin/e2e.test
       - >
@@ -108,6 +115,7 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
+        --stage=${STAGE}
 reports:
   e2e-reports:
     files:

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -89,6 +89,8 @@ env:
     T_SSH_PRIVATE_KEY: "vsphere_ci_beta_connection:base64_encoded_ssh_private_key"
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 phases:
   pre_build:
     commands:
@@ -112,6 +114,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - mv bin/vsphere/e2e.test bin/e2e.test
       - >
@@ -128,6 +135,7 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
+        --stage=${STAGE}
   post_build:
     commands:
       - unset AWS_SDK_LOAD_CONFIG AWS_PROFILE

--- a/internal/test/e2e/common.go
+++ b/internal/test/e2e/common.go
@@ -13,5 +13,14 @@ func (e *E2ESession) setupCommonEnv() error {
 			e.testEnvVars[eVar] = val
 		}
 	}
+
+	// overwrite license token env variables for staging
+	for _, eVar := range requiredEnvVars {
+		if e.stage == "staging" {
+			if val, ok := os.LookupEnv("STAGING_" + eVar); ok {
+				e.testEnvVars[eVar] = val
+			}
+		}
+	}
 	return nil
 }

--- a/internal/test/e2e/run.go
+++ b/internal/test/e2e/run.go
@@ -51,6 +51,7 @@ type ParallelRunConf struct {
 	TestReportFolder       string
 	BranchName             string
 	Logger                 logr.Logger
+	Stage                  string
 }
 
 type (
@@ -202,6 +203,7 @@ type instanceRunConf struct {
 	CleanupResources        bool
 	Logger                  logr.Logger
 	Session                 *session.Session
+	Stage                   string
 }
 
 //nolint:gocyclo, revive // RunTests responsible launching test runner to run tests is complex.
@@ -238,7 +240,7 @@ func RunTests(conf instanceRunConf, inventoryCatalogue map[string]*hardwareCatal
 		"branch_name", conf.BranchName, "ip_pool", conf.IPPool.ToString(),
 		"hardware_count", conf.HardwareCount, "tinkerbell_airgapped_test", conf.TinkerbellAirgappedTest,
 		"bundles_override", conf.BundlesOverride, "test_runner_type", conf.TestRunnerType,
-		"cleanup_resources", conf.CleanupResources)
+		"cleanup_resources", conf.CleanupResources, "stage", conf.Stage)
 
 	instanceId, err := testRunner.createInstance(conf)
 	if err != nil {
@@ -518,6 +520,7 @@ func newInstanceRunConf(awsSession *session.Session, conf ParallelRunConf, jobNu
 		TestRunnerType:          testRunnerType,
 		TestRunnerConfig:        *testRunnerConfig,
 		Logger:                  conf.Logger.WithValues("jobID", jobID, "test", testRegex),
+		Stage:                   conf.Stage,
 	}
 }
 

--- a/internal/test/e2e/setup.go
+++ b/internal/test/e2e/setup.go
@@ -47,6 +47,7 @@ type E2ESession struct {
 	branchName          string
 	hardware            []*api.Hardware
 	logger              logr.Logger
+	stage               string
 }
 
 func newE2ESession(instanceId string, conf instanceRunConf) (*E2ESession, error) {
@@ -64,6 +65,7 @@ func newE2ESession(instanceId string, conf instanceRunConf) (*E2ESession, error)
 		branchName:          conf.BranchName,
 		hardware:            conf.Hardware,
 		logger:              conf.Logger,
+		stage:               conf.Stage,
 	}
 
 	return e, nil


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR updates the e2e tests to use the prod license tokens for the tests triggered by the staging pipeline. This is because we updated the extended support validations in [#9248](https://github.com/aws/eks-anywhere/pull/9248) to use a different public key for verifying the license tokens as we don't want the license tokens from non-production subscriptions to be valid in prod EKS-A releases.

The license token env variable value is overwritten with a different staging env variable from secrets manager with a logic similar to how it was done before for the regional packages test in [#6964](https://github.com/aws/eks-anywhere/pull/6964).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

