### PR TITLE
Fix vsphere group creation

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -1078,11 +1078,13 @@ func (g *Govc) GroupExists(ctx context.Context, name string) (bool, error) {
 	}
 
 	response, err := g.exec(ctx, params...)
-	if err != nil {
+	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("group %s doesn't exist", name)) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
-
-	return response.Len() > 0, nil
+	// govc returns empty response when group exists
+	return response.Len() == 0, nil
 }
 
 // AddUserToGroup adds a user to a group.

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -1327,9 +1327,10 @@ func TestGovcCreateRole(t *testing.T) {
 func TestGovcGroupExistsFalse(t *testing.T) {
 	ctx := context.Background()
 	_, g, executable, env := setup(t)
-	group := "EKSA"
+	group := "FakeGroup"
+	expectedErr := "govc: ServerFaultCode: The specified principal (FakeGroup@vsphere.local) is invalid.\nCaused by: group FakeGroup doesn't exist or multiple groups same name"
 
-	executable.EXPECT().ExecuteWithEnv(ctx, env, "sso.group.ls", group).Return(*bytes.NewBufferString(""), nil)
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "sso.group.ls", group).Return(*bytes.NewBufferString(""), errors.New(expectedErr))
 
 	exists, err := g.GroupExists(ctx, group)
 	gt := NewWithT(t)
@@ -1341,8 +1342,8 @@ func TestGovcGroupExistsTrue(t *testing.T) {
 	ctx := context.Background()
 	_, g, executable, env := setup(t)
 	group := "EKSA"
-
-	executable.EXPECT().ExecuteWithEnv(ctx, env, "sso.group.ls", group).Return(*bytes.NewBufferString(group), nil)
+	// If group exists, govc should give empty response
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "sso.group.ls", group).Return(*bytes.NewBufferString(""), nil)
 
 	exists, err := g.GroupExists(ctx, group)
 	gt := NewWithT(t)
@@ -1354,8 +1355,7 @@ func TestGovcGroupExistsError(t *testing.T) {
 	ctx := context.Background()
 	_, g, executable, env := setup(t)
 	group := "EKSA"
-
-	executable.EXPECT().ExecuteWithEnv(ctx, env, "sso.group.ls", group).Return(*bytes.NewBufferString(""), errors.New("operation failed"))
+	executable.EXPECT().ExecuteWithEnv(ctx, env, "sso.group.ls", group).Return(*bytes.NewBufferString(""), errors.New("unexpected error"))
 
 	_, err := g.GroupExists(ctx, group)
 	gt := NewWithT(t)


### PR DESCRIPTION
*Issue #, if available:*
See details here
[3097](https://github.com/aws/eks-anywhere-internal/issues/3097)
*Description of changes:*
- Altered GroupExists method to account for change in govc response behavior
- Modified unit tests

*Testing (if applicable):*
Modified unit tests in govc_test.go to mimic new behavior
*Documentation added/planned (if applicable):*
n/a
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

