### PR TITLE
Use workloadclustername in e2e certmanager package namespace

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -25,7 +25,7 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		test.ManagementCluster.SetPackageBundleActive()
 		packageName := "cert-manager"
 		packagePrefix := "test"
-		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace)
+		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace, e.ClusterName)
 		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withCluster(test.ManagementCluster))
 		e.CleanupCerts(withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2051,10 +2051,10 @@ func (e *ClusterE2ETest) InstallAutoScaler(workloadClusterName, targetNamespace 
 var certManagerPackageTemplate string
 
 // InstallCertManagerPackageWithAwsCredentials installs cert-manager package by setting aws credentials in the pod.
-func (e *ClusterE2ETest) InstallCertManagerPackageWithAwsCredentials(prefix, packageName, namespace string) {
+func (e *ClusterE2ETest) InstallCertManagerPackageWithAwsCredentials(prefix, packageName, namespace, workloadClusterName string) {
 	generatedName := fmt.Sprintf("%s-%s", prefix, packageName)
 	targetNamespace := namespace
-	namespace = fmt.Sprintf("%s-%s", namespace, e.ClusterName)
+	namespace = fmt.Sprintf("%s-%s", namespace, workloadClusterName)
 	ctx := context.Background()
 	accessKeyID := os.Getenv(route53AccessKey)
 	secretKey := os.Getenv(route53SecretKey)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Certmanager tests are failling with below error. This is because test is trying to install package on management cluster

```
Error installing cert-manager pacakge: executing apply: Error from server (package test-cert-manager failed validation with error: package test-cert-manager should only be installed on a workload cluster): error when creating "STDIN": admission webhook "vpackage.kb.io" denied the request: package test-cert-manager failed validation with error: package test-cert-manager should only be installed on a workload cluster
```

In this PR, I am adding change to use workloadcluster name when installing package


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
