### PR TITLE
Add flag to include api server audit logs in support bundle

### DIFF
--- a/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
+++ b/cmd/eksctl-anywhere/cmd/generatebundleconfig.go
@@ -84,7 +84,7 @@ func (gsbo *generateSupportBundleOptions) generateBundleConfig(ctx context.Conte
 	}
 	defer close(ctx, deps)
 
-	return deps.DignosticCollectorFactory.DiagnosticBundleWorkloadCluster(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Cluster.Name))
+	return deps.DignosticCollectorFactory.DiagnosticBundleWorkloadCluster(clusterSpec, deps.Provider, kubeconfig.FromClusterName(clusterSpec.Cluster.Name), false)
 }
 
 func (gsbo *generateSupportBundleOptions) generateDefaultBundleConfig(ctx context.Context) (diagnostics.DiagnosticBundle, error) {

--- a/docs/content/en/docs/clustermgmt/support/supportbundle.md
+++ b/docs/content/en/docs/clustermgmt/support/supportbundle.md
@@ -43,6 +43,7 @@ If you want to generate support bundle in an airgapped environment, the `--bundl
 of your eks-a bundles manifest yaml file.
 ```
 Flags:
+      --audit-logs             Include the latest api server audit log file in the support bundle
       --bundle-config string   Bundle Config file to use when generating support bundle
   -f, --filename string        Filename that contains EKS-A cluster configuration
   -h, --help                   Help for support-bundle

--- a/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle.md
+++ b/docs/content/en/docs/reference/eksctl/anywhere_generate_support-bundle.md
@@ -18,6 +18,7 @@ anywhere generate support-bundle -f my-cluster.yaml [flags]
 ### Options
 
 ```
+      --audit-logs             Include the latest api server audit log file in the support bundle
       --bundle-config string   Bundle Config file to use when generating support bundle
   -f, --filename string        Filename that contains EKS-A cluster configuration
   -h, --help                   help for support-bundle

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -445,7 +445,7 @@ func (c *ClusterManager) SaveLogsWorkloadCluster(ctx context.Context, provider p
 		return nil
 	}
 
-	bundle, err := c.diagnosticsFactory.DiagnosticBundleWorkloadCluster(spec, provider, cluster.KubeconfigFile)
+	bundle, err := c.diagnosticsFactory.DiagnosticBundleWorkloadCluster(spec, provider, cluster.KubeconfigFile, false)
 	if err != nil {
 		logger.V(5).Info("Error generating support bundle for workload cluster", "error", err)
 		return nil

--- a/pkg/clustermanager/cluster_manager_test.go
+++ b/pkg/clustermanager/cluster_manager_test.go
@@ -141,7 +141,7 @@ func TestClusterManagerSaveLogsSuccess(t *testing.T) {
 	m.diagnosticsFactory.EXPECT().DiagnosticBundleManagementCluster(clusterSpec, bootstrapCluster.KubeconfigFile).Return(b, nil)
 	b.EXPECT().CollectAndAnalyze(ctx, gomock.AssignableToTypeOf(&time.Time{}))
 
-	m.diagnosticsFactory.EXPECT().DiagnosticBundleWorkloadCluster(clusterSpec, m.provider, workloadCluster.KubeconfigFile).Return(b, nil)
+	m.diagnosticsFactory.EXPECT().DiagnosticBundleWorkloadCluster(clusterSpec, m.provider, workloadCluster.KubeconfigFile, false).Return(b, nil)
 	b.EXPECT().CollectAndAnalyze(ctx, gomock.AssignableToTypeOf(&time.Time{}))
 
 	if err := c.SaveLogsManagementCluster(ctx, clusterSpec, bootstrapCluster); err != nil {

--- a/pkg/diagnostics/collector_types.go
+++ b/pkg/diagnostics/collector_types.go
@@ -15,6 +15,7 @@ type Collect struct {
 	Exec             *exec             `json:"exec,omitempty"`
 	RunPod           *runPod           `json:"runPod,omitempty"`
 	Run              *Run              `json:"run,omitempty"`
+	RunDaemonSet     *RunDaemonSet     `json:"runDaemonSet,omitempty"`
 }
 
 type clusterResources struct {
@@ -107,4 +108,14 @@ type Run struct {
 	OutputDir        string            `json:"outputDir,omitempty"`
 	Input            map[string]string `json:"input,omitempty"`
 	Timeout          string            `json:"timeout,omitempty"`
+}
+
+// RunDaemonSet is used to define config for daemonset ran on hosts via troubleshoot.
+type RunDaemonSet struct {
+	collectorMeta    `json:",inline"`
+	Name             string      `json:"name,omitempty"`
+	Namespace        string      `json:"namespace,omitempty"`
+	PodSpec          *v1.PodSpec `json:"podSpec"`
+	Timeout          string      `json:"timeout,omitempty"`
+	imagePullSecrets `json:",inline"`
 }

--- a/pkg/diagnostics/factory.go
+++ b/pkg/diagnostics/factory.go
@@ -35,9 +35,9 @@ func NewFactory(opts EksaDiagnosticBundleFactoryOpts) *eksaDiagnosticBundleFacto
 	}
 }
 
-func (f *eksaDiagnosticBundleFactory) DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig string, bundlePath string) (DiagnosticBundle, error) {
+func (f *eksaDiagnosticBundleFactory) DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig string, bundlePath string, auditLogs bool) (DiagnosticBundle, error) {
 	if bundlePath == "" && spec != nil {
-		b, err := f.DiagnosticBundleWorkloadCluster(spec, provider, kubeconfig)
+		b, err := f.DiagnosticBundleWorkloadCluster(spec, provider, kubeconfig, auditLogs)
 		return b, err
 	}
 	return f.DiagnosticBundleCustom(kubeconfig, bundlePath), nil
@@ -47,8 +47,8 @@ func (f *eksaDiagnosticBundleFactory) DiagnosticBundleManagementCluster(spec *cl
 	return newDiagnosticBundleManagementCluster(f.analyzerFactory, f.collectorFactory, spec, f.client, f.kubectl, kubeconfig, f.writer)
 }
 
-func (f *eksaDiagnosticBundleFactory) DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (DiagnosticBundle, error) {
-	return newDiagnosticBundleFromSpec(f.analyzerFactory, f.collectorFactory, spec, provider, f.client, f.kubectl, kubeconfig, f.writer)
+func (f *eksaDiagnosticBundleFactory) DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string, auditLogs bool) (DiagnosticBundle, error) {
+	return newDiagnosticBundleFromSpec(f.analyzerFactory, f.collectorFactory, spec, provider, f.client, f.kubectl, kubeconfig, f.writer, auditLogs)
 }
 
 func (f *eksaDiagnosticBundleFactory) DiagnosticBundleDefault() DiagnosticBundle {

--- a/pkg/diagnostics/interfaces.go
+++ b/pkg/diagnostics/interfaces.go
@@ -16,8 +16,8 @@ type BundleClient interface {
 }
 
 type DiagnosticBundleFactory interface {
-	DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig string, bundlePath string) (DiagnosticBundle, error)
-	DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (DiagnosticBundle, error)
+	DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig string, bundlePath string, auditLogs bool) (DiagnosticBundle, error)
+	DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string, auditLogs bool) (DiagnosticBundle, error)
 	DiagnosticBundleManagementCluster(spec *cluster.Spec, kubeconfig string) (DiagnosticBundle, error)
 	DiagnosticBundleDefault() DiagnosticBundle
 	DiagnosticBundleCustom(kubeconfig string, bundlePath string) DiagnosticBundle
@@ -56,6 +56,7 @@ type CollectorFactory interface {
 	PackagesCollectors() []*Collect
 	DefaultCollectors() []*Collect
 	HostCollectors(datacenter v1alpha1.Ref) []*Collect
+	AuditLogCollectors() []*Collect
 	FileCollectors(paths []string) []*Collect
 	ManagementClusterCollectors() []*Collect
 	EksaHostCollectors(configs []providers.MachineConfig) []*Collect

--- a/pkg/diagnostics/interfaces/mocks/diagnostics.go
+++ b/pkg/diagnostics/interfaces/mocks/diagnostics.go
@@ -94,18 +94,18 @@ func (m *MockDiagnosticBundleFactory) EXPECT() *MockDiagnosticBundleFactoryMockR
 }
 
 // DiagnosticBundle mocks base method.
-func (m *MockDiagnosticBundleFactory) DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig, bundlePath string) (diagnostics.DiagnosticBundle, error) {
+func (m *MockDiagnosticBundleFactory) DiagnosticBundle(spec *cluster.Spec, provider providers.Provider, kubeconfig, bundlePath string, auditLogs bool) (diagnostics.DiagnosticBundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiagnosticBundle", spec, provider, kubeconfig, bundlePath)
+	ret := m.ctrl.Call(m, "DiagnosticBundle", spec, provider, kubeconfig, bundlePath, auditLogs)
 	ret0, _ := ret[0].(diagnostics.DiagnosticBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DiagnosticBundle indicates an expected call of DiagnosticBundle.
-func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundle(spec, provider, kubeconfig, bundlePath interface{}) *gomock.Call {
+func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundle(spec, provider, kubeconfig, bundlePath, auditLogs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundle", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundle), spec, provider, kubeconfig, bundlePath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundle", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundle), spec, provider, kubeconfig, bundlePath, auditLogs)
 }
 
 // DiagnosticBundleCustom mocks base method.
@@ -152,18 +152,18 @@ func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleManagementClu
 }
 
 // DiagnosticBundleWorkloadCluster mocks base method.
-func (m *MockDiagnosticBundleFactory) DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string) (diagnostics.DiagnosticBundle, error) {
+func (m *MockDiagnosticBundleFactory) DiagnosticBundleWorkloadCluster(spec *cluster.Spec, provider providers.Provider, kubeconfig string, auditLogs bool) (diagnostics.DiagnosticBundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiagnosticBundleWorkloadCluster", spec, provider, kubeconfig)
+	ret := m.ctrl.Call(m, "DiagnosticBundleWorkloadCluster", spec, provider, kubeconfig, auditLogs)
 	ret0, _ := ret[0].(diagnostics.DiagnosticBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DiagnosticBundleWorkloadCluster indicates an expected call of DiagnosticBundleWorkloadCluster.
-func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleWorkloadCluster(spec, provider, kubeconfig interface{}) *gomock.Call {
+func (mr *MockDiagnosticBundleFactoryMockRecorder) DiagnosticBundleWorkloadCluster(spec, provider, kubeconfig, auditLogs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleWorkloadCluster", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleWorkloadCluster), spec, provider, kubeconfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiagnosticBundleWorkloadCluster", reflect.TypeOf((*MockDiagnosticBundleFactory)(nil).DiagnosticBundleWorkloadCluster), spec, provider, kubeconfig, auditLogs)
 }
 
 // MockDiagnosticBundle is a mock of DiagnosticBundle interface.
@@ -542,6 +542,20 @@ func NewMockCollectorFactory(ctrl *gomock.Controller) *MockCollectorFactory {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCollectorFactory) EXPECT() *MockCollectorFactoryMockRecorder {
 	return m.recorder
+}
+
+// AuditLogCollectors mocks base method.
+func (m *MockCollectorFactory) AuditLogCollectors() []*diagnostics.Collect {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuditLogCollectors")
+	ret0, _ := ret[0].([]*diagnostics.Collect)
+	return ret0
+}
+
+// AuditLogCollectors indicates an expected call of AuditLogCollectors.
+func (mr *MockCollectorFactoryMockRecorder) AuditLogCollectors() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuditLogCollectors", reflect.TypeOf((*MockCollectorFactory)(nil).AuditLogCollectors))
 }
 
 // DataCenterConfigCollectors mocks base method.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3210
*Description of changes:*
Adds a flag `--audit-logs` to `generate support-bundle` command. When specified, will include the latest api server audit log file in the support bundle.

It achieves this by using troubleshoot, with the RunDaemonSet collector. It only runs on control plane nodes, via a node selector. Only the latest log file will be collected, which can be up to 512MB due to `audit-log-maxsize: "512"` on api server pods. With multiple control plane nodes, the max size of these logs included could be a few GB. 

Example run

```
./bin/eksctl-anywhere generate support-bundle -f ~/vsphere/largchar-colo-mgmt-vsphere.yaml --audit-logs
```

Example output from my support bundle

```
[ec2-user@ip-172-31-22-5 eks-anywhere]$ ls -lh support-bundle-2025-04-29T20_31_39/audit-logs/
total 636M
-rw-------. 1 ec2-user ec2-user 282M Apr 29 20:35 largchar-colo-mgmt-vsphere-44jzw.log
-rw-------. 1 ec2-user ec2-user 355M Apr 29 20:35 largchar-colo-mgmt-vsphere-knspr.log
```

*Testing (if applicable):*
Tested on Ubuntu, RHEL and Bottlerocket
*Documentation added/planned (if applicable):*
Flag has been added to public docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

