### PR TITLE
Fix non-unique license token errors in packages workload cluster tests

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -15,9 +15,10 @@ const (
 )
 
 func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
+	licenseToken := framework.GetLicenseToken2()
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(e *framework.WorkloadCluster) {
-		e.GenerateClusterConfig()
+		e.GenerateClusterConfigWithLicenseToken(licenseToken)
 		e.ApplyClusterManifest()
 		e.WaitForKubeconfig()
 		e.ValidateClusterState()

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -56,9 +56,10 @@ func runCuratedPackageInstallSimpleFlowRegistryMirror(test *framework.ClusterE2E
 }
 
 func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
+	licenseToken := framework.GetLicenseToken2()
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(e *framework.WorkloadCluster) {
-		e.GenerateClusterConfig()
+		e.GenerateClusterConfigWithLicenseToken(licenseToken)
 		e.ApplyClusterManifest()
 		e.WaitForKubeconfig()
 		e.ValidateClusterState()


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR fixes the packages workload cluster tests failing with the following error:
```
validating licenseToken is unique for cluster eksa-test-f4b7542-w-0: license token <license-token-string> is already in use by cluster eksa-test-f4b7542
```
This should fix the following tests:
```
TestVSphereKubernetes128UbuntuWorkloadClusterCuratedPackagesSimpleFlow
TestVSphereKubernetes128UbuntuWorkloadClusterCuratedPackagesEmissarySimpleFlow
TestVSphereKubernetes128BottleRocketWorkloadClusterCuratedPackagesSimpleFlow
TestVSphereKubernetes128BottleRocketWorkloadClusterCuratedPackagesEmissarySimpleFlow
TestVSphereKubernetes128UbuntuWorkloadClusterCuratedPackagesCertManagerSimpleFlow
TestVSphereKubernetes128BottleRocketWorkloadClusterCuratedPackagesCertManagerSimpleFlow

TestCloudStackKubernetes128RedhatCuratedPackagesCertManagerSimpleFlow
TestCloudStackKubernetes128RedhatWorkloadClusterCuratedPackagesEmissarySimpleFlow
TestCloudStackKubernetes128RedhatWorkloadClusterCuratedPackagesSimpleFlow
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

