### PR TITLE
Revert 9636 and 9609

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -390,7 +390,7 @@ func (r *ClusterReconciler) preClusterProviderReconcile(ctx context.Context, log
 		return controller.Result{}, err
 	}
 
-	if err := validateExtendedKubernetesSupport(ctx, r.client, cluster); err != nil {
+	if err := validateExtendedK8sVersionSupport(ctx, r.client, cluster); err != nil {
 		return controller.Result{}, err
 	}
 
@@ -464,7 +464,8 @@ func (r *ClusterReconciler) updateStatus(ctx context.Context, log logr.Logger, c
 
 	defaultCNIConfiguredCondition := conditions.Get(cluster, anywherev1.DefaultCNIConfiguredCondition)
 	if defaultCNIConfiguredCondition == nil ||
-		(defaultCNIConfiguredCondition.Status == "False" &&
+		(defaultCNIConfiguredCondition != nil &&
+			defaultCNIConfiguredCondition.Status == "False" &&
 			defaultCNIConfiguredCondition.Reason != anywherev1.SkipUpgradesForDefaultCNIConfiguredReason) {
 		summarizedConditionTypes = append(summarizedConditionTypes, anywherev1.DefaultCNIConfiguredCondition)
 	}
@@ -641,7 +642,7 @@ func validateEksaRelease(ctx context.Context, client client.Client, cluster *any
 	return nil
 }
 
-func validateExtendedKubernetesSupport(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
+func validateExtendedK8sVersionSupport(ctx context.Context, client client.Client, cluster *anywherev1.Cluster) error {
 	eksaVersion := cluster.Spec.EksaVersion
 	if cluster.Spec.DatacenterRef.Kind == "SnowDatacenterConfig" || eksaVersion == nil {
 		return nil

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -517,7 +517,7 @@ func TestClusterReconcilerReconcileConditions(t *testing.T) {
 				func(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) {
 					kcpReadyCondition := conditions.Get(kcp, clusterv1.ReadyCondition)
 					if kcpReadyCondition == nil ||
-						(kcpReadyCondition.Status == "False") {
+						(kcpReadyCondition != nil && kcpReadyCondition.Status == "False") {
 						conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.ControlPlaneNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 						return
 					}
@@ -793,7 +793,7 @@ func TestClusterReconcilerReconcileSelfManagedClusterConditions(t *testing.T) {
 				func(ctx context.Context, log logr.Logger, cluster *anywherev1.Cluster) {
 					kcpReadyCondition := conditions.Get(kcp, clusterv1.ReadyCondition)
 					if kcpReadyCondition == nil ||
-						(kcpReadyCondition.Status == "False") {
+						(kcpReadyCondition != nil && kcpReadyCondition.Status == "False") {
 						conditions.MarkFalse(cluster, anywherev1.DefaultCNIConfiguredCondition, anywherev1.ControlPlaneNotReadyReason, clusterv1.ConditionSeverityInfo, "")
 						return
 					}

--- a/pkg/signature/manifest.go
+++ b/pkg/signature/manifest.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"text/template"
 
-	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/itchyny/gojq"
 	"sigs.k8s.io/yaml"
@@ -39,7 +38,7 @@ import (
 func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid bool, err error) {
 	bundleSig := bundle.Annotations[constants.SignatureAnnotation]
 	if bundleSig == "" {
-		return false, errors.New("missing bundle signature annotation")
+		return false, errors.New("missing signature annotation")
 	}
 
 	digest, _, err := getBundleDigest(bundle)
@@ -49,7 +48,7 @@ func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid b
 
 	sig, err := base64.StdEncoding.DecodeString(bundleSig)
 	if err != nil {
-		return false, fmt.Errorf("bundle signature in metadata isn't base64 encoded: %w", err)
+		return false, fmt.Errorf("signature in metadata isn't base64 encoded: %w", err)
 	}
 
 	pubkey, err := parsePublicKey(pubKey)
@@ -58,59 +57,6 @@ func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid b
 	}
 
 	return ecdsa.VerifyASN1(pubkey, digest[:], sig), nil
-}
-
-// ValidateEKSDistroManifestSignature validates the signature annotation of the bundles object using KMS public key.
-func ValidateEKSDistroManifestSignature(release *eksdv1alpha1.Release, signature, pubKey, releaseChannel string) (valid bool, err error) {
-	if signature == "" {
-		return false, fmt.Errorf("missing %s eks distro manifest signature annotation", releaseChannel)
-	}
-
-	digest, _, err := getEKSDistroReleaseDigest(release)
-	if err != nil {
-		return false, err
-	}
-
-	sig, err := base64.StdEncoding.DecodeString(signature)
-	if err != nil {
-		return false, fmt.Errorf("eks distro manifest signature in metadata for %s release channel isn't base64 encoded: %w", releaseChannel, err)
-	}
-
-	pubkey, err := parsePublicKey(pubKey)
-	if err != nil {
-		return false, err
-	}
-
-	return ecdsa.VerifyASN1(pubkey, digest[:], sig), nil
-}
-
-// getEksdDigest computes the SHA256 digest for an EKS Distro release object.
-// It follows similar steps as getBundleDigest() for Bundles by marshalling the object,
-// converting it to JSON, filtering out undesired fields, and then computing the hash.
-func getEKSDistroReleaseDigest(release *eksdv1alpha1.Release) ([32]byte, []byte, error) {
-	var zero [32]byte
-
-	// Marshal the eks-distro release object to YAML.
-	yamlBytes, err := yaml.Marshal(release)
-	if err != nil {
-		return zero, nil, fmt.Errorf("marshalling eks distro release to YAML: %v", err)
-	}
-
-	// Convert the YAML to JSON for easier gojq processing.
-	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
-	if err != nil {
-		return zero, nil, fmt.Errorf("converting eks distro release YAML to JSON: %v", err)
-	}
-
-	// Build and execute the gojq filter that deletes excluded fields.
-	filtered, err := filterExcludes(jsonBytes, constants.EKSDistroExcludes)
-	if err != nil {
-		return zero, nil, fmt.Errorf("filtering excluded fields: %v", err)
-	}
-
-	// Compute the SHA256 digest of the filtered JSON.
-	digest := sha256.Sum256(filtered)
-	return digest, filtered, nil
 }
 
 // getBundleDigest converts the Bundles manifest to JSON, excludes certain fields, then
@@ -132,7 +78,7 @@ func getBundleDigest(bundle *anywherev1alpha1.Bundles) ([32]byte, []byte, error)
 	}
 
 	// Build and execute the gojq filter that deletes excluded fields
-	filtered, err := filterExcludes(jsonBytes, constants.Excludes)
+	filtered, err := filterExcludes(jsonBytes)
 	if err != nil {
 		return zero, nil, fmt.Errorf("filtering excluded fields: %w", err)
 	}
@@ -145,20 +91,18 @@ func getBundleDigest(bundle *anywherev1alpha1.Bundles) ([32]byte, []byte, error)
 
 // filterExcludes applies the default and user-specified excludes to the JSON
 // representation of the Bundles object using gojq.
-func filterExcludes(jsonBytes []byte, excludes string) ([]byte, error) {
+// This function has dependency on constants.AlwaysExcludedFields and constants.Excludes fields.
+func filterExcludes(jsonBytes []byte) ([]byte, error) {
 	// Decode the base64-encoded excludes
-	exclBytes, err := base64.StdEncoding.DecodeString(excludes)
+	exclBytes, err := base64.StdEncoding.DecodeString(constants.Excludes)
 	if err != nil {
-		return nil, fmt.Errorf("decoding Excludes: %v", err)
+		return nil, fmt.Errorf("decoding Excludes: %w", err)
 	}
 	// Convert them into slice of strings
 	userExcludes := strings.Split(string(exclBytes), "\n")
 
 	// Combine AlwaysExcluded with userExcludes
-	allExcludes := constants.AlwaysExcludedFields
-	if userExcludes[0] != "" {
-		allExcludes = append(allExcludes, userExcludes...)
-	}
+	allExcludes := append(constants.AlwaysExcludedFields, userExcludes...)
 
 	// Build the argument to the gojq template
 	var tmplBuf bytes.Buffer
@@ -177,19 +121,19 @@ func filterExcludes(jsonBytes []byte, excludes string) ([]byte, error) {
 	if err := gojqTemplate.Execute(&tmplBuf, map[string]interface{}{
 		"Excludes": allExcludes,
 	}); err != nil {
-		return nil, fmt.Errorf("executing gojq template: %v", err)
+		return nil, fmt.Errorf("executing gojq template: %w", err)
 	}
 
 	// Parse the final gojq query
 	query, err := gojq.Parse(tmplBuf.String())
 	if err != nil {
-		return nil, fmt.Errorf("gojq parse error: %v", err)
+		return nil, fmt.Errorf("gojq parse error: %w", err)
 	}
 
 	// Unmarshal the JSON into a generic interface so gojq can operate
 	var input interface{}
 	if err := json.Unmarshal(jsonBytes, &input); err != nil {
-		return nil, fmt.Errorf("unmarshalling JSON: %v", err)
+		return nil, fmt.Errorf("unmarshalling JSON: %w", err)
 	}
 
 	// Run the query
@@ -199,13 +143,13 @@ func filterExcludes(jsonBytes []byte, excludes string) ([]byte, error) {
 		return nil, errors.New("gojq produced no result")
 	}
 	if errVal, ok := finalVal.(error); ok {
-		return nil, fmt.Errorf("gojq execution error: %v", errVal)
+		return nil, fmt.Errorf("gojq execution error: %w", errVal)
 	}
 
 	// Marshal the filtered result back to JSON
 	filtered, err := json.Marshal(finalVal)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling final result to JSON: %v", err)
+		return nil, fmt.Errorf("marshalling final result to JSON: %w", err)
 	}
 	return filtered, nil
 }

--- a/pkg/signature/manifest_test.go
+++ b/pkg/signature/manifest_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +49,7 @@ func TestValidateSignature(t *testing.T) {
 				},
 			},
 			valid:   false,
-			wantErr: fmt.Errorf("missing bundle signature annotation"),
+			wantErr: fmt.Errorf("missing signature annotation"),
 		},
 		{
 			name: "invalid signature",
@@ -70,7 +69,7 @@ func TestValidateSignature(t *testing.T) {
 				},
 			},
 			valid:   false,
-			wantErr: fmt.Errorf("bundle signature in metadata isn't base64 encoded"),
+			wantErr: fmt.Errorf("signature in metadata isn't base64 encoded"),
 		},
 		{
 			name: "invalid public key",
@@ -175,114 +174,6 @@ func TestValidateSignature(t *testing.T) {
 	}
 }
 
-func TestValidateEKSDistroManifestSignature(t *testing.T) {
-	// Create a dummy release with some nonempty Spec (so filtering produces a valid JSON payload).
-	testRelease := &eksdv1alpha1.Release{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "Release",
-			APIVersion: eksdv1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "kubernetes-1-28-46",
-			Namespace: constants.EksaSystemNamespace,
-		},
-		Spec: eksdv1alpha1.ReleaseSpec{
-			Channel: "1-28",
-			Number:  46,
-		},
-		Status: eksdv1alpha1.ReleaseStatus{
-			Components: []eksdv1alpha1.Component{
-				{
-					Name:   "metrics-server",
-					GitTag: "v0.7.2",
-					Assets: []eksdv1alpha1.Asset{
-						{
-							Name: "metrics-server-image",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name           string
-		release        *eksdv1alpha1.Release
-		signature      string
-		publicKey      string
-		releaseChannel string
-		valid          bool
-		wantErr        error
-	}{
-		{
-			name:           "no eks distro manifest signature",
-			release:        testRelease,
-			signature:      "",
-			publicKey:      constants.EKSDistroKMSPublicKey,
-			releaseChannel: "1-28",
-			valid:          false,
-			wantErr:        fmt.Errorf("missing 1-28 eks distro manifest signature annotation"),
-		},
-		{
-			name:           "invalid signature",
-			release:        testRelease,
-			signature:      "invalid",
-			publicKey:      constants.EKSDistroKMSPublicKey,
-			releaseChannel: "1-29",
-			valid:          false,
-			wantErr:        fmt.Errorf("eks distro manifest signature in metadata for 1-29 release channel isn't base64 encoded"),
-		},
-		{
-			name:           "invalid public key",
-			release:        testRelease,
-			signature:      "MEUCICV1iiNA4owIUdZBIowSgWjTKx+JT5/CE8PzmF2CBD5+AiEAk8Fcc1X/LNGm0YCyZISWFhbh4qdc7ENyYCU3DB0u4b0=",
-			publicKey:      "invalid",
-			releaseChannel: "test-channel",
-			valid:          false,
-			wantErr:        fmt.Errorf("decoding the public key as string"),
-		},
-		{
-			name:           "invalid encoded public key",
-			release:        testRelease,
-			signature:      "MEUCICV1iiNA4owIUdZBIowSgWjTKx+JT5/CE8PzmF2CBD5+AiEAk8Fcc1X/LNGm0YCyZISWFhbh4qdc7ENyYCU3DB0u4b0=",
-			publicKey:      "TUVVQ0lDVjFpaU5BNG93SVVkWkJJb3dTZ1dqVEt4K0pUNS9DRThQem1GMkNCRDUrQWlFQWs4RmNjMVgvTE5HbTBZQ3laSVNXRmhiaDRxZGM3RU55WUNVM0RCMHU0YjA9Cg==",
-			releaseChannel: "test-channel",
-			valid:          false,
-			wantErr:        fmt.Errorf("parsing the public key (not PKIX)"),
-		},
-		{
-			name:           "signature verification fail",
-			release:        testRelease,
-			signature:      "MEUCICV1iiNA4owIUdZBIowSgWjTKx+JT5/CE8PzmF2CBD5+AiEAk8Fcc1X/LNGm0YCyZISWFhbh4qdc7ENyYCU3DB0u4b0=",
-			publicKey:      constants.EKSDistroKMSPublicKey,
-			releaseChannel: "test-channel",
-			valid:          false,
-			wantErr:        nil,
-		},
-		{
-			name:           "signature verification succeeded",
-			release:        testRelease,
-			signature:      "MEUCIQC3uP3Dhfb/nhCeir0Hwtf4bddKVfVIauFWBidT18XZOwIgHjzH1mOxBm1N2l2w9wBVy9W1o6CQXpdDz7UcbCszZYc=",
-			publicKey:      constants.EKSDistroKMSPublicKey,
-			releaseChannel: "1-28",
-			valid:          true,
-			wantErr:        nil,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			valid, err := ValidateEKSDistroManifestSignature(tc.release, tc.signature, tc.publicKey, tc.releaseChannel)
-			if err != nil && (tc.wantErr == nil || !strings.Contains(err.Error(), tc.wantErr.Error())) {
-				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)
-			}
-			if valid != tc.valid {
-				t.Errorf("%v got = %v, \nwant %v", tc.name, valid, tc.valid)
-			}
-		})
-	}
-}
-
 func TestGetBundleDigest(t *testing.T) {
 	testCases := []struct {
 		testName        string
@@ -329,70 +220,17 @@ func TestGetBundleDigest(t *testing.T) {
 
 			digest, filtered, err := getBundleDigest(tt.bundle)
 			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(gomega.HaveOccurred(), "Expected success but got error: %v", err)
-				g.Expect(digest).NotTo(gomega.BeZero(), "Expected digest to be non-zero")
-				g.Expect(filtered).NotTo(gomega.BeEmpty(), "Expected filtered bytes to be non-empty")
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "Expected success but got error")
+				g.Expect(digest).NotTo(gomega.BeZero(),
+					"Expected digest to be non-zero array")
+				g.Expect(filtered).NotTo(gomega.BeEmpty(),
+					"Expected filtered bytes to be non-empty")
 			} else {
-				g.Expect(err).To(gomega.HaveOccurred(), "Expected error but got none")
-				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
-				g.Expect(digest).To(gomega.BeZero())
-				g.Expect(filtered).To(gomega.BeNil())
-			}
-		})
-	}
-}
-
-func TestGetEKSDistroReleaseDigest(t *testing.T) {
-	testCases := []struct {
-		testName        string
-		release         *eksdv1alpha1.Release
-		expectErrSubstr string
-	}{
-		{
-			testName: "Simple valid release",
-			release: &eksdv1alpha1.Release{
-				TypeMeta: v1.TypeMeta{
-					Kind:       "Release",
-					APIVersion: eksdv1alpha1.GroupVersion.String(),
-				},
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "kubernetes-1-28-46",
-					Namespace: constants.EksaSystemNamespace,
-				},
-				Spec: eksdv1alpha1.ReleaseSpec{
-					Channel: "1-28",
-					Number:  46,
-				},
-				Status: eksdv1alpha1.ReleaseStatus{
-					Components: []eksdv1alpha1.Component{
-						{
-							Name:   "metrics-server",
-							GitTag: "v0.7.2",
-							Assets: []eksdv1alpha1.Asset{
-								{
-									Name: "metrics-server-image",
-								},
-							},
-						},
-					},
-				},
-			},
-			expectErrSubstr: "",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.testName, func(t *testing.T) {
-			g := gomega.NewWithT(t)
-
-			digest, filtered, err := getEKSDistroReleaseDigest(tt.release)
-			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(gomega.HaveOccurred(), "Expected success but got error: %v", err)
-				g.Expect(digest).NotTo(gomega.BeZero(), "Expected digest to be non-zero")
-				g.Expect(filtered).NotTo(gomega.BeEmpty(), "Expected filtered bytes to be non-empty")
-			} else {
-				g.Expect(err).To(gomega.HaveOccurred(), "Expected error but got none")
-				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(err).To(gomega.HaveOccurred(),
+					"Expected error but got none")
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectErrSubstr),
+					"Error message should contain substring %q, got: %v",
+					tt.expectErrSubstr, err)
 				g.Expect(digest).To(gomega.BeZero())
 				g.Expect(filtered).To(gomega.BeNil())
 			}
@@ -478,7 +316,7 @@ func TestFilterExcludes(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
-			filtered, err := filterExcludes([]byte(tt.jsonPayload), constants.Excludes)
+			filtered, err := filterExcludes([]byte(tt.jsonPayload))
 
 			if tt.expectErrSubstr == "" {
 				g.Expect(err).NotTo(gomega.HaveOccurred(),

--- a/pkg/validations/extendedversion_test.go
+++ b/pkg/validations/extendedversion_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -23,6 +24,7 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 		name        string
 		cluster     anywherev1.Cluster
 		bundle      *v1alpha1.Bundles
+		eksdRelease *eksdv1alpha1.Release
 		wantErr     error
 	}{
 		{
@@ -85,6 +87,33 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 				},
 			},
 			bundle: validBundle(),
+			eksdRelease: &eksdv1alpha1.Release{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Release",
+					APIVersion: eksdv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes-1-28-46",
+					Namespace: constants.EksaSystemNamespace,
+				},
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number:  46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "metrics-server",
+							GitTag: "v0.7.2",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "metrics-server-image",
+								},
+							},
+						},
+					},
+				},
+			},
 			wantErr: fmt.Errorf("licenseToken is required for extended kubernetes support"),
 		},
 		{
@@ -96,6 +125,33 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 				},
 			},
 			bundle:  validBundle(),
+			eksdRelease: &eksdv1alpha1.Release{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Release",
+					APIVersion: eksdv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes-1-28-46",
+					Namespace: constants.EksaSystemNamespace,
+				},
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number:  46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "metrics-server",
+							GitTag: "v0.7.2",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "metrics-server-image",
+								},
+							},
+						},
+					},
+				},
+			},
 			wantErr: fmt.Errorf("getting licenseToken"),
 		},
 	}
@@ -103,6 +159,11 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(_ *testing.T) {
 			client := test.NewFakeKubeClient()
+			if tc.eksdRelease != nil {
+				cb := fake.NewClientBuilder()
+				cl := cb.WithRuntimeObjects(tc.eksdRelease).Build()
+				client = test.NewKubeClient(cl)
+			}
 
 			err := ValidateExtendedK8sVersionSupport(ctx, tc.cluster, tc.bundle, client)
 			if err != nil && !strings.Contains(err.Error(), tc.wantErr.Error()) {
@@ -185,7 +246,7 @@ func validBundle() *v1alpha1.Bundles {
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
 				constants.SignatureAnnotation:                                  "MEUCIC1XI8WELDFzpbc3GEy8N0ZHIGWYmuoxVhK7nNU7lB3JAiEAkw3jtXn3eHnRuuo/P9Nr+Z6X8FXhTGVv+0ZiOpx7Sls=",
-				fmt.Sprintf("%s-1-28", constants.EKSDistroSignatureAnnotation): "MEUCIG6ESJds+DgstQDs2ScLGgEVxtNKNpf8rY1cl2DbA3hvAiEAsxL4SWCopeAy9vzNWTxBRq22/oPdtr8w8Cp4yCER9TE=",
+				fmt.Sprintf("%s-1-28", constants.EKSDistroSignatureAnnotation): "MEUCIQC3uP3Dhfb/nhCeir0Hwtf4bddKVfVIauFWBidT18XZOwIgHjzH1mOxBm1N2l2w9wBVy9W1o6CQXpdDz7UcbCszZYc=",
 			},
 		},
 		Spec: v1alpha1.BundlesSpec{

--- a/pkg/validations/extendedversion_test.go
+++ b/pkg/validations/extendedversion_test.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"testing"
 
-	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 	"github.com/aws/eks-anywhere/release/api/v1alpha1"
@@ -19,13 +19,14 @@ import (
 
 func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 	ctx := context.Background()
+	client := test.NewFakeKubeClient()
 
 	tests := []struct {
-		name        string
-		cluster     anywherev1.Cluster
-		bundle      *v1alpha1.Bundles
-		eksdRelease *eksdv1alpha1.Release
-		wantErr     error
+		name    string
+		cluster anywherev1.Cluster
+		bundle  *v1alpha1.Bundles
+		client  kubernetes.Client
+		wantErr error
 	}{
 		{
 			name:    "no bundle signature",
@@ -37,7 +38,7 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 					},
 				},
 			},
-			wantErr: fmt.Errorf("missing bundle signature annotation"),
+			wantErr: fmt.Errorf("missing signature annotation"),
 		},
 		{
 			name: "kubernetes version not supported",
@@ -86,34 +87,7 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 					LicenseToken:      "",
 				},
 			},
-			bundle: validBundle(),
-			eksdRelease: &eksdv1alpha1.Release{
-				TypeMeta: v1.TypeMeta{
-					Kind:       "Release",
-					APIVersion: eksdv1alpha1.GroupVersion.String(),
-				},
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "kubernetes-1-28-46",
-					Namespace: constants.EksaSystemNamespace,
-				},
-				Spec: eksdv1alpha1.ReleaseSpec{
-					Channel: "1-28",
-					Number:  46,
-				},
-				Status: eksdv1alpha1.ReleaseStatus{
-					Components: []eksdv1alpha1.Component{
-						{
-							Name:   "metrics-server",
-							GitTag: "v0.7.2",
-							Assets: []eksdv1alpha1.Asset{
-								{
-									Name: "metrics-server-image",
-								},
-							},
-						},
-					},
-				},
-			},
+			bundle:  validBundle(),
 			wantErr: fmt.Errorf("licenseToken is required for extended kubernetes support"),
 		},
 		{
@@ -125,46 +99,12 @@ func TestValidateExtendedK8sVersionSupport(t *testing.T) {
 				},
 			},
 			bundle:  validBundle(),
-			eksdRelease: &eksdv1alpha1.Release{
-				TypeMeta: v1.TypeMeta{
-					Kind:       "Release",
-					APIVersion: eksdv1alpha1.GroupVersion.String(),
-				},
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "kubernetes-1-28-46",
-					Namespace: constants.EksaSystemNamespace,
-				},
-				Spec: eksdv1alpha1.ReleaseSpec{
-					Channel: "1-28",
-					Number:  46,
-				},
-				Status: eksdv1alpha1.ReleaseStatus{
-					Components: []eksdv1alpha1.Component{
-						{
-							Name:   "metrics-server",
-							GitTag: "v0.7.2",
-							Assets: []eksdv1alpha1.Asset{
-								{
-									Name: "metrics-server-image",
-								},
-							},
-						},
-					},
-				},
-			},
 			wantErr: fmt.Errorf("getting licenseToken"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(_ *testing.T) {
-			client := test.NewFakeKubeClient()
-			if tc.eksdRelease != nil {
-				cb := fake.NewClientBuilder()
-				cl := cb.WithRuntimeObjects(tc.eksdRelease).Build()
-				client = test.NewKubeClient(cl)
-			}
-
 			err := ValidateExtendedK8sVersionSupport(ctx, tc.cluster, tc.bundle, client)
 			if err != nil && !strings.Contains(err.Error(), tc.wantErr.Error()) {
 				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)
@@ -245,8 +185,7 @@ func validBundle() *v1alpha1.Bundles {
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
-				constants.SignatureAnnotation:                                  "MEUCIC1XI8WELDFzpbc3GEy8N0ZHIGWYmuoxVhK7nNU7lB3JAiEAkw3jtXn3eHnRuuo/P9Nr+Z6X8FXhTGVv+0ZiOpx7Sls=",
-				fmt.Sprintf("%s-1-28", constants.EKSDistroSignatureAnnotation): "MEUCIQC3uP3Dhfb/nhCeir0Hwtf4bddKVfVIauFWBidT18XZOwIgHjzH1mOxBm1N2l2w9wBVy9W1o6CQXpdDz7UcbCszZYc=",
+				constants.SignatureAnnotation: "MEYCIQC8Fuo81dxibtkvrOFZpbFXZGmJnhLN6bkJjx4YB0fGIQIhAJIxIAl3s26eXqcmS6kAyjDd0NXDlBbM0d/GCHcL2Xoo",
 			},
 		},
 		Spec: v1alpha1.BundlesSpec{
@@ -255,11 +194,6 @@ func validBundle() *v1alpha1.Bundles {
 				{
 					KubeVersion:          "1.28",
 					EndOfStandardSupport: "2024-12-31",
-					EksD: v1alpha1.EksDRelease{
-						Name:           "kubernetes-1-28-46",
-						ReleaseChannel: "1-28",
-						EksDReleaseUrl: "https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-46.yaml",
-					},
 				},
 			},
 		},

--- a/release/cli/pkg/operations/bundle_release.go
+++ b/release/cli/pkg/operations/bundle_release.go
@@ -268,7 +268,7 @@ func SignEKSDistroManifest(ctx context.Context, bundle *anywherev1alpha1.Bundles
 
 		fmt.Printf("Generating eks distro manifest signature for %s release channel with KMS key: %s\n", releaseChannel, constants.EKSDistroManifestKmsKey)
 
-		signature, err := sig.GetEKSDistroManifestSignature(ctx, constants.EKSDistroManifestKmsKey, releaseUrl)
+		signature, err := sig.GetEKSDistroManifestSignature(ctx, bundle, constants.EKSDistroManifestKmsKey, releaseUrl)
 		if err != nil {
 			return err
 		}

--- a/release/cli/pkg/signature/manifest.go
+++ b/release/cli/pkg/signature/manifest.go
@@ -84,7 +84,7 @@ func GetBundleSignature(ctx context.Context, bundle *anywherev1alpha1.Bundles, k
 
 // GetEKSDistroManifestSignature calls KMS and retrieves a signature, then base64-encodes it
 // to store in the Bundles manifest annotation.
-func GetEKSDistroManifestSignature(ctx context.Context, key, releaseUrl string) (string, error) {
+func GetEKSDistroManifestSignature(ctx context.Context, bundle *anywherev1alpha1.Bundles, key, releaseUrl string) (string, error) {
 	// Retrieve the eks-distro release from the release URL.
 	eksdRelease, err := filereader.GetEksdRelease(releaseUrl)
 	if err != nil {

--- a/release/cli/pkg/signature/manifest_test.go
+++ b/release/cli/pkg/signature/manifest_test.go
@@ -16,7 +16,6 @@ package signature
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -24,8 +23,6 @@ import (
 	anywherev1constants "github.com/aws/eks-anywhere/pkg/constants"
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
-
-	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 )
 
 func TestGetBundleSignature(t *testing.T) {
@@ -119,58 +116,19 @@ func TestGetBundleSignature(t *testing.T) {
 			sig, err := GetBundleSignature(ctx, tt.bundle, tt.key)
 
 			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(HaveOccurred(), "Expected no error but got: %v", err)
-				g.Expect(sig).NotTo(BeEmpty(), "Expected non-empty signature on success")
+				// Expecting no particular error substring -> test for success
+				g.Expect(err).NotTo(HaveOccurred(),
+					"Expected no error but got error: %v", err)
+				g.Expect(sig).NotTo(BeEmpty(),
+					"Expected signature string to be non-empty on success")
 			} else {
-				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
-				g.Expect(sig).To(BeEmpty(), "Expected empty signature when error occurs")
-			}
-		})
-	}
-}
-
-func TestGetEKSDistroManifestSignature(t *testing.T) {
-	testCases := []struct {
-		testName        string
-		bundle          *anywherev1alpha1.Bundles
-		key             string
-		releaseUrl      string
-		expectErrSubstr string
-	}{
-		{
-			testName:        "Invalid release URL",
-			bundle:          &anywherev1alpha1.Bundles{},
-			key:             constants.EKSDistroManifestKmsKey,
-			releaseUrl:      "invalid-test-url",
-			expectErrSubstr: "getting eks distro release",
-		},
-		{
-			testName:        "Valid eks distro manifest signature generation",
-			bundle:          &anywherev1alpha1.Bundles{},
-			key:             constants.EKSDistroManifestKmsKey,
-			releaseUrl:      "https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-46.yaml",
-			expectErrSubstr: "",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.testName, func(t *testing.T) {
-			g := NewWithT(t)
-
-			ctx := context.Background()
-			sig, err := GetEKSDistroManifestSignature(ctx, tt.bundle, tt.key, tt.releaseUrl)
-			if tt.testName == "Valid eks distro manifest signature generation" {
-				fmt.Println(sig)
-			}
-			
-			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(HaveOccurred(), "Expected no error but got: %v", err)
-				g.Expect(sig).NotTo(BeEmpty(), "Expected non-empty signature on success")
-			} else {
-				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error should contain substring %q, got: %v", tt.expectErrSubstr, err)
-				g.Expect(sig).To(BeEmpty(), "Expected empty signature when error occurs")
+				// Expecting an error substring -> test for error presence
+				g.Expect(err).To(HaveOccurred(),
+					"Expected an error but got none")
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr),
+					"Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(sig).To(BeEmpty(),
+					"Expected signature to be empty when error occurs")
 			}
 		})
 	}
@@ -222,67 +180,17 @@ func TestGetBundleDigest(t *testing.T) {
 
 			digest, filtered, err := getBundleDigest(tt.bundle)
 			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(HaveOccurred(), "Expected success but got error: %v", err)
-				g.Expect(digest).NotTo(BeZero(), "Expected non-zero digest")
-				g.Expect(filtered).NotTo(BeEmpty(), "Expected non-empty filtered output")
+				g.Expect(err).NotTo(HaveOccurred(), "Expected success but got error")
+				g.Expect(digest).NotTo(BeZero(),
+					"Expected digest to be non-zero array")
+				g.Expect(filtered).NotTo(BeEmpty(),
+					"Expected filtered bytes to be non-empty")
 			} else {
-				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
-				g.Expect(digest).To(BeZero())
-				g.Expect(filtered).To(BeNil())
-			}
-		})
-	}
-}
-
-func TestGetEKSDistroReleaseDigest(t *testing.T) {
-	testCases := []struct {
-		testName        string
-		release         *eksdv1alpha1.Release
-		expectErrSubstr string
-	}{
-		{
-			testName:        "Simple valid eks distro release",
-			release:         &eksdv1alpha1.Release{},
-			expectErrSubstr: "",
-		},
-		{
-			testName: "Populated eks distro release",
-			release: &eksdv1alpha1.Release{
-				Spec: eksdv1alpha1.ReleaseSpec{
-					Channel: "1-28",
-					Number: 46,
-				},
-				Status: eksdv1alpha1.ReleaseStatus{
-					Components: []eksdv1alpha1.Component{
-						{
-							Name:   "metrics-server",
-							GitTag: "v0.7.2",
-							Assets: []eksdv1alpha1.Asset{
-								{
-									Name: "metrics-server-image",
-								},
-							},
-						},
-					},
-				},
-			},
-			expectErrSubstr: "",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.testName, func(t *testing.T) {
-			g := NewWithT(t)
-
-			digest, filtered, err := getEKSDistroReleaseDigest(tt.release)
-			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(HaveOccurred(), "Expected success but got error: %v", err)
-				g.Expect(digest).NotTo(BeZero(), "Expected non-zero digest")
-				g.Expect(filtered).NotTo(BeEmpty(), "Expected non-empty filtered output")
-			} else {
-				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(err).To(HaveOccurred(),
+					"Expected error but got none")
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr),
+					"Error message should contain substring %q, got: %v",
+					tt.expectErrSubstr, err)
 				g.Expect(digest).To(BeZero())
 				g.Expect(filtered).To(BeNil())
 			}

--- a/release/cli/pkg/signature/manifest_test.go
+++ b/release/cli/pkg/signature/manifest_test.go
@@ -16,6 +16,7 @@ package signature
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -132,18 +133,21 @@ func TestGetBundleSignature(t *testing.T) {
 func TestGetEKSDistroManifestSignature(t *testing.T) {
 	testCases := []struct {
 		testName        string
+		bundle          *anywherev1alpha1.Bundles
 		key             string
 		releaseUrl      string
 		expectErrSubstr string
 	}{
 		{
 			testName:        "Invalid release URL",
+			bundle:          &anywherev1alpha1.Bundles{},
 			key:             constants.EKSDistroManifestKmsKey,
 			releaseUrl:      "invalid-test-url",
 			expectErrSubstr: "getting eks distro release",
 		},
 		{
 			testName:        "Valid eks distro manifest signature generation",
+			bundle:          &anywherev1alpha1.Bundles{},
 			key:             constants.EKSDistroManifestKmsKey,
 			releaseUrl:      "https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-46.yaml",
 			expectErrSubstr: "",
@@ -155,7 +159,10 @@ func TestGetEKSDistroManifestSignature(t *testing.T) {
 			g := NewWithT(t)
 
 			ctx := context.Background()
-			sig, err := GetEKSDistroManifestSignature(ctx, tt.key, tt.releaseUrl)
+			sig, err := GetEKSDistroManifestSignature(ctx, tt.bundle, tt.key, tt.releaseUrl)
+			if tt.testName == "Valid eks distro manifest signature generation" {
+				fmt.Println(sig)
+			}
 			
 			if tt.expectErrSubstr == "" {
 				g.Expect(err).NotTo(HaveOccurred(), "Expected no error but got: %v", err)


### PR DESCRIPTION
*Issue #, if available:*
The 1.28 airgapped registry mirror tests failed with the following error:
```
"failureMessage": "reading eksd release manifest file: open eks-anywhere-downloads/1.28/eks-distro/kubernetes-1-28-eks-46.yaml: no such file or directory",
"failureReason": "ExtendedKubernetesVersionSupportNotSupported"
```
This is because the EKS-A controller is not able to access the local file path for the distro manifest on the admin machine. The controller should get the manifest from the Release object within the cluster once the EKS-D manifest is applied during cluster creation for any future upgrade validations. The CLI can get it from the local file path so this will require separate handling from the controller and the logic for eks distro manifest signature validation needs to be moved out of the common logic for the CLI and controller extended support validations. We will do this in the next patch release.

*Description of changes:*
This PR reverts #9609 and and #9636.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

