### PR TITLE
[DO NOT MERGE] Revert 9497, 9504, 9511 and 9514

### DIFF
--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -120,7 +120,7 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 }
 
 func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string, eksaArtifacts map[string][]releasetypes.Artifact, shaMap map[string]anywherev1alpha1.Image) error {
-	helmChart := strings.Split(i.SourceImageURI, ":")
+	helmChart := strings.Split(i.ReleaseImageURI, ":")
 	helmtag := helmChart[1]
 
 	// Overwrite Chart.yaml
@@ -485,7 +485,7 @@ func GetPackagesImageTags(packagesArtifacts map[string][]releasetypes.Artifact) 
 	for _, artifacts := range packagesArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
-				m[artifact.Image.AssetName] = artifact.Image.SourceImageURI
+				m[artifact.Image.AssetName] = artifact.Image.ReleaseImageURI
 			}
 		}
 	}

--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -120,10 +120,7 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 }
 
 func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string, eksaArtifacts map[string][]releasetypes.Artifact, shaMap map[string]anywherev1alpha1.Image) error {
-	helmChart := strings.Split(i.ReleaseImageURI, ":")
-	if packagesutils.NeedsPackagesAccountArtifacts(r) && (i.AssetName == "eks-anywhere-packages" || i.AssetName == "ecr-token-refresher" || i.AssetName == "credential-provider-package") {
-		helmChart = strings.Split(i.SourceImageURI, ":")
-	}
+	helmChart := strings.Split(i.SourceImageURI, ":")
 	helmtag := helmChart[1]
 
 	// Overwrite Chart.yaml


### PR DESCRIPTION
*Description of changes:*
This PR reverts #9497, #9504 and #9511 because it is trying to pull the `ecr-token-refresher` and `eks-anywhere-packages` images with the `latest` tag on main and `release-0.22` tag on release branch for staging test.

Dev packages tests:
```
"message": "Back-off pulling image "public.ecr.aws/x3k6m8v0/ecr-token-refresher:latest"
```
Staging packages tests:
```
"message": "Back-off pulling image "public.ecr.aws/w9m0f3l5/ecr-token-refresher:release-0.22"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

