### PR TITLE
Append the IAD profile instead of overwriting

### DIFF
--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -116,7 +116,7 @@ func CopyToDestination(sourceAuthConfig, releaseAuthConfig *docker.AuthConfigura
 	releaseRegistryUsername := releaseAuthConfig.Username
 	releaseRegistryPassword := releaseAuthConfig.Password
 	err := retrier.Retry(func() error {
-		cmd := exec.Command("skopeo", "--debug", "copy", "--src-creds", fmt.Sprintf("%s:%s", sourceRegistryUsername, sourceRegistryPassword), "--dest-creds", fmt.Sprintf("%s:%s", releaseRegistryUsername, releaseRegistryPassword), fmt.Sprintf("docker://%s", sourceImageUri), fmt.Sprintf("docker://%s", releaseImageUri), "-f", "oci", "--all")
+		cmd := exec.Command("skopeo", "copy", "--src-creds", fmt.Sprintf("%s:%s", sourceRegistryUsername, sourceRegistryPassword), "--dest-creds", fmt.Sprintf("%s:%s", releaseRegistryUsername, releaseRegistryPassword), fmt.Sprintf("docker://%s", sourceImageUri), fmt.Sprintf("docker://%s", releaseImageUri), "-f", "oci", "--all")
 		out, err := commandutils.ExecCommand(cmd)
 		fmt.Println(out)
 		if err != nil {

--- a/release/scripts/setup-aws-config.sh
+++ b/release/scripts/setup-aws-config.sh
@@ -31,7 +31,7 @@ credential_source=EcsContainer
 EOF
     fi
     if [ "$release_environment" = "" ]; then
-        cat << EOF > awscliconfig
+        cat << EOF >> awscliconfig
 [profile packages-beta-iad]
 role_arn=$PACKAGES_ECR_ROLE
 region=us-east-1


### PR DESCRIPTION
*Description of changes:*
This PR appends the IAD profile to the aws config file instead of overwriting as we need both the profiles for dev release. It also removes the verbose debug logging from skopeo command to reduce noise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

