### PR TITLE
Fixing routingMode parameters for helm configuration

### DIFF
--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -350,8 +350,9 @@ func TestTemplaterGenerateManifestDirectModeManualIPCIDRSuccess(t *testing.T) {
 		"prometheus": map[string]interface{}{
 			"enabled": true,
 		},
-		"rollOutCiliumPods":     true,
-		"autoDirectNodeRoutes":  true,
+		"rollOutCiliumPods": true,
+
+		"autoDirectNodeRoutes":  "true",
 		"routingMode":           "native",
 		"ipv4NativeRoutingCIDR": "192.168.0.0/24",
 		"ipv6NativeRoutingCIDR": "2001:db8::/32",
@@ -376,6 +377,9 @@ func TestTemplaterGenerateManifestDirectModeManualIPCIDRSuccess(t *testing.T) {
 	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv4NativeRoutingCIDR = "192.168.0.0/24"
 	tt.spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.IPv6NativeRoutingCIDR = "2001:db8::/32"
 	tt.expectHelmClientFactoryGet("", "")
+
+	fmt.Println(wantValues)
+	fmt.Println()
 	tt.expectHelmTemplateWith(eqMap(wantValues), "1.22").Return(tt.manifest, nil)
 
 	tt.Expect(tt.t.GenerateManifest(tt.ctx, tt.spec)).To(Equal(tt.manifest), "templater.GenerateManifest() should return right manifest")

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -119,8 +119,8 @@ func TestTemplaterGenerateUpgradePreflightManifestSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -190,8 +190,8 @@ func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -228,8 +228,8 @@ func TestTemplaterGenerateManifestPolicyEnforcementModeSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -271,8 +271,8 @@ func TestTemplaterGenerateManifestEgressMasqueradeInterfacesSuccess(t *testing.T
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -312,7 +312,7 @@ func TestTemplaterGenerateManifestDirectRouteModeSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods":    true,
-		"routing-mode":         "native",
+		"routingMode":          "native",
 		"autoDirectNodeRoutes": "true",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
@@ -351,7 +351,8 @@ func TestTemplaterGenerateManifestDirectModeManualIPCIDRSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods":     true,
-		"routing-mode":          "native",
+		"autoDirectNodeRoutes":  true,
+		"routingMode":           "native",
 		"ipv4NativeRoutingCIDR": "192.168.0.0/24",
 		"ipv6NativeRoutingCIDR": "2001:db8::/32",
 		"image": map[string]interface{}{
@@ -459,8 +460,8 @@ func wantUpgradeValues() map[string]interface{} {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:
The routingMode parameter name injecting differently "routing-mode" This cause the wrong cilium configuration deployment.

With 1.15 , cilium also require ipv4NativeRoutingCIDR or ipv6NativeRoutingCIDR parameters if routingMode is set to native


*Testing (if applicable): vsphere deployment

*Documentation added/planned (if applicable): Planning to update native configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

