### PR TITLE
Add logic to release packages images to beta account public ECR for dev release

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -377,7 +377,7 @@ func (pc *PackageControllerClient) waitForActiveBundle(ctx context.Context) erro
 				return
 			}
 
-			if pbc != nil && pbc.Spec.ActiveBundle != "" {
+			if pbc.Spec.ActiveBundle != "" {
 				logger.V(6).Info("found packages bundle controller active bundle",
 					"name", pbc.Spec.ActiveBundle)
 				readyCnt++

--- a/pkg/curatedpackages/regional_registry.go
+++ b/pkg/curatedpackages/regional_registry.go
@@ -112,9 +112,6 @@ func ParseAWSConfig(ctx context.Context, awsConfig string) (*aws.Config, error) 
 		return nil, err
 	}
 	defer os.Remove(file.Name())
-	if err != nil {
-		return nil, err
-	}
 
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithSharedConfigFiles([]string{file.Name()}),

--- a/release/Makefile
+++ b/release/Makefile
@@ -14,6 +14,7 @@ RELEASE_BUCKET?=release-bucket
 SOURCE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 PACKAGES_SOURCE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 RELEASE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+PACKAGES_RELEASE_CONTAINER_REGISTRY?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 CDN?=https://$(RELEASE_BUCKET)
 CLI_REPO_URL?=https://github.com/aws/eks-anywhere.git
 BUILD_REPO_URL?=https://github.com/aws/eks-anywhere-build-tooling.git
@@ -133,7 +134,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 ##@ ReleaseTestGenerateManifestAssets
 
 dev-release: build ## Perform a dev release of EKS-A bundles and CLI manifests
-	scripts/release.sh $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(PACKAGES_SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_URL) $(CLI_REPO_URL) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(DRY_RUN) $(WEEKLY)
+	scripts/release.sh $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(SOURCE_CONTAINER_REGISTRY) $(PACKAGES_SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(PACKAGES_RELEASE_CONTAINER_REGISTRY) $(BUILD_REPO_URL) $(CLI_REPO_URL) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(DRY_RUN) $(WEEKLY)
 
 bundle-release: build ## Perform EKS-A versioned bundles release
 	scripts/bundle-release.sh $(REPO_ROOT)/release/downloaded-artifacts $(SOURCE_BUCKET) $(RELEASE_BUCKET) $(CDN) $(BUNDLE_NUMBER) $(CLI_MIN_VERSION) $(CLI_MAX_VERSION) $(SOURCE_CONTAINER_REGISTRY) $(PACKAGES_SOURCE_CONTAINER_REGISTRY) $(RELEASE_CONTAINER_REGISTRY) $(RELEASE_ENVIRONMENT) $(BUILD_REPO_BRANCH_NAME) $(CLI_REPO_BRANCH_NAME) $(BUILD_REPO_URL) $(CLI_REPO_URL)

--- a/release/api/v1alpha1/groupversion_info.go
+++ b/release/api/v1alpha1/groupversion_info.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package v1alpha1 contains API Schema definitions for the release v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the release v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=anywhere.eks.amazonaws.com
 package v1alpha1

--- a/release/cli/cmd/release.go
+++ b/release/cli/cmd/release.go
@@ -75,6 +75,7 @@ var releaseCmd = &cobra.Command{
 		sourceContainerRegistry := viper.GetString("source-container-registry")
 		packagesSourceContainerRegistry := viper.GetString("packages-source-container-registry")
 		releaseContainerRegistry := viper.GetString("release-container-registry")
+		packagesReleaseContainerRegistry := viper.GetString("packages-release-container-registry")
 		cdn := viper.GetString("cdn")
 		devRelease := viper.GetBool("dev-release")
 		dryRun := viper.GetBool("dry-run")
@@ -96,31 +97,32 @@ var releaseCmd = &cobra.Command{
 		}
 
 		releaseConfig := &releasetypes.ReleaseConfig{
-			CliRepoSource:                   cliRepoDir,
-			BuildRepoSource:                 buildRepoDir,
-			CliRepoUrl:                      cliRepoUrl,
-			BuildRepoUrl:                    buildRepoUrl,
-			BuildRepoBranchName:             buildRepoBranchName,
-			CliRepoBranchName:               cliRepoBranchName,
-			ArtifactDir:                     artifactDir,
-			SourceBucket:                    sourceBucket,
-			ReleaseBucket:                   releaseBucket,
-			SourceContainerRegistry:         sourceContainerRegistry,
-			PackagesSourceContainerRegistry: packagesSourceContainerRegistry,
-			ReleaseContainerRegistry:        releaseContainerRegistry,
-			CDN:                             cdn,
-			BundleNumber:                    bundleNumber,
-			ReleaseNumber:                   releaseNumber,
-			ReleaseVersion:                  releaseVersion,
-			ReleaseDate:                     releaseDate,
-			ReleaseTime:                     releaseTime,
-			DevRelease:                      devRelease,
-			BundleRelease:                   bundleRelease,
-			DryRun:                          dryRun,
-			Weekly:                          weekly,
-			ReleaseEnvironment:              releaseEnvironment,
-			AwsSignerProfileArn:             awsSignerProfileArn,
-			MaxReleasesInManifest:           -1,
+			CliRepoSource:                    cliRepoDir,
+			BuildRepoSource:                  buildRepoDir,
+			CliRepoUrl:                       cliRepoUrl,
+			BuildRepoUrl:                     buildRepoUrl,
+			BuildRepoBranchName:              buildRepoBranchName,
+			CliRepoBranchName:                cliRepoBranchName,
+			ArtifactDir:                      artifactDir,
+			SourceBucket:                     sourceBucket,
+			ReleaseBucket:                    releaseBucket,
+			SourceContainerRegistry:          sourceContainerRegistry,
+			PackagesSourceContainerRegistry:  packagesSourceContainerRegistry,
+			ReleaseContainerRegistry:         releaseContainerRegistry,
+			PackagesReleaseContainerRegistry: packagesReleaseContainerRegistry,
+			CDN:                              cdn,
+			BundleNumber:                     bundleNumber,
+			ReleaseNumber:                    releaseNumber,
+			ReleaseVersion:                   releaseVersion,
+			ReleaseDate:                      releaseDate,
+			ReleaseTime:                      releaseTime,
+			DevRelease:                       devRelease,
+			BundleRelease:                    bundleRelease,
+			DryRun:                           dryRun,
+			Weekly:                           weekly,
+			ReleaseEnvironment:               releaseEnvironment,
+			AwsSignerProfileArn:              awsSignerProfileArn,
+			MaxReleasesInManifest:            -1,
 		}
 
 		err := operations.SetRepoHeads(releaseConfig)
@@ -376,6 +378,7 @@ func init() {
 	releaseCmd.Flags().String("source-container-registry", "", "The container registry to pull images from for a dev release")
 	releaseCmd.Flags().String("packages-source-container-registry", "", "The container registry to pull packages images from for a dev release")
 	releaseCmd.Flags().String("release-container-registry", "", "The container registry that images wll be pushed to")
+	releaseCmd.Flags().String("packages-release-container-registry", "", "The container registry to push packages images to for a dev release")
 	releaseCmd.Flags().Bool("dev-release", true, "Flag to indicate a dev release")
 	releaseCmd.Flags().Bool("bundle-release", true, "Flag to indicate a bundle release")
 	releaseCmd.Flags().String("release-environment", "", "Release environment")

--- a/release/cli/pkg/assets/tagger/tagger.go
+++ b/release/cli/pkg/assets/tagger/tagger.go
@@ -25,6 +25,8 @@ import (
 	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
 )
 
+// BuildToolingGitTagAssigner reads the Git tag from the eks-anywhere-build-tooling repository using the branch name.
+// If overrideBranch is provided, it takes precedence over the default branch from the release config.
 func BuildToolingGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranch string) (string, error) {
 	branchName := rc.BuildRepoBranchName
 	if overrideBranch != "" {
@@ -38,6 +40,10 @@ func BuildToolingGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, over
 	return gitTag, nil
 }
 
+// CliGitTagAssigner determines the Git tag to use for the CLI repository based on the release configuration.
+// If the release is a development release (DevRelease is true), it fetches the list of version tags from the repository
+// and returns the most recent (highest) tag in descending semantic version order.
+// Otherwise, it uses the explicitly defined ReleaseVersion from the release configuration.
 func CliGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranch string) (string, error) {
 	var gitTag string
 
@@ -54,10 +60,15 @@ func CliGitTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranc
 	return gitTag, nil
 }
 
+// NonExistentTagAssigner is a placeholder GitTagAssigner that always returns the tag "non-existent".
+// This can be used in scenarios where Git tagging is irrelevant.
 func NonExistentTagAssigner(rc *releasetypes.ReleaseConfig, gitTagPath, overrideBranch string) (string, error) {
 	return "non-existent", nil
 }
 
+// GetGitTagAssigner returns the GitTagAssigner function to be used for the asset configuration.
+// If a custom GitTagAssigner is defined in the AssetConfig, it returns that.
+// Otherwise, it defaults to using the BuildToolingGitTagAssigner.
 func GetGitTagAssigner(ac *assettypes.AssetConfig) assettypes.GitTagAssigner {
 	if ac.GitTagAssigner != nil {
 		return assettypes.GitTagAssigner(ac.GitTagAssigner)

--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -40,7 +40,7 @@ func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR)
 				},
 			},
 			RepositoryName: aws.String(repository),
-			RegistryId: aws.String(accountId),
+			RegistryId:     aws.String(accountId),
 		},
 	)
 	if err != nil {
@@ -108,7 +108,7 @@ func DescribeImagesPaginated(ecrClient *ecr.ECR, describeInput *ecr.DescribeImag
 func FilterECRRepoByTagPrefix(ecrClient *ecr.ECR, repoName, prefix string, hasTag bool) (string, string, error) {
 	imageDetails, err := DescribeImagesPaginated(ecrClient, &ecr.DescribeImagesInput{
 		RepositoryName: aws.String(repoName),
-		RegistryId: aws.String("067575901363"),
+		RegistryId:     aws.String("067575901363"),
 	})
 	if len(imageDetails) == 0 {
 		return "", "", fmt.Errorf("no image details obtained: %v", err)

--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -63,13 +63,13 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
-		PackageImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
+		PackageImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.PackagesReleaseContainerRegistry, "eks-anywhere-packages", Imagetag), r.PackagesReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 		if err != nil {
 			fmt.Printf("Error checking image version existance for EKS Anywhere package controller, using latest version: %v", err)
 		}
 		if !PackageImage {
-			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
-			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
+			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.PackagesReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
+			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "eks-anywhere-packages", Imagetag), fmt.Sprintf("%s/%s:%s", r.PackagesReleaseContainerRegistry, "eks-anywhere-packages", Imagetag))
 			if err != nil {
 				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
 			}
@@ -78,13 +78,13 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package token refresher, using latest version %v", err)
 		}
-		TokenImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag), r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
+		TokenImage, err := ecrpublic.CheckImageExistence(fmt.Sprintf("%s/%s:%s", r.PackagesReleaseContainerRegistry, "ecr-token-refresher", Tokentag), r.PackagesReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
 		if err != nil {
 			fmt.Printf("Error checking image version existance for EKS Anywhere package token refresher, using latest version: %v", err)
 		}
 		if !TokenImage {
-			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
-			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.ReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
+			fmt.Printf("Did not find the required helm image in Public ECR... copying image: %v\n", fmt.Sprintf("%s/%s:%s", r.PackagesReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
+			err := images.CopyToDestination(r.SourceClients.Packages.AuthConfig, r.ReleaseClients.ECRPublic.AuthConfig, fmt.Sprintf("%s/%s:%s", r.PackagesSourceContainerRegistry, "ecr-token-refresher", Tokentag), fmt.Sprintf("%s/%s:%s", r.PackagesReleaseContainerRegistry, "ecr-token-refresher", Tokentag))
 			if err != nil {
 				fmt.Printf("Error copying dev EKS Anywhere package token refresher image, to ECR Public: %v", err)
 			}
@@ -117,10 +117,10 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 					if err != nil {
 						return anywherev1alpha1.PackageBundle{}, fmt.Errorf("loading digest from image digests table: %v", err)
 					}
-					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && TokenSha != "" && Tokentag != "" {
+					if strings.HasSuffix(imageArtifact.AssetName, "eks-anywhere-packages") && r.DevRelease && Imagesha != "" && Imagetag != "" {
 						imageDigest = Imagesha
 						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Imagetag)
-					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && Imagesha != "" && Imagetag != "" {
+					} else if strings.HasSuffix(imageArtifact.AssetName, "ecr-token-refresher") && r.DevRelease && TokenSha != "" && Tokentag != "" {
 						imageDigest = TokenSha
 						imageArtifact.ReleaseImageURI = replaceTag(imageArtifact.ReleaseImageURI, Tokentag)
 					}

--- a/release/cli/pkg/git/git.go
+++ b/release/cli/pkg/git/git.go
@@ -37,6 +37,8 @@ func DescribeTag(gitRoot string) (string, error) {
 	return commandutils.ExecCommand(cmd)
 }
 
+// GetRepoTagsDescending retrieves all Git tags in the specified repository root that match the pattern "v*"
+// and returns them as a single string sorted in descending semantic version order (e.g., v3.0.0, v2.1.0, v1.0.0).
 func GetRepoTagsDescending(gitRoot string) (string, error) {
 	cmd := exec.Command("git", "-C", gitRoot, "tag", "-l", "v*", "--sort", "-v:refname")
 	return commandutils.ExecCommand(cmd)

--- a/release/cli/pkg/types/types.go
+++ b/release/cli/pkg/types/types.go
@@ -24,40 +24,41 @@ import (
 
 // ReleaseConfig contains metadata fields for a release.
 type ReleaseConfig struct {
-	ReleaseVersion                  string
-	DevReleaseUriVersion            string
-	BundleNumber                    int
-	CliMinVersion                   string
-	CliMaxVersion                   string
-	CliRepoUrl                      string
-	CliRepoSource                   string
-	CliRepoHead                     string
-	CliRepoBranchName               string
-	BuildRepoUrl                    string
-	BuildRepoSource                 string
-	BuildRepoHead                   string
-	BuildRepoBranchName             string
-	ArtifactDir                     string
-	SourceBucket                    string
-	ReleaseBucket                   string
-	SourceContainerRegistry         string
-	PackagesSourceContainerRegistry string
-	ReleaseContainerRegistry        string
-	CDN                             string
-	ReleaseNumber                   int
-	ReleaseDate                     string
-	ReleaseTime                     time.Time
-	DevRelease                      bool
-	BundleRelease                   bool
-	DryRun                          bool
-	Weekly                          bool
-	ReleaseEnvironment              string
-	SourceClients                   *clients.SourceClients
-	ReleaseClients                  *clients.ReleaseClients
-	BundleArtifactsTable            ArtifactsTable
-	EksAArtifactsTable              ArtifactsTable
-	AwsSignerProfileArn             string
-	MaxReleasesInManifest           int
+	ReleaseVersion                   string
+	DevReleaseUriVersion             string
+	BundleNumber                     int
+	CliMinVersion                    string
+	CliMaxVersion                    string
+	CliRepoUrl                       string
+	CliRepoSource                    string
+	CliRepoHead                      string
+	CliRepoBranchName                string
+	BuildRepoUrl                     string
+	BuildRepoSource                  string
+	BuildRepoHead                    string
+	BuildRepoBranchName              string
+	ArtifactDir                      string
+	SourceBucket                     string
+	ReleaseBucket                    string
+	SourceContainerRegistry          string
+	PackagesSourceContainerRegistry  string
+	ReleaseContainerRegistry         string
+	PackagesReleaseContainerRegistry string
+	CDN                              string
+	ReleaseNumber                    int
+	ReleaseDate                      string
+	ReleaseTime                      time.Time
+	DevRelease                       bool
+	BundleRelease                    bool
+	DryRun                           bool
+	Weekly                           bool
+	ReleaseEnvironment               string
+	SourceClients                    *clients.SourceClients
+	ReleaseClients                   *clients.ReleaseClients
+	BundleArtifactsTable             ArtifactsTable
+	EksAArtifactsTable               ArtifactsTable
+	AwsSignerProfileArn              string
+	MaxReleasesInManifest            int
 }
 
 type ImageTagOverride struct {

--- a/release/scripts/release.sh
+++ b/release/scripts/release.sh
@@ -33,12 +33,13 @@ CDN="${4?Specify fourth argument - cdn}"
 SOURCE_CONTAINER_REGISTRY="${5?Specify fifth argument - source container registry}"
 PACKAGES_SOURCE_CONTAINER_REGISTRY="${6?Specify sixth argument - packages source container registry}"
 RELEASE_CONTAINER_REGISTRY="${7?Specify seventh argument - release container registry}"
-BUILD_REPO_URL="${8?Specify eighth argument - Build repo URL}"
-CLI_REPO_URL="${9?Specify ninth argument - CLI repo URL}"
-BUILD_REPO_BRANCH_NAME="${10?Specify tenth argument - Build repo branch name}"
-CLI_REPO_BRANCH_NAME="${11?Specify eleventh argument - CLI repo branch name}"
-DRY_RUN="${12?Specify twelfth argument - Dry run}"
-WEEKLY="${13?Specify thirteenth argument - Weekly release}"
+PACKAGES_RELEASE_CONTAINER_REGISTRY="${8?Specify eighth argument - packages release container registry}"
+BUILD_REPO_URL="${9?Specify ninth argument - Build repo URL}"
+CLI_REPO_URL="${10?Specify tenth argument - CLI repo URL}"
+BUILD_REPO_BRANCH_NAME="${11?Specify eleventh argument - Build repo branch name}"
+CLI_REPO_BRANCH_NAME="${12?Specify twelfth argument - CLI repo branch name}"
+DRY_RUN="${13?Specify thirteenth argument - Dry run}"
+WEEKLY="${14?Specify fourteenth argument - Weekly release}"
 
 mkdir -p "${ARTIFACTS_DIR}"
 
@@ -59,6 +60,7 @@ ${BASE_DIRECTORY}/release/bin/eks-anywhere-release release \
     --cdn "${CDN}" \
     --release-bucket "${RELEASE_BUCKET}" \
     --release-container-registry "${RELEASE_CONTAINER_REGISTRY}" \
+    --packages-release-container-registry "${PACKAGES_RELEASE_CONTAINER_REGISTRY}" \
     --dev-release=true \
     --dry-run=${DRY_RUN} \
     --weekly=${WEEKLY} \


### PR DESCRIPTION
*Issue #, if available:*
Currently, all the packages tests are failing on main with the following error:
```
2025-03-31T17:14:29.986Z        PackageBundleController Unable to get latest bundle     {"error": "pulling package bundle: fetch manifest: GET \"https://067575901363.dkr.ecr.us-west-2.amazonaws.com/v2/eks-anywhere-packages-bundles/manifests/v1-30-latest\": basic credential not found"}
```
This is because we recently moved away from long-term IAM user credentials and started using IAM roles to configure temporary credentials through session token for packages tests ([#2650](https://github.com/aws/eks-anywhere-internal/issues/2650)). We cut a new tag for the packages controller with those changes but the dev bundle still points to an older tag for the `eks-anywhere-packages` and `ecr-token-refresher` images from last year when we migrated all the build pipelines and codebuild projects from build account to the regional packages beta account. Due to this, the session token doesn't get set in the `aws-secret` object causing the PBC to fail to pull the latest bundle.

*Description of changes:*
This PR attempts to fix the packages tests by adding logic in the dev-release to release images to the packages beta account public ECR ([x3k6m8v0](https://gallery.ecr.aws/x3k6m8v0/eks-anywhere-packages)) instead of build account public ECR ([l0g8r8j6](https://gallery.ecr.aws/l0g8r8j6/eks-anywhere-packages)) as we also updated the EKS-A CLI last year to install the helm chart from that source registry.

Additionally, the PR also adds useful comments to some complex functions used in the release CLI for future reference and fixes any lint issues.

**NOTE:** PackagesReleaseContainerRegistry in the release config will be set as an env variable in the codebuild job through the build CDK and the necessary permissions to push images to the registry will also be configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

