### PR TITLE
Improvement: AdditionlTrustBundle using ConfigMap to CAPX

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -35,9 +35,9 @@ spec:
   prismCentral:
 {{- if .nutanixAdditionalTrustBundle }}
     additionalTrustBundle:
-      kind: String
-      data: |
-{{ .nutanixAdditionalTrustBundle | indent 8 }}
+      kind: ConfigMap
+      name: "{{.clusterName}}-trust-bundle"
+      namespace: {{.eksaSystemNamespace}}
 {{- end }}
     address: "{{.nutanixEndpoint}}"
     port: {{.nutanixPort}}
@@ -614,8 +614,8 @@ data:
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: user-ca-bundle
-      namespace: kube-system
+      name: {{.clusterName}}-trust-bundle
+      namespace: {{.eksaSystemNamespace}}
     data:
       ca.crt: |
 {{ .nutanixAdditionalTrustBundle | indent 8 }}
@@ -646,8 +646,8 @@ data:
             }{{- if .nutanixAdditionalTrustBundle }},
             "additionalTrustBundle": {
               "kind": "ConfigMap",
-              "name": "user-ca-bundle",
-              "namespace": "kube-system"
+              "name": {{.clusterName}}-trust-bundle,
+              "namespace": {{.eksaSystemNamespace}}
             }{{- end }}
           },
           "enableCustomLabeling": false,
@@ -836,7 +836,8 @@ spec:
     name: {{.clusterName}}-nutanix-ccm-secret
 {{- if .nutanixAdditionalTrustBundle }}
   - kind: ConfigMap
-    name: user-ca-bundle
+    name: {{.clusterName}}-trust-bundle
+    namespace: {{.eksaSystemNamespace}}
 {{- end }}
   strategy: Reconcile
 ---

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -7,29 +7,9 @@ spec:
   failureDomains: []
   prismCentral:
     additionalTrustBundle:
-      kind: String
-      data: |
-        -----BEGIN CERTIFICATE-----
-        MIIDajCCAlKgAwIBAgIUZOD4pznfHyCO8gMvP87F+PnhGHMwDQYJKoZIhvcNAQEL
-        BQAwNDELMAkGA1UEBhMCREUxFDASBgNVBAgMC0xhbmQgQmVybGluMQ8wDQYDVQQH
-        DAZCZXJsaW4wHhcNMjIwODI1MTYxNzI5WhcNMzIwODIyMTYxNzI5WjA0MQswCQYD
-        VQQGEwJERTEUMBIGA1UECAwLTGFuZCBCZXJsaW4xDzANBgNVBAcMBkJlcmxpbjCC
-        ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAO280znVj6qLpCqAeNgpw7gw
-        0OE54gBW8Y9gBtEYxBux6hXBl+doj+JNZLcfIoDoqdTlgZX13Y//WakfMuvuhYUN
-        53fpwsiup3pqqL+JHhKy+Bq/BSQcHkLGi/aUGph7qK/wQMZBGBbbBXaCwnhjYovl
-        nRq4p+Cm5wm4S/QUhgyvqyoeNWAc6+2AHniuIzo6Q1MU9ktaSAdL8ZdW5g6el5iA
-        oHjDHNjTwyTeybKFScEQvFqO6qfzTRn8eV6dwH4gOYec1IdDwSp8PSv9R7J9AC+1
-        DtAjsYtqO4i6qRpgf0zyGQb+uNKXdz/ovOGa58twfMKYU7Z2crPj3K7NOJVelZEC
-        AwEAAaN0MHIwHQYDVR0OBBYEFPlcZspynb+2DwRN5K3slRyEV0nxMB8GA1UdIwQY
-        MBaAFPlcZspynb+2DwRN5K3slRyEV0nxMA4GA1UdDwEB/wQEAwIFoDAgBgNVHSUB
-        Af8EFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBACXY
-        FH72svBSALkqmTyU9rsh4rRK9yo7tmNJkFkRQ/cjYycpNKZ6Cg9+wGwN6o6pXdqb
-        JfeuePclDdGcgYe8SbGr0T7pFXdUIVmuO/jjatKCftXQQZK5zHCkUTLhVlAbnNpC
-        3NIU4wWjx/QLtk+zEqjl5kyDgXD5GwxXbgzzY+7wi4QZO8VRyLG5lawZVKer3gkt
-        +NGIOtoyz4RjnWIKV34Z6HUDhdgbVyX1uPG/a5mLmcbLjuSf39WdAgv9bFGkUHZk
-        2dU0bIXepIZ5Mz3aovl35EjbGAbpI8tpKWlsHNoiVNQm1vojfKvKVibVS2FNo0cD
-        gu45O/O1hxzezDKiKKU=
-        -----END CERTIFICATE-----
+      kind: ConfigMap
+      name: "eksa-unit-test-trust-bundle"
+      namespace: eksa-system
     address: "prism.nutanix.com"
     port: 9440
     insecure: false
@@ -400,8 +380,8 @@ data:
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: user-ca-bundle
-      namespace: kube-system
+      name: eksa-unit-test-trust-bundle
+      namespace: eksa-system
     data:
       ca.crt: |
         -----BEGIN CERTIFICATE-----
@@ -451,8 +431,8 @@ data:
             },
             "additionalTrustBundle": {
               "kind": "ConfigMap",
-              "name": "user-ca-bundle",
-              "namespace": "kube-system"
+              "name": eksa-unit-test-trust-bundle,
+              "namespace": eksa-system
             }
           },
           "enableCustomLabeling": false,
@@ -640,7 +620,8 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   - kind: ConfigMap
-    name: user-ca-bundle
+    name: eksa-unit-test-trust-bundle
+    namespace: eksa-system
   strategy: Reconcile
 ---
 apiVersion: v1


### PR DESCRIPTION
*Description of changes:*
Passing AdditionalTrustBundle to CAPX using ConfigMap

*Testing (if applicable):*
Deployment CLI logs: 
[deployment.txt](https://github.com/user-attachments/files/20451778/deployment.txt)
Upgrade CLI logs after removing trustBunlde: 
[upgrade.txt](https://github.com/user-attachments/files/20451871/upgrade.txt)


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

