### PR TITLE
Updated testdata yaml for ADOT package

### DIFF
--- a/test/framework/testdata/adot_package_daemonset.yaml
+++ b/test/framework/testdata/adot_package_daemonset.yaml
@@ -53,14 +53,14 @@ spec:
         batch: {}
         memory_limiter: null
       exporters:
-        logging:
-          loglevel: info
+        debug:
+          verbosity: basic
       service:
         pipelines:
           metrics:
             receivers: [prometheus]
             processors: [batch]
-            exporters: [logging]
+            exporters: [debug]
         telemetry:
           metrics:
             address: 0.0.0.0:8888

--- a/test/framework/testdata/adot_package_deployment.yaml
+++ b/test/framework/testdata/adot_package_deployment.yaml
@@ -53,14 +53,14 @@ spec:
         batch: {}
         memory_limiter: null
       exporters:
-        logging:
-          loglevel: info
+        debug:
+          verbosity: basic
       service:
         pipelines:
           metrics:
             receivers: [prometheus]
             processors: [batch]
-            exporters: [logging]
+            exporters: [debug]
         telemetry:
           metrics:
             address: 0.0.0.0:8888


### PR DESCRIPTION
*Description of changes:*
- This PR updates e2e testdata config for ADOT package by replacing logging exporter with debug exporter, logging exporter was removed from [upstream](https://github.com/open-telemetry/opentelemetry-collector/pull/11037) so this will resolve the failing e2e tests for ADOT.

*Testing (if applicable):*
- Verified the changes by successfully executing the local e2e-test `TestVSphereKubernetes131CuratedPackagesAdotUpdateFlow`.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you c an use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

