### PR TITLE
Add extended support validation to verify the eks distro manifest signature

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -390,7 +390,7 @@ func (r *ClusterReconciler) preClusterProviderReconcile(ctx context.Context, log
 		return controller.Result{}, err
 	}
 
-	if err := validateExtendedK8sVersionSupport(ctx, r.client, cluster); err != nil {
+	if err := validateExtendedKubernetesSupport(ctx, r.client, cluster); err != nil {
 		return controller.Result{}, err
 	}
 
@@ -464,8 +464,7 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 
 	defaultCNIConfiguredCondition := conditions.Get(cluster, anywherev1.DefaultCNIConfiguredCondition)
 	if defaultCNIConfiguredCondition == nil ||
-		(defaultCNIConfiguredCondition != nil &&
-			defaultCNIConfiguredCondition.Status == "False" &&
+		(defaultCNIConfiguredCondition.Status == "False" &&
 			defaultCNIConfiguredCondition.Reason != anywherev1.SkipUpgradesForDefaultCNIConfiguredReason) {
 		summarizedConditionTypes = append(summarizedConditionTypes, anywherev1.DefaultCNIConfiguredCondition)
 	}
@@ -642,7 +641,7 @@ func validateEksaRelease(ctx context.Context, client client.Client, cluster *any
 	return nil
 }
 
-func validateExtendedK8sVersionSupport(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
+func validateExtendedKubernetesSupport(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
 	eksaVersion := cluster.Spec.EksaVersion
 	if cluster.Spec.DatacenterRef.Kind == "SnowDatacenterConfig" || eksaVersion == nil {
 		return nil

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/eks-anywhere/controllers/mocks"
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/internal/test/envtest"
-	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -202,7 +201,7 @@ func TestClusterReconcilerReconcileUnclearedClusterFailure(t *testing.T) {
 	config.Cluster.Spec.EksaVersion = &version
 	config.Cluster.Generation = 1
 
-	config.Cluster.SetFailure(v1alpha1.FailureReasonType("InvalidCluster"), "invalid cluster")
+	config.Cluster.SetFailure(anywherev1.FailureReasonType("InvalidCluster"), "invalid cluster")
 
 	kcp := testKubeadmControlPlaneFromCluster(config.Cluster)
 	machineDeployments := machineDeploymentsFromCluster(config.Cluster)
@@ -518,7 +517,7 @@ func TestClusterReconcilerReconcileConditions(t *testing.T) {
 				func(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) {
 					kcpReadyCondition := conditions.Get(kcp, clusterv1.ReadyCondition)
 					if kcpReadyCondition == nil ||
-						(kcpReadyCondition != nil && kcpReadyCondition.Status == "False") {
+						(kcpReadyCondition.Status == "False") {
 						conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.ControlPlaneNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 						return
 					}
@@ -794,7 +793,7 @@ func TestClusterReconcilerReconcileSelfManagedClusterConditions(t *testing.T) {
 				func(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) {
 					kcpReadyCondition := conditions.Get(kcp, clusterv1.ReadyCondition)
 					if kcpReadyCondition == nil ||
-						(kcpReadyCondition != nil && kcpReadyCondition.Status == "False") {
+						(kcpReadyCondition.Status == "False") {
 						conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.ControlPlaneNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 						return
 					}

--- a/pkg/signature/manifest.go
+++ b/pkg/signature/manifest.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"text/template"
 
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/itchyny/gojq"
 	"sigs.k8s.io/yaml"
@@ -38,7 +39,7 @@ import (
 func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid bool, err error) {
 	bundleSig := bundle.Annotations[constants.SignatureAnnotation]
 	if bundleSig == "" {
-		return false, errors.New("missing signature annotation")
+		return false, errors.New("missing bundle signature annotation")
 	}
 
 	digest, _, err := getBundleDigest(bundle)
@@ -48,7 +49,7 @@ func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid b
 
 	sig, err := base64.StdEncoding.DecodeString(bundleSig)
 	if err != nil {
-		return false, fmt.Errorf("signature in metadata isn't base64 encoded: %w", err)
+		return false, fmt.Errorf("bundle signature in metadata isn't base64 encoded: %w", err)
 	}
 
 	pubkey, err := parsePublicKey(pubKey)
@@ -57,6 +58,59 @@ func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid b
 	}
 
 	return ecdsa.VerifyASN1(pubkey, digest[:], sig), nil
+}
+
+// ValidateEKSDistroManifestSignature validates the signature annotation of the bundles object using KMS public key.
+func ValidateEKSDistroManifestSignature(release *eksdv1alpha1.Release, signature, pubKey, releaseChannel string) (valid bool, err error) {
+	if signature == "" {
+		return false, fmt.Errorf("missing %s eks distro manifest signature annotation", releaseChannel)
+	}
+
+	digest, _, err := getEKSDistroReleaseDigest(release)
+	if err != nil {
+		return false, err
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false, fmt.Errorf("eks distro manifest signature in metadata for %s release channel isn't base64 encoded: %w", releaseChannel, err)
+	}
+
+	pubkey, err := parsePublicKey(pubKey)
+	if err != nil {
+		return false, err
+	}
+
+	return ecdsa.VerifyASN1(pubkey, digest[:], sig), nil
+}
+
+// getEksdDigest computes the SHA256 digest for an EKS Distro release object.
+// It follows similar steps as getBundleDigest() for Bundles by marshalling the object,
+// converting it to JSON, filtering out undesired fields, and then computing the hash.
+func getEKSDistroReleaseDigest(release *eksdv1alpha1.Release) ([32]byte, []byte, error) {
+	var zero [32]byte
+
+	// Marshal the eks-distro release object to YAML.
+	yamlBytes, err := yaml.Marshal(release)
+	if err != nil {
+		return zero, nil, fmt.Errorf("marshalling eks distro release to YAML: %v", err)
+	}
+
+	// Convert the YAML to JSON for easier gojq processing.
+	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
+	if err != nil {
+		return zero, nil, fmt.Errorf("converting eks distro release YAML to JSON: %v", err)
+	}
+
+	// Build and execute the gojq filter that deletes excluded fields.
+	filtered, err := filterExcludes(jsonBytes, constants.EKSDistroExcludes)
+	if err != nil {
+		return zero, nil, fmt.Errorf("filtering excluded fields: %v", err)
+	}
+
+	// Compute the SHA256 digest of the filtered JSON.
+	digest := sha256.Sum256(filtered)
+	return digest, filtered, nil
 }
 
 // getBundleDigest converts the Bundles manifest to JSON, excludes certain fields, then
@@ -78,7 +132,7 @@ func getBundleDigest(bundle *anywherev1alpha1.Bundles) ([32]byte, []byte, error)
 	}
 
 	// Build and execute the gojq filter that deletes excluded fields
-	filtered, err := filterExcludes(jsonBytes)
+	filtered, err := filterExcludes(jsonBytes, constants.Excludes)
 	if err != nil {
 		return zero, nil, fmt.Errorf("filtering excluded fields: %w", err)
 	}
@@ -91,18 +145,20 @@ func getBundleDigest(bundle *anywherev1alpha1.Bundles) ([32]byte, []byte, error)
 
 // filterExcludes applies the default and user-specified excludes to the JSON
 // representation of the Bundles object using gojq.
-// This function has dependency on constants.AlwaysExcludedFields and constants.Excludes fields.
-func filterExcludes(jsonBytes []byte) ([]byte, error) {
+func filterExcludes(jsonBytes []byte, excludes string) ([]byte, error) {
 	// Decode the base64-encoded excludes
-	exclBytes, err := base64.StdEncoding.DecodeString(constants.Excludes)
+	exclBytes, err := base64.StdEncoding.DecodeString(excludes)
 	if err != nil {
-		return nil, fmt.Errorf("decoding Excludes: %w", err)
+		return nil, fmt.Errorf("decoding Excludes: %v", err)
 	}
 	// Convert them into slice of strings
 	userExcludes := strings.Split(string(exclBytes), "\n")
 
 	// Combine AlwaysExcluded with userExcludes
-	allExcludes := append(constants.AlwaysExcludedFields, userExcludes...)
+	allExcludes := constants.AlwaysExcludedFields
+	if userExcludes[0] != "" {
+		allExcludes = append(allExcludes, userExcludes...)
+	}
 
 	// Build the argument to the gojq template
 	var tmplBuf bytes.Buffer
@@ -121,19 +177,19 @@ func filterExcludes(jsonBytes []byte) ([]byte, error) {
 	if err := gojqTemplate.Execute(&tmplBuf, map[string]interface{}{
 		"Excludes": allExcludes,
 	}); err != nil {
-		return nil, fmt.Errorf("executing gojq template: %w", err)
+		return nil, fmt.Errorf("executing gojq template: %v", err)
 	}
 
 	// Parse the final gojq query
 	query, err := gojq.Parse(tmplBuf.String())
 	if err != nil {
-		return nil, fmt.Errorf("gojq parse error: %w", err)
+		return nil, fmt.Errorf("gojq parse error: %v", err)
 	}
 
 	// Unmarshal the JSON into a generic interface so gojq can operate
 	var input interface{}
 	if err := json.Unmarshal(jsonBytes, &input); err != nil {
-		return nil, fmt.Errorf("unmarshalling JSON: %w", err)
+		return nil, fmt.Errorf("unmarshalling JSON: %v", err)
 	}
 
 	// Run the query
@@ -143,13 +199,13 @@ func filterExcludes(jsonBytes []byte) ([]byte, error) {
 		return nil, errors.New("gojq produced no result")
 	}
 	if errVal, ok := finalVal.(error); ok {
-		return nil, fmt.Errorf("gojq execution error: %w", errVal)
+		return nil, fmt.Errorf("gojq execution error: %v", errVal)
 	}
 
 	// Marshal the filtered result back to JSON
 	filtered, err := json.Marshal(finalVal)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling final result to JSON: %w", err)
+		return nil, fmt.Errorf("marshalling final result to JSON: %v", err)
 	}
 	return filtered, nil
 }

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -176,7 +176,7 @@ func ValidateManagementEksaVersion(mgmtCluster, cluster *v1alpha1.Cluster) error
 		reason := v1alpha1.EksaVersionInvalidReason
 		cluster.Status.FailureMessage = ptr.String(errMsg)
 		cluster.Status.FailureReason = &reason
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	// reset failure message if old matches this validation

--- a/pkg/validations/extendedversion.go
+++ b/pkg/validations/extendedversion.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/golang-jwt/jwt/v5"
+	"sigs.k8s.io/yaml"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -28,19 +32,54 @@ func ValidateExtendedK8sVersionSupport(ctx context.Context, clusterSpec anywhere
 		return fmt.Errorf("validating bundle signature: %w", err)
 	}
 
+	versionsBundle, err := cluster.GetVersionsBundle(clusterSpec.Spec.KubernetesVersion, bundle)
+	if err != nil {
+		return fmt.Errorf("getting versions bundle for %s kubernetes version: %w", clusterSpec.Spec.KubernetesVersion, err)
+	}
+
 	// Check whether the kubernetes version for the cluster is currently under extended support by comparing the endOfStandardSupport date from the bundle with the current date.
-	isExtended, err := isExtendedSupport(clusterSpec.Spec.KubernetesVersion, bundle)
+	isExtended, err := isExtendedSupport(versionsBundle)
 	if err != nil {
 		return err
 	}
 	if isExtended {
+		// Validate EKS Distro manifest has not been modified by verifying the signature in the EKS-A bundle annotation
+		releaseChannel := versionsBundle.EksD.ReleaseChannel
+		signatureAnnotation := constants.EKSDistroSignatureAnnotation + "-" + releaseChannel
+		sig := bundle.Annotations[signatureAnnotation]
+		releaseManifest := &eksdv1alpha1.Release{}
+		if strings.Contains(versionsBundle.EksD.EksDReleaseUrl, "eks-anywhere-downloads") {
+			releaseManifestFilePath := versionsBundle.EksD.EksDReleaseUrl
+			// Read the EKS-D release manifest file from the given path.
+			contents, err := os.ReadFile(releaseManifestFilePath)
+			if err != nil {
+				return fmt.Errorf("reading eksd release manifest file: %w", err)
+			}
+			// Unmarshal the file contents into the releaseManifest variable.
+			if err := yaml.Unmarshal(contents, releaseManifest); err != nil {
+				return fmt.Errorf("unmarshalling eksd release manifest file: %w", err)
+			}
+		} else {
+			if err := k.Get(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace, releaseManifest); err != nil {
+				return fmt.Errorf("getting %s eks distro release: %w", versionsBundle.EksD.Name, err)
+			}
+		}
+		if err := validateEKSDistroManifestSignature(releaseManifest, sig, releaseChannel); err != nil {
+			return fmt.Errorf("validating eks distro manifest signature: %w", err)
+		}
+
+		// Validate that the claims in the license token have not been modified by verifying the signature in the token
 		token, err := getLicense(clusterSpec.Spec.LicenseToken)
 		if err != nil {
 			return fmt.Errorf("getting licenseToken: %w", err)
 		}
+
+		// Validate that the license token has not expired yet
 		if err = validateLicense(token); err != nil {
 			return fmt.Errorf("validating licenseToken: %w", err)
 		}
+
+		// Validate that the same license token is not being used by multiple clusters
 		if clusterSpec.IsManaged() {
 			if err := validateLicenseKeyIsUnique(ctx, clusterSpec.Name, clusterSpec.Spec.LicenseToken, k); err != nil {
 				return fmt.Errorf("validating licenseToken is unique for cluster %s: %w", clusterSpec.Name, err)
@@ -62,12 +101,19 @@ func validateBundleSignature(bundle *v1alpha1.Bundles) error {
 	return nil
 }
 
-func isExtendedSupport(kubernetesVersion anywherev1.KubernetesVersion, bundle *v1alpha1.Bundles) (bool, error) {
-	versionsBundle, err := cluster.GetVersionsBundle(kubernetesVersion, bundle)
+// validateEKSDistroManifestSignature validates eks distro manifest signature with the KMS public key.
+func validateEKSDistroManifestSignature(eksdReleaseManifest *eksdv1alpha1.Release, sig, releaseChannel string) error {
+	valid, err := signature.ValidateEKSDistroManifestSignature(eksdReleaseManifest, sig, constants.EKSDistroKMSPublicKey, releaseChannel)
 	if err != nil {
-		return false, fmt.Errorf("getting versions bundle for %s kubernetes version: %w", kubernetesVersion, err)
+		return err
 	}
+	if !valid {
+		return fmt.Errorf("signature on the %s eks distro manifest is invalid", releaseChannel)
+	}
+	return nil
+}
 
+func isExtendedSupport(versionsBundle *v1alpha1.VersionsBundle) (bool, error) {
 	endOfStandardSupport, err := time.Parse("2006-01-02", versionsBundle.EndOfStandardSupport)
 	if err != nil {
 		return false, fmt.Errorf("parsing EndOfStandardSupport field format: %w", err)

--- a/pkg/validations/extendedversion_test.go
+++ b/pkg/validations/extendedversion_test.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -19,14 +19,13 @@ import (
 
 func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 	ctx := context.Background()
-	client := test.NewFakeKubeClient()
 
 	tests := []struct {
-		name    string
-		cluster anywherev1.Cluster
-		bundle  *v1alpha1.Bundles
-		client  kubernetes.Client
-		wantErr error
+		name        string
+		cluster     anywherev1.Cluster
+		bundle      *v1alpha1.Bundles
+		eksdRelease *eksdv1alpha1.Release
+		wantErr     error
 	}{
 		{
 			name:    "no bundle signature",
@@ -38,7 +37,7 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 					},
 				},
 			},
-			wantErr: fmt.Errorf("missing signature annotation"),
+			wantErr: fmt.Errorf("missing bundle signature annotation"),
 		},
 		{
 			name: "kubernetes version not supported",
@@ -87,7 +86,34 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 					LicenseToken:      "",
 				},
 			},
-			bundle:  validBundle(),
+			bundle: validBundle(),
+			eksdRelease: &eksdv1alpha1.Release{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Release",
+					APIVersion: eksdv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes-1-28-46",
+					Namespace: constants.EksaSystemNamespace,
+				},
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number:  46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "metrics-server",
+							GitTag: "v0.7.2",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "metrics-server-image",
+								},
+							},
+						},
+					},
+				},
+			},
 			wantErr: fmt.Errorf("licenseToken is required for extended kubernetes support"),
 		},
 		{
@@ -99,12 +125,46 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 				},
 			},
 			bundle:  validBundle(),
+			eksdRelease: &eksdv1alpha1.Release{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Release",
+					APIVersion: eksdv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes-1-28-46",
+					Namespace: constants.EksaSystemNamespace,
+				},
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number:  46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "metrics-server",
+							GitTag: "v0.7.2",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "metrics-server-image",
+								},
+							},
+						},
+					},
+				},
+			},
 			wantErr: fmt.Errorf("getting licenseToken"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(_ *testing.T) {
+			client := test.NewFakeKubeClient()
+			if tc.eksdRelease != nil {
+				cb := fake.NewClientBuilder()
+				cl := cb.WithRuntimeObjects(tc.eksdRelease).Build()
+				client = test.NewKubeClient(cl)
+			}
+
 			err := ValidateExtendedK8sVersionSupport(ctx, tc.cluster, tc.bundle, client)
 			if err != nil && !strings.Contains(err.Error(), tc.wantErr.Error()) {
 				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)
@@ -185,7 +245,8 @@ func validBundle() *v1alpha1.Bundles {
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
-				constants.SignatureAnnotation: "MEYCIQC8Fuo81dxibtkvrOFZpbFXZGmJnhLN6bkJjx4YB0fGIQIhAJIxIAl3s26eXqcmS6kAyjDd0NXDlBbM0d/GCHcL2Xoo",
+				constants.SignatureAnnotation:                                  "MEUCIC1XI8WELDFzpbc3GEy8N0ZHIGWYmuoxVhK7nNU7lB3JAiEAkw3jtXn3eHnRuuo/P9Nr+Z6X8FXhTGVv+0ZiOpx7Sls=",
+				fmt.Sprintf("%s-1-28", constants.EKSDistroSignatureAnnotation): "MEUCIQC3uP3Dhfb/nhCeir0Hwtf4bddKVfVIauFWBidT18XZOwIgHjzH1mOxBm1N2l2w9wBVy9W1o6CQXpdDz7UcbCszZYc=",
 			},
 		},
 		Spec: v1alpha1.BundlesSpec{
@@ -194,6 +255,11 @@ func validBundle() *v1alpha1.Bundles {
 				{
 					KubeVersion:          "1.28",
 					EndOfStandardSupport: "2024-12-31",
+					EksD: v1alpha1.EksDRelease{
+						Name:           "kubernetes-1-28-46",
+						ReleaseChannel: "1-28",
+						EksDReleaseUrl: "https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-46.yaml",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*
[#2994](https://github.com/aws/eks-anywhere-internal/issues/2994)

*Description of changes:*
This PR adds a new extended support validation in the CLI and controller to verify the eks distro release manifest signature from the EKS-A bundle annotations.

Doc:- https://quip-amazon.com/HHz8AFaq0CAF/EKS-Distro-Manifest-Signing

*Testing (if applicable):*
Ran the following commands from the root folder:
```
make eks-a
make lint
make build-e2e-test-binary
make unit-test
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

