### PR TITLE
Implement validation checks for failuredomain fields

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -756,23 +756,20 @@ func (g *Govc) NetworkExists(ctx context.Context, network string) (bool, error) 
 	return exists, nil
 }
 
-func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, _ *bool) error {
-	envMap, err := g.validateAndSetupCreds()
+func (g *Govc) getDatastorePath(ctx context.Context, datacenter string, datastorePath string, envMap map[string]string) (string, error) {
+	fullPath, err := prependPath(datastore, datastorePath, datacenter)
 	if err != nil {
-		return fmt.Errorf("failed govc validations: %v", err)
+		return "", err
 	}
-	machineConfig.Spec.Datastore, err = prependPath(datastore, machineConfig.Spec.Datastore, datacenterConfig.Spec.Datacenter)
-	if err != nil {
-		return err
-	}
-	params := []string{"datastore.info", machineConfig.Spec.Datastore}
+
+	params := []string{"datastore.info", fullPath}
 	err = g.Retry(func() error {
 		_, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		if err != nil {
-			datastorePath := filepath.Dir(machineConfig.Spec.Datastore)
-			isValidDatastorePath := g.isValidPath(ctx, envMap, datastorePath)
+			parentPath := filepath.Dir(fullPath)
+			isValidDatastorePath := g.isValidPath(ctx, envMap, parentPath)
 			if isValidDatastorePath {
-				leafDir := filepath.Base(machineConfig.Spec.Datastore)
+				leafDir := filepath.Base(fullPath)
 				return fmt.Errorf("valid path, but '%s' is not a datastore", leafDir)
 			} else {
 				return fmt.Errorf("failed to get datastore: %v", err)
@@ -781,79 +778,143 @@ func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenter
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get datastore: %v", err)
+		return "", fmt.Errorf("failed to get datastore: %v", err)
 	}
 	logger.MarkPass("Datastore validated")
+	return fullPath, nil
+}
 
-	if len(machineConfig.Spec.Folder) > 0 {
-		machineConfig.Spec.Folder, err = prependPath(vm, machineConfig.Spec.Folder, datacenterConfig.Spec.Datacenter)
-		if err != nil {
-			return err
-		}
-		params = []string{"folder.info", machineConfig.Spec.Folder}
-		err = g.Retry(func() error {
-			_, err := g.ExecuteWithEnv(ctx, envMap, params...)
-			if err != nil {
-				err = g.createFolder(ctx, envMap, machineConfig)
-				if err != nil {
-					currPath := "/" + datacenterConfig.Spec.Datacenter + "/"
-					dirs := strings.Split(machineConfig.Spec.Folder, "/")
-					for _, dir := range dirs[2:] {
-						currPath += dir + "/"
-						if !g.isValidPath(ctx, envMap, currPath) {
-							return fmt.Errorf("%s is an invalid intermediate directory", currPath)
-						}
-					}
-					return err
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to get folder: %v", err)
-		}
-		logger.MarkPass("Folder validated")
+func (g *Govc) getFolderPath(ctx context.Context, datacenter string, folder string, envMap map[string]string) (string, error) {
+	if len(folder) == 0 {
+		return "", nil
 	}
 
-	var poolInfoResponse bytes.Buffer
-	params = []string{"find", "-json", "/" + datacenterConfig.Spec.Datacenter, "-type", "p", "-name", filepath.Base(machineConfig.Spec.ResourcePool)}
+	fullPath, err := prependPath(vm, folder, datacenter)
+	if err != nil {
+		return "", err
+	}
+
+	params := []string{"folder.info", fullPath}
 	err = g.Retry(func() error {
+		_, err := g.ExecuteWithEnv(ctx, envMap, params...)
+		if err != nil {
+			err = g.createFolder(ctx, envMap, fullPath)
+			if err != nil {
+				currPath := "/" + datacenter + "/"
+				dirs := strings.Split(fullPath, "/")
+				for _, dir := range dirs[2:] {
+					currPath += dir + "/"
+					if !g.isValidPath(ctx, envMap, currPath) {
+						return fmt.Errorf("%s is an invalid intermediate directory", currPath)
+					}
+				}
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get folder: %v", err)
+	}
+	logger.MarkPass("Folder validated")
+	return fullPath, nil
+}
+
+func (g *Govc) getResourcePoolPath(ctx context.Context, datacenter string, resourcePool string, envMap map[string]string) (string, error) {
+	var poolInfoResponse bytes.Buffer
+	params := []string{"find", "-json", "/" + datacenter, "-type", "p", "-name", filepath.Base(resourcePool)}
+
+	err := g.Retry(func() error {
+		var err error
 		poolInfoResponse, err = g.ExecuteWithEnv(ctx, envMap, params...)
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("getting resource pool: %v", err)
+		return "", fmt.Errorf("getting resource pool: %v", err)
 	}
 
 	poolInfoJson := poolInfoResponse.String()
 	poolInfoJson = strings.TrimSuffix(poolInfoJson, "\n")
 	if poolInfoJson == "null" || poolInfoJson == "" {
-		return fmt.Errorf("resource pool '%s' not found", machineConfig.Spec.ResourcePool)
+		return "", fmt.Errorf("resource pool '%s' not found", resourcePool)
 	}
 
 	poolInfo := make([]string, 0)
 	if err = json.Unmarshal([]byte(poolInfoJson), &poolInfo); err != nil {
-		return fmt.Errorf("failed unmarshalling govc response: %v", err)
+		return "", fmt.Errorf("failed unmarshalling govc response: %v", err)
 	}
 
-	machineConfig.Spec.ResourcePool = strings.TrimPrefix(machineConfig.Spec.ResourcePool, "*/")
+	resourcePool = strings.TrimPrefix(resourcePool, "*/")
 	bPoolFound := false
 	var foundPool string
 	for _, p := range poolInfo {
-		if strings.HasSuffix(p, machineConfig.Spec.ResourcePool) {
+		if strings.HasSuffix(p, resourcePool) {
 			if bPoolFound {
-				return fmt.Errorf("specified resource pool '%s' maps to multiple paths within the datacenter '%s'", machineConfig.Spec.ResourcePool, datacenterConfig.Spec.Datacenter)
+				return "", fmt.Errorf("specified resource pool '%s' maps to multiple paths within the datacenter '%s'", resourcePool, datacenter)
 			}
 			bPoolFound = true
 			foundPool = p
 		}
 	}
 	if !bPoolFound {
-		return fmt.Errorf("resource pool '%s' not found", machineConfig.Spec.ResourcePool)
+		return "", fmt.Errorf("resource pool '%s' not found", resourcePool)
 	}
-	machineConfig.Spec.ResourcePool = foundPool
 
 	logger.MarkPass("Resource pool validated")
+	return foundPool, nil
+}
+
+func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, _ *bool) error {
+	envMap, err := g.validateAndSetupCreds()
+	if err != nil {
+		return fmt.Errorf("failed govc validations: %v", err)
+	}
+
+	if datastore, err := g.getDatastorePath(ctx, datacenterConfig.Spec.Datacenter, machineConfig.Spec.Datastore, envMap); err != nil {
+		return err
+	} else {
+		machineConfig.Spec.Datastore = datastore
+	}
+
+	if folder, err := g.getFolderPath(ctx, datacenterConfig.Spec.Datacenter, machineConfig.Spec.Folder, envMap); err != nil {
+		return err
+	} else {
+		machineConfig.Spec.Folder = folder
+	}
+
+	if resourcePool, err := g.getResourcePoolPath(ctx, datacenterConfig.Spec.Datacenter, machineConfig.Spec.ResourcePool, envMap); err != nil {
+		return err
+	} else {
+		machineConfig.Spec.ResourcePool = resourcePool
+	}
+
+	return nil
+}
+
+func (g *Govc) ValidateFailureDomainConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, failureDomain *v1alpha1.FailureDomain) error {
+	envMap, err := g.validateAndSetupCreds()
+	if err != nil {
+		return fmt.Errorf("failed govc validations: %v", err)
+	}
+
+	if datastore, err := g.getDatastorePath(ctx, datacenterConfig.Spec.Datacenter, failureDomain.Datastore, envMap); err != nil {
+		return err
+	} else {
+		failureDomain.Datastore = datastore
+	}
+
+	if folder, err := g.getFolderPath(ctx, datacenterConfig.Spec.Datacenter, failureDomain.Folder, envMap); err != nil {
+		return err
+	} else {
+		failureDomain.Folder = folder
+	}
+
+	if resourcePool, err := g.getResourcePoolPath(ctx, datacenterConfig.Spec.Datacenter, failureDomain.ResourcePool, envMap); err != nil {
+		return err
+	} else {
+		failureDomain.ResourcePool = resourcePool
+	}
+
 	return nil
 }
 
@@ -872,8 +933,8 @@ func prependPath(folderType FolderType, folderPath string, datacenter string) (s
 	return modPath, nil
 }
 
-func (g *Govc) createFolder(ctx context.Context, envMap map[string]string, machineConfig *v1alpha1.VSphereMachineConfig) error {
-	params := []string{"folder.create", machineConfig.Spec.Folder}
+func (g *Govc) createFolder(ctx context.Context, envMap map[string]string, folderPath string) error {
+	params := []string{"folder.create", folderPath}
 	err := g.Retry(func() error {
 		_, err := g.ExecuteWithEnv(ctx, envMap, params...)
 		if err != nil {

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -498,6 +498,20 @@ func (mr *MockProviderGovcClientMockRecorder) UserExists(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserExists", reflect.TypeOf((*MockProviderGovcClient)(nil).UserExists), arg0, arg1)
 }
 
+// ValidateFailureDomainConfig mocks base method.
+func (m *MockProviderGovcClient) ValidateFailureDomainConfig(arg0 context.Context, arg1 *v1alpha1.VSphereDatacenterConfig, arg2 *v1alpha1.FailureDomain) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateFailureDomainConfig", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateFailureDomainConfig indicates an expected call of ValidateFailureDomainConfig.
+func (mr *MockProviderGovcClientMockRecorder) ValidateFailureDomainConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateFailureDomainConfig", reflect.TypeOf((*MockProviderGovcClient)(nil).ValidateFailureDomainConfig), arg0, arg1, arg2)
+}
+
 // ValidateVCenterAuthentication mocks base method.
 func (m *MockProviderGovcClient) ValidateVCenterAuthentication(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/reconciler/reconciler.go
+++ b/pkg/providers/vsphere/reconciler/reconciler.go
@@ -175,13 +175,13 @@ func (r *Reconciler) ValidateMachineConfigs(ctx context.Context, log logr.Logger
 }
 
 // ValidateFailureDomains performs validations for the provided failure domains and the assigned failure domains in worker node group.
-func (r *Reconciler) ValidateFailureDomains(_ context.Context, log logr.Logger, clusterSpec *c.Spec) (controller.Result, error) {
+func (r *Reconciler) ValidateFailureDomains(ctx context.Context, log logr.Logger, clusterSpec *c.Spec) (controller.Result, error) {
 	if features.IsActive(features.VsphereFailureDomainEnabled()) {
 		log = log.WithValues("phase", "validateFailureDomains")
 
 		vsphereClusterSpec := vsphere.NewSpec(clusterSpec)
 
-		if err := r.validator.ValidateFailureDomains(vsphereClusterSpec); err != nil {
+		if err := r.validator.ValidateFailureDomains(ctx, vsphereClusterSpec); err != nil {
 			log.Error(err, "Invalid Failure domain setup")
 			failureMessage := err.Error()
 			clusterSpec.Cluster.SetFailure(anywherev1.FailureDomainInvalidReason, failureMessage)

--- a/pkg/providers/vsphere/validator.go
+++ b/pkg/providers/vsphere/validator.go
@@ -78,29 +78,30 @@ func (v *Validator) ValidateVCenterConfig(ctx context.Context, datacenterConfig 
 	if err := v.validateDatacenter(ctx, datacenterConfig.Spec.Datacenter); err != nil {
 		return err
 	}
-	logger.MarkPass("Datacenter validated")
 
 	if err := v.validateNetwork(ctx, datacenterConfig.Spec.Network); err != nil {
 		return err
 	}
-	logger.MarkPass("Network validated")
 
 	return nil
 }
 
 // ValidateFailureDomains validates the provided list of failure domains.
-func (v *Validator) ValidateFailureDomains(vsphereClusterSpec *Spec) error {
+func (v *Validator) ValidateFailureDomains(ctx context.Context, vsphereClusterSpec *Spec) error {
+	failureDomains := vsphereClusterSpec.VSphereDatacenter.Spec.FailureDomains
+
 	if !features.IsActive(features.VsphereFailureDomainEnabled()) {
-		if len(vsphereClusterSpec.VSphereDatacenter.Spec.FailureDomains) > 0 {
-			return fmt.Errorf("Failure Domains feature is not enabled. Please set the env variable %v", features.VSphereFailureDomainEnabledEnvVar)
+		if len(failureDomains) > 0 {
+			return fmt.Errorf("failure domains feature is not enabled. Please set the env variable %v", features.VSphereFailureDomainEnabledEnvVar)
 		}
 		return nil
 	}
 
-	providedFailureDomains := collection.MapSet(vsphereClusterSpec.VSphereDatacenter.Spec.FailureDomains, func(fd anywherev1.FailureDomain) string {
+	providedFailureDomains := collection.MapSet(failureDomains, func(fd anywherev1.FailureDomain) string {
 		return fd.Name
 	})
 
+	failureDomainsAssigned := false
 	for _, wng := range vsphereClusterSpec.Cluster.Spec.WorkerNodeGroupConfigurations {
 
 		if len(wng.FailureDomains) == 0 {
@@ -110,14 +111,36 @@ func (v *Validator) ValidateFailureDomains(vsphereClusterSpec *Spec) error {
 		if len(wng.FailureDomains) > 1 {
 			return fmt.Errorf("multiple failure domains provided in the worker node group: %s. Please provide only one failure domain", wng.Name)
 		}
-
 		assignedFailureDomain := wng.FailureDomains[0]
 
 		if !providedFailureDomains.Contains(assignedFailureDomain) {
 			return fmt.Errorf("provided invalid failure domain %s in the worker node group %s", assignedFailureDomain, wng.Name)
 		}
+		failureDomainsAssigned = true
 
 	}
+
+	if !failureDomainsAssigned {
+		// TODO: Error message here if Failure Domain not being used by workernodegroups?
+		// Skipping further validation currently
+		// return fmt.Errorf("failure domain defined, but no worker node group references")
+		return nil
+	}
+	logger.Info("Start failure domain validation")
+	for _, fd := range failureDomains {
+
+		if err := v.validateNetwork(ctx, fd.Network); err != nil {
+			return err
+		}
+
+		if err := v.govc.ValidateFailureDomainConfig(ctx, vsphereClusterSpec.VSphereDatacenter, &fd); err != nil {
+			return err
+		}
+
+		// TODO: compute cluster validation
+
+	}
+	logger.Info("Finished failure domain validation")
 
 	return nil
 }
@@ -343,6 +366,7 @@ func (v *Validator) validateDatacenter(ctx context.Context, datacenter string) e
 	if !exists {
 		return fmt.Errorf("datacenter %s not found", datacenter)
 	}
+	logger.MarkPass("Datacenter validated")
 
 	return nil
 }
@@ -356,6 +380,7 @@ func (v *Validator) validateNetwork(ctx context.Context, network string) error {
 	if !exists {
 		return fmt.Errorf("network %s not found", network)
 	}
+	logger.MarkPass("Network validated")
 
 	return nil
 }

--- a/pkg/providers/vsphere/validator_test.go
+++ b/pkg/providers/vsphere/validator_test.go
@@ -370,15 +370,57 @@ func TestValidatorValidateMachineConfigTemplateDoesNotExist(t *testing.T) {
 }
 
 func TestValidateFailureDomains(t *testing.T) {
+	defaultSpec := &Spec{
+		Spec: &cluster.Spec{
+			Config: &cluster.Config{
+				Cluster: &v1alpha1.Cluster{
+					Spec: v1alpha1.ClusterSpec{
+						WorkerNodeGroupConfigurations: []v1alpha1.WorkerNodeGroupConfiguration{
+							{
+								Name:           "wd-1",
+								FailureDomains: []string{"fd-1"},
+							},
+						},
+					},
+				},
+				VSphereDatacenter: &v1alpha1.VSphereDatacenterConfig{
+					Spec: v1alpha1.VSphereDatacenterConfigSpec{
+						Datacenter: "myDatacenter",
+						Server:     "myServer",
+						Network:    "/myDatacenter/network/myNetwork",
+						FailureDomains: []v1alpha1.FailureDomain{
+							{
+								Name:           "fd-1",
+								ComputeCluster: "myComputeCluster",
+								ResourcePool:   "myResourcePool",
+								Datastore:      "myDatastore",
+								Folder:         "myFolder",
+								Network:        "/myDatacenter/network/myNetwork",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name                       string
 		spec                       *Spec
 		expectedErr                string
 		enableVsphereFailureDomain bool
+		networkExists              bool
+		folderExists               bool
+		datastoreExists            bool
+		resourcepoolExists         bool
 	}{
 		{
 			name:                       "TestValidateFailureDomains success case",
 			enableVsphereFailureDomain: true,
+			networkExists:              true,
+			folderExists:               true,
+			datastoreExists:            true,
+			resourcepoolExists:         true,
 			spec: &Spec{
 				Spec: &cluster.Spec{
 					Config: &cluster.Config{
@@ -432,7 +474,7 @@ func TestValidateFailureDomains(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "Failure Domains feature is not enabled",
+			expectedErr: "failure domains feature is not enabled",
 		},
 		{
 			name:                       "TestValidateFailureDomains with feature flag disabled and without failure domains",
@@ -577,18 +619,98 @@ func TestValidateFailureDomains(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                       "TestValidateFailureDomains datastore does not exist",
+			enableVsphereFailureDomain: true,
+			networkExists:              true,
+			datastoreExists:            false,
+			folderExists:               true,
+			resourcepoolExists:         true,
+			expectedErr:                "failed to get datastore: myDatastore is not a datastore",
+			spec:                       defaultSpec,
+		},
+		{
+			name:                       "TestValidateFailureDomains folder does not exist",
+			enableVsphereFailureDomain: true,
+			networkExists:              true,
+			datastoreExists:            true,
+			folderExists:               false,
+			resourcepoolExists:         true,
+			expectedErr:                "failed to get folder: folder myFolder not found",
+			spec:                       defaultSpec,
+		},
+		{
+			name:                       "TestValidateFailureDomains resourcepool does not exist",
+			enableVsphereFailureDomain: true,
+			networkExists:              true,
+			datastoreExists:            true,
+			folderExists:               true,
+			resourcepoolExists:         false,
+			expectedErr:                "resource pool 'myResourcePool' not found",
+			spec:                       defaultSpec,
+		},
+		{
+			name:                       "TestValidateFailureDomains network does not exist",
+			enableVsphereFailureDomain: true,
+			networkExists:              false,
+			datastoreExists:            true,
+			folderExists:               true,
+			resourcepoolExists:         true,
+			expectedErr:                "failed checking if network '/myDatacenter/network/myNetwork' exists: network not found",
+			spec:                       defaultSpec,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 			t.Setenv(features.VSphereFailureDomainEnabledEnvVar, strconv.FormatBool(tt.enableVsphereFailureDomain))
 			ctrl := gomock.NewController(t)
 			govc := govcmocks.NewMockProviderGovcClient(ctrl)
 
+			if tt.enableVsphereFailureDomain && len(tt.spec.VSphereDatacenter.Spec.FailureDomains) > 0 {
+				govc.EXPECT().
+					NetworkExists(gomock.Any(), gomock.AssignableToTypeOf("")).
+					DoAndReturn(func(_ context.Context, network string) (bool, error) {
+						if tt.networkExists {
+							return true, nil
+						}
+						return false, fmt.Errorf("failed checking if network '%s' exists: network not found", network)
+					}).AnyTimes()
+
+				govc.EXPECT().
+					ValidateFailureDomainConfig(
+						gomock.Any(),
+						gomock.AssignableToTypeOf(&v1alpha1.VSphereDatacenterConfig{}),
+						gomock.AssignableToTypeOf(&v1alpha1.FailureDomain{}),
+					).DoAndReturn(func(_ context.Context, _ *v1alpha1.VSphereDatacenterConfig, fd *v1alpha1.FailureDomain) error {
+					// Only proceed with these validations if network exists
+					if !tt.networkExists {
+						return nil
+					}
+
+					if !tt.datastoreExists {
+						return fmt.Errorf("failed to get datastore: %s is not a datastore", fd.Datastore)
+					}
+
+					if !tt.folderExists {
+						return fmt.Errorf("failed to get folder: folder %s not found", fd.Folder)
+					}
+
+					if !tt.resourcepoolExists {
+						return fmt.Errorf("resource pool '%s' not found", fd.ResourcePool)
+					}
+
+					return nil
+				}).AnyTimes()
+
+			}
+
 			v := Validator{
 				govc: govc,
 			}
-			err := v.ValidateFailureDomains(tt.spec)
+
+			err := v.ValidateFailureDomains(ctx, tt.spec)
 			if tt.expectedErr != "" {
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -97,6 +97,7 @@ type ProviderGovcClient interface {
 	TemplateHasSnapshot(ctx context.Context, template string) (bool, error)
 	GetWorkloadAvailableSpace(ctx context.Context, datastore string) (float64, error)
 	ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, selfSigned *bool) error
+	ValidateFailureDomainConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, failureDomain *v1alpha1.FailureDomain) error
 	ValidateVCenterConnection(ctx context.Context, server string) error
 	ValidateVCenterAuthentication(ctx context.Context) error
 	IsCertSelfSigned(ctx context.Context) bool
@@ -325,7 +326,7 @@ func (p *vsphereProvider) SetupAndValidateCreateCluster(ctx context.Context, clu
 		return err
 	}
 
-	if err := p.validator.ValidateFailureDomains(vSphereClusterSpec); err != nil {
+	if err := p.validator.ValidateFailureDomains(ctx, vSphereClusterSpec); err != nil {
 		return err
 	}
 
@@ -407,7 +408,7 @@ func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cl
 		return err
 	}
 
-	if err := p.validator.ValidateFailureDomains(vSphereClusterSpec); err != nil {
+	if err := p.validator.ValidateFailureDomains(ctx, vSphereClusterSpec); err != nil {
 		return err
 	}
 

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -112,6 +112,10 @@ func (pc *DummyProviderGovcClient) NetworkExists(ctx context.Context, network st
 	return true, nil
 }
 
+func (pc *DummyProviderGovcClient) ValidateFailureDomainConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, failureDomain *v1alpha1.FailureDomain) error {
+	return nil
+}
+
 func (pc *DummyProviderGovcClient) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, selfSigned *bool) error {
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*
[3004](https://github.com/aws/eks-anywhere-internal/issues/3004)
*Description of changes:*
Broke up ValidateVCenterSetupMachineConfig method into three sub functions: 
 - getDatastorePath 
 - getFolderPath
 - getResourcePoolPath

New ValidateFailureDomainConfig validation logic to ensure existence of fields in vcenter

*Testing (if applicable):*
New tests in validator_test.go
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

