### PR TITLE
Add hyperlink to public.ecr repository

### DIFF
--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -22,7 +22,7 @@ NAMESPACE       NAME        STATE
 eksa-packages   v1-27-125   available
 ```
 
-To get a package bundle manually, you can use `oras` to pull the package bundle (bundle.yaml) from the [public.ecr.aws/eks-anywhere](https://anywhere.eks.amazonaws.com/docs/packages/packagebundles/) repository. (See the [ORAS CLI official documentation](https://oras.land/docs/) for more details)
+To get a package bundle manually, you can use `oras` to pull the package bundle (bundle.yaml) from the [public.ecr.aws/eks-anywhere](https://gallery.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles) repository. (See the [ORAS CLI official documentation](https://oras.land/docs/) for more details)
 
 ```
 oras pull public.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles:v1-27-latest

--- a/docs/content/en/docs/packages/packagebundles.md
+++ b/docs/content/en/docs/packages/packagebundles.md
@@ -22,7 +22,7 @@ NAMESPACE       NAME        STATE
 eksa-packages   v1-27-125   available
 ```
 
-To get a package bundle manually, you can use `oras` to pull the package bundle (bundle.yaml) from the `public.ecr.aws/eks-anywhere` repository. (See the [ORAS CLI official documentation](https://oras.land/docs/) for more details)
+To get a package bundle manually, you can use `oras` to pull the package bundle (bundle.yaml) from the [public.ecr.aws/eks-anywhere](https://anywhere.eks.amazonaws.com/docs/packages/packagebundles/) repository. (See the [ORAS CLI official documentation](https://oras.land/docs/) for more details)
 
 ```
 oras pull public.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles:v1-27-latest


### PR DESCRIPTION
Enhances the Package Bundles documentation by adding a direct hyperlink to the ECR repository (https://gallery.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles). Current documentation only references public.ecr.aws/eks-anywhere without a direct link

Adding the ECR repository link will:
  - Improve user experience by providing quick access to the repository
  - Enable users to easily discover and access historical package bundle versions
  - Simplify the process of finding specific tags for packagebundles images

*Issue #, if available:*

*Description of changes:*  docs/content/en/docs/packages/packagebundles.md | line 25 


*Testing (if applicable):*

*Documentation added/planned (if applicable):* https://gallery.ecr.aws/eks-anywhere/eks-anywhere-packages-bundles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

