### PR TITLE
Fix eks distro manifest signature annotations on the bundle

### DIFF
--- a/release/cli/pkg/operations/bundle_release.go
+++ b/release/cli/pkg/operations/bundle_release.go
@@ -273,7 +273,7 @@ func SignEKSDistroManifest(ctx context.Context, bundle *anywherev1alpha1.Bundles
 			return err
 		}
 
-		signatureAnnotation := anywhereconstants.EKSDistroSignatureAnnotation + "/" + releaseChannel
+		signatureAnnotation := anywhereconstants.EKSDistroSignatureAnnotation + "-" + releaseChannel
 		bundle.Annotations[signatureAnnotation] = signature
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
After merging [#9578](https://github.com/aws/eks-anywhere/pull/9578), all the e2e tests started failing with the following error:
```
* metadata.annotations: Invalid value: "distro.eks.amazonaws.com/signature/1-31": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```

*Description of changes:*
This PR fixes the above issue by replacing the '/' in the eks distro manifest signature annotations on the bundle with '-' to use a valid annotation key.

*Testing (if applicable):*
Ran the following commands from the root folder:
```
make -C release build
make -C release lint
make -C release unit-test
CGO_ENABLED=0 make -C release dev-release
```
Verified that the generated bundle manifest has the expected annotations:
```
apiVersion: anywhere.eks.amazonaws.com/v1alpha1
kind: Bundles
metadata:
  annotations:
    anywhere.eks.amazonaws.com/excludes: LnNwZWMudmVyc2lvbnNCdW5kbGVzW10uYm9vdHN0cmFwCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmJvdHRsZXJvY2tldEhvc3RDb250YWluZXJzCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmNlcnRNYW5hZ2VyCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmNpbGl1bQouc3BlYy52ZXJzaW9uc0J1bmRsZXNbXS5jbG91ZFN0YWNrCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmNsdXN0ZXJBUEkKLnNwZWMudmVyc2lvbnNCdW5kbGVzW10uY29udHJvbFBsYW5lCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmRvY2tlcgouc3BlYy52ZXJzaW9uc0J1bmRsZXNbXS5la3NhCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmVrc0QuY29tcG9uZW50cwouc3BlYy52ZXJzaW9uc0J1bmRsZXNbXS5la3NELm1hbmlmZXN0VXJsCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmV0Y2RhZG1Cb290c3RyYXAKLnNwZWMudmVyc2lvbnNCdW5kbGVzW10uZXRjZGFkbUNvbnRyb2xsZXIKLnNwZWMudmVyc2lvbnNCdW5kbGVzW10uZmx1eAouc3BlYy52ZXJzaW9uc0J1bmRsZXNbXS5oYXByb3h5Ci5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLmtpbmRuZXRkCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLm51dGFuaXgKLnNwZWMudmVyc2lvbnNCdW5kbGVzW10ucGFja2FnZUNvbnRyb2xsZXIKLnNwZWMudmVyc2lvbnNCdW5kbGVzW10uc25vdwouc3BlYy52ZXJzaW9uc0J1bmRsZXNbXS50aW5rZXJiZWxsCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLnVwZ3JhZGVyCi5zcGVjLnZlcnNpb25zQnVuZGxlc1tdLnZTcGhlcmU=
    anywhere.eks.amazonaws.com/signature: MEUCIGZxRxCpaHJ/+z0BVpH/zBqrbLFSEj8sIH/b/hdjzzcKAiEA2Kxm0RgQYwBfJM/oACXVOLWfr9wp/PQ05yhuPj4gpeM=
    distro.eks.amazonaws.com/excludes: Cg==
    distro.eks.amazonaws.com/signature-1-28: MEQCIEyKUtpipSXLcn+Fp3Rn72NFWBBTH+vXS7HbU9wVCJ+ZAiBAgCOQc+C/ZqSuNTtjvh4h4a6qxCz0Xhui3iZrkj8Xow==
    distro.eks.amazonaws.com/signature-1-29: MEUCICVIWAohdGNG6X5aNFLRyA+m5aWyNDYmUsoQ4HAzU/0sAiEA1ozuotOedbqF4Cpm4TQKO735PTYnUOKocI6FxQf0N+Y=
    distro.eks.amazonaws.com/signature-1-30: MEUCIQCx3ENj8aaz7GtW8PwKeKX+V1l3LZs+Mf7aHwRxqEESLAIgUgfKe3bEVPa1LD/xJLmOi+bz7ZWSeTfPs5Jjb5ndWhI=
    distro.eks.amazonaws.com/signature-1-31: MEQCIF3b910LGIkQN3N+K1xe+pTjEVeil7LbnpWGrsARGWABAiARpva8oRKYOZvhxXcrMnRDG2XfezG8Ut09yrOo2IHyDg==
    distro.eks.amazonaws.com/signature-1-32: MEUCIQCh08E9PNpFhUYvxRNA6vACroq/YoISdH3545FQuZpMnAIgaJdOo34eh2kX3D/qUTAg1un5jFkVNHfe6Xhpr6aG1Mg=
  creationTimestamp: "2025-04-12T06:16:29Z"
  name: bundles-0
spec:
  cliMaxVersion: v0.0.0
  cliMinVersion: v0.0.0
  number: 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

