### PR TITLE
Add compute cluster validations for failure domains

### DIFF
--- a/pkg/executables/govc.go
+++ b/pkg/executables/govc.go
@@ -870,6 +870,52 @@ func (g *Govc) GetResourcePoolPath(ctx context.Context, datacenter string, resou
 	return foundPool, nil
 }
 
+// GetComputeClusterPath finds and validates a compute cluster in the specified datacenter.
+// Returns an error if the compute cluster doesn't exist or if multiple matching compute clusters are found.
+func (g *Govc) GetComputeClusterPath(ctx context.Context, datacenter string, computeCluster string, envMap map[string]string) (string, error) {
+	var computeClusterResponse bytes.Buffer
+	params := []string{"find", "-json", "/" + datacenter, "-type", "c", "-name", filepath.Base(computeCluster)}
+
+	err := g.Retry(func() error {
+		var err error
+		computeClusterResponse, err = g.ExecuteWithEnv(ctx, envMap, params...)
+		return err
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting compute cluster: %v", err)
+	}
+
+	computeClusterJSON := computeClusterResponse.String()
+	computeClusterJSON = strings.TrimSuffix(computeClusterJSON, "\n")
+	if computeClusterJSON == "null" || computeClusterJSON == "" {
+		return "", fmt.Errorf("compute cluster '%s' not found", computeCluster)
+	}
+
+	computeClusterInfo := make([]string, 0)
+	if err = json.Unmarshal([]byte(computeClusterJSON), &computeClusterInfo); err != nil {
+		return "", fmt.Errorf("failed unmarshalling govc response: %v", err)
+	}
+
+	computeCluster = strings.TrimPrefix(computeCluster, "*/")
+	computeClusterFound := false
+	var foundCluster string
+	for _, cc := range computeClusterInfo {
+		if strings.HasSuffix(cc, computeCluster) {
+			if computeClusterFound {
+				return "", fmt.Errorf("specified compute cluster '%s' maps to multiple paths within the datacenter '%s'", computeCluster, datacenter)
+			}
+			computeClusterFound = true
+			foundCluster = cc
+		}
+	}
+	if !computeClusterFound {
+		return "", fmt.Errorf("compute cluster '%s' not found", computeCluster)
+	}
+
+	logger.MarkPass("Compute cluster validated")
+	return foundCluster, nil
+}
+
 // ValidateVCenterSetupMachineConfig validates that all resources specified in a
 // VSphereMachineConfig exist and are accessible.
 func (g *Govc) ValidateVCenterSetupMachineConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, machineConfig *v1alpha1.VSphereMachineConfig, _ *bool) error {
@@ -924,6 +970,12 @@ func (g *Govc) ValidateFailureDomainConfig(ctx context.Context, datacenterConfig
 		return err
 	}
 	failureDomain.ResourcePool = resourcePool
+
+	computeCluster, err := g.GetComputeClusterPath(ctx, datacenterConfig.Spec.Datacenter, failureDomain.ComputeCluster, envMap)
+	if err != nil {
+		return err
+	}
+	failureDomain.ComputeCluster = computeCluster
 
 	return nil
 }

--- a/pkg/executables/govc_test.go
+++ b/pkg/executables/govc_test.go
@@ -976,6 +976,258 @@ func TestValidateFailureDomainConfigResourcePoolFailure(t *testing.T) {
 	gt.Expect(err.Error()).To(ContainSubstring("resource pool '*/Resources/Compute ResourcePool' not found"))
 }
 
+func TestValidateFailureDomainConfigComputeClusterFailure(t *testing.T) {
+	ctx := context.Background()
+	datacenterConfig := v1alpha1.VSphereDatacenterConfig{
+		Spec: v1alpha1.VSphereDatacenterConfigSpec{
+			Datacenter: "SDDC Datacenter",
+			Network:    "/SDDC Datacenter/network/test network",
+			Server:     "vcenter.123.vmwarevmc.com",
+			Insecure:   true,
+		},
+	}
+	failureDomain := v1alpha1.FailureDomain{
+		Name:           "fd-1",
+		Datastore:      "/SDDC Datacenter/datastore/testDatastore",
+		Folder:         "/SDDC Datacenter/vm/test",
+		ResourcePool:   "*/Resources/Compute-ResourcePool",
+		ComputeCluster: "*/Cluster-1",
+	}
+
+	_, g, executable, env := setup(t)
+	g.Retrier = retrier.NewWithMaxRetries(5, 0)
+	gt := NewWithT(t)
+
+	gomock.InOrder(
+		executable.EXPECT().ExecuteWithEnv(ctx, env, gomock.Any()).Return(bytes.Buffer{}, nil),
+		executable.EXPECT().ExecuteWithEnv(ctx, env, gomock.Any()).Return(bytes.Buffer{}, nil),
+		executable.EXPECT().ExecuteWithEnv(ctx, gomock.Any(), gomock.Any()).
+			Return(*bytes.NewBufferString(`["/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool"]`), nil),
+		executable.EXPECT().ExecuteWithEnv(ctx, env, gomock.Any()).Return(bytes.Buffer{}, nil).AnyTimes(),
+		executable.EXPECT().ExecuteWithEnv(ctx, env, gomock.Any()).Return(bytes.Buffer{}, nil).AnyTimes(),
+	)
+
+	err := g.ValidateFailureDomainConfig(ctx, &datacenterConfig, &failureDomain)
+
+	gt.Expect(err).ToNot(BeNil())
+	gt.Expect(err.Error()).To(ContainSubstring("compute cluster '*/Cluster-1' not found"))
+}
+
+func TestGetResourcePoolPathSuccessRelativePath(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	resourcePool := "*/Resources/Compute-ResourcePool"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	executable.EXPECT().ExecuteWithEnv(
+		ctx,
+		env,
+		"find",
+		"-json",
+		"/"+datacenter,
+		"-type",
+		"p",
+		"-name",
+		"Compute-ResourcePool",
+	).Return(*bytes.NewBufferString("[\"/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool\"]"), nil)
+
+	path, err := g.GetResourcePoolPath(ctx, datacenter, resourcePool, env)
+	gt.Expect(err).To(BeNil())
+	gt.Expect(path).To(Equal("/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool"))
+}
+
+func TestGetResourcePoolPathSuccessFullPath(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	resourcePool := "/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	executable.EXPECT().ExecuteWithEnv(
+		ctx,
+		env,
+		"find",
+		"-json",
+		"/"+datacenter,
+		"-type",
+		"p",
+		"-name",
+		"Compute-ResourcePool",
+	).Return(*bytes.NewBufferString("[\"/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool\"]"), nil)
+
+	path, err := g.GetResourcePoolPath(ctx, datacenter, resourcePool, env)
+	gt.Expect(err).To(BeNil())
+	gt.Expect(path).To(Equal("/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool"))
+}
+
+func TestGetComputeClusterPathSuccessRelativePath(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "*/Cluster-1"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	executable.EXPECT().ExecuteWithEnv(
+		ctx,
+		env,
+		"find",
+		"-json",
+		"/"+datacenter,
+		"-type",
+		"c",
+		"-name",
+		"Cluster-1",
+	).Return(*bytes.NewBufferString("[\"/SDDC-Datacenter/host/Cluster-1\"]"), nil)
+
+	path, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+	gt.Expect(err).To(BeNil())
+	gt.Expect(path).To(Equal("/SDDC-Datacenter/host/Cluster-1"))
+}
+
+func TestGetComputeClusterPathSuccessFullPath(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "/SDDC-Datacenter/host/Cluster-1"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	executable.EXPECT().ExecuteWithEnv(
+		ctx,
+		env,
+		"find",
+		"-json",
+		"/"+datacenter,
+		"-type",
+		"c",
+		"-name",
+		"Cluster-1",
+	).Return(*bytes.NewBufferString("[\"/SDDC-Datacenter/host/Cluster-1\"]"), nil)
+
+	path, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+	gt.Expect(err).To(BeNil())
+	gt.Expect(path).To(Equal("/SDDC-Datacenter/host/Cluster-1"))
+}
+
+func TestGetComputeClusterPathErrorMultipleClustersFound(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "*/Cluster-1"
+	trimmedCluster := strings.TrimPrefix(computeCluster, "*/")
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	g.Retrier = retrier.NewWithMaxRetries(1, 0)
+
+	executable.EXPECT().
+		ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "c", "-name", filepath.Base(computeCluster)).
+		Return(*bytes.NewBufferString(`["/SDDC-Datacenter/host/Cluster-1", "/SDDC-Datacenter/host/sub-folder/Cluster-1"]`), nil)
+
+	_, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+	gt.Expect(err).NotTo(BeNil())
+	gt.Expect(err.Error()).To(Equal(fmt.Sprintf("specified compute cluster '%s' maps to multiple paths within the datacenter '%s'", trimmedCluster, datacenter)))
+}
+
+func TestGetComputeClusterPathErrorInvalidJSONResponse(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "*/Cluster-1"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	g.Retrier = retrier.NewWithMaxRetries(1, 0)
+
+	executable.EXPECT().
+		ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "c", "-name", filepath.Base(computeCluster)).
+		Return(*bytes.NewBufferString(`{"this": "is not a string array"}`), nil)
+
+	_, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+	gt.Expect(err).NotTo(BeNil())
+	gt.Expect(err.Error()).To(Equal("failed unmarshalling govc response: json: cannot unmarshal object into Go value of type []string"))
+}
+
+func TestGetComputeClusterPathErrorFailedToGetComputeCluster(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "*/Cluster-1"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	g.Retrier = retrier.NewWithMaxRetries(1, 0)
+
+	executable.EXPECT().
+		ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "c", "-name", filepath.Base(computeCluster)).
+		Return(bytes.Buffer{}, errors.New("failed to execute find command"))
+
+	_, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+	gt.Expect(err).NotTo(BeNil())
+	gt.Expect(err.Error()).To(Equal("getting compute cluster: failed to execute find command"))
+}
+
+func TestGetComputeClusterPathErrorComputeClusterNotFound(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "*/NonExistentCluster"
+
+	_, g, executable, env := setup(t)
+	gt := NewWithT(t)
+
+	g.Retrier = retrier.NewWithMaxRetries(1, 0)
+
+	// Return an empty JSON array, simulating no results found
+	executable.EXPECT().
+		ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "c", "-name", filepath.Base(computeCluster)).
+		Return(*bytes.NewBufferString("[]"), nil)
+
+	_, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+	gt.Expect(err).NotTo(BeNil())
+	gt.Expect(err.Error()).To(Equal("compute cluster 'NonExistentCluster' not found"))
+}
+
+func TestGetComputeClusterPathErrorNullOrEmptyResponse(t *testing.T) {
+	ctx := context.Background()
+	datacenter := "SDDC-Datacenter"
+	computeCluster := "*/Cluster-1"
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "null response",
+			response: "null",
+		},
+		{
+			name:     "empty response",
+			response: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, g, executable, env := setup(t)
+			gt := NewWithT(t)
+
+			g.Retrier = retrier.NewWithMaxRetries(1, 0)
+
+			executable.EXPECT().
+				ExecuteWithEnv(ctx, env, "find", "-json", "/"+datacenter, "-type", "c", "-name", filepath.Base(computeCluster)).
+				Return(*bytes.NewBufferString(tt.response), nil)
+
+			_, err := g.GetComputeClusterPath(ctx, datacenter, computeCluster, env)
+			gt.Expect(err).NotTo(BeNil())
+			gt.Expect(err.Error()).To(Equal(fmt.Sprintf("compute cluster '%s' not found", computeCluster)))
+		})
+	}
+}
+
 func TestGovcValidateVCenterSetupMachineConfig(t *testing.T) {
 	ctx := context.Background()
 	ts := newHTTPSServer(t)

--- a/pkg/providers/vsphere/mocks/client.go
+++ b/pkg/providers/vsphere/mocks/client.go
@@ -226,6 +226,21 @@ func (mr *MockProviderGovcClientMockRecorder) GetCertThumbprint(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertThumbprint", reflect.TypeOf((*MockProviderGovcClient)(nil).GetCertThumbprint), arg0)
 }
 
+// GetComputeClusterPath mocks base method.
+func (m *MockProviderGovcClient) GetComputeClusterPath(arg0 context.Context, arg1, arg2 string, arg3 map[string]string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetComputeClusterPath", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetComputeClusterPath indicates an expected call of GetComputeClusterPath.
+func (mr *MockProviderGovcClientMockRecorder) GetComputeClusterPath(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComputeClusterPath", reflect.TypeOf((*MockProviderGovcClient)(nil).GetComputeClusterPath), arg0, arg1, arg2, arg3)
+}
+
 // GetDatastorePath mocks base method.
 func (m *MockProviderGovcClient) GetDatastorePath(arg0 context.Context, arg1, arg2 string, arg3 map[string]string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -108,6 +108,7 @@ type ProviderGovcClient interface {
 	GetFolderPath(ctx context.Context, datacenter string, folder string, envMap map[string]string) (string, error)
 	GetDatastorePath(ctx context.Context, datacenter string, datastorePath string, envMap map[string]string) (string, error)
 	GetResourcePoolPath(ctx context.Context, datacenter string, resourcePool string, envMap map[string]string) (string, error)
+	GetComputeClusterPath(ctx context.Context, datacenter string, computeCluster string, envMap map[string]string) (string, error)
 	CreateLibrary(ctx context.Context, datastore, library string) error
 	DeployTemplateFromLibrary(ctx context.Context, templateDir, templateName, library, datacenter, datastore, network, resourcePool string, resizeDisk2 bool) error
 	ImportTemplate(ctx context.Context, library, ovaURL, name string) error

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -128,6 +128,11 @@ func (pc *DummyProviderGovcClient) GetDatastorePath(ctx context.Context, datacen
 }
 
 //nolint:revive
+func (pc *DummyProviderGovcClient) GetComputeClusterPath(ctx context.Context, datacenter string, computeCluster string, envMap map[string]string) (string, error) {
+	return "", nil
+}
+
+//nolint:revive
 func (pc *DummyProviderGovcClient) ValidateFailureDomainConfig(ctx context.Context, datacenterConfig *v1alpha1.VSphereDatacenterConfig, failureDomain *v1alpha1.FailureDomain) error {
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3004
*Description of changes:*
adds compute cluster validation for failure domains
*Testing (if applicable):*
See compute cluster validation fields
```
[ec2-user@ip-172-31-22-5 eks-anywhere]$ ./bin/eksctl-anywhere exp validate create cluster -f ~/vsphere/largchar-colo-mgmt-vsphere-fd.yaml
Warning: VSphereDatacenterConfig configured in insecure mode
Warning: The recommended size of an external etcd cluster is 3 or 5
Warning: VSphereDatacenterConfig configured in insecure mode
✅ Connected to server
✅ Authenticated to vSphere
✅ Datacenter validated
✅ Network validated
Start failure domain validation for 'fd-1' 
✅ Network validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Compute cluster validated
Start failure domain validation for 'fd-2' 
✅ Network validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Compute cluster validated
Finished failure domain validations
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
✅ Machine config tags validated
✅ Control plane and Workload templates validated
✅ largchar@vsphere.local user vSphere privileges validated
✅ Validate vsphere Provider
✅ Validate OS is compatible with registry mirror configuration
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
✅ Validate cluster's eksaVersion matches EKS-A version
✅ Validate extended kubernetes version support is supported
```

Compute cluster that does not exist
```
[ec2-user@ip-172-31-22-5 eks-anywhere]$ ./bin/eksctl-anywhere exp validate create cluster -f ~/vsphere/largchar-colo-mgmt-vsphere-fd.yaml
Warning: VSphereDatacenterConfig configured in insecure mode
Warning: The recommended size of an external etcd cluster is 3 or 5
Warning: VSphereDatacenterConfig configured in insecure mode
✅ Connected to server
✅ Authenticated to vSphere
✅ Datacenter validated
✅ Network validated
Start failure domain validation for 'fd-1' 
✅ Network validated
✅ Datastore validated
✅ Folder validated
✅ Resource pool validated
❌ Validation failed    {"validation": "validate vsphere Provider", "error": "compute cluster '/Denver/host/EKS-A-Wrong' not found", "remediation": ""}
✅ Validate OS is compatible with registry mirror configuration
✅ Validate certificate for registry mirror
✅ Validate authentication for git provider
✅ Validate cluster's eksaVersion matches EKS-A version
✅ Validate extended kubernetes version support is supported
Error: validations failed: compute cluster '/Denver/host/EKS-A-Wrong' not found
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

