### PR TITLE
Doc improvement for default OS on baremetal

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/bare-spec.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-spec.md
@@ -75,7 +75,7 @@ metadata:
   name: my-cluster-name-cp
 spec:
   hardwareSelector: {}
-  osFamily: bottlerocket
+  osFamily: ubuntu
   templateRef: {}
   users:
   - name: ec2-user
@@ -89,7 +89,7 @@ metadata:
   name: my-cluster-name
 spec:
   hardwareSelector: {}
-  osFamily: bottlerocket
+  osFamily: ubuntu
   templateRef:
     kind: TinkerbellTemplateConfig
     name: my-cluster-name
@@ -342,7 +342,7 @@ spec:
     node: "cp-machine"
 ```
 ### osFamily (required)
-Operating system on the machine. Permitted values: `bottlerocket`, `ubuntu`, `redhat` (Default: `bottlerocket`).
+Operating system on the machine. Permitted values: `ubuntu` and `redhat` (Default: `ubuntu`).
 
 ### osImageURL (required)
 Required field to set the operating system. In order to use Ubuntu or RHEL see [building baremetal node images]({{< relref "../../osmgmt/artifacts/#build-bare-metal-node-images" >}}). This field is also useful if you want to provide a customized operating system image or simply host the standard image locally. To upgrade a node or group of nodes to a new operating system version (ie. RHEL 8.7 to RHEL 8.8), modify this field to point to the new operating system image URL and run [upgrade cluster command]({{< relref "../../clustermgmt/cluster-upgrades/baremetal-upgrades/#upgrade-cluster-command" >}}). The `osImageURL` must contain the `Cluster.Spec.KubernetesVersion` or `Cluster.Spec.WorkerNodeGroupConfiguration[].KubernetesVersion` version (in case of modular upgrade). For example, if the Kubernetes version is 1.31, the `osImageURL` name should include 1.31, 1_31, 1-31 or 131.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Doc improvement for default OS on baremetal, we stopped supporting bottlerocket on baremetal since release 0.19 and are using Ubuntu as default OS.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

