### PR TITLE
Fix fetching the eksd release manifest by getting it from release url

### DIFF
--- a/pkg/validations/extendedversion.go
+++ b/pkg/validations/extendedversion.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -47,11 +49,11 @@ func ValidateExtendedK8sVersionSupport(ctx context.Context, clusterSpec anywhere
 		releaseChannel := versionsBundle.EksD.ReleaseChannel
 		signatureAnnotation := constants.EKSDistroSignatureAnnotation + "-" + releaseChannel
 		sig := bundle.Annotations[signatureAnnotation]
+		releaseURL := versionsBundle.EksD.EksDReleaseUrl
 		releaseManifest := &eksdv1alpha1.Release{}
-		if strings.Contains(versionsBundle.EksD.EksDReleaseUrl, "eks-anywhere-downloads") {
-			releaseManifestFilePath := versionsBundle.EksD.EksDReleaseUrl
+		if strings.Contains(releaseURL, "eks-anywhere-downloads") {
 			// Read the EKS-D release manifest file from the given path.
-			contents, err := os.ReadFile(releaseManifestFilePath)
+			contents, err := os.ReadFile(releaseURL)
 			if err != nil {
 				return fmt.Errorf("reading eksd release manifest file: %w", err)
 			}
@@ -60,8 +62,9 @@ func ValidateExtendedK8sVersionSupport(ctx context.Context, clusterSpec anywhere
 				return fmt.Errorf("unmarshalling eksd release manifest file: %w", err)
 			}
 		} else {
-			if err := k.Get(ctx, versionsBundle.EksD.Name, constants.EksaSystemNamespace, releaseManifest); err != nil {
-				return fmt.Errorf("getting %s eks distro release: %w", versionsBundle.EksD.Name, err)
+			releaseManifest, err = getEksdRelease(releaseURL)
+			if err != nil {
+				return fmt.Errorf("getting eks distro release: %w", err)
 			}
 		}
 		if err := validateEKSDistroManifestSignature(releaseManifest, sig, releaseChannel); err != nil {
@@ -173,6 +176,35 @@ func validateLicenseKeyIsUnique(ctx context.Context, clusterName string, license
 		}
 	}
 	return nil
+}
+
+func getEksdRelease(eksdReleaseURL string) (*eksdv1alpha1.Release, error) {
+	content, err := readHTTPFile(eksdReleaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	eksd := &eksdv1alpha1.Release{}
+	if err = yaml.UnmarshalStrict(content, eksd); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal eksd manifest: %w", err)
+	}
+
+	return eksd, nil
+}
+
+func readHTTPFile(uri string) ([]byte, error) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file from url [%s]: %w", uri, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file from url [%s]: %w", uri, err)
+	}
+
+	return data, nil
 }
 
 // ShouldSkipBundleSignatureValidation returns true if the eksa version is less than v0.22.0


### PR DESCRIPTION
*Issue:*
After merging [#9609](https://github.com/aws/eks-anywhere/pull/9609),all the 1.28 e2e tests started failing on staging for release-0.22 branch with the following error:
```
2025-04-17T05:36:03.074Z	V0	❌ Validation failed	{"validation": "validate extended kubernetes version support is supported", "error": "getting kubernetes-1-28-eks-46 eks distro release: getting Release.v1alpha1.distro.eks.amazonaws.com with kubectl: error: stat release-i-0e6bd-78e4421/release-i-0e6bd-78e4421-eks-a-cluster.kubeconfig: no such file or directory\n", "remediation": "ensure you have a valid license for extended Kubernetes version support"}
```

*Description of changes:*
This PR fixes the above issue by fetching the eksd release manifest from the release URL instead of getting it with kubectl. The `getEksdRelease` and `readHTTPFile` helper functions have been copied directly from the [filereader](https://github.com/aws/eks-anywhere/blob/main/release/cli/pkg/filereader/file_reader.go) module.

*Testing (if applicable):*
Ran the following commands from the root folder:
```
make eks-a
make lint
make build-e2e-test-binary
```
Manually ran the `TestDockerKubernetes128CuratedPackagesSimpleFlow` e2e test locally and it passed all the preflight validations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

