### PR TITLE
Fix license token errors in e2e tests

### DIFF
--- a/test/e2e/airgap.go
+++ b/test/e2e/airgap.go
@@ -199,7 +199,7 @@ func runDockerAirgapConfigFlow(test *framework.ClusterE2ETest) {
 
 func runDockerAirgapUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *releasev1.EksARelease, wantVersion anywherev1.KubernetesVersion) {
 	test.SetRegistryMirrorDefaultInstanceSecurityGroupOnCleanup()
-	test.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	test.GenerateClusterConfigForVersion(latestRelease.Version, "", framework.ExecuteWithEksaRelease(latestRelease))
 
 	// Downloading and importing the artifacts from the previous version
 	test.DownloadArtifacts(framework.ExecuteWithEksaRelease(latestRelease))

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -1088,7 +1088,7 @@ func TestDockerKubernetes131to132UpgradeFromLatestMinorReleaseAPI(t *testing.T) 
 	managementCluster := framework.NewClusterE2ETest(
 		t, provider,
 	)
-	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	managementCluster.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	managementCluster.UpdateClusterConfig(api.ClusterToConfigFiller(
 		api.WithKubernetesVersion(v1alpha1.Kube131),
 	))
@@ -1097,7 +1097,7 @@ func TestDockerKubernetes131to132UpgradeFromLatestMinorReleaseAPI(t *testing.T) 
 	wc := framework.NewClusterE2ETest(
 		t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
 	)
-	wc.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	wc.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	wc.UpdateClusterConfig(api.ClusterToConfigFiller(
 		api.WithKubernetesVersion(v1alpha1.Kube131),
 		api.WithManagementCluster(managementCluster.ClusterName),
@@ -1289,7 +1289,7 @@ func TestDockerUpgradeFromLatestMinorReleaseCiliumSkipUpgrade_CLIUpgrade(t *test
 
 	test.ValidateCiliumCLIAvailable()
 
-	test.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	test.CreateCluster(framework.ExecuteWithEksaRelease(release))
 	test.ReplaceCiliumWithOSSCilium()
 

--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -37,7 +37,7 @@ func runWorkloadClusterExistingConfigFlow(test *framework.MulticlusterE2ETest) {
 func runWorkloadClusterPrevVersionCreateFlow(test *framework.MulticlusterE2ETest, latestMinorRelease *releasev1.EksARelease) {
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.GenerateClusterConfigForVersion(latestMinorRelease.Version, framework.ExecuteWithEksaRelease(latestMinorRelease))
+		w.GenerateClusterConfigForVersion(latestMinorRelease.Version, "", framework.ExecuteWithEksaRelease(latestMinorRelease))
 		w.CreateCluster(framework.ExecuteWithEksaRelease(latestMinorRelease))
 		w.DeleteCluster()
 	})
@@ -46,8 +46,9 @@ func runWorkloadClusterPrevVersionCreateFlow(test *framework.MulticlusterE2ETest
 
 func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.CreateManagementClusterWithConfig()
+	licenseToken := framework.GetLicenseToken2()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.GenerateClusterConfig()
+		w.GenerateClusterConfigWithLicenseToken(licenseToken)
 		w.CreateCluster()
 		w.UpgradeWithGitOps(clusterOpts...)
 		time.Sleep(5 * time.Minute)

--- a/test/e2e/side_effects.go
+++ b/test/e2e/side_effects.go
@@ -214,7 +214,7 @@ func runTestManagementClusterUpgradeSideEffects(t *testing.T, provider framework
 	latestRelease := latestMinorRelease(t)
 
 	managementCluster := framework.NewClusterE2ETest(t, provider, framework.PersistentCluster())
-	managementCluster.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	managementCluster.GenerateClusterConfigForVersion(latestRelease.Version, "", framework.ExecuteWithEksaRelease(latestRelease))
 	managementCluster.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithControlPlaneCount(1),
@@ -234,7 +234,7 @@ func runTestManagementClusterUpgradeSideEffects(t *testing.T, provider framework
 	workloadCluster := framework.NewClusterE2ETest(t, provider,
 		framework.WithClusterName(test.NewWorkloadClusterName()),
 	)
-	workloadCluster.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	workloadCluster.GenerateClusterConfigForVersion(latestRelease.Version, licenseToken, framework.ExecuteWithEksaRelease(latestRelease))
 	workloadCluster.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithManagementCluster(managementCluster.ClusterName),
@@ -248,7 +248,6 @@ func runTestManagementClusterUpgradeSideEffects(t *testing.T, provider framework
 			),
 			api.WithEtcdCountIfExternal(3),
 			api.WithCiliumPolicyEnforcementMode(anywherev1.CiliumPolicyModeAlways),
-			api.WithLicenseToken(licenseToken),
 		),
 		provider.WithNewWorkerNodeGroup(
 			"workers-0",

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1767,7 +1767,7 @@ func TestTinkerbellKubernetes128UpgradeManagementComponents(t *testing.T) {
 		framework.WithWorkerHardware(1),
 	)
 	// create cluster with old eksa
-	test.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	test.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube128),

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -34,7 +34,7 @@ func prevLatestMinorRelease(t testing.TB) *releasev1.EksARelease {
 }
 
 func runUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *releasev1.EksARelease, wantVersion anywherev1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
-	test.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	test.GenerateClusterConfigForVersion(latestRelease.Version, "", framework.ExecuteWithEksaRelease(latestRelease))
 	test.CreateCluster(framework.ExecuteWithEksaRelease(latestRelease))
 	// Adding this manual wait because old versions of the cli don't wait long enough
 	// after creation, which makes the upgrade preflight validations fail
@@ -46,7 +46,7 @@ func runUpgradeFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *re
 }
 
 func runUpgradeWithFluxFromReleaseFlow(test *framework.ClusterE2ETest, latestRelease *releasev1.EksARelease, wantVersion anywherev1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
-	test.GenerateClusterConfigForVersion(latestRelease.Version, framework.ExecuteWithEksaRelease(latestRelease))
+	test.GenerateClusterConfigForVersion(latestRelease.Version, "", framework.ExecuteWithEksaRelease(latestRelease))
 	test.CreateCluster(framework.ExecuteWithEksaRelease(latestRelease))
 	// Adding this manual wait because old versions of the cli don't wait long enough
 	// after creation, which makes the upgrade preflight validations fail
@@ -200,7 +200,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 func runUpgradeManagementComponentsFlow(t *testing.T, release *releasev1.EksARelease, provider framework.Provider, kubeVersion anywherev1.KubernetesVersion, os framework.OS) {
 	test := framework.NewClusterE2ETest(t, provider)
 	// create cluster with old eksa
-	test.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	test.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(kubeVersion),

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -5413,7 +5413,7 @@ func TestVSphereKubernetes131To132UbuntuInPlaceUpgradeFromLatestMinorRelease(t *
 		provider,
 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
 	)
-	test.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	test.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube131),
@@ -5597,7 +5597,7 @@ func TestVSphereKubernetes131to132UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 	managementCluster := framework.NewClusterE2ETest(
 		t, provider,
 	)
-	managementCluster.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	managementCluster.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	managementCluster.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube131),
@@ -5612,7 +5612,7 @@ func TestVSphereKubernetes131to132UpgradeFromLatestMinorReleaseBottleRocketAPI(t
 	wc := framework.NewClusterE2ETest(
 		t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
 	)
-	wc.GenerateClusterConfigForVersion(release.Version, framework.ExecuteWithEksaRelease(release))
+	wc.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
 	wc.UpdateClusterConfig(
 		api.ClusterToConfigFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube131),

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -359,7 +359,7 @@ func (e *ClusterE2ETest) GenerateClusterConfig(opts ...CommandOpt) {
 	if licenseToken != "" {
 		e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
 	}
-	e.GenerateClusterConfigForVersion("", opts...)
+	e.GenerateClusterConfigForVersion("", "", opts...)
 }
 
 // GenerateClusterConfigWithLicenseToken generates a cluster configuration while setting a specific license token.
@@ -367,7 +367,7 @@ func (e *ClusterE2ETest) GenerateClusterConfigWithLicenseToken(licenseToken stri
 	if licenseToken != "" {
 		e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
 	}
-	e.GenerateClusterConfigForVersion("", opts...)
+	e.GenerateClusterConfigForVersion("", "", opts...)
 }
 
 func newBmclibClient(log logr.Logger, hostIP, username, password string) *bmclib.Client {
@@ -488,7 +488,8 @@ func (e *ClusterE2ETest) generateHardwareConfig(opts ...CommandOpt) {
 	e.RunEKSA(generateHardwareConfigArgs, opts...)
 }
 
-func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opts ...CommandOpt) {
+// GenerateClusterConfigForVersion generates cluster configuration for the specified EKS-A version and license token.
+func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion, licenseToken string, opts ...CommandOpt) {
 	if eksaVersion != "" {
 		// LicenseToken field was introduced in cluster spec only in release-22
 		// attempting to populate the field for any prior versions would break the api.
@@ -503,9 +504,11 @@ func (e *ClusterE2ETest) GenerateClusterConfigForVersion(eksaVersion string, opt
 		}
 
 		if currentSemver.Compare(semverV022) != -1 {
-			licenseToken := GetStagingLicenseToken()
 			if licenseToken != "" {
 				e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(licenseToken))
+			} else {
+				defaultLicenseToken := GetStagingLicenseToken()
+				e.clusterFillers = append(e.clusterFillers, api.WithLicenseToken(defaultLicenseToken))
 			}
 		}
 	}

--- a/test/framework/multicluster.go
+++ b/test/framework/multicluster.go
@@ -108,7 +108,7 @@ func (m *MulticlusterE2ETest) RunConcurrently(flows ...func()) {
 }
 
 func (m *MulticlusterE2ETest) CreateManagementClusterForVersion(eksaVersion string, opts ...CommandOpt) {
-	m.ManagementCluster.GenerateClusterConfigForVersion(eksaVersion)
+	m.ManagementCluster.GenerateClusterConfigForVersion(eksaVersion, "")
 	m.CreateManagementCluster(opts...)
 }
 


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR fixes the following license token errors for e2e tests:
```
Error: the cluster config file provided is invalid: unable to parse release-i-0427d-e459c61-w-0/release-i-0427d-e459c61-w-0-eks-a.yaml file: error unmarshaling JSON: while decoding JSON: json: unknown field "licenseToken"
```
This error was observed in all `TestCloudStackKubernetes1XXWithOIDCManagementClusterUpgradeFromLatestSideEffects ` tests on staging pipeline for release-0.22 patch release. This is because when the test is triggered from 0.22 branch, the latest previous minor release is 0.21 which does not have extended support.

```
Error: validations failed: validating licenseToken is unique for cluster release-i-0dcad-2b18c1e-w-0: license token <license-token-string> is already in use by cluster release-i-0dcad-2b18c1e
```
This error was observed in `TestCloudStackUpgradeKubernetes129MulticlusterWorkloadClusterWithGithubFlux` test because it was using the same license token for mgmt and workload clusters.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

