### PR TITLE
Fix vSPhere e2e tests from latest minor release

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -5475,7 +5475,7 @@ func TestVSphereKubernetes131BottlerocketTo132StackedEtcdUpgrade(t *testing.T) {
 	)
 }
 
-func TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+func TestVSphereKubernetes131Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
 	licenseToken := framework.GetLicenseToken()
 	release := latestMinorRelease(t)
 	useBundlesOverride := false
@@ -5483,12 +5483,12 @@ func TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) 
 		framework.WithVSphereFillers(
 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
 		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.RedHat9, release, useBundlesOverride),
+		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube131, framework.RedHat9, release, useBundlesOverride),
 	)
 	test := framework.NewClusterE2ETest(
 		t,
 		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
@@ -5506,9 +5506,9 @@ func TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) 
 	)
 }
 
-func TestVSphereKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+func TestVSphereKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewVSphere(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.Ubuntu2004, v1alpha1.Kube132)
+	runTestManagementClusterUpgradeSideEffects(t, provider, framework.Ubuntu2004, v1alpha1.Kube131)
 }
 
 func TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {


### PR DESCRIPTION
The TestVSphereKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects e2e test have been failing on the release-0.22 branch with the following error:

```
Error: unable to get cluster config from file: kubernetes version 1.32 is not supported by bundles manifest 98
```
and test TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease fails with panic.

This is because the latest minor release from 0.22 branch would be 0.21 which does not have kubernetes version 1.32 supported.

*Description of changes:*

This PR fixes the above issue by using kubernetes version 1.31 for these tests.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

