### PR TITLE
Add v0.22 to doc site versions config

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -180,10 +180,16 @@ icon = "fab fa-github"
 desc = "Development takes place here!"
 
 [[params.versions]]
-fullversion = "v0.21"
-version = "v0.21"
+fullversion = "v0.22"
+version = "v0.22"
 docsbranch = "main"
 url = "https://anywhere.eks.amazonaws.com"
+
+[[params.versions]]
+fullversion = "v0.21"
+version = "v0.21"
+docsbranch = "release-0.21"
+url = "https://release-0.21.anywhere.eks.amazonaws.com"
 
 [[params.versions]]
 fullversion = "v0.20"


### PR DESCRIPTION
Add v0.22 to doc site versions config

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

