### PR TITLE
Use staging license token for upgrade from latest minor release tests

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -64,6 +64,7 @@ const (
 	CleanupResourcesVar                    = "T_CLEANUP_RESOURCES"
 	LicenseTokenEnvVar                     = "LICENSE_TOKEN"
 	LicenseToken2EnvVar                    = "LICENSE_TOKEN2"
+	StagingLicenseTokenEnvVar              = "STAGING_LICENSE_TOKEN"
 	hardwareYamlPath                       = "hardware.yaml"
 	hardwareCsvPath                        = "hardware.csv"
 	EksaPackagesInstallation               = "eks-anywhere-packages"
@@ -501,7 +502,7 @@ func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opt
 		}
 
 		if currentSemver.Compare(semverV022) != -1 {
-			licenseToken := GetLicenseToken()
+			licenseToken := GetStagingLicenseToken()
 			if licenseToken != "" {
 				e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
 			}
@@ -1111,6 +1112,11 @@ func GetLicenseToken() string {
 // GetLicenseToken2 retrieves the license token 2 from the environment variables.
 func GetLicenseToken2() string {
 	return os.Getenv(LicenseToken2EnvVar)
+}
+
+// GetStagingLicenseToken retrieves the staging license token from the environment variables.
+func GetStagingLicenseToken() string {
+	return os.Getenv(StagingLicenseTokenEnvVar)
 }
 
 func getCleanupResourcesVar() (bool, error) {

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -3,6 +3,7 @@ package framework
 var requiredCommonEnvVars = []string{
 	LicenseTokenEnvVar,
 	LicenseToken2EnvVar,
+	StagingLicenseTokenEnvVar,
 }
 
 // RequiredCommonEnvVars returns the list of env variables required for all tests.


### PR DESCRIPTION
*Description of changes:*
This PR updates the upgrade from latest minor release tests to use the staging license token for extended support. This is because these tests first create a cluster from the latest production minor release binary for which the CLI and controller does the license token verification with a different KMS public key used specifically for production releases.

*Testing (if applicable):*
Ran a test locally and it passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

