### PR TITLE
Push packages helm chart to public ECR on all branches

### DIFF
--- a/release/cli/pkg/bundles/package-controller.go
+++ b/release/cli/pkg/bundles/package-controller.go
@@ -51,7 +51,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
 	artifactHashes := []string{}
 
-	// Find latest Package Dev build for the Helm chart and Image which will always start with `0.0.0` and is built off of the package Github repo main on every commit.
+	// Find latest Packages dev build for the Helm chart and Image which will always start with `0.0.0` for helm chart and `v0.0.0` for images respectively.
 	// If we can't find the build starting with our substring, we default to the original dev tag.
 	// If we do find the Tag in Private ECR, but it doesn't exist in Public ECR Copy the image over so the helm chart will work correctly.
 	if r.DevRelease && !r.DryRun {
@@ -157,7 +157,7 @@ func GetPackagesBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.
 		}
 	}
 
-	if !r.DryRun && r.DevRelease && r.BuildRepoBranchName == "main" {
+	if !r.DryRun && r.DevRelease {
 		for _, componentName := range sortedComponentNames {
 			for _, artifact := range packagesArtifacts[componentName] {
 				if artifact.Image != nil {


### PR DESCRIPTION
*Issue #, if available:*
All the packages E2E tests are failing on the release branch with the following error:
```
2025-04-20T03:46:56.748Z	V0	⚠️  Failed to install the optional EKS-A Curated Package Controller. Please try installation again through eksctl after the cluster creation succeeds	{"warning": "Error: public.ecr.aws/x3k6m8v0/eks-anywhere-packages:0.0.0-6b6163d76e817b54370ebe30334465d02363cfd9-release-0.22-helm: not found\n"}
```
This is because the packages helm charts for the release branch does not exist in the public ECR.

*Description of changes:*
This PR updates the bundles manifest spec generation phase in the dev release to push the packages helm charts for all the branches and not just for the main branch to fix the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

