### PR TITLE
Fix upgrade from latest minor release E2E test failures

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -487,7 +487,6 @@ func (e *ClusterE2ETest) generateHardwareConfig(opts ...CommandOpt) {
 }
 
 func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opts ...CommandOpt) {
-	e.generateClusterConfigObjects(opts...)
 	if eksaVersion != "" {
 		// LicenseToken field was introduced in cluster spec only in release-22
 		// attempting to populate the field for any prior versions would break the api.
@@ -509,6 +508,7 @@ func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opt
 		}
 	}
 
+	e.generateClusterConfigObjects(opts...)
 	e.buildClusterConfigFile()
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#2855

*Description of changes:*
This PR fixes the upgrade from latest minor release E2E tests for all providers. Some of these tests include:
```
TestDockerKubernetes128to129UpgradeFromLatestMinorRelease
TestVSphereKubernetes128UpgradeManagementComponents
TestVSphereKubernetes128To129RedhatUpgradeFromLatestMinorRelease
TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease
TestCloudStackKubernetes128WithOIDCManagementClusterUpgradeFromLatestSideEffects
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

