### PR TITLE
[release-0.22] Documentation change for RHEL 9 support

### DIFF
--- a/docs/content/en/docs/osmgmt/overview.md
+++ b/docs/content/en/docs/osmgmt/overview.md
@@ -20,9 +20,7 @@ Reference the table below for the operating systems supported per deployment opt
 | :---: | :---: |
 | Bottlerocket | 1.19.x |
 | Ubuntu | 20.04.x, 22.04.x |
-| RHEL | 8.x, 9.x<sup>*</sup> |
-
-<sup>*</sup>Nutanix and CloudStack only
+| RHEL | 8.x, 9.x |
 
 With the vSphere, bare metal, Snow, CloudStack and Nutanix deployment options, EKS Anywhere provisions the operating system when new machines are deployed during cluster creation, upgrade, and scaling operations. You can configure the operating system to use through the EKS Anywhere cluster spec, which varies by deployment option. See the deployment option sections below for an overview of how the operating system configuration works per deployment option.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cherry-picked from https://github.com/aws/eks-anywhere/pull/9594
RHEL 9 is supported on vsphere since release v0.22.2 and is supported on baremetal since v0.20.0

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

