### PR TITLE
Filter images based on branch and get the latest tag

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -51,42 +51,41 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	artifactHashes := []string{}
 
-	// Find latest Package Dev build for the Helm chart and Image and is built off of the package Github repo main on every commit.
-	// If we can't find the build starting with our substring, we default to the original dev tag.
-	// If we do find the Tag in Private ECR, but it doesn't exist in Public ECR Copy the image over so the helm chart will work correctly.
+	// Find latest packages dev build for the Helm chart and Image
+	// If we do find the tag in private ECR but it doesn't exist in public ECR, skopeo copy the image so that the helm chart works correctly
 	if r.DevRelease && !r.DryRun {
-		Helmtag, Helmsha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "", true)
+		Helmtag, Helmsha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", r.BuildRepoBranchName, true)
 		if err != nil {
 			fmt.Printf("Error getting dev version helm tag EKS Anywhere package controller, using latest version %v", err)
 		}
-		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "", true)
+		Imagetag, Imagesha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", r.BuildRepoBranchName, false)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
 		PackageImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 		if err != nil {
-			fmt.Printf("Error checking image version existance for EKS Anywhere package controller, using latest version: %v", err)
+			fmt.Printf("Error checking image version existence for EKS Anywhere package controller, using latest version: %v", err)
 		}
 		if !PackageImage {
-			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
+			fmt.Printf("Required helm image not found in public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
 			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
 			if err != nil {
 				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
 			}
 		}
-		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", "", true)
+		Tokentag, TokenSha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", r.BuildRepoBranchName, false)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package token refresher, using latest version %v", err)
 		}
 		TokenImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 		if err != nil {
-			fmt.Printf("Error checking image version existance for EKS Anywhere package token refresher, using latest version: %v", err)
+			fmt.Printf("Error checking image version existence for EKS Anywhere package ecr token refresher, using latest version: %v", err)
 		}
 		if !TokenImage {
-			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
+			fmt.Printf("Required helm image not found in public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
 			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
 			if err != nil {
-				fmt.Printf("Error copying dev EKS Anywhere package token refresher image, to ECR Public: %v", err)
+				fmt.Printf("Error copying dev EKS Anywhere package ecr token refresher image, to ECR Public: %v", err)
 			}
 		}
 	}
@@ -103,11 +102,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 					}
 					if r.DevRelease && Helmsha != "" && Helmtag != "" {
 						imageDigest = Helmsha
-						if imageArtifact.AssetName == "eks-anywhere-packages-helm" {
-							imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Helmtag)
-						} else {
-							imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Helmtag)
-						}
+						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Helmtag)
 					}
 					assetName := strings.TrimSuffix(imageArtifact.AssetName, "-helm")
 					bundleImageArtifact = anywherev1alpha1.Image{


### PR DESCRIPTION
*Issue #, if available:*
After merging [#9519](https://github.com/aws/eks-anywhere/pull/9519), the dev bundle now has the latest tag but it still doesn't filter the tags based on branch name. This is why the dev bundle built from main has the tag from the release branch. The helm chart and the image for the eks-anywhere-packages repository both have the same tag but they are expected to have different tags. Helm chart tags start directly with the semver (ex:- 0.4.6) whereas image tags start with the 'v' followed by the semver (ex:- v0.4.6). 

*Description of changes:*
This PR updates the logic to get the latest tag based on branch name and also uses different tags for helm charts and images based on whether the tag contains "helm" in it. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

