### PR TITLE
Fix setting the stage variable in integration tests buildspec files

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -98,7 +98,7 @@ phases:
         fi
       - STAGE="dev"
       - |
-        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
           STAGE="staging"
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)

--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -156,7 +156,7 @@ phases:
         fi
       - STAGE="dev"
       - |
-        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
           STAGE="staging"
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -48,7 +48,7 @@ phases:
         fi
       - STAGE="dev"
       - |
-        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
           STAGE="staging"
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -49,6 +49,8 @@ env:
     T_NUTANIX_TEMPLATE_NAME_REDHAT_9_1_32: "nutanix_ci:nutanix_template_rhel_9_1_32"
     LICENSE_TOKEN: "extended_support:license_token"
     LICENSE_TOKEN2: "extended_support:license_token2"
+    STAGING_LICENSE_TOKEN: "extended_support:staging_license_token"
+    STAGING_LICENSE_TOKEN2: "extended_support:staging_license_token2"
 phases:
   pre_build:
     commands:
@@ -76,6 +78,11 @@ phases:
         if [ -f ./bin/local-bundle-release.yaml ]; then
           BUNDLES_OVERRIDE=true
         fi
+      - STAGE="dev"
+      - |
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
+          STAGE="staging"
+        fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)
       - mv bin/nutanix/e2e.test bin/e2e.test
       - >
@@ -92,6 +99,7 @@ phases:
         --cleanup-resources=true
         --test-report-folder=reports
         --branch-name=${BRANCH_NAME}
+        --stage=${STAGE}
   post_build:
     commands:
       - >

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -233,7 +233,7 @@ phases:
         fi
       - STAGE="dev"
       - |
-        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
           STAGE="staging"
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -96,7 +96,7 @@ phases:
         fi
       - STAGE="dev"
       - |
-        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
           STAGE="staging"
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -116,7 +116,7 @@ phases:
         fi
       - STAGE="dev"
       - |
-        if [[ "$(CODEBUILD_INITIATOR)" =~ "aws-staging-eks-a-release" ]]; then
+        if [[ "$CODEBUILD_INITIATOR" =~ "aws-staging-eks-a-release" ]]; then
           STAGE="staging"
         fi
       - SKIPPED_TESTS=$(yq e ".skipped_tests | @csv" ${CODEBUILD_SRC_DIR}/test/e2e/SKIPPED_TESTS.yaml)


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR fixes setting the stage variable in integration tests buildspec files for staging pipeline. The staging job was throwing the following error before this change:
```
/codebuild/output/tmp/script.sh: line 4: CODEBUILD_INITIATOR: command not found
```

This is because of the round brackets around that variable in the buildspec file. The round brackets in bash script makes it a command instead of a variable. Removing the brackets should fix this issue. This PR also updates the buildspec for Nutanix to use the prod license token for staging tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

