### PR TITLE
Use roles to get access key details in build spec

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -11,11 +11,7 @@ env:
     TEST_RUNNER_GOVC_TEMPLATE: "eks-a-admin-ci"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
   secrets-manager:
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
-    ROUTE53_ACCESS_KEY_ID: "packages_ci_beta:route53_access_key_id"
-    ROUTE53_SECRET_ACCESS_KEY: "packages_ci_beta:route53_secret_access_key"
     ROUTE53_REGION: "packages_ci_beta:route53_region"
     ROUTE53_ZONEID: "packages_ci_beta:route53_zoneid"
     EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
@@ -88,6 +84,16 @@ phases:
         -n ${CLUSTER_NAME_PREFIX}
         --delete-duplicate-networks
         -v 6
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
+      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test)
+      - export CERT_MANAGER_ROLE
+      - export ROUTE53_ACCESS_KEY_ID=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export ROUTE53_SECRET_ACCESS_KEY=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export ROUTE53_SESSION_TOKEN=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -40,8 +40,6 @@ env:
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
     VSPHERE_SERVER: "vsphere_ci_beta_connection:vsphere_url"
     GOVC_INSECURE: "vsphere_ci_beta_connection:govc_insecure"
@@ -146,6 +144,11 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
       - make conformance-tests
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken') 
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -7,11 +7,7 @@ env:
     EKSA_GIT_PRIVATE_KEY: "/tmp/private-key"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
   secrets-manager:
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
-    NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:non_regional_aws_access_key_id"
-    NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:non_regional_aws_secret_access_key_id"
     EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
     T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
     T_GIT_REPOSITORY: "github-eks-anywhere-flux-bot:github-repository"
@@ -38,6 +34,16 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e docker" E2E_OUTPUT_FILE=bin/docker/e2e.test
         fi
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
+      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional)
+      - export NON_REGIONAL_PACKAGES_ROLE
+      - export NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export NON_REGIONAL_EKSA_AWS_SESSION_TOKEN=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -12,8 +12,6 @@ env:
     T_NUTANIX_SYSTEMDISK_SIZE: "40Gi"
     T_NUTANIX_INSECURE: true
   secrets-manager:
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
     EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
     T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
@@ -70,6 +68,11 @@ phases:
         --insecure
         --ignoreErrors
         -v 4
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken') 
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -46,11 +46,7 @@ env:
     TEST_RUNNER_GOVC_LIBRARY: "eks-a-templates"
     TEST_RUNNER_GOVC_TEMPLATE: "eks-a-admin-ci"
   secrets-manager:
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
-    NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:non_regional_aws_access_key_id"
-    NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:non_regional_aws_secret_access_key_id"
     EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
     T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
     T_GIT_REPOSITORY: "github-eks-anywhere-flux-bot:github-repository"
@@ -225,6 +221,16 @@ phases:
         --insecure
         --ignoreErrors
         -v 4
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
+      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional)
+      - export NON_REGIONAL_PACKAGES_ROLE
+      - export NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export NON_REGIONAL_EKSA_AWS_SESSION_TOKEN=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
@@ -7,8 +7,6 @@ env:
     EKSA_GIT_PRIVATE_KEY: "/tmp/private-key"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
   secrets-manager:
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
     EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
     T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
@@ -34,6 +32,11 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e snow" E2E_OUTPUT_FILE=bin/snow/e2e.test
         fi
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken') 
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -12,8 +12,6 @@ env:
     TEST_RUNNER_GOVC_TEMPLATE: "eks-a-admin-ci"
     INTEGRATION_TEST_INFRA_CONFIG: "/tmp/test-infra.yml"
   secrets-manager:
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
     EKSA_GITHUB_TOKEN: "github-eks-anywhere-flux-bot:github-token"
     T_GITHUB_USER: "github-eks-anywhere-flux-bot:github-user"
@@ -86,6 +84,11 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e tinkerbell" E2E_OUTPUT_FILE=bin/tinkerbell/e2e.test
         fi
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')        
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -33,11 +33,7 @@ env:
   secrets-manager:
     EKSA_VSPHERE_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
     EKSA_VSPHERE_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
-    EKSA_AWS_ACCESS_KEY_ID: "packages_ci_beta:aws_access_key_id"
-    EKSA_AWS_SECRET_ACCESS_KEY: "packages_ci_beta:aws_secret_access_key_id"
     EKSA_AWS_REGION: "packages_ci_beta:aws_region"
-    ROUTE53_ACCESS_KEY_ID: "packages_ci_beta:route53_access_key_id"
-    ROUTE53_SECRET_ACCESS_KEY: "packages_ci_beta:route53_secret_access_key"
     ROUTE53_REGION: "packages_ci_beta:route53_region"
     ROUTE53_ZONEID: "packages_ci_beta:route53_zoneid"
     VSPHERE_SERVER: "vsphere_ci_beta_connection:vsphere_url"
@@ -106,6 +102,16 @@ phases:
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}
         -v 4
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test)
+      - export PACKAGES_ROLE
+      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
+      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test)
+      - export CERT_MANAGER_ROLE
+      - export ROUTE53_ACCESS_KEY_ID=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.AccessKeyId')
+      - export ROUTE53_SECRET_ACCESS_KEY=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+      - export ROUTE53_SESSION_TOKEN=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/9178

*Description of changes:*
Updating code build spec to use role for fetching aws credentials and setting them as environment variables.

*Testing (if applicable):*
Tested the logic of getting credentials by running an code build with override.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
