### PR TITLE
Update noProxyList for package controller to include control plane endpoint, service CIDR and pod CIDR

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1670,7 +1670,15 @@ func (f *Factory) WithNutanixClientCache() *Factory {
 func getProxyConfiguration(clusterSpec *cluster.Spec) (httpProxy, httpsProxy string, noProxy []string) {
 	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
 	if proxyConfiguration != nil {
-		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, proxyConfiguration.NoProxy
+		noProxyList := append(proxyConfiguration.NoProxy, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+		if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
+			noProxyList = append(
+				noProxyList,
+				clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host,
+			)
+		}
+		return proxyConfiguration.HttpProxy, proxyConfiguration.HttpsProxy, noProxyList
 	}
 	return "", "", nil
 }

--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -1670,8 +1670,15 @@ func (f *Factory) WithNutanixClientCache() *Factory {
 func getProxyConfiguration(clusterSpec *cluster.Spec) (httpProxy, httpsProxy string, noProxy []string) {
 	proxyConfiguration := clusterSpec.Cluster.Spec.ProxyConfiguration
 	if proxyConfiguration != nil {
-		noProxyList := append(proxyConfiguration.NoProxy, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
+		capacity := len(clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks) +
+			len(clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy) + 1
+
+		noProxyList := make([]string, 0, capacity)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Pods.CidrBlocks...)
 		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ClusterNetwork.Services.CidrBlocks...)
+		noProxyList = append(noProxyList, clusterSpec.Cluster.Spec.ProxyConfiguration.NoProxy...)
+
 		if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint != nil && clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host != "" {
 			noProxyList = append(
 				noProxyList,

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -548,6 +548,25 @@ func TestFactoryBuildWithPackageControllerClientProxy(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: anywherev1.ClusterSpec{
+					ControlPlaneConfiguration: anywherev1.ControlPlaneConfiguration{
+						Count: 3,
+						Endpoint: &anywherev1.Endpoint{
+							Host: "test-ip",
+						},
+						MachineGroupRef: &anywherev1.Ref{
+							Kind: anywherev1.VSphereMachineConfigKind,
+							Name: "eksa-unit-test",
+						},
+					},
+					ClusterNetwork: anywherev1.ClusterNetwork{
+						CNIConfig: &anywherev1.CNIConfig{Cilium: &anywherev1.CiliumConfig{}},
+						Pods: anywherev1.Pods{
+							CidrBlocks: []string{"192.168.0.0/16"},
+						},
+						Services: anywherev1.Services{
+							CidrBlocks: []string{"10.96.0.0/12"},
+						},
+					},
 					ProxyConfiguration: &anywherev1.ProxyConfiguration{
 						HttpProxy:  "1.1.1.1",
 						HttpsProxy: "1.1.1.1",

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -336,6 +336,58 @@ func TestVSphereKubernetes132CuratedPackagesSimpleFlow(t *testing.T) {
 	runCuratedPackageInstallSimpleFlow(test)
 }
 
+func TestVSphereKubernetes129CuratedPackagesWithProxyConfigFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu129()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube129),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+	)
+	runCuratedPackageInstallSimpleFlow(test)
+}
+
+func TestVSphereKubernetes130CuratedPackagesWithProxyConfigFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu130()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube130),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+	)
+	runCuratedPackageInstallSimpleFlow(test)
+}
+
+func TestVSphereKubernetes131CuratedPackagesWithProxyConfigFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu131()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube131),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+	)
+	runCuratedPackageInstallSimpleFlow(test)
+}
+
+func TestVSphereKubernetes132CuratedPackagesWithProxyConfigFlow(t *testing.T) {
+	framework.CheckCuratedPackagesCredentials(t)
+	test := framework.NewClusterE2ETest(t,
+		framework.NewVSphere(t, framework.WithUbuntu132()),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube132),
+			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
+			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+	)
+	runCuratedPackageInstallSimpleFlow(test)
+}
+
 func TestVSphereKubernetes128BottleRocketCuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
 	test := framework.NewClusterE2ETest(t,


### PR DESCRIPTION
*Description of changes:*
- Updated `noProxyList` for package controller to include control plane endpoint, service CIDR and pod CIDR
- Added tests for curated packages simple flow with proxy configuration.

*Testing:*

`./bin/e2e.test -test.v -test.run TestVSphereKubernetes130CuratedPackagesProxyConfigFlow`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

