### PR TITLE
Use regional beta account for packages to get image digests

### DIFF
--- a/release/cli/pkg/aws/ecrpublic/ecrpublic.go
+++ b/release/cli/pkg/aws/ecrpublic/ecrpublic.go
@@ -28,6 +28,10 @@ import (
 
 func GetImageDigest(imageUri, imageContainerRegistry string, ecrPublicClient *ecrpublic.ECRPublic) (string, error) {
 	repository, tag := artifactutils.SplitImageUri(imageUri, imageContainerRegistry)
+	accountId := "857151390494" // Use build account id by default
+	if strings.Contains(imageUri, "x3k6m8v0") {
+		accountId = "067575901363" // Use packages beta account id for packages images
+	}
 	describeImagesOutput, err := ecrPublicClient.DescribeImages(
 		&ecrpublic.DescribeImagesInput{
 			ImageIds: []*ecrpublic.ImageIdentifier{
@@ -36,6 +40,7 @@ func GetImageDigest(imageUri, imageContainerRegistry string, ecrPublicClient *ec
 				},
 			},
 			RepositoryName: aws.String(repository),
+			RegistryId:     aws.String(accountId),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
Similar to [#3171](https://github.com/aws/eks-anywhere-internal/issues/3171) for packages public ECR release registry

*Description of changes:*
This PR explicity sets the registry id in the describe-images API input to get the image digests from the registry in the appropriate account. For packages, we get the images from the regional beta account public ECR whereas for all other components, we get it from the build account public ECR.

**NOTE:** This is a similar workaround as [#9534](https://github.com/aws/eks-anywhere/pull/9534).

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

