### PR TITLE
Remove TestVSphereKubernetes131To132RedHatUpgrade from e2e tests

### DIFF
--- a/test/e2e/QUICK_TESTS.yaml
+++ b/test/e2e/QUICK_TESTS.yaml
@@ -2,7 +2,7 @@ quick_tests:
 # Docker
 - TestDocker.*132
 # vSphere
-- ^TestVSphereKubernetes131To132RedHatUpgrade$
+- ^TestVSphereKubernetes130To131RedHatUpgrade$
 - TestVSphereKubernetes131To132StackedEtcdRedHatUpgrade
 - ^TestVSphereKubernetes131UbuntuTo132Upgrade$
 - TestVSphereKubernetes131UbuntuTo132StackedEtcdUpgrade

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -4269,21 +4269,6 @@ func TestVSphereKubernetes130To131RedHatUpgrade(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes131To132RedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat131VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat132Template()),
-	)
-}
-
 func TestVSphereKubernetes128To129StackedEtcdRedHatUpgrade(t *testing.T) {
 	provider := framework.NewVSphere(t, framework.WithRedHat128VSphere())
 	test := framework.NewClusterE2ETest(


### PR DESCRIPTION
Remove TestVSphereKubernetes131To132RedHatUpgrade from e2e tests since k8s 1.32 does not support RHEL 8.
Change quick e2e to run the 130to131 upgrade test.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

