### PR TITLE
Add packages and etcdadm reserved namespaces in callouts for docs

### DIFF
--- a/docs/content/en/docs/clustermgmt/security/best-practices.md
+++ b/docs/content/en/docs/clustermgmt/security/best-practices.md
@@ -82,13 +82,16 @@ For more information about creating limited roles for day-to-day administration 
 The critical namespaces include:
 
 * `eksa-system`
-* `capv-system`
+* `eksa-packages`
 * `flux-system`
+* `capv-system` (or the respective provider you are using)
 * `capi-system`
 * `capi-webhook-system`
 * `capi-kubeadm-control-plane-system`
 * `capi-kubeadm-bootstrap-system`
 * `cert-manager`
+* `etcdadm-controller-system`
+* `etcdadm-bootstrap-provider-system`
 * `kube-system` (as with any Kubernetes cluster, this namespace is critical to the functioning of your cluster and should be treated with the highest level of sensitivity.)
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3219

*Description of changes:*
Adding the other namespaces that were not called out

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

