### PR TITLE
Set duration of packages roles to 1 hour

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -84,12 +84,12 @@ phases:
         -n ${CLUSTER_NAME_PREFIX}
         --delete-duplicate-networks
         -v 6
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
       - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export CERT_MANAGER_ROLE
       - export ROUTE53_ACCESS_KEY_ID=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export ROUTE53_SECRET_ACCESS_KEY=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -144,7 +144,7 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
       - make conformance-tests
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -34,12 +34,12 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e docker" E2E_OUTPUT_FILE=bin/docker/e2e.test
         fi
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
       - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional --duration-seconds 43200)
+      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional --duration-seconds 3600)
       - export NON_REGIONAL_PACKAGES_ROLE
       - export NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -68,7 +68,7 @@ phases:
         --insecure
         --ignoreErrors
         -v 4
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -221,12 +221,12 @@ phases:
         --insecure
         --ignoreErrors
         -v 4
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
       - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional --duration-seconds 43200)
+      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional --duration-seconds 3600)
       - export NON_REGIONAL_PACKAGES_ROLE
       - export NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
@@ -32,7 +32,7 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e snow" E2E_OUTPUT_FILE=bin/snow/e2e.test
         fi
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -84,7 +84,7 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e tinkerbell" E2E_OUTPUT_FILE=bin/tinkerbell/e2e.test
         fi
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -102,12 +102,12 @@ phases:
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}
         -v 4
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export PACKAGES_ROLE
       - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
       - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test --duration-seconds 43200)
+      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test --duration-seconds 3600)
       - export CERT_MANAGER_ROLE
       - export ROUTE53_ACCESS_KEY_ID=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.AccessKeyId')
       - export ROUTE53_SECRET_ACCESS_KEY=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SecretAccessKey')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous PR: https://github.com/aws/eks-anywhere/pull/9482

Need to set it to 1 hour as role chaining duration limit is only 1 hour

Error:
```
An error occurred (ValidationError) when calling the AssumeRole operation: The requested DurationSeconds exceeds the 1 hour session limit for roles assumed by role chaining.
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

