### PR TITLE
Use SourceImageURI only for packages helm chart modification in dev release

### DIFF
--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -120,7 +120,10 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 }
 
 func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string, eksaArtifacts map[string][]releasetypes.Artifact, shaMap map[string]anywherev1alpha1.Image) error {
-	helmChart := strings.Split(i.SourceImageURI, ":")
+	helmChart := strings.Split(i.ReleaseImageURI, ":")
+	if packagesutils.NeedsPackagesAccountArtifacts(r) && (i.AssetName == "eks-anywhere-packages" || i.AssetName == "ecr-token-refresher" || i.AssetName == "credential-provider-package") {
+		helmChart = strings.Split(i.SourceImageURI, ":")
+	}
 	helmtag := helmChart[1]
 
 	// Overwrite Chart.yaml


### PR DESCRIPTION
*Issue #, if available:*
The dev release started failing after https://github.com/aws/eks-anywhere/pull/9497 was merged with the following error:
```
Error generating image digests table: generating image digests table: getting image digest for image public.ecr.aws/l0g8r8j6/tinkerbell/stack:0.6.2-eks-a-v0.23.0-dev-build.58: ImageNotFoundException: The image with imageId {imageDigest:'null', imageTag:'0.6.2-eks-a-v0.23.0-dev-build.58'} does not exist within the repository with name 'tinkerbell/stack' in the registry with id '857151390494'
```

I think this is because the `ModifyAndPushChartYaml` function is also being called during artifacts upload phase for the tinkerbell helm chart images [here](https://github.com/aws/eks-anywhere/blob/main/release/cli/pkg/operations/upload.go#L157) due to which incorrect source registry is getting used for tinkerbell charts as well.

*Description of changes:*
This PR adds a condition to use source image URI only for packages helm charts and keep it release image URI for other charts by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

