### PR TITLE
Add skip-validations flag to upgrade management components command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
+++ b/cmd/eksctl-anywhere/cmd/upgrademanagementcomponents.go
@@ -9,11 +9,13 @@ import (
 	"github.com/aws/eks-anywhere/pkg/dependencies"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/types"
+	"github.com/aws/eks-anywhere/pkg/validations"
 	"github.com/aws/eks-anywhere/pkg/workflows/management"
 )
 
 type upgradeManagementComponentsOptions struct {
 	clusterOptions
+	skipValidations []string
 }
 
 var umco = &upgradeManagementComponentsOptions{}
@@ -84,11 +86,12 @@ var upgradeManagementComponentsCmd = &cobra.Command{
 			KubeconfigFile: kubeconfig.FromClusterName(clusterSpec.Cluster.Name),
 		}
 
-		validator := management.NewUMCValidator(managementCluster, clusterSpec.EKSARelease, deps.UnAuthKubectlClient)
+		validator := management.NewUMCValidator(managementCluster, clusterSpec.EKSARelease, deps.UnAuthKubectlClient, umco.skipValidations)
 		return runner.Run(ctx, clusterSpec, managementCluster, validator)
 	},
 }
 
 func init() {
 	upgradeCmd.AddCommand(upgradeManagementComponentsCmd)
+	upgradeManagementComponentsCmd.Flags().StringArrayVar(&umco.skipValidations, "skip-validations", []string{}, fmt.Sprintf("Bypass upgrade management components validations by name. Valid arguments you can pass are --skip-validations=%s", validations.EksaVersionSkew))
 }

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -43,6 +43,10 @@ const (
 	// skipIPCheckAnnotation skips the availability control plane IP validation during cluster creation. Use only if your network configuration is conflicting with the default port scan.
 	skipIPCheckAnnotation = "anywhere.eks.amazonaws.com/skip-ip-check"
 
+	// skipEksaVersionSkewCheck is an annotation that bypasses the EKS-A version compatibility check during upgrades.
+	// WARNING: Use this with caution as skipping minor versions could break component compatibility and cause cluster instability or failures.
+	skipEksaVersionSkewCheck = "anywhere.eks.amazonaws.com/skip-eksa-version-skew-check"
+
 	// managementAnnotation points to the name of a management cluster
 	// cluster object.
 	managementAnnotation = "anywhere.eks.amazonaws.com/managed-by"
@@ -1408,6 +1412,22 @@ func (c *Cluster) DisableControlPlaneIPCheck() {
 // ControlPlaneIPCheckDisabled checks it the `skip-ip-check` annotation is set on the Cluster object.
 func (c *Cluster) ControlPlaneIPCheckDisabled() bool {
 	if s, ok := c.Annotations[skipIPCheckAnnotation]; ok {
+		return s == "true"
+	}
+	return false
+}
+
+// DisableEksaVersionSkewCheck sets the `skip-eksa-version-skew-check` annotation on the Cluster object.
+func (c *Cluster) DisableEksaVersionSkewCheck() {
+	if c.Annotations == nil {
+		c.Annotations = make(map[string]string, 1)
+	}
+	c.Annotations[skipEksaVersionSkewCheck] = "true"
+}
+
+// EksaVersionSkewCheckDisabled checks if the `skip-eksa-version-skew-check` annotation is set on the Cluster object.
+func (c *Cluster) EksaVersionSkewCheckDisabled() bool {
+	if s, ok := c.Annotations[skipEksaVersionSkewCheck]; ok {
 		return s == "true"
 	}
 	return false

--- a/pkg/api/v1alpha1/cluster_types_test.go
+++ b/pkg/api/v1alpha1/cluster_types_test.go
@@ -3142,6 +3142,46 @@ func TestClusterControlPlaneIPCheckDisabled(t *testing.T) {
 	}
 }
 
+func TestClusterDisableEksaVersionSkewCheck(t *testing.T) {
+	cluster := &v1alpha1.Cluster{}
+	cluster.DisableEksaVersionSkewCheck()
+	got := cluster.EksaVersionSkewCheckDisabled()
+
+	if !got {
+		t.Error("DisableControlPlaneIPCheck() failed: expected control plane IP check to be disabled")
+	}
+}
+
+func TestClusterEksaVersionSkewCheckDisabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *v1alpha1.Cluster
+		want    bool
+	}{
+		{
+			name: "annotation exists",
+			want: true,
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.DisableEksaVersionSkewCheck()
+			}),
+		},
+		{
+			name: "annotation does not exist",
+			want: false,
+			cluster: baseCluster(func(c *v1alpha1.Cluster) {
+				c.Annotations = nil
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cluster.EksaVersionSkewCheckDisabled(); got != tt.want {
+				t.Errorf("ControlPlaneIPCheckDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWorkerNodesUpgradeRolloutStrategyEqual(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -103,7 +103,9 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) (admission.Warnings, error)
 
 	allErrs = append(allErrs, validateEksaVersionCluster(r, oldCluster)...)
 
-	allErrs = append(allErrs, ValidateEksaVersionSkew(r, oldCluster)...)
+	if !r.EksaVersionSkewCheckDisabled() {
+		allErrs = append(allErrs, ValidateEksaVersionSkew(r, oldCluster)...)
+	}
 
 	allErrs = append(allErrs, ValidateWorkerKubernetesVersionSkew(r, oldCluster)...)
 

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -202,6 +202,8 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 					Err:         validations.ValidateEksaVersionSkew(ctx, k, u.Opts.ManagementCluster, u.Opts.Spec),
 				}
 			})
+	} else {
+		u.Opts.Spec.Cluster.DisableEksaVersionSkewCheck()
 	}
 	return upgradeValidations
 }


### PR DESCRIPTION
Upgrade cluster command already supports a skip-validations flag that lets users skip a preflight that's skippable. Add similar functionality to upgrade management-components command. The only preflight that will be skippable in this command would be the 'eksa-version-skew' which checks for version skew during an upgrade is not more than 1 minor version. Also for the upgrade command controller wasn't honoring the skipped validations passed through the flag. This change also fixes the controller to respect the flag.

```
eksadmin@rahulgab-dev:~/L3/eks-anywhere$ ./bin/skip-skew/eksctl-anywhere upgrade management-components -h
The term 'management components' encompasses all Kubernetes controllers and their CRDs present in the management cluster that are responsible for reconciling your EKS Anywhere (EKS-A) cluster. This command is specifically designed to facilitate the upgrade of these management components. Post this upgrade, the cluster itself can be upgraded by updating the 'eksaVersion' field in your EKS-A Cluster object.

Usage:
  anywhere upgrade management-components [flags]

Flags:
      --bundles-override string        A path to a custom bundles manifest
  -f, --filename string                Path that contains a cluster configuration
  -h, --help                           help for management-components
      --skip-validations stringArray   Bypass upgrade management components validations by name. Valid arguments you can pass are --skip-validations=eksa-version-skew
```

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*
Validated upgrading a cluster from v0.19.6 to v0.22.0. Verified that we are able to upgrade both management-components and the cluster by passing in this flag.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

