### PR TITLE
Fix cert manager e2e tests

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -25,7 +25,7 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		test.ManagementCluster.SetPackageBundleActive()
 		packageName := "cert-manager"
 		packagePrefix := "test"
-		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace)
+		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace, e.ClusterName)
 		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withCluster(test.ManagementCluster))
 		e.CleanupCerts(withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2051,10 +2051,10 @@ func (e *ClusterE2ETest) InstallAutoScaler(workloadClusterName, targetNamespace 
 var certManagerPackageTemplate string
 
 // InstallCertManagerPackageWithAwsCredentials installs cert-manager package by setting aws credentials in the pod.
-func (e *ClusterE2ETest) InstallCertManagerPackageWithAwsCredentials(prefix, packageName, namespace string) {
+func (e *ClusterE2ETest) InstallCertManagerPackageWithAwsCredentials(prefix, packageName, namespace, clusterName string) {
 	generatedName := fmt.Sprintf("%s-%s", prefix, packageName)
 	targetNamespace := namespace
-	namespace = fmt.Sprintf("%s-%s", namespace, e.ClusterName)
+	namespace = fmt.Sprintf("%s-%s", namespace, clusterName)
 	ctx := context.Background()
 	accessKeyID := os.Getenv(route53AccessKey)
 	secretKey := os.Getenv(route53SecretKey)
@@ -2070,13 +2070,13 @@ func (e *ClusterE2ETest) InstallCertManagerPackageWithAwsCredentials(prefix, pac
 
 	certManagerPackageDeployment, err := templater.Execute(certManagerPackageTemplate, data)
 	if err != nil {
-		e.T.Fatalf("Failed creating cert-manager Package Deployment: %s", err)
+		e.T.Fatalf("Failed creating cert-manager package deployment: %s", err)
 	}
 
 	err = e.KubectlClient.ApplyKubeSpecFromBytesWithNamespace(ctx, e.Cluster(), certManagerPackageDeployment,
 		namespace)
 	if err != nil {
-		e.T.Fatalf("Error installing cert-manager pacakge: %s", err)
+		e.T.Fatalf("Error installing cert-manager package: %s", err)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
After merging [#9455](https://github.com/aws/eks-anywhere/pull/9455), all the cert manager e2e tests started failing with the following error:
```
cluster.go:2079: Error installing cert-manager pacakge: executing apply: Error from server (package test-cert-manager failed validation with error: package test-cert-manager should only be installed on a workload cluster): error when creating "STDIN": admission webhook "vpackage.kb.io" denied the request: package test-cert-manager failed validation with error: package test-cert-manager should only be installed on a workload cluster
``` 

*Description of changes:*
This PR sets the workload cluster name in the `InstallCertManagerPackageWithAwsCredentials` function to install the cert-manager package on the workload cluster to fix the above issue.

*Testing (if applicable):*
Ran the following commands from the root folder:
```
make eks-a
make build-e2e-test-binary
make lint
```
Manually ran one of the cert-manager tests locally and it passed:
```
--- PASS: TestVSphereKubernetes130BottleRocketWorkloadClusterCuratedPackagesCertManagerSimpleFlow (1763.55s)
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

