### PR TITLE
Revert 9528 9525 9522 and 9519

### DIFF
--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -17,6 +17,7 @@ package ecr
 import (
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -101,114 +102,94 @@ func DescribeImagesPaginated(ecrClient *ecr.ECR, describeInput *ecr.DescribeImag
 	return images, nil
 }
 
-// GetLatestImage takes a repository as input and returns the latest pushed image along with it's sha256 digest.
-func GetLatestImage(ecrClient *ecr.ECR, repoName, branchName string, isHelmChart bool) (string, string, error) {
+// FilterECRRepoByTagPrefix will take a substring, and a repository as input and find the latest pushed image matching that substring.
+func FilterECRRepoByTagPrefix(ecrClient *ecr.ECR, repoName, prefix string, hasTag bool) (string, string, error) {
 	imageDetails, err := DescribeImagesPaginated(ecrClient, &ecr.DescribeImagesInput{
 		RepositoryName: aws.String(repoName),
 	})
 	if len(imageDetails) == 0 {
-		return "", "", fmt.Errorf("no image details obtained with DescribeImages API for %s repo: %v", repoName, err)
+		return "", "", fmt.Errorf("no image details obtained: %v", err)
 	}
 	if err != nil {
 		return "", "", errors.Cause(err)
 	}
-	
-	filteredImageDetails := filterImageDetailsWithBranchName(imageDetails, branchName, isHelmChart)
-	if len(filteredImageDetails) == 0 {
-		return "", "", fmt.Errorf("no images found with the required filters")
+	var filteredImageDetails []*ecr.ImageDetail
+	if hasTag {
+		filteredImageDetails = imageTagFilter(imageDetails, prefix)
+	} else {
+		filteredImageDetails = imageTagFilterWithout(imageDetails, prefix)
 	}
 
-	version, sha, err := getLatestOCIShaTag(filteredImageDetails)
+	// Filter out any tags that don't match our prefix for doubletagged scenarios
+	for _, detail := range filteredImageDetails {
+		for _, tag := range detail.ImageTags {
+			if tag != nil && !strings.HasPrefix(*tag, prefix) {
+				detail.ImageTags = removeStringSlice(detail.ImageTags, *tag)
+			}
+		}
+	}
+
+	// In case we don't find any tag substring matches, we still want to populate the bundle with the latest version.
+	if len(filteredImageDetails) < 1 {
+		filteredImageDetails = imageDetails
+	}
+	version, sha, err := getLastestOCIShaTag(filteredImageDetails)
 	if err != nil {
 		return "", "", err
 	}
 	return version, sha, nil
 }
 
-// filterImageDetailsWithBranchName filters ECR image details based on tag content and branch naming conventions.
-func filterImageDetailsWithBranchName(imageDetails []*ecr.ImageDetail, branchName string, isHelmChart bool) []*ecr.ImageDetail {
-	filteredImageDetails := []*ecr.ImageDetail{}
-	for _, detail := range imageDetails {
-		// Skip invalid image entries
-		if detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 {
-			continue
-		}
-
-		// Exclude image if any tag contains "cache"
-		skip := false
+// imageTagFilter is used when filtering a list of ECR images for a specific tag or tag substring
+func imageTagFilter(details []*ecr.ImageDetail, substring string) []*ecr.ImageDetail {
+	var filteredDetails []*ecr.ImageDetail
+	for _, detail := range details {
 		for _, tag := range detail.ImageTags {
-			if strings.Contains(*tag, "cache") {
-				skip = true
-				break
+			if strings.HasPrefix(*tag, substring) {
+				filteredDetails = append(filteredDetails, detail)
 			}
 		}
-		if skip {
-			continue
-		}
-
-		// Helm chart filtering logic:
-		// - If isHelmChart is false: exclude any image that has a tag containing "helm"
-		// - If isHelmChart is true: exclude any image that does not have at least one tag containing "helm"
-		if !isHelmChart {
-			for _, tag := range detail.ImageTags {
-				if strings.Contains(*tag, "helm") {
-					skip = true
-					break
-				}
-			}
-			if skip {
-				continue
-			}
-		} else {
-			containsHelm := false
-			for _, tag := range detail.ImageTags {
-				if strings.Contains(*tag, "helm") {
-					containsHelm = true
-					break
-				}
-			}
-			if !containsHelm {
-				continue
-			}
-		}
-
-		if branchName == "main" {
-			// Exclude image if any tag contains "release"
-			for _, tag := range detail.ImageTags {
-				if strings.Contains(*tag, "release") {
-					skip = true
-					break
-				}
-			}
-			if skip {
-				continue
-			}
-		} else {
-			// Exclude image if none of the tags contain the branchName
-			containsBranch := false
-			for _, tag := range detail.ImageTags {
-				if strings.Contains(*tag, branchName) {
-					containsBranch = true
-					break
-				}
-			}
-			if !containsBranch {
-				continue
-			}
-		}
-		filteredImageDetails = append(filteredImageDetails, detail)
 	}
-	return filteredImageDetails
+	return filteredDetails
 }
 
-// getLatestOCIShaTag is used to find the tag/sha of the latest pushed OCI image from a list.
-func getLatestOCIShaTag(details []*ecr.ImageDetail) (string, string, error) {
+// imageTagFilterWithout is used when filtering a list of ECR images for images without a specific tag or tag substring
+func imageTagFilterWithout(details []*ecr.ImageDetail, substring string) []*ecr.ImageDetail {
+	var filteredDetails []*ecr.ImageDetail
+	for _, detail := range details {
+		for _, tag := range detail.ImageTags {
+			if !strings.HasPrefix(*tag, substring) {
+				filteredDetails = append(filteredDetails, detail)
+			}
+		}
+	}
+	return filteredDetails
+}
+
+// getLastestOCIShaTag is used to find the tag/sha of the latest pushed OCI image from a list.
+func getLastestOCIShaTag(details []*ecr.ImageDetail) (string, string, error) {
 	latest := &ecr.ImageDetail{}
 	latest.ImagePushedAt = &time.Time{}
 	for _, detail := range details {
-		if latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
+		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 {
+			continue
+		}
+		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
 			latest = detail
 		}
 	}
+	if reflect.DeepEqual(latest, ecr.ImageDetail{}) {
+		return "", "", fmt.Errorf("error no images found")
+	}
 	return *latest.ImageTags[0], *latest.ImageDigest, nil
+}
+
+// removeStringSlice removes a named string from a slice, without knowing it's index or it being ordered.
+func removeStringSlice(l []*string, item string) []*string {
+	for i, other := range l {
+		if *other == item {
+			return append(l[:i], l[i+1:]...)
+		}
+	}
+	return l
 }

--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -106,6 +106,7 @@ func DescribeImagesPaginated(ecrClient *ecr.ECR, describeInput *ecr.DescribeImag
 func FilterECRRepoByTagPrefix(ecrClient *ecr.ECR, repoName, prefix string, hasTag bool) (string, string, error) {
 	imageDetails, err := DescribeImagesPaginated(ecrClient, &ecr.DescribeImagesInput{
 		RepositoryName: aws.String(repoName),
+		RegistryId: aws.String("067575901363"),
 	})
 	if len(imageDetails) == 0 {
 		return "", "", fmt.Errorf("no image details obtained: %v", err)

--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -105,7 +105,6 @@ func DescribeImagesPaginated(ecrClient *ecr.ECR, describeInput *ecr.DescribeImag
 func GetLatestImage(ecrClient *ecr.ECR, repoName, branchName string, isHelmChart bool) (string, string, error) {
 	imageDetails, err := DescribeImagesPaginated(ecrClient, &ecr.DescribeImagesInput{
 		RepositoryName: aws.String(repoName),
-		RegistryId: aws.String("067575901363"),
 	})
 	if len(imageDetails) == 0 {
 		return "", "", fmt.Errorf("no image details obtained with DescribeImages API for %s repo: %v", repoName, err)

--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -51,41 +51,42 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	artifactHashes := []string{}
 
-	// Find latest packages dev build for the Helm chart and Image
-	// If we do find the tag in private ECR but it doesn't exist in public ECR, skopeo copy the image so that the helm chart works correctly
+	// Find latest Package Dev build for the Helm chart and Image and is built off of the package Github repo main on every commit.
+	// If we can't find the build starting with our substring, we default to the original dev tag.
+	// If we do find the Tag in Private ECR, but it doesn't exist in Public ECR Copy the image over so the helm chart will work correctly.
 	if r.DevRelease && !r.DryRun {
-		Helmtag, Helmsha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", r.BuildRepoBranchName, true)
+		Helmtag, Helmsha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version helm tag EKS Anywhere package controller, using latest version %v", err)
 		}
-		Imagetag, Imagesha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", r.BuildRepoBranchName, false)
+		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
 		PackageImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 		if err != nil {
-			fmt.Printf("Error checking image version existence for EKS Anywhere package controller, using latest version: %v", err)
+			fmt.Printf("Error checking image version existance for EKS Anywhere package controller, using latest version: %v", err)
 		}
 		if !PackageImage {
-			fmt.Printf("Required helm image not found in public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
+			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
 			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
 			if err != nil {
 				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
 			}
 		}
-		Tokentag, TokenSha, err = ecr.GetLatestImage(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", r.BuildRepoBranchName, false)
+		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", "", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package token refresher, using latest version %v", err)
 		}
 		TokenImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 		if err != nil {
-			fmt.Printf("Error checking image version existence for EKS Anywhere package ecr token refresher, using latest version: %v", err)
+			fmt.Printf("Error checking image version existance for EKS Anywhere package token refresher, using latest version: %v", err)
 		}
 		if !TokenImage {
-			fmt.Printf("Required helm image not found in public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
+			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
 			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
 			if err != nil {
-				fmt.Printf("Error copying dev EKS Anywhere package ecr token refresher image, to ECR Public: %v", err)
+				fmt.Printf("Error copying dev EKS Anywhere package token refresher image, to ECR Public: %v", err)
 			}
 		}
 	}
@@ -102,7 +103,11 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 					}
 					if r.DevRelease && Helmsha != "" && Helmtag != "" {
 						imageDigest = Helmsha
-						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Helmtag)
+						if imageArtifact.AssetName == "eks-anywhere-packages-helm" {
+							imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Helmtag)
+						} else {
+							imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Helmtag)
+						}
 					}
 					assetName := strings.TrimSuffix(imageArtifact.AssetName, "-helm")
 					bundleImageArtifact = anywherev1alpha1.Image{

--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -51,15 +51,15 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	artifactHashes := []string{}
 
-	// Find latest Package Dev build for the Helm chart and Image and is built off of the package Github repo main on every commit.
+	// Find latest Package Dev build for the Helm chart and Image which will always start with `0.0.0` and is built off of the package Github repo main on every commit.
 	// If we can't find the build starting with our substring, we default to the original dev tag.
 	// If we do find the Tag in Private ECR, but it doesn't exist in Public ECR Copy the image over so the helm chart will work correctly.
 	if r.DevRelease && !r.DryRun {
-		Helmtag, Helmsha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "", true)
+		Helmtag, Helmsha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "0.0.0", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version helm tag EKS Anywhere package controller, using latest version %v", err)
 		}
-		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "", true)
+		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "v0.0.0", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
@@ -74,7 +74,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
 			}
 		}
-		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", "", true)
+		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", "v0.0.0", true)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package token refresher, using latest version %v", err)
 		}

--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -488,12 +488,12 @@ func GetPackagesImageTags(packagesArtifacts map[string][]releasetypes.Artifact) 
 	for _, artifacts := range packagesArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
-				m[artifact.Image.AssetName] = artifact.Image.ReleaseImageURI
+				m[artifact.Image.AssetName] = artifact.Image.SourceImageURI
 			}
 		}
 	}
 	if len(m) == 0 {
-		return nil, fmt.Errorf("no assets found for eks-anywhere-packages, or ecr-token-refresher in packagesArtifacts")
+		return nil, fmt.Errorf("No assets found for eks-anywhere-packages, or ecr-token-refresher in packagesArtifacts")
 	}
 	return m, nil
 }


### PR DESCRIPTION
*Description of changes:*
This PR reverts #9528, #9525, #9522 and #9519 and just updates the registry account id to the regional beta account to get the latest commit with prefix `0.0.0` for helm charts and `v0.0.0` for images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

