### PR TITLE
Skip bundle signature validation for EKS-A versions prior to v0.22.0

### DIFF
--- a/controllers/cluster_controller_test_test.go
+++ b/controllers/cluster_controller_test_test.go
@@ -422,7 +422,7 @@ func TestClusterReconcilerWorkloadClusterMgmtClusterNameFail(t *testing.T) {
 func TestClusterReconcilerNoBundleFound(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	version := test.DevEksaVersion()
+	version := anywherev1.EksaVersion("v0.22.0")
 
 	cluster := &anywherev1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -445,7 +445,10 @@ func TestClusterReconcilerNoBundleFound(t *testing.T) {
 
 	clusterValidator := mocks.NewMockClusterValidator(controller)
 	registry := newRegistryMock(providerReconciler)
-	c := fake.NewClientBuilder().WithRuntimeObjects(cluster, kcp, test.EKSARelease()).
+	eksaReleaseV022 := test.EKSARelease()
+	eksaReleaseV022.Name = "eksa-v0-22-0"
+	eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
+	c := fake.NewClientBuilder().WithRuntimeObjects(cluster, kcp, eksaReleaseV022).
 		WithStatusSubresource(cluster).
 		Build()
 	mockPkgs := mocks.NewMockPackagesClient(controller)
@@ -458,7 +461,7 @@ func TestClusterReconcilerNoBundleFound(t *testing.T) {
 func TestClusterReconcilerFailSignatureValidation(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
-	version := test.DevEksaVersion()
+	version := anywherev1.EksaVersion("v0.22.0")
 
 	cluster := &anywherev1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -471,7 +474,9 @@ func TestClusterReconcilerFailSignatureValidation(t *testing.T) {
 			ReconciledGeneration: 1,
 		},
 	}
-	eksaRelease := test.EKSARelease()
+	eksaReleaseV022 := test.EKSARelease()
+	eksaReleaseV022.Name = "eksa-v0-22-0"
+	eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
 	bundles := createBundle()
 	bundles.Spec.VersionsBundles[0].KubeVersion = "1.25"
 
@@ -484,7 +489,7 @@ func TestClusterReconcilerFailSignatureValidation(t *testing.T) {
 
 	clusterValidator := mocks.NewMockClusterValidator(controller)
 	registry := newRegistryMock(providerReconciler)
-	c := fake.NewClientBuilder().WithRuntimeObjects(cluster, kcp, eksaRelease, bundles).
+	c := fake.NewClientBuilder().WithRuntimeObjects(cluster, kcp, eksaReleaseV022, bundles).
 		WithStatusSubresource(cluster).
 		Build()
 	mockPkgs := mocks.NewMockPackagesClient(controller)

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -21,7 +21,10 @@ import (
 	releasev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
 
-const supportedManagementComponentsMinorVersionIncrement int64 = 1
+const (
+	supportedManagementComponentsMinorVersionIncrement int64 = 1
+	releaseV022                                              = "v0.22.0"
+)
 
 // ValidateOSForRegistryMirror checks if the OS is valid for the provided registry mirror configuration.
 func ValidateOSForRegistryMirror(clusterSpec *cluster.Spec, provider providers.Provider) error {
@@ -300,7 +303,12 @@ func ValidateExtendedKubernetesSupport(ctx context.Context, clusterSpec v1alpha1
 		b, err = bundles.Read(reader, bundlesOverride)
 	} else {
 		eksaVersion := clusterSpec.Spec.EksaVersion
-		if eksaVersion == nil {
+		skip, err := ShouldSkipBundleSignatureValidation((*string)(eksaVersion))
+		if err != nil {
+			return err
+		}
+		// Skip the signature validation for those versions prior to 'v0.22.0'
+		if skip {
 			return nil
 		}
 		b, err = reader.ReadBundlesForVersion(string(*eksaVersion))

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -35,7 +35,7 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 	ctrl := gomock.NewController(t)
 	k := mocks.NewMockKubectlClient(ctrl)
 
-	version := test.DevEksaVersion()
+	version := anywherev1.EksaVersion("v0.22.0")
 
 	c := &types.Cluster{
 		KubeconfigFile: "kubeconfig",
@@ -53,7 +53,11 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 		}
 	})
 
-	objects := []client.Object{test.EKSARelease()}
+	eksaReleaseV022 := test.EKSARelease()
+	eksaReleaseV022.Name = "eksa-v0-22-0"
+	eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
+
+	objects := []client.Object{eksaReleaseV022}
 	opts := &validations.Opts{
 		Kubectl:           k,
 		Spec:              clusterSpec,

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -318,7 +318,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 	}
 
-	ver := test.DevEksaVersion()
+	ver := anywherev1.EksaVersion("v0.22.0")
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = testclustername
@@ -356,7 +356,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 			helm := stackmocks.NewMockHelm(mockCtrl)
 			writer := filewritermocks.NewMockFileWriter(mockCtrl)
 			tlsValidator := mocks.NewMockTlsValidator(mockCtrl)
-			version := test.DevEksaVersion()
+			version := anywherev1.EksaVersion("v0.22.0")
 			provider := newProvider(defaultDatacenterSpec, givenTinkerbellMachineConfigs(t), clusterSpec.Cluster, writer, docker, helm, kubectl, false)
 			opts := &validations.Opts{
 				Kubectl:           k,
@@ -1066,7 +1066,7 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 	}
 
-	ver := test.DevEksaVersion()
+	ver := anywherev1.EksaVersion("v0.22.0")
 
 	defaultClusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = testclustername
@@ -1140,8 +1140,13 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 			if tc.modifyDefaultSpecFunc != nil {
 				tc.modifyDefaultSpecFunc(clusterSpec)
 			}
-			objects := []client.Object{test.EKSARelease()}
-			version := test.DevEksaVersion()
+
+			eksaReleaseV022 := test.EKSARelease()
+			eksaReleaseV022.Name = "eksa-v0-22-0"
+			eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
+
+			objects := []client.Object{eksaReleaseV022}
+			version := anywherev1.EksaVersion("v0.22.0")
 			opts := &validations.Opts{
 				Kubectl:           k,
 				Spec:              clusterSpec,
@@ -1310,7 +1315,7 @@ func TestPreFlightValidationsGit(t *testing.T) {
 		},
 	}
 
-	ver := test.DevEksaVersion()
+	ver := anywherev1.EksaVersion("v0.22.0")
 
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster.Name = testclustername
@@ -1382,7 +1387,7 @@ func TestPreFlightValidationsGit(t *testing.T) {
 			}
 
 			provider := mockproviders.NewMockProvider(mockCtrl)
-			version := test.DevEksaVersion()
+			version := anywherev1.EksaVersion("v0.22.0")
 			opts := &validations.Opts{
 				Kubectl:           k,
 				Spec:              clusterSpec,


### PR DESCRIPTION
*Description of changes:*
This change introduces version-based conditional validation for bundle signatures by skipping signature validation for EKS-A versions before v0.22.0. The change ensures backward compatibility while enforcing signature validation for newer EKS-A versions (v0.22.0 and above), which is when extended Kubernetes support was introduced.

*Testing (if applicable):*
When testing an LCM operation on workload cluster after upgrading the management cluster to v0.22.x notices the below error on reconciler for the workload cluster:

`{"ts":1744271253480.7832,"caller":"controller/controller.go:329","msg":"Reconciler error","controller":"cluster","controllerGroup":"anywhere.eks.amazonaws.com","controllerKind":"Cluster","Cluster":{"name":"rahul-tink-wkld","namespace":"default"},"namespace":"default","name":"rahul-tink-wkld","reconcileID":"d9ff2d03-7294-410e-9511-051cf3e37bbb","err":"validating bundle signature: missing signature annotation"}
`
The preflight check for extended K8s version support didn't factor in the eks-a version on the cluster. Built the controller with above changes and saw that workload cluster LCM operation worked without any errors. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

