### PR TITLE
Fix framework setup for TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -1683,7 +1683,7 @@ func TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
 		framework.NewTinkerbell(t,
-			framework.WithUbuntu131Tinkerbell(),
+			framework.WithUbuntu132Tinkerbell(),
 			framework.WithHookImagesURLPath("http://"+localIp.String()+":8080"),
 		),
 		framework.WithClusterFiller(


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow has been failing with below error. This is because it is using 131 framework setup

```
Validation failed    {"validation": "tinkerbell Provider setup is valid", "error": "missing kube version from OSImageURL: url=http://10.80.18.43:8080/ubuntu/2004/ubuntu-1-31.gz, version=1.32", "remediation": ""}
```

In this PR, I am updating the test to use 132 framework setup

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

