### PR TITLE
Export AWS_SDK_LOAD_CONFIG env variable to use the correct profiles for clients

### DIFF
--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -31,7 +31,6 @@ import (
 
 func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR) (string, error) {
 	repository, tag := artifactutils.SplitImageUri(imageUri, imageContainerRegistry)
-	accountId := strings.Split(imageContainerRegistry, ".")[0]
 	imageDetails, err := DescribeImagesPaginated(ecrClient,
 		&ecr.DescribeImagesInput{
 			ImageIds: []*ecr.ImageIdentifier{
@@ -40,7 +39,6 @@ func GetImageDigest(imageUri, imageContainerRegistry string, ecrClient *ecr.ECR)
 				},
 			},
 			RepositoryName: aws.String(repository),
-			RegistryId:     aws.String(accountId),
 		},
 	)
 	if err != nil {

--- a/release/cli/pkg/aws/ecrpublic/ecrpublic.go
+++ b/release/cli/pkg/aws/ecrpublic/ecrpublic.go
@@ -28,10 +28,6 @@ import (
 
 func GetImageDigest(imageUri, imageContainerRegistry string, ecrPublicClient *ecrpublic.ECRPublic) (string, error) {
 	repository, tag := artifactutils.SplitImageUri(imageUri, imageContainerRegistry)
-	accountId := "857151390494" // Use build account id by default
-	if strings.Contains(imageUri, "x3k6m8v0") {
-		accountId = "067575901363" // Use packages beta account id for packages images
-	}
 	describeImagesOutput, err := ecrPublicClient.DescribeImages(
 		&ecrpublic.DescribeImagesInput{
 			ImageIds: []*ecrpublic.ImageIdentifier{
@@ -40,7 +36,6 @@ func GetImageDigest(imageUri, imageContainerRegistry string, ecrPublicClient *ec
 				},
 			},
 			RepositoryName: aws.String(repository),
-			RegistryId:     aws.String(accountId),
 		},
 	)
 	if err != nil {

--- a/release/scripts/setup-aws-config.sh
+++ b/release/scripts/setup-aws-config.sh
@@ -19,10 +19,13 @@ set -x
 set -o pipefail
 
 function set_aws_config() {
+    export AWS_SDK_LOAD_CONFIG=1
+    export AWS_CONFIG_FILE=$(pwd)/awscliconfig
+
     release_environment="$1"
     release_type="$2"
     if [ "$release_environment" = "" ] || ([ "$release_environment" = "development" ] && [ "$release_type" = "bundle" ]); then
-        cat << EOF > awscliconfig
+        cat << EOF > ${AWS_CONFIG_FILE}
 [profile packages-beta-pdx]
 role_arn=$PACKAGES_ECR_ROLE
 region=us-west-2
@@ -31,7 +34,7 @@ credential_source=EcsContainer
 EOF
     fi
     if [ "$release_environment" = "" ]; then
-        cat << EOF >> awscliconfig
+        cat << EOF >> ${AWS_CONFIG_FILE}
 [profile packages-beta-iad]
 role_arn=$PACKAGES_ECR_ROLE
 region=us-east-1
@@ -44,7 +47,7 @@ EOF
             echo "Empty STAGING_ARTIFACT_DEPLOYMENT_ROLE"
             exit 1
         fi
-        cat << EOF >> awscliconfig
+        cat << EOF >> ${AWS_CONFIG_FILE}
 [profile artifacts-staging]
 role_arn=$STAGING_ARTIFACT_DEPLOYMENT_ROLE
 region=us-east-1
@@ -56,14 +59,12 @@ EOF
                 echo "Empty PROD_ARTIFACT_DEPLOYMENT_ROLE"
                 exit 1
             fi
-            cat << EOF >> awscliconfig
+            cat << EOF >> ${AWS_CONFIG_FILE}
 [profile artifacts-production]
 role_arn=$PROD_ARTIFACT_DEPLOYMENT_ROLE
 region=us-east-1
 credential_source=EcsContainer
 EOF
         fi
-fi
-
-    export AWS_CONFIG_FILE=$(pwd)/awscliconfig
+    fi
 }


### PR DESCRIPTION
*Issue #, if available:*
[#3171](https://github.com/aws/eks-anywhere-internal/issues/3171)

*Description of changes:*
This PR exports the `AWS_SDK_LOAD_CONFIG` env variable to use the correct profiles for clients and reverts [#9534](https://github.com/aws/eks-anywhere/pull/9534) and [#9581](https://github.com/aws/eks-anywhere/pull/9581).

*Testing (if applicable):*
Manually kicked off a one-off job run with the env variable set and it succeeded
https://tiny.amazon.com/jxkct0gb/IsenLink

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

