### PR TITLE
Skip extended kubernetes version support validations for Snow provider

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.5
+          version: v2.0.1
           only-new-issues: true
           args: --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,49 +1,53 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
-    - gofumpt
-    - gci
+    - gocyclo
     - godot
     - nakedret
-    - gocyclo
     - revive
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/aws/eks-anywhere)
-    custom-order: true
-    skip-generated: false
-  godot:
-    exclude:
-      # Exclude todo comments.
-      - "(?i)^\\s*todo"
-    period: true
-  nakedret:
-    # never allow naked returns
-    max-func-lines: 0
-  gocyclo:
-    # Minimal code complexity to report.
-    min-complexity: 10
-
+  settings:
+    gocyclo:
+      min-complexity: 10
+    godot:
+      exclude:
+        - (?i)^\s*todo
+      period: true
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - std-error-handling
+    paths:
+      - zz_generated.*\.go$
+      - .*/mocks
+      - manager/tilt_modules
+      - internal/aws-sdk-go-v2
+      - pkg/providers/snow/api/v1beta1
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  max-same-issues: 0
   max-issues-per-linter: 0
-
-  exclude-files:
-    - "zz_generated.*\\.go$"
-
-  exclude-dirs:
-    - ".*/mocks"
-    - "manager/tilt_modules"
-    - "internal/aws-sdk-go-v2"
-    - "pkg/providers/snow/api/v1beta1"
-
-  include:
-    - EXC0012 # EXC0012 revive: exported (.+) should have comment( \(or a comment on this block\))? or be unexported
-    - EXC0014 # EXC0014 revive: comment on exported (.+) should be of the form "(.+)..."
-    - EXC0009 # EXC0009 revive: (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+  max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/aws/eks-anywhere)
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*\.go$
+      - .*/mocks
+      - manager/tilt_modules
+      - internal/aws-sdk-go-v2
+      - pkg/providers/snow/api/v1beta1
+      - third_party$
+      - builtin$
+      - examples$

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -642,6 +642,9 @@ func validateEksaRelease(ctx context.Context, client client.Client, cluster *any
 }
 
 func validateExtendedK8sVersionSupport(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
+	if cluster.Spec.DatacenterRef.Kind == "SnowDatacenterConfig" {
+		return nil
+	}
 	bundle, err := c.BundlesForCluster(ctx, clientutil.NewKubeClient(client), cluster)
 	if err != nil {
 		reason := anywherev1.BundleNotFoundReason

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -291,6 +291,9 @@ func ValidateBottlerocketKubeletConfig(spec *cluster.Spec) error {
 
 // ValidateExtendedKubernetesSupport validates the extended kubernetes version support for create and upgrade operations.
 func ValidateExtendedKubernetesSupport(ctx context.Context, clusterSpec v1alpha1.Cluster, reader *manifests.Reader, k kubernetes.Client, bundlesOverride string) error {
+	if clusterSpec.Spec.DatacenterRef.Kind == "SnowDatacenterConfig" {
+		return nil
+	}
 	var b *releasev1alpha1.Bundles
 	var err error
 	if bundlesOverride != "" {


### PR DESCRIPTION
*Issue #, if available:*
https://t.corp.amazon.com/P211307329

*Description of changes:*
**Commit 1**
Snow team ran into an issue with one of their airgapped upgrade tests for EKS-A v0.22.x versions where the test failed with the following validation error:
```
[ec2-user@ip-34-223-14-196 ~]$ eksctl anywhere upgrade cluster -f /home/ec2-user/eksa-cluster-eks-anywhere-cluster-1742487914005.yaml -v4 --bundles-override /usr/lib/eks-a/manifests/bundle-release.yaml

2025-03-20T20:21:16.949Z    V4  Reading release manifest    {"url": "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"}
2025-03-20T20:21:17.016Z    V0  ❌ Validation failed {"validation": "validate extended kubernetes version support is supported", "error": "getting bundle for cluster: reading Releases file: failed reading file from url [https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml]: Get \"https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml\": dial tcp 18.161.6.112:443: connect: no route to host", "remediation": "ensure you have a valid license for extended Kubernetes version support"}
```
There are two things to note here. First, the CLI should not be fetching the release manifest from the cloudfront URL if it is an airgapped upgrade scenario. It should have the manifest locally. Second, it shouldn't be running the extended kubernetes version support validation for Snow. This commit skips running the validation for Snow provider to fix the above issue.

**Commit 2**
Golangci-lint action failed with the following error:
```
Error: Failed to run: Error: invalid version string 'v1.64.5', golangci-lint v1 is not supported by golangci-lint-action v7., Error: invalid version string 'v1.64.5', golangci-lint v1 is not supported by golangci-lint-action v7.
```
This is because the dependabot PR was recently merged which bumped the golangci lint version from v6 to v7 and golanci-lint-action [v7.0.0](https://github.com/golangci/golangci-lint-action/releases/tag/v7.0.0) has a breaking change to support golangci-lint v2 only. This commit updates the golangci-lint version to v2.0.1 following the migration guide [here](https://golangci-lint.run/product/migration-guide/) with the `golangci-lint migrate` command.

*Testing (if applicable):*
```
make eks-a
make unit-test
make lint
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

