### PR TITLE
Get account id from the image registry instead of hardcoding

### DIFF
--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -31,14 +31,7 @@ import (
 
 func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR) (string, error) {
 	repository, tag := artifactutils.SplitImageUri(imageUri, imageContainerRegistry)
-	// We are not getting the accountId from the registry because this function 
-	// is also called to fetch public ECR images for prod bundles and in that case, 
-	// the imageContainerRegistry would be public.ecr.aws which would not have the 
-	// accountId and that's why we set it to the build account by default.
-	accountId := "857151390494" // By default, use build account registry id
-	if strings.Contains(imageUri, "067575901363") {
-		accountId = "067575901363"
-	}
+	accountId := strings.Split(imageContainerRegistry, ".")[0]
 	imageDetails, err := DescribeImagesPaginated(ecrClient,
 		&ecr.DescribeImagesInput{
 			ImageIds: []*ecr.ImageIdentifier{


### PR DESCRIPTION
*Description of changes:*
Account ID can be fetched directly from the image container registry since we are not calling this function with the public ECR registry. There is another [GetImageDigest](https://github.com/aws/eks-anywhere/blob/main/release/cli/pkg/aws/ecrpublic/ecrpublic.go#L29) function defined in the `ecrpublic` package for public ECR registries so that doesn't need to be handled here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

