### PR TITLE
Fix docs url for release 0.21

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -189,7 +189,7 @@ url = "https://anywhere.eks.amazonaws.com"
 fullversion = "v0.21"
 version = "v0.21"
 docsbranch = "release-0.21"
-url = "https://release-0.21.anywhere.eks.amazonaws.com"
+url = "https://release-0-21.anywhere.eks.amazonaws.com"
 
 [[params.versions]]
 fullversion = "v0.20"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix docs url for release 0.21, change 0.21 to 0-21

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

