### PR TITLE
Add ROUTE53_SESSION_TOKEN to required envs

### DIFF
--- a/test/framework/curatedpackages.go
+++ b/test/framework/curatedpackages.go
@@ -54,6 +54,7 @@ var requiredCertManagerEnvVars = []string{
 	route53Region,
 	route53AccessKey,
 	route53SecretKey,
+	route53SessionToken,
 	route53ZoneID,
 }
 


### PR DESCRIPTION


*Description of changes:*
In e2e test, cert manager pod in worklaod cluster does not have session token set. This is because it is not in required env variables and hence we are not setting it. In this PR, I am adding to required env vars so that session token will be available in the cert manager pod def

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


