### PR TITLE
Use regional beta account for packages to get image digests

### DIFF
--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -31,6 +31,10 @@ import (
 
 func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR) (string, error) {
 	repository, tag := artifactutils.SplitImageUri(imageUri, imageContainerRegistry)
+	accountId := "857151390494" // By default, use build account registry id
+	if strings.Contains(imageUri, "067575901363") {
+		accountId = "067575901363"
+	}
 	imageDetails, err := DescribeImagesPaginated(ecrClient,
 		&ecr.DescribeImagesInput{
 			ImageIds: []*ecr.ImageIdentifier{
@@ -39,6 +43,7 @@ func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR)
 				},
 			},
 			RepositoryName: aws.String(repository),
+			RegistryId: aws.String(accountId),
 		},
 	)
 	if err != nil {

--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -31,6 +31,10 @@ import (
 
 func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR) (string, error) {
 	repository, tag := artifactutils.SplitImageUri(imageUri, imageContainerRegistry)
+	// We are not getting the accountId from the registry because this function 
+	// is also called to fetch public ECR images for prod bundles and in that case, 
+	// the imageContainerRegistry would be public.ecr.aws which would not have the 
+	// accountId and that's why we set it to the build account by default.
 	accountId := "857151390494" // By default, use build account registry id
 	if strings.Contains(imageUri, "067575901363") {
 		accountId = "067575901363"


### PR DESCRIPTION
*Issue #, if available:*
[#3171](https://github.com/aws/eks-anywhere-internal/issues/3171)

*Description of changes:*
This PR explicity sets the registry id in the describe-images API input to get the images from the registry in the appropriate account. For packages, we get the images from the regional beta account private ECR whereas for all other components, we get it from the build account private ECR.

*Testing (if applicable):*
Tested the dev-release by triggering the codebuild job manually and it gets the images from the correct account for packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

