### PR TITLE
Enable api server audit logs on kind bootstrap cluster

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -16,6 +16,26 @@ kubeadmConfigPatches:
         imageTag: {{.EtcdVersion}}
     imageRepository: {{.KubernetesRepository}}
     kubernetesVersion: {{.KubernetesVersion}}
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
 {{- if .RegistryMirrorMap }}
 containerdConfigPatches:
   - |
@@ -36,26 +56,25 @@ containerdConfigPatches:
         password = "{{.RegistryPassword}}"
 {{- end }}
 {{- end }}
-{{- if or (ne .RegistryCACertPath "") (.DockerExtraMounts) (ne (len .ExtraPortMappings) 0)}}
 nodes:
 - role: control-plane
-{{- if or (ne .RegistryCACertPath "") (.DockerExtraMounts) }}
   extraMounts:
+  - hostPath: {{ .AuditPolicyPath }}
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true
 {{- if (ne .RegistryCACertPath "") }}
-    - containerPath: /etc/containerd/certs.d
-      hostPath: {{.RegistryCACertPath}}
-      readOnly: true
+  - containerPath: /etc/containerd/certs.d
+    hostPath: {{.RegistryCACertPath}}
+    readOnly: true
 {{- end }}
 {{- if .DockerExtraMounts }}
-    - hostPath: /var/run/docker.sock
-      containerPath: /var/run/docker.sock
-{{- end }}
+  - hostPath: /var/run/docker.sock
+    containerPath: /var/run/docker.sock
 {{- end }}
 {{- if ne (len .ExtraPortMappings) 0 }}
   extraPortMappings:
 {{- range .ExtraPortMappings }}
   - containerPort: {{ . }}
     hostPort: {{ . }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/pkg/executables/testdata/kind_config.yaml
+++ b/pkg/executables/testdata/kind_config.yaml
@@ -16,3 +16,29 @@ kubeadmConfigPatches:
         imageTag: v3.4.14-eks-1-19-2
     imageRepository: public.ecr.aws/eks-distro/kubernetes
     kubernetesVersion: v1.19.6-eks-1-19-2
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: test_cluster/generated/kubernetes/audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true

--- a/pkg/executables/testdata/kind_config_docker_mount_networking.yaml
+++ b/pkg/executables/testdata/kind_config_docker_mount_networking.yaml
@@ -16,8 +16,31 @@ kubeadmConfigPatches:
         imageTag: v3.4.14-eks-1-19-2
     imageRepository: public.ecr.aws/eks-distro/kubernetes
     kubernetesVersion: v1.19.6-eks-1-19-2
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
 nodes:
 - role: control-plane
   extraMounts:
-    - hostPath: /var/run/docker.sock
-      containerPath: /var/run/docker.sock
+  - hostPath: test_cluster/generated/kubernetes/audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true
+  - hostPath: /var/run/docker.sock
+    containerPath: /var/run/docker.sock

--- a/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
+++ b/pkg/executables/testdata/kind_config_extra_port_mappings.yaml
@@ -16,8 +16,32 @@ kubeadmConfigPatches:
         imageTag: v3.4.14-eks-1-19-2
     imageRepository: public.ecr.aws/eks-distro/kubernetes
     kubernetesVersion: v1.19.6-eks-1-19-2
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
 nodes:
 - role: control-plane
+  extraMounts:
+  - hostPath: test_cluster/generated/kubernetes/audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true
   extraPortMappings:
   - containerPort: 80
     hostPort: 80

--- a/pkg/executables/testdata/kind_config_registry_mirror_insecure.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_insecure.yaml
@@ -16,6 +16,26 @@ kubeadmConfigPatches:
         imageTag: v3.4.14-eks-1-19-2
     imageRepository: registry-mirror.test:443/eks-anywhere/eks-distro/kubernetes
     kubernetesVersion: v1.19.6-eks-1-19-2
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
 containerdConfigPatches:
   - |
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
@@ -23,3 +43,9 @@ containerdConfigPatches:
         endpoint = ["https://registry-mirror.test:443/v2/eks-anywhere"]
       [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-mirror.test:443".tls]
         insecure_skip_verify = true
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: test_cluster/generated/kubernetes/audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true

--- a/pkg/executables/testdata/kind_config_registry_mirror_with_auth.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_with_auth.yaml
@@ -16,6 +16,26 @@ kubeadmConfigPatches:
         imageTag: v3.4.14-eks-1-19-2
     imageRepository: registry-mirror.test:443/eks-anywhere/eks-distro/kubernetes
     kubernetesVersion: v1.19.6-eks-1-19-2
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
 containerdConfigPatches:
   - |
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
@@ -28,3 +48,9 @@ containerdConfigPatches:
       [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-mirror.test:443".auth]
         username = "username"
         password = "password"
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: test_cluster/generated/kubernetes/audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true

--- a/pkg/executables/testdata/kind_config_registry_mirror_with_ca.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_with_ca.yaml
@@ -16,6 +16,26 @@ kubeadmConfigPatches:
         imageTag: v3.4.14-eks-1-19-2
     imageRepository: registry-mirror.test:443/eks-distro/kubernetes
     kubernetesVersion: v1.19.6-eks-1-19-2
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "512"
+          audit-log-path: /var/log/kubernetes/api-audit.log
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: DirectoryOrCreate
+          - name: audit-logs
+            hostPath: /var/log/kubernetes
+            mountPath: /var/log/kubernetes
+            readOnly: false
+            pathType: DirectoryOrCreate
 containerdConfigPatches:
   - |
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
@@ -26,6 +46,9 @@ containerdConfigPatches:
 nodes:
 - role: control-plane
   extraMounts:
-    - containerPath: /etc/containerd/certs.d
-      hostPath: test_cluster/generated/certs.d
-      readOnly: true
+  - hostPath: test_cluster/generated/kubernetes/audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true
+  - containerPath: /etc/containerd/certs.d
+    hostPath: test_cluster/generated/certs.d
+    readOnly: true


### PR DESCRIPTION
*Issue #, if available:*
See [here](https://github.com/aws/eks-anywhere-internal/issues/3210) for details on change and verifications 
*Description of changes:*
enables api server audit logs on kind bootstrap cluster
*Testing (if applicable):*
- unit tests
- tested on vsphere and docker providers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

