### PR TITLE
Add a filter to get the latest image based on branch for helm charts

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -55,11 +55,11 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 	// If we can't find the build starting with our substring, we default to the original dev tag.
 	// If we do find the Tag in Private ECR, but it doesn't exist in Public ECR Copy the image over so the helm chart will work correctly.
 	if r.DevRelease && !r.DryRun {
-		Helmtag, Helmsha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "0.0.0", true)
+		Helmtag, Helmsha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "0.0.0", r.BuildRepoBranchName, true)
 		if err != nil {
 			fmt.Printf("Error getting dev version helm tag EKS Anywhere package controller, using latest version %v", err)
 		}
-		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "v0.0.0", true)
+		Imagetag, Imagesha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "eks-anywhere-packages", "v0.0.0", r.BuildRepoBranchName, false)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package controller, using latest version %v", err)
 		}
@@ -74,7 +74,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 				fmt.Printf("Error copying dev EKS Anywhere package controller image, to ECR Public: %v", err)
 			}
 		}
-		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", "v0.0.0", true)
+		Tokentag, TokenSha, err = ecr.FilterECRRepoByTagPrefix(r.SourceClients.Packages.EcrClient, "ecr-token-refresher", "v0.0.0", r.BuildRepoBranchName, false)
 		if err != nil {
 			fmt.Printf("Error getting dev version Image tag EKS Anywhere package token refresher, using latest version %v", err)
 		}

--- a/release/cli/pkg/operations/bundle_release.go
+++ b/release/cli/pkg/operations/bundle_release.go
@@ -262,7 +262,7 @@ func getImageDigest(_ context.Context, r *releasetypes.ReleaseConfig, artifact r
 		releaseImageUri := artifact.Image.ReleaseImageURI
 		releaseContainerRegistry := r.ReleaseContainerRegistry
 		ecrPublicClient := r.ReleaseClients.ECRPublic.Client
-		if r.DevRelease  && (strings.Contains(releaseImageUri, "eks-anywhere-packages") || strings.Contains(releaseImageUri, "ecr-token-refresher") || strings.Contains(releaseImageUri, "credential-provider-package")) {
+		if r.DevRelease && (strings.Contains(releaseImageUri, "eks-anywhere-packages") || strings.Contains(releaseImageUri, "ecr-token-refresher") || strings.Contains(releaseImageUri, "credential-provider-package")) {
 			ecrPublicClient = r.ReleaseClients.Packages.Client
 			releaseContainerRegistry = r.PackagesReleaseContainerRegistry
 		}


### PR DESCRIPTION
*Issue #, if available:*
The dev bundle now has the latest tag but it still doesn't filter the tags based on branch name. This is why the dev bundle built from main has the tag from the release branch.
```
helmChart:
        description: Helm chart for eks-anywhere-packages
        imageDigest: sha256:52d1e552fd9ff933cc2d3ec2e57650294c23b4f6baecaab2108e8b01b27e09f8
        name: eks-anywhere-packages
        uri: public.ecr.aws/x3k6m8v0/eks-anywhere-packages:0.0.0-f34bb981a71e07b93ef8197b4937ca795f81d313-release-0.22-helm
```

*Description of changes:*
This PR updates the logic to get the latest tag for helm chart images based on the branch name.

*Testing (if applicable):*
```
make -C release build
make -C release lint
make -C release unit-test
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

