### PR TITLE
Remove conditional sessiontoken in cert manager test data pod

### DIFF
--- a/test/framework/testdata/certmanager/certmanager_package.yaml
+++ b/test/framework/testdata/certmanager/certmanager_package.yaml
@@ -12,7 +12,5 @@ spec:
         value: {{.accessKeyId}}
       - name: AWS_SECRET_ACCESS_KEY
         value: {{.secretKey}}
-{{- if .sessionToken }}
       - name: AWS_SESSION_TOKEN
         value: {{.sessionToken}}
-{{- end }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Session token is not being passed to cert manager test pod. Removing conditional sessiontoken in cert manager test data pod as this is not required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


