### PR TITLE
Add doc in vsphere error message & improve verbose logging output

### DIFF
--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -9,8 +9,6 @@ import (
 	"net"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
-
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/collection"
 	"github.com/aws/eks-anywhere/pkg/config"
@@ -553,13 +551,14 @@ func (v *Validator) validatePrivs(ctx context.Context, privObjs []PrivAssociatio
 	}
 
 	if len(missingPrivs) != 0 {
-		content, err := yaml.Marshal(missingPrivs)
+
+		_, err := json.Marshal(missingPrivs)
 		if err != nil {
 			return passed, fmt.Errorf("failed to marshal missing permissions: %v", err)
 		}
 
 		errMsg := fmt.Sprintf("user %s missing vSphere permissions", username)
-		logger.V(3).Info(errMsg, "Permissions", string(content))
+		logger.V(3).Info(errMsg, "Missing Permissions (JSON)", missingPrivs)
 
 		return passed, fmt.Errorf("user %s missing vSphere permissions", username)
 	}

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -51,6 +51,11 @@ const (
 	MemoryAvailable          = "Memory_Available"
 )
 
+const (
+	// Documentation URLs.
+	vSpherePermissionDoc = "https://anywhere.eks.amazonaws.com/docs/getting-started/vsphere/vsphere-preparation/"
+)
+
 //go:embed config/template-cp.yaml
 var defaultCAPIConfigCP string
 
@@ -376,7 +381,7 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 
 	if !p.skippedValidations[validations.VSphereUserPriv] {
 		if err := p.validator.validateVsphereUserPrivs(ctx, vSphereClusterSpec); err != nil {
-			return fmt.Errorf("validating vsphere user privileges: %v", err)
+			return fmt.Errorf("validating vsphere user privileges: %w, please refer to %s for required permissions or use -v 3 for full missing permissions", err, vSpherePermissionDoc)
 		}
 	}
 

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -41,27 +41,27 @@ import (
 )
 
 const (
-	testClusterConfigMainFilename            = "cluster_main.yaml"
-	testClusterConfigMainStackedEtcdFilename = "cluster_main_stacked_etcd.yaml"
-	testClusterConfigMain121Filename         = "cluster_main_121.yaml"
-	testClusterConfigMain121CPOnlyFilename   = "cluster_main_121_cp_only.yaml"
-	testClusterConfigWithCPUpgradeStrategy   = "cluster_main_121_cp_upgrade_strategy.yaml"
-	testClusterConfigWithMDUpgradeStrategy   = "cluster_main_121_md_upgrade_strategy.yaml"
-	testClusterConfigRedhatFilename          = "cluster_redhat_external_etcd.yaml"
-	testDataDir                              = "testdata"
-	expectedVSphereName                      = "vsphere"
-	expectedVSphereUsername                  = "vsphere_username"
-	expectedVSpherePassword                  = "vsphere_password"
-	expectedVSphereServer                    = "vsphere_server"
-	expectedExpClusterResourceSet            = "expClusterResourceSetKey"
-	eksd119Release                           = "kubernetes-1-19-eks-4"
-	eksd119ReleaseTag                        = "eksdRelease:kubernetes-1-19-eks-4"
-	eksd121ReleaseTag                        = "eksdRelease:kubernetes-1-21-eks-4"
-	eksd129ReleaseTag                        = "eksdRelease:kubernetes-1-29-eks-4"
-	ubuntuOSTag                              = "os:ubuntu"
-	bottlerocketOSTag                        = "os:bottlerocket"
-	testTemplate                             = "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6"
-	testVsphereClusterConfigMainFailueDomainFilename            = "cluster_vsphere_failuredomain.yaml"
+	testClusterConfigMainFilename                    = "cluster_main.yaml"
+	testClusterConfigMainStackedEtcdFilename         = "cluster_main_stacked_etcd.yaml"
+	testClusterConfigMain121Filename                 = "cluster_main_121.yaml"
+	testClusterConfigMain121CPOnlyFilename           = "cluster_main_121_cp_only.yaml"
+	testClusterConfigWithCPUpgradeStrategy           = "cluster_main_121_cp_upgrade_strategy.yaml"
+	testClusterConfigWithMDUpgradeStrategy           = "cluster_main_121_md_upgrade_strategy.yaml"
+	testClusterConfigRedhatFilename                  = "cluster_redhat_external_etcd.yaml"
+	testDataDir                                      = "testdata"
+	expectedVSphereName                              = "vsphere"
+	expectedVSphereUsername                          = "vsphere_username"
+	expectedVSpherePassword                          = "vsphere_password"
+	expectedVSphereServer                            = "vsphere_server"
+	expectedExpClusterResourceSet                    = "expClusterResourceSetKey"
+	eksd119Release                                   = "kubernetes-1-19-eks-4"
+	eksd119ReleaseTag                                = "eksdRelease:kubernetes-1-19-eks-4"
+	eksd121ReleaseTag                                = "eksdRelease:kubernetes-1-21-eks-4"
+	eksd129ReleaseTag                                = "eksdRelease:kubernetes-1-29-eks-4"
+	ubuntuOSTag                                      = "os:ubuntu"
+	bottlerocketOSTag                                = "os:bottlerocket"
+	testTemplate                                     = "/SDDC-Datacenter/vm/Templates/ubuntu-1804-kube-v1.19.6"
+	testVsphereClusterConfigMainFailueDomainFilename = "cluster_vsphere_failuredomain.yaml"
 )
 
 type DummyProviderGovcClient struct {
@@ -1557,8 +1557,8 @@ func TestSetupAndValidateCreateClusterMissingPrivError(t *testing.T) {
 	provider.validator.vSphereClientBuilder = vscb
 
 	err := provider.SetupAndValidateCreateCluster(ctx, clusterSpec)
-
-	thenErrorExpected(t, "validating vsphere user privileges: error", err)
+	expectedErrorMsg := fmt.Sprintf("validating vsphere user privileges: error, please refer to %s for required permissions or use -v 3 for full missing permissions", vSpherePermissionDoc)
+	thenErrorExpected(t, expectedErrorMsg, err)
 }
 
 func TestSetupAndValidateUpgradeClusterMissingPrivError(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
[3055](https://github.com/aws/eks-anywhere-internal/issues/3055)
*Description of changes:*
- When a user tries to create a vSphere cluster and does not have sufficient permissions, a documentation link to our vSphere permissions docs is now added along with a tip on increasing verbosity for additional info.
- Verbose logging output of missing permissions is now output in JSON and indicated as so, versus YAML for easier identification and parsing.

*Testing (if applicable):*
modified existing test in vsphere_test.go

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

