### PR TITLE
Revert 9514 9511 9504 and 9497

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -117,12 +117,12 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 					if err != nil {
 						return anywherev1alpha1.PackageBundle{}, fmt.Errorf("loading digest from image digests table: %v", err)
 					}
-					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && Imagesha != "" && Imagetag != "" {
+					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && TokenSha != "" && Tokentag != "" {
 						imageDigest = Imagesha
-						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Imagetag)
-					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && TokenSha != "" && Tokentag != "" {
+						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Imagetag)
+					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && Imagesha != "" && Imagetag != "" {
 						imageDigest = TokenSha
-						imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Tokentag)
+						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Tokentag)
 					}
 					bundleImageArtifact = anywherev1alpha1.Image{
 						Name:        imageArtifact.AssetName,

--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -103,11 +103,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 					}
 					if r.DevRelease && Helmsha != "" && Helmtag != "" {
 						imageDigest = Helmsha
-						if imageArtifact.AssetName == "eks-anywhere-packages-helm" {
-							imageArtifact.SourceImageURI = replaceTag(imageArtifact.SourceImageURI, Helmtag)
-						} else {
-							imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Helmtag)
-						}
+						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Helmtag)
 					}
 					assetName := strings.TrimSuffix(imageArtifact.AssetName, "-helm")
 					bundleImageArtifact = anywherev1alpha1.Image{

--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -120,7 +120,7 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 }
 
 func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string, eksaArtifacts map[string][]releasetypes.Artifact, shaMap map[string]anywherev1alpha1.Image) error {
-	helmChart := strings.Split(i.SourceImageURI, ":")
+	helmChart := strings.Split(i.ReleaseImageURI, ":")
 	helmtag := helmChart[1]
 
 	// Overwrite Chart.yaml
@@ -485,7 +485,7 @@ func GetPackagesImageTags(packagesArtifacts map[string][]releasetypes.Artifact) 
 	for _, artifacts := range packagesArtifacts {
 		for _, artifact := range artifacts {
 			if artifact.Image != nil {
-				m[artifact.Image.AssetName] = artifact.Image.SourceImageURI
+				m[artifact.Image.AssetName] = artifact.Image.ReleaseImageURI
 			}
 		}
 	}

--- a/release/cli/pkg/helm/helm.go
+++ b/release/cli/pkg/helm/helm.go
@@ -120,10 +120,7 @@ func GetChartImageTags(d *helmDriver, helmDest string) (*Requires, error) {
 }
 
 func ModifyAndPushChartYaml(i releasetypes.ImageArtifact, r *releasetypes.ReleaseConfig, d *helmDriver, helmDest string, eksaArtifacts map[string][]releasetypes.Artifact, shaMap map[string]anywherev1alpha1.Image) error {
-	helmChart := strings.Split(i.ReleaseImageURI, ":")
-	if packagesutils.NeedsPackagesAccountArtifacts(r) && (i.AssetName == "eks-anywhere-packages" || i.AssetName == "ecr-token-refresher" || i.AssetName == "credential-provider-package") {
-		helmChart = strings.Split(i.SourceImageURI, ":")
-	}
+	helmChart := strings.Split(i.SourceImageURI, ":")
 	helmtag := helmChart[1]
 
 	// Overwrite Chart.yaml


### PR DESCRIPTION
*Issue #, if available:*
Even after reverting the prefix changes in #9531, we are still seeing `ImagePullBackOff` errors for packages images due to incorrect tags being set in the helm chart. This is because we replaced release image URI with source image URI for helm chart modifications.
```
"message": "Back-off pulling image "public.ecr.aws/w9m0f3l5/ecr-token-refresher:release-0.22"
```

*Description of changes:*
This PR reverts #9514, #9511, #9504 and #9497.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

