### PR TITLE
Use IAD session for packages release public ECR client

### DIFF
--- a/release/cli/pkg/clients/clients.go
+++ b/release/cli/pkg/clients/clients.go
@@ -93,12 +93,23 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 		return nil, nil, errors.Cause(err)
 	}
 
-	// Session for beta-pdx-packages
-	packagesSession, err := session.NewSessionWithOptions(session.Options{
+	// PDX Session for beta-pdx-packages
+	packagesPDXSession, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			Region: aws.String("us-west-2"),
 		},
-		Profile: "packages-beta",
+		Profile: "packages-beta-pdx",
+	})
+	if err != nil {
+		return nil, nil, errors.Cause(err)
+	}
+
+	// IAD Session for beta-pdx-packages
+	packagesIADSession, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Region: aws.String("us-east-1"),
+		},
+		Profile: "packages-beta-iad",
 	})
 	if err != nil {
 		return nil, nil, errors.Cause(err)
@@ -117,7 +128,7 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 	}
 
 	// Get packages source ECR auth config
-	packagesECRClient := ecrsdk.New(packagesSession)
+	packagesECRClient := ecrsdk.New(packagesPDXSession)
 	packagesSourceAuthConfig, err := ecr.GetAuthConfig(packagesECRClient)
 	if err != nil {
 		return nil, nil, errors.Cause(err)
@@ -131,7 +142,7 @@ func CreateDevReleaseClients(dryRun bool) (*SourceClients, *ReleaseClients, erro
 	}
 
 	// Get packages release ECR Public auth config
-	packagesECRPublicClient := ecrpublicsdk.New(packagesSession)
+	packagesECRPublicClient := ecrpublicsdk.New(packagesIADSession)
 	packagesReleaseAuthConfig, err := ecrpublic.GetAuthConfig(packagesECRPublicClient)
 	if err != nil {
 		return nil, nil, errors.Cause(err)
@@ -225,7 +236,7 @@ func CreateStagingReleaseClients(bundleRelease bool) (*SourceClients, *ReleaseCl
 	var packagesSourceAuthConfig *docker.AuthConfiguration
 	if bundleRelease {
 		// Session for beta-pdx-packages
-		packagesSession, err := session.NewSessionWithOptions(session.Options{
+		packagesPDXSession, err := session.NewSessionWithOptions(session.Options{
 			Config: aws.Config{
 				Region: aws.String("us-west-2"),
 			},
@@ -236,7 +247,7 @@ func CreateStagingReleaseClients(bundleRelease bool) (*SourceClients, *ReleaseCl
 		}
 
 		// Get packages source ECR auth config
-		packagesECRClient = ecrsdk.New(packagesSession)
+		packagesECRClient = ecrsdk.New(packagesPDXSession)
 		packagesSourceAuthConfig, err = ecr.GetAuthConfig(packagesECRClient)
 		if err != nil {
 			return nil, nil, errors.Cause(err)

--- a/release/scripts/setup-aws-config.sh
+++ b/release/scripts/setup-aws-config.sh
@@ -23,10 +23,20 @@ function set_aws_config() {
     release_type="$2"
     if [ "$release_environment" = "" ] || ([ "$release_environment" = "development" ] && [ "$release_type" = "bundle" ]); then
         cat << EOF > awscliconfig
-[profile packages-beta]
+[profile packages-beta-pdx]
 role_arn=$PACKAGES_ECR_ROLE
 region=us-west-2
 credential_source=EcsContainer
+
+EOF
+    fi
+    if [ "$release_environment" = "" ]; then
+        cat << EOF > awscliconfig
+[profile packages-beta-iad]
+role_arn=$PACKAGES_ECR_ROLE
+region=us-east-1
+credential_source=EcsContainer
+
 EOF
     fi
     if [ "$release_environment" = "development" ] || [ "$release_environment" = "production" ]; then


### PR DESCRIPTION
*Issue #, if available:*
The `dev-release` on main failed with the following error:
```
==========================================================
             Dev Release Clients Creation
==========================================================
Error creating clients: UnsupportedCommandException: GetAuthorizationToken command is only supported in us-east-1.
```

*Description of changes:*
This PR updates the packages public ECR client to use the IAD session for fixing the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

