### PR TITLE
Fix condition to check for packages dev registry

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -245,7 +245,7 @@ func (pc *PackageControllerClient) GetCuratedPackagesRegistries(ctx context.Cont
 	sourceRegistry = prodPublicRegistryURI
 	defaultImageRegistry = prodNonRegionalPrivateRegistryURI
 	registry := prodPublicRegistryAlias
-	if strings.Contains(pc.chart.Image(), devNonRegionalPublicRegistryAlias) {
+	if strings.Contains(pc.chart.Image(), devRegionalPublicRegistryAlias) {
 		registry = devRegionalPublicRegistryAlias
 		defaultImageRegistry = devRegionalPrivateRegistryURI
 		sourceRegistry = devRegionalPublicRegistryURI


### PR DESCRIPTION
*Description of changes:*
This PR fixes the condition in the package controller client to check for the regional beta account public ECR alias when setting the dev registry. This is because we recently updated the release CLI to push the packages images to beta account instead of build account public ECR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

