### PR TITLE
Use tag from release image URI when overriding packages image tag in helm chart

### DIFF
--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -488,12 +488,12 @@ func GetPackagesImageTags(packagesArtifacts map[string][]releasetypes.Artifact) 
 	for _, artifacts := range packagesArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
-				m[artifact.Image.AssetName] = artifact.Image.SourceImageURI
+				m[artifact.Image.AssetName] = artifact.Image.ReleaseImageURI
 			}
 		}
 	}
 	if len(m) == 0 {
-		return nil, fmt.Errorf("No assets found for eks-anywhere-packages, or ecr-token-refresher in packagesArtifacts")
+		return nil, fmt.Errorf("no assets found for eks-anywhere-packages, or ecr-token-refresher in packagesArtifacts")
 	}
 	return m, nil
 }


### PR DESCRIPTION
*Issue #, if available:*
After merging #9525, the dev-release is failing with the following error:
```
message": "Back-off pulling image \"public.ecr.aws/x3k6m8v0/ecr-token-refresher:latest\""
```
This is because the values.yaml file in the helm chart is modified to look for the latest tags in the regional beta public ECR where it doesn't exist.

*Description of changes:*
This PR updates the logic to use tags from the release image URI instead of source image URI when modifying the helm chart so that it gets the correct tag from the build account public ECR. It was recently changed from release image URI to source image URI in #9497.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

