### PR TITLE
Use correct registry account id when pulling latest image and cleanup old code

### DIFF
--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -105,6 +105,7 @@ func DescribeImagesPaginated(ecrClient *ecr.ECR, describeInput *ecr.DescribeImag
 func GetLatestImage(ecrClient *ecr.ECR, repoName, branchName string, isHelmChart bool) (string, string, error) {
 	imageDetails, err := DescribeImagesPaginated(ecrClient, &ecr.DescribeImagesInput{
 		RepositoryName: aws.String(repoName),
+		RegistryId: aws.String("067575901363"),
 	})
 	if len(imageDetails) == 0 {
 		return "", "", fmt.Errorf("no image details obtained with DescribeImages API for %s repo: %v", repoName, err)

--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -22,10 +22,8 @@ import (
 
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/release/cli/pkg/aws/ecr"
-	"github.com/aws/eks-anywhere/release/cli/pkg/aws/ecrpublic"
 	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
 	"github.com/aws/eks-anywhere/release/cli/pkg/helm"
-	"github.com/aws/eks-anywhere/release/cli/pkg/images"
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
 	bundleutils "github.com/aws/eks-anywhere/release/cli/pkg/util/bundles"
 	"github.com/aws/eks-anywhere/release/cli/pkg/version"
@@ -52,7 +50,6 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 	artifactHashes := []string{}
 
 	// Find latest packages dev build for the Helm chart and Image
-	// If we do find the tag in private ECR but it doesn't exist in public ECR, skopeo copy the image so that the helm chart works correctly
 	if r.DevRelease && !r.DryRun {
 		Helmtag, Helmsha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", r.BuildRepoBranchName, true)
 		if err != nil {
@@ -62,31 +59,9 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
-		PackageImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
-		if err != nil {
-			fmt.Printf("Error checking image version existence for EKS Anywhere package controller, using latest version: %v", err)
-		}
-		if !PackageImage {
-			fmt.Printf("Required helm image not found in public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
-			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
-			if err != nil {
-				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
-			}
-		}
 		Tokentag, TokenSha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", r.BuildRepoBranchName, false)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package token refresher, using latest version %v", err)
-		}
-		TokenImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
-		if err != nil {
-			fmt.Printf("Error checking image version existence for EKS Anywhere package ecr token refresher, using latest version: %v", err)
-		}
-		if !TokenImage {
-			fmt.Printf("Required helm image not found in public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
-			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
-			if err != nil {
-				fmt.Printf("Error copying dev EKS Anywhere package ecr token refresher image, to ECR Public: %v", err)
-			}
 		}
 	}
 	for _, componentName := range sortedComponentNames {


### PR DESCRIPTION
*Issue #, if available:*
After merging [#9519](https://github.com/aws/eks-anywhere/pull/9519), the dev release started throwing this error message but the job itself didn't fail:
```
msg="initializing source docker://067575901363.dkr.ecr.us-west-2.amazonaws.com/ecr-token-refresher:v0.4.5-ee5506184b3dce86716eaf644d4b416661ae459f: reading manifest v0.4.5-ee5506184b3dce86716eaf644d4b416661ae459f in 067575901363.dkr.ecr.us-west-2.amazonaws.com/ecr-token-refresher: manifest unknown: Requested image not found"
Error happened during retry after 10 retries: executing skopeo copy command: exit status 1
Execution aborted by retry policy
Error copying dev EKS Anywhere package ecr token refresher image, to ECR Public: retries exhausted performing image copy from source [067575901363.dkr.ecr.us-west-2.amazonaws.com/ecr-token-refresher:v0.4.5-ee5506184b3dce86716eaf644d4b416661ae459f] to destination [public.ecr.aws/l0g8r8j6/ecr-token-refresher:v0.4.5-ee5506184b3dce86716eaf644d4b416661ae459f]: executing skopeo copy command: exit status 1
✅ Successfully generated bundle manifest spec
```
But there was still an issue with the dev release on main using the latest tag for release-0.22 branch. So [#9522](https://github.com/aws/eks-anywhere/pull/9522) was merged after this to filter tags based on branch. But now the dev-release started failing with the following error in addition to the above error:
```
Modifying helm chart for eks-anywhere-packages
Getting Helm destination folder for eks-anywhere-packages
Starting to modifying helm chart 067575901363.dkr.ecr.us-west-2.amazonaws.com/eks-anywhere-packages
Pulling helm chart 067575901363.dkr.ecr.us-west-2.amazonaws.com/eks-anywhere-packages:0.4.6-e7a42b8cb791d4027001fd1bb2f04df5696fdfb8
Error generating bundles manifest: pulling the helm chart: running the Helm LocateChart command, you might need run an AWS ECR Login: 067575901363.dkr.ecr.us-west-2.amazonaws.com/eks-anywhere-packages:0.4.6-e7a42b8cb791d4027001fd1bb2f04df5696fdfb8: not found
``` 
This is because it is still trying to pull the latest image from the build account even though we updated the packages source clients to use the regional beta account in [#8628](https://github.com/aws/eks-anywhere/pull/8628).

*Description of changes:*
This PR includes the registry account id when calling the describe images API to explicitly pull images from the regional packages beta account to fix the above issue. Additionally, it cleans up the old code from the former packages team to check for the existence of packages images in public ECR and copying them if they don't exist. They probably added it in [#5034](https://github.com/aws/eks-anywhere/pull/5034) because they ran into some local registry tests and tinkerbell issues based on the PR title. We probably don't need it anymore since we are building from the regional packages beta account and we handle copying images in ecr image replication job.
(Ref:- https://github.com/aws/eks-anywhere/blob/main/release/cli/docs/package_helm_chart.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

