### PR TITLE
Fix bundles override flag issue for upgrade cluster command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/upgradecluster.go
+++ b/cmd/eksctl-anywhere/cmd/upgradecluster.go
@@ -200,7 +200,7 @@ func (uc *upgradeClusterOptions) upgradeCluster(cmd *cobra.Command, args []strin
 		SkippedValidations: skippedValidations,
 		KubeClient:         deps.UnAuthKubeClient.KubeconfigClient(managementCluster.KubeconfigFile),
 		ManifestReader:     deps.ManifestReader,
-		BundlesOverride:    cc.bundlesOverride,
+		BundlesOverride:    uc.bundlesOverride,
 	}
 
 	upgradeValidations := upgradevalidations.New(validationOpts)


### PR DESCRIPTION
*Description of changes:*
In the release-0.22, in an airgapped environment, upgrade command with the `--bunldles-override` flag panics during pre flight validation. This PR fixes that issue.

*Testing (if applicable):*
Created a cluster with the release version `v0.21.7` and upgraded it successfully with the release version `v0.22.x`.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

