### PR TITLE
Use source image URI for replacing packages and ecr token refresher image tags

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -117,12 +117,12 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 					if err != nil {
 						return anywherev1alpha1.PackageBundle{}, fmt.Errorf("loading digest from image digests table: %v", err)
 					}
-					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && TokenSha != "" && Tokentag != "" {
+					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && Imagesha != "" && Imagetag != "" {
 						imageDigest = Imagesha
-						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Imagetag)
-					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && Imagesha != "" && Imagetag != "" {
+						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Imagetag)
+					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && TokenSha != "" && Tokentag != "" {
 						imageDigest = TokenSha
-						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Tokentag)
+						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Tokentag)
 					}
 					bundleImageArtifact = anywherev1alpha1.Image{
 						Name:        imageArtifact.AssetName,


### PR DESCRIPTION
*Issue #, if available:*
We are seeing `ImagePullBackoff` error in the packages tests on main and release branches after merging #9497 and #9504.

Packages tests on main:
```
"message": "Back-off pulling image "public.ecr.aws/x3k6m8v0/ecr-token-refresher:latest"
```
Packages tests on release-0.22:
```
"message": "Back-off pulling image "public.ecr.aws/w9m0f3l5/ecr-token-refresher:release-0.22"
```

I believe this is because we didn't replace the ReleaseImageUri with SourceImageUri when updating the tags for the `eks-anywhere-packages` and `ecr-token-refresher` images.

*Description of changes:*
This PR replaces the ReleaseImageUri with SourceImageUri in the logic for updating the image tags for the `eks-anywhere-packages` and `ecr-token-refresher` images. It also fixes the conditions for non-empty tags and shas for packages and token refresher which were mistakenly swapped.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

