### PR TITLE
Add failure domains into missing permissions logic

### DIFF
--- a/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_types.go
@@ -51,6 +51,18 @@ type FailureDomain struct {
 	Network string `json:"network"`
 }
 
+// ResourcePaths returns a map of vSphere resource paths defined in the FailureDomain.
+// It collects the ComputeCluster, ResourcePool, Datastore, and Folder paths
+// into a structured map for easier access and validation during cluster operations.
+func (fd *FailureDomain) ResourcePaths() map[string]string {
+	return map[string]string{
+		"computeCluster": fd.ComputeCluster,
+		"resourcePool":   fd.ResourcePool,
+		"datastore":      fd.Datastore,
+		"folder":         fd.Folder,
+	}
+}
+
 // VSphereDatacenterConfigStatus defines the observed state of VSphereDatacenterConfig.
 type VSphereDatacenterConfigStatus struct { // Important: Run "make generate" to regenerate code after modifying this file
 	// SpecValid is set to true if vspheredatacenterconfig is validated.

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_types_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_types_test.go
@@ -1,0 +1,76 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFailureDomain_ResourcePaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		failureDomain FailureDomain
+		want          map[string]string
+	}{
+		{
+			name: "complete failure domain",
+			failureDomain: FailureDomain{
+				Name:           "test-fd",
+				ComputeCluster: "test-cluster",
+				ResourcePool:   "test-pool",
+				Datastore:      "test-datastore",
+				Folder:         "test-folder",
+				Network:        "test-network",
+			},
+			want: map[string]string{
+				"computeCluster": "test-cluster",
+				"resourcePool":   "test-pool",
+				"datastore":      "test-datastore",
+				"folder":         "test-folder",
+			},
+		},
+		{
+			name: "failure domain with empty values",
+			failureDomain: FailureDomain{
+				Name:           "empty-fd",
+				ComputeCluster: "",
+				ResourcePool:   "",
+				Datastore:      "",
+				Folder:         "",
+				Network:        "",
+			},
+			want: map[string]string{
+				"computeCluster": "",
+				"resourcePool":   "",
+				"datastore":      "",
+				"folder":         "",
+			},
+		},
+		{
+			name: "failure domain with inventory paths",
+			failureDomain: FailureDomain{
+				Name:           "path-fd",
+				ComputeCluster: "/dc/compute/cluster1",
+				ResourcePool:   "/dc/compute/cluster1/Resources",
+				Datastore:      "/dc/datastore/ds1",
+				Folder:         "/dc/vm/folder1",
+				Network:        "/dc/network/network1",
+			},
+			want: map[string]string{
+				"computeCluster": "/dc/compute/cluster1",
+				"resourcePool":   "/dc/compute/cluster1/Resources",
+				"datastore":      "/dc/datastore/ds1",
+				"folder":         "/dc/vm/folder1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.failureDomain.ResourcePaths()
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FailureDomain.ResourcePaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/v1alpha1/vspheremachineconfig_types.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types.go
@@ -30,6 +30,18 @@ type VSphereMachineConfigSpec struct {
 	HostOSConfiguration *HostOSConfiguration `json:"hostOSConfiguration,omitempty"`
 }
 
+// ResourcePaths returns a map of vSphere resource paths defined in the VSphereMachineConfig.
+// It collects the Template, ResourcePool, Datastore, and Folder paths
+// into a structured map for easier access and validation during cluster operations.
+func (c *VSphereMachineConfig) ResourcePaths() map[string]string {
+	return map[string]string{
+		"folder":       c.Spec.Folder,
+		"datastore":    c.Spec.Datastore,
+		"resourcePool": c.Spec.ResourcePool,
+		"template":     c.Spec.Template,
+	}
+}
+
 func (c *VSphereMachineConfig) PauseReconcile() {
 	c.Annotations[pausedAnnotation] = "true"
 }

--- a/pkg/api/v1alpha1/vspheremachineconfig_types_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_types_test.go
@@ -1,0 +1,108 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVSphereMachineConfig_ResourcePaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		config VSphereMachineConfig
+		want   map[string]string
+	}{
+		{
+			name: "complete config",
+			config: VSphereMachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VSphereMachineConfig",
+					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-config",
+				},
+				Spec: VSphereMachineConfigSpec{
+					Folder:       "/dc/vm/folder1",
+					Datastore:    "/dc/datastore/ds1",
+					ResourcePool: "/dc/host/cluster1/Resources",
+					Template:     "ubuntu-2204-kube-v1.27",
+					NumCPUs:      2,
+					MemoryMiB:    8192,
+					OSFamily:     Ubuntu,
+				},
+			},
+			want: map[string]string{
+				"folder":       "/dc/vm/folder1",
+				"datastore":    "/dc/datastore/ds1",
+				"resourcePool": "/dc/host/cluster1/Resources",
+				"template":     "ubuntu-2204-kube-v1.27",
+			},
+		},
+		{
+			name: "empty paths",
+			config: VSphereMachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VSphereMachineConfig",
+					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "empty-paths-config",
+				},
+				Spec: VSphereMachineConfigSpec{
+					Folder:       "",
+					Datastore:    "",
+					ResourcePool: "",
+					Template:     "",
+					NumCPUs:      2,
+					MemoryMiB:    4096,
+					OSFamily:     Bottlerocket,
+				},
+			},
+			want: map[string]string{
+				"folder":       "",
+				"datastore":    "",
+				"resourcePool": "",
+				"template":     "",
+			},
+		},
+		{
+			name: "partial paths",
+			config: VSphereMachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VSphereMachineConfig",
+					APIVersion: "anywhere.eks.amazonaws.com/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "partial-paths-config",
+				},
+				Spec: VSphereMachineConfigSpec{
+					Folder:       "/dc/vm/folder2",
+					Datastore:    "/dc/datastore/ds2",
+					ResourcePool: "",
+					Template:     "bottlerocket-kube-v1.28",
+					NumCPUs:      4,
+					MemoryMiB:    16384,
+					OSFamily:     Bottlerocket,
+				},
+			},
+			want: map[string]string{
+				"folder":       "/dc/vm/folder2",
+				"datastore":    "/dc/datastore/ds2",
+				"resourcePool": "",
+				"template":     "bottlerocket-kube-v1.28",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.ResourcePaths()
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VSphereMachineConfig.ResourcePaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/govmomi/client.go
+++ b/pkg/govmomi/client.go
@@ -15,6 +15,7 @@ const (
 	VSphereTypeResourcePool   = "ResourcePool"
 	VSphereTypeDatastore      = "Datastore"
 	VSphereTypeVirtualMachine = "VirtualMachine"
+	VSphereTypeComputeCluster = "ComputeCluster"
 )
 
 type VMOMIAuthorizationManager interface {
@@ -26,6 +27,7 @@ type VMOMIFinder interface {
 	Folder(ctx context.Context, path string) (*object.Folder, error)
 	Network(ctx context.Context, path string) (object.NetworkReference, error)
 	ResourcePool(ctx context.Context, path string) (*object.ResourcePool, error)
+	ClusterComputeResource(ctx context.Context, path string) (*object.ClusterComputeResource, error)
 	VirtualMachine(ctx context.Context, path string) (*object.VirtualMachine, error)
 	Datacenter(ctx context.Context, path string) (*object.Datacenter, error)
 	SetDatacenter(dc *object.Datacenter) *find.Finder
@@ -68,6 +70,8 @@ func (vsc *VMOMIClient) GetPrivsOnEntity(ctx context.Context, path string, objTy
 		vSphereObjectReference, err = vsc.getResourcePool(ctx, path)
 	case VSphereTypeVirtualMachine:
 		vSphereObjectReference, err = vsc.getVirtualMachine(ctx, path)
+	case VSphereTypeComputeCluster:
+		vSphereObjectReference, err = vsc.getComputeCluster(ctx, path)
 	}
 
 	if err != nil {
@@ -121,6 +125,14 @@ func (vsc *VMOMIClient) getResourcePool(ctx context.Context, path string) (types
 	} else {
 		return obj.Common.Reference(), nil
 	}
+}
+
+func (vsc *VMOMIClient) getComputeCluster(ctx context.Context, path string) (types.ManagedObjectReference, error) {
+	obj, err := vsc.Finder.ClusterComputeResource(ctx, path)
+	if err != nil {
+		return types.ManagedObjectReference{}, err
+	}
+	return obj.Reference(), nil
 }
 
 func (vsc *VMOMIClient) getVirtualMachine(ctx context.Context, path string) (types.ManagedObjectReference, error) {

--- a/pkg/govmomi/mocks/client.go
+++ b/pkg/govmomi/mocks/client.go
@@ -131,6 +131,21 @@ func (m *MockVMOMIFinder) EXPECT() *MockVMOMIFinderMockRecorder {
 	return m.recorder
 }
 
+// ClusterComputeResource mocks base method.
+func (m *MockVMOMIFinder) ClusterComputeResource(arg0 context.Context, arg1 string) (*object.ClusterComputeResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterComputeResource", arg0, arg1)
+	ret0, _ := ret[0].(*object.ClusterComputeResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClusterComputeResource indicates an expected call of ClusterComputeResource.
+func (mr *MockVMOMIFinderMockRecorder) ClusterComputeResource(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterComputeResource", reflect.TypeOf((*MockVMOMIFinder)(nil).ClusterComputeResource), arg0, arg1)
+}
+
 // Datacenter mocks base method.
 func (m *MockVMOMIFinder) Datacenter(arg0 context.Context, arg1 string) (*object.Datacenter, error) {
 	m.ctrl.T.Helper()

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -434,7 +434,7 @@ func (p *vsphereProvider) SetupAndValidateUpgradeCluster(ctx context.Context, cl
 
 	if !p.skippedValidations[validations.VSphereUserPriv] {
 		if err := p.validator.validateVsphereUserPrivs(ctx, vSphereClusterSpec); err != nil {
-			return fmt.Errorf("validating vsphere user privileges: %v", err)
+			return fmt.Errorf("validating vsphere user privileges: %w, please refer to %s for required permissions or use -v 3 for full missing permissions", err, vSpherePermissionDoc)
 		}
 	}
 

--- a/pkg/providers/vsphere/vsphere_test.go
+++ b/pkg/providers/vsphere/vsphere_test.go
@@ -1605,7 +1605,8 @@ func TestSetupAndValidateUpgradeClusterMissingPrivError(t *testing.T) {
 
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
 
-	thenErrorExpected(t, "validating vsphere user privileges: error", err)
+	expectedErrorMsg := fmt.Sprintf("validating vsphere user privileges: error, please refer to %s for required permissions or use -v 3 for full missing permissions", vSpherePermissionDoc)
+	thenErrorExpected(t, expectedErrorMsg, err)
 }
 
 func TestSetupAndValidateCreateWorkloadClusterSuccess(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
[issue](https://github.com/aws/eks-anywhere-internal/issues/2985?issue=aws%7Ceks-anywhere-internal%7C3004)
*Description of changes:*
- Adjusted missing permissions code to take a common interface between vspheremachineconfigs and failuredomains to compare similar values
- Added compute cluster permissions checking (using AdminPrivs file)
- Unit testing
- Here is an [example](https://tiny.amazon.com/x2boue8e/paste) missing permissions output when user has no permissions.
