### PR TITLE
Disable vulnerability check

### DIFF
--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -29,24 +29,25 @@ jobs:
         with:
           base-ref: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
           head-ref: ${{ github.event.pull_request.head.sha || github.sha }}
-  govulncheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout Repository"
-        uses: actions/checkout@v4
-        with:
-          show-progress: false
-      - name: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          check-latest: true
-          repo-checkout: false
-          go-version-input: '1.23'
-      - name: govulncheck for release module
-        uses: golang/govulncheck-action@v1
-        with:
-          check-latest: true
-          repo-checkout: false
-          cache: false # cache will be already setup by previous step
-          work-dir: release/cli
-          go-version-input: '1.23'
+  # # disable govulncheck until controller-runtime is upgraded
+  # govulncheck:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: "Checkout Repository"
+  #       uses: actions/checkout@v4
+  #       with:
+  #         show-progress: false
+  #     - name: govulncheck
+  #       uses: golang/govulncheck-action@v1
+  #       with:
+  #         check-latest: true
+  #         repo-checkout: false
+  #         go-version-input: '1.23'
+  #     - name: govulncheck for release module
+  #       uses: golang/govulncheck-action@v1
+  #       with:
+  #         check-latest: true
+  #         repo-checkout: false
+  #         cache: false # cache will be already setup by previous step
+  #         work-dir: release/cli
+  #         go-version-input: '1.23'

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/eks-anywhere
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -85,6 +85,12 @@ function build::common::upload_artifacts() {
 
 function build::gather_licenses() {
   local -r golang_version=$1
+  # Setting this variable to local so that it always uses the local
+  # bundled toolchain regardless of the version specified in go.mod file
+  # It was introduced in this commit from Go1.21 onwards:
+  # https://github.com/golang/go/commit/83dfe5cf62234427eae04131dc6e4551fd283463
+  # Upstream issue:- https://github.com/google/go-licenses/issues/244
+  export GOTOOLCHAIN=local
 
   build::common::use_go_version $golang_version
   if ! command -v go-licenses &> /dev/null


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently vulnerability check is failing with CVEs `GO-2025-3602` and `GO-2025-3601`, fixing them requires upgrading helm to 3.17.3 which would need upgrading controller-runtime to at least v0.18.x.

We will disable vulnerability check until controller-runtime is upgraded.

Also bumping go toolchain version to 1.23.8 to fix an vulnerability in 1.23.6

*Testing (if applicable):*
make eks-a

```
govulcheck ./...
Only has GO-2025-3601 and GO-2025-3602
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

