### PR TITLE
Use source image URI for overriding the helm tag

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -97,19 +97,19 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 				sourceBranch = imageArtifact.SourcedFromBranch
 				bundleImageArtifact := anywherev1alpha1.Image{}
 				if strings.HasSuffix(imageArtifact.AssetName, "helm") {
-					imageDigest, err := imageDigests.Load(imageArtifact.ReleaseImageURI)
+					imageDigest, err := imageDigests.Load(imageArtifact.SourceImageURI)
 					if err != nil {
 						return anywherev1alpha1.PackageBundle{}, fmt.Errorf("loading digest from image digests table: %v", err)
 					}
 					if r.DevRelease && Helmsha != "" && Helmtag != "" {
 						imageDigest = Helmsha
-						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Helmtag)
+						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Helmtag)
 					}
 					assetName := strings.TrimSuffix(imageArtifact.AssetName, "-helm")
 					bundleImageArtifact = anywherev1alpha1.Image{
 						Name:        assetName,
 						Description: fmt.Sprintf("Helm chart for %s", assetName),
-						URI:         imageArtifact.ReleaseImageURI,
+						URI:         imageArtifact.SourceImageURI,
 						ImageDigest: imageDigest,
 					}
 				} else {


### PR DESCRIPTION
*Issue #, if available:*
The dev release started failing after [#9497](https://github.com/aws/eks-anywhere/pull/9497) was merged with the following error:
```
Error generating image digests table: generating image digests table: getting image digest for image public.ecr.aws/l0g8r8j6/tinkerbell/stack:0.6.2-eks-a-v0.23.0-dev-build.58: ImageNotFoundException: The image with imageId {imageDigest:'null', imageTag:'0.6.2-eks-a-v0.23.0-dev-build.58'} does not exist within the repository with name 'tinkerbell/stack' in the registry with id '857151390494'
```
I believe this is because the helm tags were still getting replaced for the release image URI and not for the source image URI.

*Description of changes:*
This PR updates the logic to replace the helm tags for the source image URI instead of the release image URI as a simple follow-up to #9497 to fix the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

