### PR TITLE
Use packages beta account public ECR for uploading packages images

### DIFF
--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -175,6 +175,9 @@ func handleImageUpload(_ context.Context, r *releasetypes.ReleaseConfig, package
 			sourceEcrClient = r.SourceClients.Packages.EcrClient
 		}
 		releaseContainerRegistry := r.ReleaseContainerRegistry
+		if r.DevRelease && !r.DryRun && (strings.Contains(releaseImageUri, "eks-anywhere-packages") || strings.Contains(releaseImageUri, "ecr-token-refresher") || strings.Contains(releaseImageUri, "credential-provider-package")) {
+			releaseContainerRegistry = r.PackagesReleaseContainerRegistry
+		}
 		releaseEcrPublicClient := r.ReleaseClients.ECRPublic.Client
 		fmt.Printf("Source Image - %s\n", sourceImageUri)
 		fmt.Printf("Destination Image - %s\n", releaseImageUri)


### PR DESCRIPTION
*Issue #, if available:*
The `dev-release` failed with the following error:
```
Error releasing bundle artifacts: uploading artifacts: checking pushability of image [public.ecr.aws/x3k6m8v0/eks-anywhere-packages:v0.4.6-eks-a-v0.23.0-dev-build.71] based on destination repository images or tags limits: RepositoryNotFoundException: The repository with name 'public.ecr.aws/x3k6m8v0/eks-anywhere-packages' does not exist in the registry with id '857151390494'
```
This is because we updated the packages release container registry to the beta account public ECR in [#9550](https://github.com/aws/eks-anywhere/pull/9550) but didn't handle that scenario in the Artifacts Upload phase.

*Description of changes:*
This PR updates the release container registry to use packages beta account public ECR for uploading packages images to fix the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

