### PR TITLE
Use 1.28 kubernetes version for docker upgrade from latest tests

### DIFF
--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -944,9 +944,9 @@ func TestDockerKubernetes131to132GithubFluxEnabledUpgradeFromLatestMinorRelease(
 	)
 }
 
-func TestDockerKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+func TestDockerKubernetes128WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewDocker(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube132)
+	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube128)
 }
 
 // Workload Cluster API
@@ -1439,7 +1439,7 @@ func TestDockerKubernetesNonRegionalCuratedPackages(t *testing.T) {
 func TestDockerKubernetesUpgradeManagementComponents(t *testing.T) {
 	release := latestMinorRelease(t)
 	provider := framework.NewDocker(t)
-	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube132, "")
+	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube128, "")
 }
 
 // Etcd Scale tests

--- a/test/e2e/upgrade_from_latest.go
+++ b/test/e2e/upgrade_from_latest.go
@@ -198,6 +198,7 @@ func runMulticlusterUpgradeFromReleaseFlowAPIWithFlux(test *framework.Multiclust
 }
 
 func runUpgradeManagementComponentsFlow(t *testing.T, release *releasev1.EksARelease, provider framework.Provider, kubeVersion anywherev1.KubernetesVersion, os framework.OS) {
+	licenseToken := framework.GetLicenseToken()
 	test := framework.NewClusterE2ETest(t, provider)
 	// create cluster with old eksa
 	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
@@ -206,6 +207,7 @@ func runUpgradeManagementComponentsFlow(t *testing.T, release *releasev1.EksARel
 			api.WithKubernetesVersion(kubeVersion),
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),
+			api.WithLicenseToken(licenseToken),
 		),
 		provider.WithKubeVersionAndOS(kubeVersion, os, release),
 	)


### PR DESCRIPTION
*Issue #, if available:*
The `TestDockerKubernetesUpgradeManagementComponents` and `TestDockerKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects` e2e tests have been failing on the `release-0.22` branch with the following error:
```
cluster.go:994: Command bin/v0.21.7/eksctl-anywhere [create cluster -f release-i-02fe7-b81ecc6/release-i-02fe7-b81ecc6-eks-a.yaml -v 6] failed with error: exit status 255: Error: unable to get cluster config from file: kubernetes version 1.32 is not supported by bundles manifest 91
```
This is because the latest minor release from 0.22 branch would be 0.21 which does not have kubernetes version 1.32 supported.

Failing upgrade from latest tests:
```
TestDockerKubernetesUpgradeManagementComponents
TestDockerKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects
```

*Description of changes:*
This PR fixes the above issue by using kubernetes version 1.28 for these tests which has been used on all other previous release branches as well. It also adds the license token to the upgrade management components flow so that it doesn't fail on extended kubernetes version support validations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

