### PR TITLE
Fix non-unique license token errors in emissary workload cluster tests

### DIFF
--- a/test/e2e/emissary.go
+++ b/test/e2e/emissary.go
@@ -32,9 +32,10 @@ func runCuratedPackageEmissaryInstallSimpleFlow(test *framework.ClusterE2ETest) 
 }
 
 func runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {
+	licenseToken := framework.GetLicenseToken2()
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(e *framework.WorkloadCluster) {
-		e.GenerateClusterConfig()
+		e.GenerateClusterConfigWithLicenseToken(licenseToken)
 		e.ApplyClusterManifest()
 		e.WaitForKubeconfig()
 		e.ValidateClusterState()


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
Similar to [#9416](https://github.com/aws/eks-anywhere/pull/9416), this PR fixes the emissary workload cluster tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

