### PR TITLE
Use packages-related clients for authenticating to packages release registry

### DIFF
--- a/release/cli/pkg/clients/clients.go
+++ b/release/cli/pkg/clients/clients.go
@@ -43,6 +43,7 @@ type SourceClients struct {
 type ReleaseClients struct {
 	S3        *ReleaseS3Clients
 	ECRPublic *ReleaseECRPublicClient
+	Packages  *ReleaseECRPublicClient
 }
 
 type SourceS3Clients struct {
@@ -129,6 +130,13 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 		return nil, nil, errors.Cause(err)
 	}
 
+	// Get packages release ECR Public auth config
+	packagesECRPublicClient := ecrpublicsdk.New(packagesSession)
+	packagesReleaseAuthConfig, err := ecrpublic.GetAuthConfig(packagesECRPublicClient)
+	if err != nil {
+		return nil, nil, errors.Cause(err)
+	}
+
 	// Constructing source clients
 	sourceClients := &SourceClients{
 		S3: &SourceS3Clients{
@@ -154,6 +162,10 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 		ECRPublic: &ReleaseECRPublicClient{
 			Client:     ecrPublicClient,
 			AuthConfig: releaseAuthConfig,
+		},
+		Packages: &ReleaseECRPublicClient{
+			Client:     packagesECRPublicClient,
+			AuthConfig: packagesReleaseAuthConfig,
 		},
 	}
 

--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -116,7 +116,7 @@ func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfigura
 	releaseRegistryUsername := releaseAuthConfig.Username
 	releaseRegistryPassword := releaseAuthConfig.Password
 	err := retrier.Retry(func() error {
-		cmd := exec.Command("skopeo", "copy", "--src-creds", fmt.Sprintf("%s:%s", sourceRegistryUsername, sourceRegistryPassword), "--dest-creds", fmt.Sprintf("%s:%s", releaseRegistryUsername, releaseRegistryPassword), fmt.Sprintf("docker://%s", sourceImageUri), fmt.Sprintf("docker://%s", releaseImageUri), "-f", "oci", "--all")
+		cmd := exec.Command("skopeo", "--debug", "copy", "--src-creds", fmt.Sprintf("%s:%s", sourceRegistryUsername, sourceRegistryPassword), "--dest-creds", fmt.Sprintf("%s:%s", releaseRegistryUsername, releaseRegistryPassword), fmt.Sprintf("docker://%s", sourceImageUri), fmt.Sprintf("docker://%s", releaseImageUri), "-f", "oci", "--all")
 		out, err := commandutils.ExecCommand(cmd)
 		fmt.Println(out)
 		if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
The `dev-release` on main failed with the following error:
```
time="2025-04-08T22:25:37Z" level=fatal msg="trying to reuse blob sha256:31edd427fc7a581b43b5bdf7025583aa4b3e73ee9809529c6065cdde0a5a738e at destination: failed to read from destination repository x3k6m8v0/credential-provider-package: 403 (Forbidden)"

time="2025-04-08T22:25:38Z" level=fatal msg="trying to reuse blob sha256:31edd427fc7a581b43b5bdf7025583aa4b3e73ee9809529c6065cdde0a5a738e at destination: failed to read from destination repository x3k6m8v0/ecr-token-refresher: 403 (Forbidden)"

time="2025-04-08T22:25:42Z" level=fatal msg="trying to reuse blob sha256:544036502652dfe56a7885ae1473056cabf38843c693d5ee62925ee1c4a831ac at destination: failed to read from destination repository x3k6m8v0/eks-anywhere-packages: 403 (Forbidden)"

time="2025-04-08T22:25:49Z" level=fatal msg="trying to reuse blob sha256:31edd427fc7a581b43b5bdf7025583aa4b3e73ee9809529c6065cdde0a5a738e at destination: failed to read from destination repository x3k6m8v0/eks-anywhere-packages: 403 (Forbidden)"
```
This is because we updated the packages release container registry to the beta account public ECR in [#9550](https://github.com/aws/eks-anywhere/pull/9550) but it didn't update the ecr clients to use the auth config for the packages public ECR registry in the Artifacts Upload phase to fix the above auth issue.

*Description of changes:*
This PR uses packages release clients for authenticating to the packages release registry before copying the images. Additionally, it also enables verbose debug logging for the skopeo copy command to better debug any failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

