### PR TITLE
Use Packages client for fetching dev image digest for  package

### DIFF
--- a/release/cli/pkg/operations/bundle_release.go
+++ b/release/cli/pkg/operations/bundle_release.go
@@ -259,7 +259,14 @@ func getImageDigest(_ context.Context, r *releasetypes.ReleaseConfig, artifact r
 		}
 		imageDigest = fmt.Sprintf("sha256:%s", sha256sum)
 	} else {
-		imageDigest, err = ecrpublic.GetImageDigest(artifact.Image.ReleaseImageURI, r.ReleaseContainerRegistry, r.ReleaseClients.ECRPublic.Client)
+		releaseImageUri := artifact.Image.ReleaseImageURI
+		releaseContainerRegistry := r.ReleaseContainerRegistry
+		ecrPublicClient := r.ReleaseClients.ECRPublic.Client
+		if r.DevRelease  && (strings.Contains(releaseImageUri, "eks-anywhere-packages") || strings.Contains(releaseImageUri, "ecr-token-refresher") || strings.Contains(releaseImageUri, "credential-provider-package")) {
+			ecrPublicClient = r.ReleaseClients.Packages.Client
+			releaseContainerRegistry = r.PackagesReleaseContainerRegistry
+		}
+		imageDigest, err = ecrpublic.GetImageDigest(releaseImageUri, releaseContainerRegistry, ecrPublicClient)
 		if err != nil {
 			return "", errors.Cause(err)
 		}


### PR DESCRIPTION

*Description of changes:*
eksa dev build is failing with below error. This is because, we have changed to pull packages from packages dev account.

`
Error generating image digests table: generating image digests table: getting image digest for image public.ecr.aws/x3k6m8v0/eks-anywhere-packages:0.4.6-eks-a-v0.23.0-dev-build.71: RepositoryNotFoundException: The repository with name 'public.ecr.aws/x3k6m8v0/eks-anywhere-packages' does not exist in the registry with id 
`

In this PR, I am updating the imageDigest logic to use packages client for packages image uri


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


