### PR TITLE
Add conformance 1.32 certification image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Source: https://github.com/cncf/artwork/tree/master/projects/kubernetes/certifie
 [<img src="docs/static/images/certified-kubernetes-1.29-cmyk.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/3049)
 [<img src="docs/static/images/certified-kubernetes-1.30-cmyk.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/3537)
 [<img src="docs/static/images/certified-kubernetes-1.31-cmyk.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/3544)
+[<img src="docs/static/images/certified-kubernetes-1.32-cmyk.svg" height=150>](https://github.com/cncf/k8s-conformance/pull/3647)
 
 ## Development
 


### PR DESCRIPTION
*Description of changes:*

Conformance certification PR: https://github.com/cncf/k8s-conformance/pull/3647

hold because the certified k8s 1.32 artwork is not available yet
https://github.com/cncf/artwork/tree/main/projects/kubernetes/certified-kubernetes

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

