### PR TITLE
Use SourceImageURI for helm chart modifications for dev

### DIFF
--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -120,7 +120,7 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 }
 
 func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string, eksaArtifacts map[string][]releasetypes.Artifact, shaMap map[string]anywherev1alpha1.Image) error {
-	helmChart := strings.Split(i.ReleaseImageURI, ":")
+	helmChart := strings.Split(i.SourceImageURI, ":")
 	helmtag := helmChart[1]
 
 	// Overwrite Chart.yaml
@@ -485,7 +485,7 @@ func GetPackagesImageTags(packagesArtifacts map[string][]releasetypes.Artifact) 
 	for _, artifacts := range packagesArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
-				m[artifact.Image.AssetName] = artifact.Image.ReleaseImageURI
+				m[artifact.Image.AssetName] = artifact.Image.SourceImageURI
 			}
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use SourceImageURI for helm chart modifications for dev similar to how we did in [other helm chart modification step](https://github.com/aws/eks-anywhere/pull/8469/files) 

Context:
In dev bundle, package controller and ecr token refresher version tags are updated incorrectly (pointing to outdated images). This PR is an attempt to fix this issue by using source image uri instead of release image uri in helm chart modification step.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


