### PR TITLE
[Release 0.22] Set some missing smee cli flags

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -282,6 +282,9 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 		"-dhcp-addr", "0.0.0.0:67",
 		"-osie-url", osiePath,
 		"-tink-server", fmt.Sprintf("%s:%s", tinkServerIP, grpcPort),
+		"-syslog-addr", tinkServerIP,
+		"-tftp-addr", tinkServerIP,
+		"-http-addr", tinkServerIP,
 	}
 	if err := s.docker.Run(ctx, s.localRegistryURL(bundle.Boots.URI), boots, cmd, flags...); err != nil {
 		return fmt.Errorf("running boots with docker: %v", err)

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -241,7 +241,15 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 			if stackTest.installOnDocker {
 				docker.EXPECT().Run(ctx, "public.ecr.aws/eks-anywhere/boots:latest",
 					boots,
-					[]string{"-backend-kube-config", "/kubeconfig", "-dhcp-addr", "0.0.0.0:67", "-osie-url", "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook", "-tink-server", "1.2.3.4:42113"},
+					[]string{
+						"-backend-kube-config", "/kubeconfig",
+						"-dhcp-addr", "0.0.0.0:67",
+						"-osie-url", "https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook",
+						"-tink-server", "1.2.3.4:42113",
+						"-syslog-addr", testIP,
+						"-tftp-addr", testIP,
+						"-http-addr", testIP,
+					},
 					"-v", gomock.Any(),
 					"--network", "host",
 					"-e", gomock.Any(),


### PR DESCRIPTION
*Description of changes:*
Manual backport of https://github.com/aws/eks-anywhere/pull/8760

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

