### PR TITLE
Set Aws credentials in cert manager package pod for e2e test

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"time"
 
-	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -26,8 +25,7 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		test.ManagementCluster.SetPackageBundleActive()
 		packageName := "cert-manager"
 		packagePrefix := "test"
-		packageFile := e.BuildPackageConfigFile(packageName, packagePrefix, EksaPackagesNamespace)
-		test.ManagementCluster.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ManagementCluster.ClusterName))
+		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace)
 		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withCluster(test.ManagementCluster))
 		e.CleanupCerts(withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()

--- a/test/framework/curatedpackages.go
+++ b/test/framework/curatedpackages.go
@@ -38,6 +38,7 @@ const (
 	eksaPackagesRegion          = "EKSA_AWS_REGION"
 	route53AccessKey            = "ROUTE53_ACCESS_KEY_ID"
 	route53SecretKey            = "ROUTE53_SECRET_ACCESS_KEY"
+	route53SessionToken         = "ROUTE53_SESSION_TOKEN"
 	route53Region               = "ROUTE53_REGION"
 	route53ZoneID               = "ROUTE53_ZONEID"
 )
@@ -87,7 +88,6 @@ func CheckCertManagerCredentials(t *testing.T) {
 }
 
 // GetRoute53Configs returns route53 configurations for cert-manager.
-func GetRoute53Configs() (string, string, string, string) {
-	return os.Getenv(route53AccessKey), os.Getenv(route53SecretKey),
-		os.Getenv(route53Region), os.Getenv(route53ZoneID)
+func GetRoute53Configs() (string, string) {
+	return os.Getenv(route53Region), os.Getenv(route53ZoneID)
 }

--- a/test/framework/testdata/certmanager/certmanager_letsencrypt_issuer.yaml
+++ b/test/framework/testdata/certmanager/certmanager_letsencrypt_issuer.yaml
@@ -13,10 +13,6 @@ spec:
           route53:
             region: "{{.route53Region}}"
             hostedZoneID: "{{.route53ZoneId}}"
-            accessKeyID: "{{.route53AccessKeyId}}"
-            secretAccessKeySecretRef:
-              name: route53-credentials-secret
-              key: secret-access-key
         selector:
           dnsZones:
             - "cert-manager-e2e.model-rocket.aws.dev"

--- a/test/framework/testdata/certmanager/certmanager_package.yaml
+++ b/test/framework/testdata/certmanager/certmanager_package.yaml
@@ -1,0 +1,18 @@
+apiVersion: packages.eks.amazonaws.com/v1alpha1
+kind: Package
+metadata:
+  name: {{.name}}
+  namespace: {{.namespace}}
+spec:
+  packageName: cert-manager
+  targetNamespace: {{.targetNamespace}}
+  config: |-
+    extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        value: {{.accessKeyId}}
+      - name: AWS_SECRET_ACCESS_KEY
+        value: {{.secretKey}}
+{{- if .sessionToken }}
+      - name: AWS_SESSION_TOKEN
+        value: {{.sessionToken}}
+{{- end }}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/9177

*Description of changes:*
In testing cert manger, we use access key and Id (see [here](https://github.com/aws/eks-anywhere/blob/c966d16b5a654c07621171a43db3502f55b90e35/test/framework/cluster.go#L1823)) to test cert manager. ClusterIssuer does not have support for session token. One workaround is to use [Ambient credentials](https://cert-manager.io/docs/configuration/acme/dns01/route53/#ambient-credentials) approach where environment variables like AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN are set in the cert manager pod.

In this PR, I am adding a test data (with AWS credentials - key, id, sessiontoken) for cert manager and use that to create cert manager pod and remove the [current logic](https://github.com/aws/eks-anywhere/blob/c966d16b5a654c07621171a43db3502f55b90e35/test/framework/cluster.go#L1813-L1828) of using access key and id in the cluster issuer. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
