### PR TITLE
Fix non-unique license token failures in upgrade from latest side effects tests

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -65,6 +65,7 @@ const (
 	LicenseTokenEnvVar                     = "LICENSE_TOKEN"
 	LicenseToken2EnvVar                    = "LICENSE_TOKEN2"
 	StagingLicenseTokenEnvVar              = "STAGING_LICENSE_TOKEN"
+	StagingLicenseToken2EnvVar             = "STAGING_LICENSE_TOKEN2"
 	hardwareYamlPath                       = "hardware.yaml"
 	hardwareCsvPath                        = "hardware.csv"
 	EksaPackagesInstallation               = "eks-anywhere-packages"
@@ -1117,6 +1118,11 @@ func GetLicenseToken2() string {
 // GetStagingLicenseToken retrieves the staging license token from the environment variables.
 func GetStagingLicenseToken() string {
 	return os.Getenv(StagingLicenseTokenEnvVar)
+}
+
+// GetStagingLicenseToken2 retrieves the staging license token 2 from the environment variables.
+func GetStagingLicenseToken2() string {
+	return os.Getenv(StagingLicenseToken2EnvVar)
 }
 
 func getCleanupResourcesVar() (bool, error) {

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -4,6 +4,7 @@ var requiredCommonEnvVars = []string{
 	LicenseTokenEnvVar,
 	LicenseToken2EnvVar,
 	StagingLicenseTokenEnvVar,
+	StagingLicenseToken2EnvVar,
 }
 
 // RequiredCommonEnvVars returns the list of env variables required for all tests.


### PR DESCRIPTION
*Description of changes:*
This PR fixes the non-unique license token failures in upgrade from latest side effects tests. Before this change, the tests fail with the following error:
```
Error: validations failed: validating licenseToken is unique for cluster main-i-0612d-53a064b-w-0: license token <license-token-string> is already in use by cluster main-i-0612d-53a064b
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

