### PR TITLE
Add boots/smee container logs to support bundle

### DIFF
--- a/pkg/diagnostics/collector_types.go
+++ b/pkg/diagnostics/collector_types.go
@@ -14,6 +14,7 @@ type Collect struct {
 	CopyFromHost     *copyFromHost     `json:"copyFromHost,omitempty"`
 	Exec             *exec             `json:"exec,omitempty"`
 	RunPod           *runPod           `json:"runPod,omitempty"`
+	Run              *Run              `json:"run,omitempty"`
 }
 
 type clusterResources struct {
@@ -93,4 +94,17 @@ type runPod struct {
 	PodSpec          *v1.PodSpec `json:"podSpec,omitempty"`
 	Timeout          string      `json:"timeout,omitempty"`
 	imagePullSecrets `json:",inline"`
+}
+
+// Run is used to define config for commands ran on host via troubleshoot.
+type Run struct {
+	CollectorName    string            `json:"collectorName,omitempty"`
+	Command          string            `json:"command"`
+	Args             []string          `json:"args"`
+	Env              []string          `json:"env,omitempty"`
+	IgnoreParentEnvs bool              `json:"ignoreParentEnvs,omitempty"`
+	InheritEnvs      []string          `json:"inheritEnvs,omitempty"`
+	OutputDir        string            `json:"outputDir,omitempty"`
+	Input            map[string]string `json:"input,omitempty"`
+	Timeout          string            `json:"timeout,omitempty"`
 }

--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -76,6 +76,17 @@ func (c *EKSACollectorFactory) EksaHostCollectors(machineConfigs []providers.Mac
 	return collectors
 }
 
+// HostCollectors returns the collectors that run on host machines.
+func (c *EKSACollectorFactory) HostCollectors(datacenter v1alpha1.Ref) []*Collect {
+	// Only Tinkerbell needs this right now to collect boots/smee logs in docker container.
+	switch datacenter.Kind {
+	case v1alpha1.TinkerbellDatacenterKind:
+		return c.hostTinkerbellCollectors()
+	default:
+		return nil
+	}
+}
+
 // DataCenterConfigCollectors returns the collectors for the provider datacenter config in the cluster spec.
 func (c *EKSACollectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Ref, spec *cluster.Spec) []*Collect {
 	switch datacenter.Kind {
@@ -170,6 +181,21 @@ func (c *EKSACollectorFactory) eksaDockerCollectors() []*Collect {
 			},
 		},
 	}
+}
+
+func (c *EKSACollectorFactory) hostTinkerbellCollectors() []*Collect {
+	collectors := []*Collect{
+		{
+			Run: &Run{
+				CollectorName: "boots-logs",
+				Command:       "docker",
+				Args:          []string{"logs", "boots"},
+				OutputDir:     "boots-logs",
+			},
+		},
+	}
+
+	return collectors
 }
 
 // ManagementClusterCollectors returns the collectors that only apply to management clusters.

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -55,6 +55,7 @@ type AnalyzerFactory interface {
 type CollectorFactory interface {
 	PackagesCollectors() []*Collect
 	DefaultCollectors() []*Collect
+	HostCollectors(datacenter v1alpha1.Ref) []*Collect
 	FileCollectors(paths []string) []*Collect
 	ManagementClusterCollectors() []*Collect
 	EksaHostCollectors(configs []providers.MachineConfig) []*Collect

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -600,6 +600,20 @@ func (mr *MockCollectorFactoryMockRecorder) FileCollectors(paths interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).FileCollectors), paths)
 }
 
+// HostCollectors mocks base method.
+func (m *MockCollectorFactory) HostCollectors(datacenter v1alpha1.Ref) []*diagnostics.Collect {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HostCollectors", datacenter)
+	ret0, _ := ret[0].([]*diagnostics.Collect)
+	return ret0
+}
+
+// HostCollectors indicates an expected call of HostCollectors.
+func (mr *MockCollectorFactoryMockRecorder) HostCollectors(datacenter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).HostCollectors), datacenter)
+}
+
 // ManagementClusterCollectors mocks base method.
 func (m *MockCollectorFactory) ManagementClusterCollectors() []*diagnostics.Collect {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/4179
*Description of changes:*
Smee logs now accessible in support-bundle

The following gets added to support bundle yaml following troubleshoot docs [here](https://troubleshoot.sh/docs/host-collect-analyze/run/)
```
---
apiVersion: troubleshoot.sh/v1beta2
kind: HostCollector
metadata:
  creationTimestamp: null
  name: host-collector
spec:
  collectors:
  - run:
      args:
      - logs
      - boots
      collectorName: boots-logs
      command: docker
      outputDir: boots-logs
```
Creates a new nested directory at `host-collectors/run-host`
```
largchar@largchar-dev:~$ ls support-bundle-2025-04-24T04_37_28/host-collectors/run-host
```
Smee logs located here
```
largchar@largchar-dev:~$ ls support-bundle-2025-04-24T04_37_28/host-collectors/run-host/
boots-logs-info.json boots-logs.txt
```

### Example content
boots-logs.txt
```
largchar@largchar-dev:~$ cat support-bundle-2025-04-24T04_37_28/host-collectors/run-host/boots-logs.txt
{"time":"2025-04-24T04:35:56.055793582Z","level":"INFO","source":{"function":"main.main","file":"cmd/smee/main.go","line":157},"msg":"starting","version":"0b77c7d"}
{"time":"2025-04-24T04:35:56.056328617Z","level":"INFO","source":{"function":"main.main","file":"cmd/smee/main.go","line":179},"msg":"starting syslog server","bind_addr":"10.80.8.110:514"}
{"time":"2025-04-24T04:35:56.056359636Z","level":"INFO","source":{"function":"main.main","file":"cmd/smee/main.go","line":209},"msg":"starting tftp server","bind_addr":"10.80.8.110:69"}
{"time":"2025-04-24T04:35:56.059453899Z","level":"INFO","source":{"function":"github.com/tinkerbell/ipxedust.(*Server).listenAndServeTFTP","file":"tinkerbell/ipxedust@v0.0.0-20241209190914-3b26a5502f13/ipxedust.go","line":201},"msg":"serving iPXE binaries via TFTP","service":"github.com/tinkerbell/smee","logger":"github.com/tinkerbell/ipxedust","addr":"10.80.8.110:69","blocksize":512,"timeout":5000000000,"singlePortEnabled":true}
{"time":"2025-04-24T04:35:56.071567685Z","level":"INFO","source":{"function":"main.main","file":"cmd/smee/main.go","line":291},"msg":"serving http","addr":"10.80.8.110:7171","trusted_proxies":null}
{"time":"2025-04-24T04:35:56.073374249Z","level":"INFO","source":{"function":"main.main","file":"cmd/smee/main.go","line":304},"msg":"starting dhcp server","bind_addr":"0.0.0.0:67"}
{"time":"2025-04-24T04:35:56.073565679Z","level":"INFO","source":{"function":"internal/dhcp/server.(*DHCP).Serve","file":"dhcp/server/dhcp.go","line":35},"msg":"Server listening on","addr":{"IP":"0.0.0.0","Port":67,"Zone":""}}
```
boots-logs-info.json
```
largchar@largchar-dev:~$ cat support-bundle-2025-04-24T04_37_28/host-collectors/run-host/boots-logs-info.json 
{"command":"/usr/bin/docker logs boots","exitCode":"0","error":"","outputDir":"","input":"","env":["PATH=/eks-a-tools/binary:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","HOSTNAME=largchar-dev","HOME=/root","TS_OUTPUT_DIR=/tmp/boots-logs3949852056/boots-logs"]}

```

