### PR TITLE
[release-0.22] Skip vSphere 1.32, RHEL9 e2e tests from latest minor release

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -9,6 +9,8 @@ skipped_tests:
 - TestVSphereKubernetes129To130Redhat9UpgradeFromLatestMinorRelease
 - TestVSphereKubernetes130To131Redhat9UpgradeFromLatestMinorRelease
 - TestVSphereKubernetes131To132Redhat9UpgradeFromLatestMinorRelease
+- TestVSphereKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects
+- TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease
 
 # CloudStack
 # Airgapped tests due to an airgapped network not being setup properly on the cloudstack CI env.


### PR DESCRIPTION
The TestVSphereKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects e2e test have been failing on the release-0.22 branch with the following error:

Error: unable to get cluster config from file: kubernetes version 1.32 is not supported by bundles manifest 98
and test TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease fails with panic.

This is because the latest minor release from 0.22 branch would be 0.21 which does not have kubernetes version 1.32 supported.

Skipping these tests on the release-0.22 branch since the previous minor release-0.21 does not have 1.32 kubernetes support as well as RHEL9 support. 

Description of changes:

This PR fixes the above issue by using kubernetes version 1.31 for these tests.