### PR TITLE
Fixing cilium routingMode parameters in helm configuration

### DIFF
--- a/docs/content/en/docs/getting-started/optional/cni.md
+++ b/docs/content/en/docs/getting-started/optional/cni.md
@@ -173,7 +173,7 @@ spec:
 
 By default all traffic is sent by Cilium over Geneve tunneling on the network. The `routingMode` option allows users to switch to [native routing](https://docs.cilium.io/en/v1.15/network/concepts/routing/#native-routing) instead.
 
-The `ipv4-native-routing-cidr` is required to set the CIDR in which native routing can be performed.
+The `ipv4NativeRoutingCIDR` is required to set the CIDR in which native routing can be performed.
 
 These fields can be set as follows:
 ```yaml
@@ -192,7 +192,7 @@ spec:
     cniConfig:
       cilium:
         routingMode: "direct"
-        ipv4-native-routing-cidr: 192.168.0.0/16
+        ipv4NativeRoutingCIDR: 192.168.0.0/16
 ```
 
 ### Use a custom CNI

--- a/docs/content/en/docs/getting-started/optional/cni.md
+++ b/docs/content/en/docs/getting-started/optional/cni.md
@@ -171,9 +171,11 @@ spec:
 
 ### RoutingMode option for Cilium plugin
 
-By default all traffic is sent by Cilium over Geneve tunneling on the network. The `routingMode` option allows users to switch to [native routing](https://docs.cilium.io/en/v1.12/concepts/networking/routing/#native-routing) instead.
+By default all traffic is sent by Cilium over Geneve tunneling on the network. The `routingMode` option allows users to switch to [native routing](https://docs.cilium.io/en/v1.15/network/concepts/routing/#native-routing) instead.
 
-This field can be set as follows:
+The `ipv4-native-routing-cidr` is required to set the CIDR in which native routing can be performed.
+
+These fields can be set as follows:
 ```yaml
 apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Cluster
@@ -190,6 +192,7 @@ spec:
     cniConfig:
       cilium:
         routingMode: "direct"
+        ipv4-native-routing-cidr: 192.168.0.0/16
 ```
 
 ### Use a custom CNI

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -796,6 +796,7 @@ func validateCNIPlugin(network ClusterNetwork) error {
 		}
 		return nil
 	}
+
 	return validateCNIConfig(network.CNIConfig)
 }
 
@@ -840,6 +841,10 @@ func validateCiliumConfig(cilium *CiliumConfig) error {
 		if cilium.PolicyEnforcementMode != "" {
 			return errors.New("when using skipUpgrades for cilium all other fields must be empty")
 		}
+	}
+
+	if cilium.RoutingMode == "direct" && cilium.IPv4NativeRoutingCIDR == "" {
+		return errors.New("direct routing mode requires IPv4NativeRoutingCIDR to be set")
 	}
 
 	if cilium.PolicyEnforcementMode == "" {

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -3073,6 +3073,17 @@ func TestValidateCNIConfig(t *testing.T) {
 			},
 		},
 		{
+			name:    "directmode needs native routing CIDR",
+			wantErr: fmt.Errorf("validating cniConfig: direct routing mode requires IPv4NativeRoutingCIDR to be set"),
+			clusterNetwork: &ClusterNetwork{
+				CNIConfig: &CNIConfig{
+					Cilium: &CiliumConfig{
+						RoutingMode: CiliumRoutingModeDirect,
+					},
+				},
+			},
+		},
+		{
 			name:    "invalid cilium policy enforcement mode",
 			wantErr: fmt.Errorf("validating cniConfig: cilium policyEnforcementMode \"invalid\" not supported"),
 			clusterNetwork: &ClusterNetwork{

--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -150,7 +150,6 @@ func (t *Templater) GenerateManifest(ctx context.Context, spec *cluster.Spec, op
 		return nil, fmt.Errorf("failed generating cilium manifest: %v", err)
 	}
 
-	// Print manifes file in string format
 	if spec.Cluster.Spec.ClusterNetwork.CNIConfig.Cilium.PolicyEnforcementMode == anywherev1.CiliumPolicyModeAlways {
 		networkPolicyManifest, err := t.GenerateNetworkPolicyManifest(spec, c.namespaces)
 		if err != nil {

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -119,8 +119,8 @@ func TestTemplaterGenerateUpgradePreflightManifestSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -190,8 +190,8 @@ func TestTemplaterGenerateManifestSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -228,8 +228,8 @@ func TestTemplaterGenerateManifestPolicyEnforcementModeSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -271,8 +271,8 @@ func TestTemplaterGenerateManifestEgressMasqueradeInterfacesSuccess(t *testing.T
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",
@@ -312,7 +312,7 @@ func TestTemplaterGenerateManifestDirectRouteModeSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods":    true,
-		"routing-mode":         "native",
+		"routingMode":          "native",
 		"autoDirectNodeRoutes": "true",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
@@ -351,7 +351,8 @@ func TestTemplaterGenerateManifestDirectModeManualIPCIDRSuccess(t *testing.T) {
 			"enabled": true,
 		},
 		"rollOutCiliumPods":     true,
-		"routing-mode":          "native",
+		"autoDirectNodeRoutes":  "true",
+		"routingMode":           "native",
 		"ipv4NativeRoutingCIDR": "192.168.0.0/24",
 		"ipv6NativeRoutingCIDR": "2001:db8::/32",
 		"image": map[string]interface{}{
@@ -459,8 +460,8 @@ func wantUpgradeValues() map[string]interface{} {
 			"enabled": true,
 		},
 		"rollOutCiliumPods": true,
-		"routing-mode":      "tunnel",
-		"tunnel-protocol":   "geneve",
+		"routingMode":       "tunnel",
+		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
 			"repository": "public.ecr.aws/isovalent/cilium",
 			"tag":        "v1.9.11-eksa.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: The routingMode parameter name injecting differently "routing-mode" This cause the wrong cilium configuration deployment.

With 1.15 , cilium also require ipv4NativeRoutingCIDR or ipv6NativeRoutingCIDR parameters if routingMode is set to native


*Testing (if applicable): Vsphere deployment is tested and  two unit tests are added  

*Documentation added/planned (if applicable):  Cilium documentation updated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

