### PR TITLE
Fix webhook method interface input args for ValidateUpate

### DIFF
--- a/pkg/api/v1alpha1/awsiamconfig_webhook.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook.go
@@ -59,7 +59,7 @@ func (r *AWSIamConfig) ValidateCreate(_ context.Context, obj runtime.Object) (ad
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *AWSIamConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *AWSIamConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	awsIamConfig, ok := obj.(*AWSIamConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected an AWSIamConfig but got %T", obj)

--- a/pkg/api/v1alpha1/awsiamconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook_test.go
@@ -18,7 +18,7 @@ func TestValidateUpdateAWSIamConfigFail(t *testing.T) {
 
 	aiNew.Spec.BackendMode = []string{"mode1"}
 	g := NewWithT(t)
-	g.Expect(aiNew.ValidateUpdate(ctx, aiNew, &aiOld)).Error().To(MatchError(ContainSubstring("config is immutable")))
+	g.Expect(aiNew.ValidateUpdate(ctx, &aiOld, aiNew)).Error().To(MatchError(ContainSubstring("config is immutable")))
 }
 
 func TestValidateUpdateAWSIamConfigSuccess(t *testing.T) {
@@ -35,7 +35,7 @@ func TestValidateUpdateAWSIamConfigSuccess(t *testing.T) {
 		},
 	}
 	g := NewWithT(t)
-	g.Expect(aiNew.ValidateUpdate(ctx, aiNew, &aiOld)).Error().To(Succeed())
+	g.Expect(aiNew.ValidateUpdate(ctx, &aiOld, aiNew)).Error().To(Succeed())
 }
 
 func TestValidateCreateAWSIamConfigSuccess(t *testing.T) {
@@ -69,7 +69,7 @@ func TestValidateUpdateAWSIamConfigFailCausedByMutableFieldChange(t *testing.T) 
 		},
 	}
 	g := NewWithT(t)
-	g.Expect(aiNew.ValidateUpdate(ctx, aiNew, &aiOld)).Error().To(MatchError(ContainSubstring("MapRoles Username is required")))
+	g.Expect(aiNew.ValidateUpdate(ctx, &aiOld, aiNew)).Error().To(MatchError(ContainSubstring("MapRoles Username is required")))
 }
 
 func TestAWSIamConfigSetDefaults(t *testing.T) {
@@ -140,7 +140,7 @@ func TestAWSIamConfigValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.AWSIamConfig{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.AWSIamConfig{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.AWSIamConfig{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
@@ -80,7 +80,7 @@ func (r *CloudStackDatacenterConfig) ValidateCreate(_ context.Context, obj runti
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *CloudStackDatacenterConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *CloudStackDatacenterConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	cloudstackConfig, ok := obj.(*CloudStackDatacenterConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a CloudStackDatacenterConfig but got %T", obj)

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook_test.go
@@ -54,7 +54,7 @@ func TestCloudStackDatacenterValidateUpdateDomainImmutable(t *testing.T) {
 
 	c.Spec.AvailabilityZones[0].Domain = "shinyNewDomain"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(HaveOccurred())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateV1beta1ToV1beta2Upgrade(t *testing.T) {
@@ -65,7 +65,7 @@ func TestCloudStackDatacenterValidateUpdateV1beta1ToV1beta2Upgrade(t *testing.T)
 
 	vNew.Spec.AvailabilityZones[0].Name = "12345678-abcd-4abc-abcd-abcd12345678"
 	g := NewWithT(t)
-	g.Expect(vNew.ValidateUpdate(ctx, vNew, &vOld)).Error().To(Succeed())
+	g.Expect(vNew.ValidateUpdate(ctx, &vOld, vNew)).Error().To(Succeed())
 }
 
 func TestCloudStackDatacenterValidateUpdateV1beta1ToV1beta2UpgradeAddAzInvalid(t *testing.T) {
@@ -77,7 +77,7 @@ func TestCloudStackDatacenterValidateUpdateV1beta1ToV1beta2UpgradeAddAzInvalid(t
 	vNew.Spec.AvailabilityZones[0].Name = "12345678-abcd-4abc-abcd-abcd12345678"
 	vNew.Spec.AvailabilityZones = append(vNew.Spec.AvailabilityZones, vNew.Spec.AvailabilityZones[0])
 	g := NewWithT(t)
-	g.Expect(vNew.ValidateUpdate(ctx, vNew, &vOld)).Error().To(HaveOccurred())
+	g.Expect(vNew.ValidateUpdate(ctx, &vOld, vNew)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateRenameAzInvalid(t *testing.T) {
@@ -88,7 +88,7 @@ func TestCloudStackDatacenterValidateUpdateRenameAzInvalid(t *testing.T) {
 
 	vNew.Spec.AvailabilityZones[0].Name = "shinyNewAzName"
 	g := NewWithT(t)
-	g.Expect(vNew.ValidateUpdate(ctx, vNew, &vOld)).Error().To(HaveOccurred())
+	g.Expect(vNew.ValidateUpdate(ctx, &vOld, vNew)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateManagementApiEndpointImmutable(t *testing.T) {
@@ -99,7 +99,7 @@ func TestCloudStackDatacenterValidateUpdateManagementApiEndpointImmutable(t *tes
 
 	c.Spec.AvailabilityZones[0].ManagementApiEndpoint = "shinyNewManagementApiEndpoint"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(HaveOccurred())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateZonesImmutable(t *testing.T) {
@@ -109,7 +109,7 @@ func TestCloudStackDatacenterValidateUpdateZonesImmutable(t *testing.T) {
 
 	c.Spec.AvailabilityZones[0].Zone.Name = "shinyNewZone"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(HaveOccurred())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateAccountImmutable(t *testing.T) {
@@ -119,7 +119,7 @@ func TestCloudStackDatacenterValidateUpdateAccountImmutable(t *testing.T) {
 
 	c.Spec.AvailabilityZones[0].Account = "shinyNewAccount"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(HaveOccurred())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateNetworkImmutable(t *testing.T) {
@@ -129,7 +129,7 @@ func TestCloudStackDatacenterValidateUpdateNetworkImmutable(t *testing.T) {
 
 	c.Spec.AvailabilityZones[0].Zone.Network.Name = "GuestNet2"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(HaveOccurred())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(HaveOccurred())
 }
 
 func TestCloudStackDatacenterValidateUpdateWithPausedAnnotation(t *testing.T) {
@@ -157,7 +157,7 @@ func TestCloudStackDatacenterValidateUpdateWithPausedAnnotation(t *testing.T) {
 	vOld.PauseReconcile()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestCloudStackDatacenterValidateUpdateInvalidType(t *testing.T) {
@@ -166,7 +166,7 @@ func TestCloudStackDatacenterValidateUpdateInvalidType(t *testing.T) {
 	c := &v1alpha1.CloudStackDatacenterConfig{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, vOld)).Error().To(HaveOccurred())
+	g.Expect(c.ValidateUpdate(ctx, vOld, c)).Error().To(HaveOccurred())
 }
 
 func cloudstackDatacenterConfig() v1alpha1.CloudStackDatacenterConfig {
@@ -235,7 +235,7 @@ func TestCloudStackDatacenterConfigValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.CloudStackDatacenterConfig{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.CloudStackDatacenterConfig{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.CloudStackDatacenterConfig{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook.go
@@ -53,7 +53,7 @@ func (r *CloudStackMachineConfig) ValidateCreate(_ context.Context, obj runtime.
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *CloudStackMachineConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *CloudStackMachineConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	cloudstackConfig, ok := obj.(*CloudStackMachineConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a CloudStackMachineConfig but got %T", obj)

--- a/pkg/api/v1alpha1/cloudstackmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/cloudstackmachineconfig_webhook_test.go
@@ -197,7 +197,7 @@ func TestCPCloudStackMachineValidateUpdateTemplateMutable(t *testing.T) {
 		Name: "newTemplate",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkersCPCloudStackMachineValidateUpdateTemplateMutable(t *testing.T) {
@@ -212,7 +212,7 @@ func TestWorkersCPCloudStackMachineValidateUpdateTemplateMutable(t *testing.T) {
 		Name: "newTemplate",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateComputeOfferingMutable(t *testing.T) {
@@ -228,7 +228,7 @@ func TestCPCloudStackMachineValidateUpdateComputeOfferingMutable(t *testing.T) {
 		Name: "newComputeOffering",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
@@ -256,7 +256,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
 		Label:      "data_disk",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailInvalidMountPath(t *testing.T) {
@@ -284,7 +284,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailInvalidMountPat
 		Label:      "data_disk",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().NotTo(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyDevice(t *testing.T) {
@@ -312,7 +312,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyDevice(t *
 		Label:      "data_disk",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().NotTo(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyFilesystem(t *testing.T) {
@@ -340,7 +340,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyFilesystem
 		Label:      "data_disk",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().NotTo(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyLabel(t *testing.T) {
@@ -368,7 +368,7 @@ func TestCPCloudStackMachineValidateUpdateDiskOfferingMutableFailEmptyLabel(t *t
 		Label:      "",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().NotTo(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateSymlinksMutable(t *testing.T) {
@@ -384,7 +384,7 @@ func TestCPCloudStackMachineValidateUpdateSymlinksMutable(t *testing.T) {
 		"/var/log": "/data_2/var/log",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateSymlinksMutableInvalidComma(t *testing.T) {
@@ -400,7 +400,7 @@ func TestCPCloudStackMachineValidateUpdateSymlinksMutableInvalidComma(t *testing
 		"/var/log": "/data_2/var/log,d",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().NotTo(Succeed())
 }
 
 func TestCPCloudStackMachineValidateUpdateSymlinksMutableColon(t *testing.T) {
@@ -416,7 +416,7 @@ func TestCPCloudStackMachineValidateUpdateSymlinksMutableColon(t *testing.T) {
 		"/var/log": "/data_2/var/log:d",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().NotTo(Succeed())
 }
 
 func TestWorkersCPCloudStackMachineValidateUpdateComputeOfferingMutable(t *testing.T) {
@@ -431,7 +431,7 @@ func TestWorkersCPCloudStackMachineValidateUpdateComputeOfferingMutable(t *testi
 		Name: "newComputeOffering",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkersCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.T) {
@@ -455,7 +455,7 @@ func TestWorkersCPCloudStackMachineValidateUpdateDiskOfferingMutable(t *testing.
 		Label:      "data_disk",
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementCloudStackMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
@@ -469,7 +469,7 @@ func TestManagementCloudStackMachineValidateUpdateSshAuthorizedKeyMutable(t *tes
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCloudStackMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
@@ -482,7 +482,7 @@ func TestWorkloadCloudStackMachineValidateUpdateSshAuthorizedKeyMutable(t *testi
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCloudStackMachineValidateUpdateSshUsernameMutable(t *testing.T) {
@@ -497,7 +497,7 @@ func TestWorkloadCloudStackMachineValidateUpdateSshUsernameMutable(t *testing.T)
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCloudStackMachineValidateUpdateInvalidUsers(t *testing.T) {
@@ -512,7 +512,7 @@ func TestWorkloadCloudStackMachineValidateUpdateInvalidUsers(t *testing.T) {
 
 	c.Spec.Users[0].Name = ""
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().ToNot(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().ToNot(Succeed())
 }
 
 func TestCloudStackMachineValidateUpdateInvalidType(t *testing.T) {
@@ -521,7 +521,7 @@ func TestCloudStackMachineValidateUpdateInvalidType(t *testing.T) {
 	c := &v1alpha1.CloudStackMachineConfig{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, vOld)).Error().NotTo(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, vOld, c)).Error().NotTo(Succeed())
 }
 
 func cloudstackMachineConfig() v1alpha1.CloudStackMachineConfig {
@@ -555,7 +555,7 @@ func TestCloudStackMachineValidateUpdateAffinityImmutable(t *testing.T) {
 
 	c.Spec.Affinity = "anti"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().ToNot(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().ToNot(Succeed())
 }
 
 func TestCloudStackMachineValidateUpdateAffinityGroupIdsImmutable(t *testing.T) {
@@ -567,11 +567,11 @@ func TestCloudStackMachineValidateUpdateAffinityGroupIdsImmutable(t *testing.T) 
 
 	c.Spec.AffinityGroupIds = []string{}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().ToNot(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().ToNot(Succeed())
 
 	c.Spec.AffinityGroupIds = []string{"affinity-group-2"}
 	g = NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().ToNot(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().ToNot(Succeed())
 }
 
 func TestCloudStackMachineConfigValidateCreateCastFail(t *testing.T) {

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -97,7 +97,7 @@ func (r *Cluster) ValidateCreate(_ context.Context, obj runtime.Object) (admissi
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *Cluster) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *Cluster) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	newCluster, ok := obj.(*Cluster)
 	if !ok {
 		return nil, fmt.Errorf("expected a Cluster but got %T", obj)

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -40,7 +40,7 @@ func TestClusterValidateUpdateManagementValueImmutable(t *testing.T) {
 	c.SetManagedBy("management-cluster")
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("field is immutable")))
 }
 
 func TestClusterValidateUpdateManagementOldNilNewTrueSuccess(t *testing.T) {
@@ -49,7 +49,7 @@ func TestClusterValidateUpdateManagementOldNilNewTrueSuccess(t *testing.T) {
 	c.SetSelfManaged()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateManagementOldNilNewFalseImmutable(t *testing.T) {
@@ -59,7 +59,7 @@ func TestClusterValidateUpdateManagementOldNilNewFalseImmutable(t *testing.T) {
 	c.SetManagedBy("management-cluster")
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("field is immutable")))
 }
 
 func TestClusterValidateUpdateManagementBothNilImmutable(t *testing.T) {
@@ -67,7 +67,7 @@ func TestClusterValidateUpdateManagementBothNilImmutable(t *testing.T) {
 	c := cOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestManagementClusterValidateUpdateKubernetesVersionMutableManagement(t *testing.T) {
@@ -77,7 +77,7 @@ func TestManagementClusterValidateUpdateKubernetesVersionMutableManagement(t *te
 	c.Spec.KubernetesVersion = v1alpha1.Kube122
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadClusterValidateUpdateKubernetesVersionSuccess(t *testing.T) {
@@ -88,7 +88,7 @@ func TestWorkloadClusterValidateUpdateKubernetesVersionSuccess(t *testing.T) {
 	c.Spec.KubernetesVersion = v1alpha1.Kube122
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadClusterValidateUpdateNoUpdateSuccess(t *testing.T) {
@@ -98,7 +98,7 @@ func TestWorkloadClusterValidateUpdateNoUpdateSuccess(t *testing.T) {
 	c := cOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestManagementClusterValidateUpdateControlPlaneConfigurationEqual(t *testing.T) {
@@ -118,7 +118,7 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationEqual(t *testin
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadClusterValidateUpdateControlPlaneConfigurationEqual(t *testing.T) {
@@ -138,7 +138,7 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationEqual(t *testing.
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateControlPlaneConfigurationImmutable(t *testing.T) {
@@ -156,7 +156,7 @@ func TestClusterValidateUpdateControlPlaneConfigurationImmutable(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateControlPlaneConfigurationOldEndpointImmutable(t *testing.T) {
@@ -170,7 +170,7 @@ func TestClusterValidateUpdateControlPlaneConfigurationOldEndpointImmutable(t *t
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateControlPlaneConfigurationOldEndpointNilImmutable(t *testing.T) {
@@ -184,7 +184,7 @@ func TestClusterValidateUpdateControlPlaneConfigurationOldEndpointNilImmutable(t
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateControlPlaneConfigurationNewEndpointNilImmutable(t *testing.T) {
@@ -198,7 +198,7 @@ func TestClusterValidateUpdateControlPlaneConfigurationNewEndpointNilImmutable(t
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
 }
 
 func TestCloudStackClusterValidateUpdateControlPlaneConfigurationOldDefaultPortNewNoPort(t *testing.T) {
@@ -209,7 +209,7 @@ func TestCloudStackClusterValidateUpdateControlPlaneConfigurationOldDefaultPortN
 	c.Spec.ControlPlaneConfiguration.Endpoint = &v1alpha1.Endpoint{Host: "1.1.1.1"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestCloudStackClusterValidateUpdateControlPlaneConfigurationOldNoPortNewDefaultPort(t *testing.T) {
@@ -220,7 +220,7 @@ func TestCloudStackClusterValidateUpdateControlPlaneConfigurationOldNoPortNewDef
 	c.Spec.ControlPlaneConfiguration.Endpoint = &v1alpha1.Endpoint{Host: "1.1.1.1:6443"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestCloudStackClusterValidateUpdateControlPlaneConfigurationOldPortImmutable(t *testing.T) {
@@ -231,7 +231,7 @@ func TestCloudStackClusterValidateUpdateControlPlaneConfigurationOldPortImmutabl
 	c.Spec.ControlPlaneConfiguration.Endpoint = &v1alpha1.Endpoint{Host: "1.1.1.2"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
 }
 
 func TestManagementClusterValidateUpdateControlPlaneConfigurationTaintsMutableManagement(t *testing.T) {
@@ -255,7 +255,7 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationTaintsMutableMa
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestManagementClusterValidateUpdateControlPlaneConfigurationLabelsMutableManagement(t *testing.T) {
@@ -270,7 +270,7 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationLabelsMutableMa
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestManagementClusterValidateUpdateControlPlaneConfigurationOldMachineGroupRefMutableManagement(t *testing.T) {
@@ -282,7 +282,7 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationOldMachineGroup
 	c.Spec.ControlPlaneConfiguration.MachineGroupRef.Name = "test2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadClusterValidateUpdateControlPlaneConfigurationMachineGroupRef(t *testing.T) {
@@ -294,7 +294,7 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationMachineGroupRef(t
 	c.Spec.ControlPlaneConfiguration.MachineGroupRef = &v1alpha1.Ref{Name: "test2", Kind: "MachineConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadClusterValidateUpdateControlPlaneConfigurationOldMachineGroupRefNilSuccess(t *testing.T) {
@@ -306,7 +306,7 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationOldMachineGroupRe
 	c.Spec.ControlPlaneConfiguration.MachineGroupRef = &v1alpha1.Ref{Name: "test", Kind: "MachineConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestManagementClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRefNilImmutable(t *testing.T) {
@@ -319,7 +319,7 @@ func TestManagementClusterValidateUpdateControlPlaneConfigurationNewMachineGroup
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("ControlPlaneConfiguration.endpoint: Forbidden: field is immutable")))
 }
 
 func TestWorkloadClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRefChangedSuccess(t *testing.T) {
@@ -331,7 +331,7 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRe
 	c.Spec.ControlPlaneConfiguration.MachineGroupRef = &v1alpha1.Ref{Name: "test-2", Kind: "MachineConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRefNilError(t *testing.T) {
@@ -342,7 +342,7 @@ func TestWorkloadClusterValidateUpdateControlPlaneConfigurationNewMachineGroupRe
 	c.Spec.ControlPlaneConfiguration.MachineGroupRef = nil
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("must specify machineGroupRef control plane machines")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("must specify machineGroupRef control plane machines")))
 }
 
 func TestWorkloadClusterValidateUpdateWorkerNodeConfigurationNewMachineGroupRefNilError(t *testing.T) {
@@ -353,7 +353,7 @@ func TestWorkloadClusterValidateUpdateWorkerNodeConfigurationNewMachineGroupRefN
 	c.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef = nil
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("must specify machineGroupRef for worker nodes")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("must specify machineGroupRef for worker nodes")))
 }
 
 func TestWorkloadClusterValidateUpdateExternalEtcdConfigurationNewMachineGroupRefNilError(t *testing.T) {
@@ -371,7 +371,7 @@ func TestWorkloadClusterValidateUpdateExternalEtcdConfigurationNewMachineGroupRe
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("must specify machineGroupRef for etcd machines")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("must specify machineGroupRef for etcd machines")))
 }
 
 func TestClusterValidateUpdateDatacenterRefImmutableEqual(t *testing.T) {
@@ -382,7 +382,7 @@ func TestClusterValidateUpdateDatacenterRefImmutableEqual(t *testing.T) {
 	c := cOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateDatacenterRefImmutable(t *testing.T) {
@@ -394,7 +394,7 @@ func TestClusterValidateUpdateDatacenterRefImmutable(t *testing.T) {
 	c.Spec.DatacenterRef = v1alpha1.Ref{Name: "test2", Kind: "SecondDatacenterConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateDatacenterRefImmutableName(t *testing.T) {
@@ -406,7 +406,7 @@ func TestClusterValidateUpdateDatacenterRefImmutableName(t *testing.T) {
 	c.Spec.DatacenterRef = v1alpha1.Ref{Name: "test2", Kind: "DatacenterConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateDatacenterRefNilImmutable(t *testing.T) {
@@ -418,7 +418,7 @@ func TestClusterValidateUpdateDatacenterRefNilImmutable(t *testing.T) {
 	c.Spec.DatacenterRef = v1alpha1.Ref{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateExternalEtcdConfiguration(t *testing.T) {
@@ -450,7 +450,7 @@ func TestClusterValidateUpdateExternalEtcdConfiguration(t *testing.T) {
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(tt.cNew.ValidateUpdate(context.TODO(), tt.cNew, tt.cOld)).Error().To(MatchError(ContainSubstring(tt.expectErr)))
+			g.Expect(tt.cNew.ValidateUpdate(context.TODO(), tt.cOld, tt.cNew)).Error().To(MatchError(ContainSubstring(tt.expectErr)))
 		})
 	}
 }
@@ -461,7 +461,7 @@ func TestClusterValidateUpdateDataCenterRefNameImmutable(t *testing.T) {
 	c.Spec.DatacenterRef.Name = "FancyNewDataCenter"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateDataCenterRefKindImmutable(t *testing.T) {
@@ -470,7 +470,7 @@ func TestClusterValidateUpdateDataCenterRefKindImmutable(t *testing.T) {
 	c.Spec.DatacenterRef.Name = v1alpha1.DockerDatacenterKind
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.datacenterRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateClusterNetworkPodsImmutable(t *testing.T) {
@@ -480,7 +480,7 @@ func TestClusterValidateUpdateClusterNetworkPodsImmutable(t *testing.T) {
 	c.Spec.ClusterNetwork.Pods.CidrBlocks = []string{"1.2.3.4/5"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.pods: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.pods: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateClusterNetworkServicesImmutable(t *testing.T) {
@@ -490,7 +490,7 @@ func TestClusterValidateUpdateClusterNetworkServicesImmutable(t *testing.T) {
 	c.Spec.ClusterNetwork.Services.CidrBlocks = []string{"1.2.3.4/9", "1.2.3.4/10"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.services: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.services: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateClusterNetworkDNSImmutable(t *testing.T) {
@@ -507,7 +507,7 @@ func TestClusterValidateUpdateClusterNetworkDNSImmutable(t *testing.T) {
 	c.Spec.ClusterNetwork.DNS.ResolvConf.Path = "other-path"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.dns: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.dns: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateClusterNetworkNodesImmutable(t *testing.T) {
@@ -518,7 +518,7 @@ func TestClusterValidateUpdateClusterNetworkNodesImmutable(t *testing.T) {
 		CIDRMaskSize: ptr.Int(10),
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.nodes: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.clusterNetwork.nodes: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
@@ -543,7 +543,7 @@ func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateProxyConfigurationImmutable(t *testing.T) {
@@ -561,7 +561,7 @@ func TestClusterValidateUpdateProxyConfigurationImmutable(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateProxyConfigurationNoProxyImmutable(t *testing.T) {
@@ -578,7 +578,7 @@ func TestClusterValidateUpdateProxyConfigurationNoProxyImmutable(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateProxyConfigurationOldNilImmutable(t *testing.T) {
@@ -593,7 +593,7 @@ func TestClusterValidateUpdateProxyConfigurationOldNilImmutable(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateProxyConfigurationNewNilImmutable(t *testing.T) {
@@ -606,7 +606,7 @@ func TestClusterValidateUpdateProxyConfigurationNewNilImmutable(t *testing.T) {
 	c := cOld.DeepCopy()
 	c.Spec.ProxyConfiguration = nil
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.ProxyConfiguration: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateGitOpsRefImmutableNilEqual(t *testing.T) {
@@ -616,7 +616,7 @@ func TestClusterValidateUpdateGitOpsRefImmutableNilEqual(t *testing.T) {
 	c := cOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateGitOpsRefMutableManagementCluster(t *testing.T) {
@@ -626,7 +626,7 @@ func TestClusterValidateUpdateGitOpsRefMutableManagementCluster(t *testing.T) {
 	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test2", Kind: "GitOpsConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateGitOpsRefImmutable(t *testing.T) {
@@ -637,7 +637,7 @@ func TestClusterValidateUpdateGitOpsRefImmutable(t *testing.T) {
 	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test2", Kind: "GitOpsConfig2"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateGitOpsRefImmutableName(t *testing.T) {
@@ -650,7 +650,7 @@ func TestClusterValidateUpdateGitOpsRefImmutableName(t *testing.T) {
 	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test2", Kind: "GitOpsConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateGitOpsRefImmutableKind(t *testing.T) {
@@ -663,7 +663,7 @@ func TestClusterValidateUpdateGitOpsRefImmutableKind(t *testing.T) {
 	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test", Kind: "GitOpsConfig2"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateGitOpsRefOldNilImmutable(t *testing.T) {
@@ -675,7 +675,7 @@ func TestClusterValidateUpdateGitOpsRefOldNilImmutable(t *testing.T) {
 	c.Spec.GitOpsRef = &v1alpha1.Ref{Name: "test", Kind: "GitOpsConfig"}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateGitOpsRefNewNilImmutable(t *testing.T) {
@@ -688,7 +688,7 @@ func TestClusterValidateUpdateGitOpsRefNewNilImmutable(t *testing.T) {
 	c.Spec.GitOpsRef = nil
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.GitOpsRef: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateAWSIamNameImmutableUpdateSameName(t *testing.T) {
@@ -708,7 +708,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableUpdateSameName(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateAWSIamNameImmutableUpdateSameNameWorkloadCluster(t *testing.T) {
@@ -730,7 +730,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableUpdateSameNameWorkloadCluster(t
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateAWSIamNameImmutableUpdateName(t *testing.T) {
@@ -750,7 +750,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableUpdateName(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateAWSIamNameImmutableEmpty(t *testing.T) {
@@ -765,7 +765,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableEmpty(t *testing.T) {
 	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateAWSIamNameImmutableAddConfig(t *testing.T) {
@@ -780,7 +780,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableAddConfig(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
 }
 
 func TestClusterValidateUpdateUnsetBundlesRefImmutable(t *testing.T) {
@@ -791,7 +791,7 @@ func TestClusterValidateUpdateUnsetBundlesRefImmutable(t *testing.T) {
 	c.Spec.EksaVersion = nil
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("spec.BundlesRef: Invalid value: \"null\": field cannot be removed after setting")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.BundlesRef: Invalid value: \"null\": field cannot be removed after setting")))
 }
 
 func TestClusterValidateUpdateEksaVersionSkew(t *testing.T) {
@@ -867,11 +867,11 @@ func TestClusterValidateUpdateEksaVersionSkew(t *testing.T) {
 			cOld.Status.FailureReason = &reason
 		}
 
-		warnings, err := c.ValidateUpdate(context.TODO(), c, cOld)
+		warnings, err := c.ValidateUpdate(context.TODO(), cOld, c)
 		g := NewWithT(t)
 		g.Expect(warnings).To(BeEmpty())
 		if tt.wantErr != "" {
-			g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring(tt.wantErr)))
+			g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring(tt.wantErr)))
 		} else {
 			g.Expect(err).To(Succeed())
 		}
@@ -891,7 +891,7 @@ func TestClusterValidateUpdateOIDCNameMutableUpdateNameWorkloadCluster(t *testin
 	c.Spec.IdentityProviderRefs[0].Name = "name2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateOIDCNameMutableUpdateNameMgmtCluster(t *testing.T) {
@@ -906,7 +906,7 @@ func TestClusterValidateUpdateOIDCNameMutableUpdateNameMgmtCluster(t *testing.T)
 	c.Spec.IdentityProviderRefs[0].Name = "name2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateOIDCNameMutableUpdateNameUnchanged(t *testing.T) {
@@ -920,7 +920,7 @@ func TestClusterValidateUpdateOIDCNameMutableUpdateNameUnchanged(t *testing.T) {
 	c := cOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateOIDCNameMutableWorkloadCluster(t *testing.T) {
@@ -938,7 +938,7 @@ func TestClusterValidateUpdateOIDCNameMutableWorkloadCluster(t *testing.T) {
 
 	c.SetManagedBy("mgmt2")
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateOIDCNameMutableMgmtCluster(t *testing.T) {
@@ -953,7 +953,7 @@ func TestClusterValidateUpdateOIDCNameMutableMgmtCluster(t *testing.T) {
 	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateOIDCNameMutableAddConfigWorkloadCluster(t *testing.T) {
@@ -972,7 +972,7 @@ func TestClusterValidateUpdateOIDCNameMutableAddConfigWorkloadCluster(t *testing
 	c.SetManagedBy("mgmt2")
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateOIDCNameMutableAddConfigMgmtCluster(t *testing.T) {
@@ -987,7 +987,7 @@ func TestClusterValidateUpdateOIDCNameMutableAddConfigMgmtCluster(t *testing.T) 
 		},
 	}
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateSwapIdentityProviders(t *testing.T) {
@@ -1015,7 +1015,7 @@ func TestClusterValidateUpdateSwapIdentityProviders(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateSwapIdentityProvidersWorkloadCluster(t *testing.T) {
@@ -1045,7 +1045,7 @@ func TestClusterValidateUpdateSwapIdentityProvidersWorkloadCluster(t *testing.T)
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateEmptyIdentityProviders(t *testing.T) {
@@ -1054,7 +1054,7 @@ func TestClusterValidateEmptyIdentityProviders(t *testing.T) {
 	c := cOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateGitOpsRefOldEmptyMutableManagement(t *testing.T) {
@@ -1063,7 +1063,7 @@ func TestClusterValidateUpdateGitOpsRefOldEmptyMutableManagement(t *testing.T) {
 	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateWithPausedAnnotation(t *testing.T) {
@@ -1074,7 +1074,7 @@ func TestClusterValidateUpdateWithPausedAnnotation(t *testing.T) {
 	c.Spec.KubernetesVersion = v1alpha1.Kube122
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateInvalidType(t *testing.T) {
@@ -1082,7 +1082,7 @@ func TestClusterValidateUpdateInvalidType(t *testing.T) {
 	c := &v1alpha1.Cluster{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("expected a Cluster but got a *v1alpha1.VSphereDatacenterConfig")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("expected a Cluster but got a *v1alpha1.VSphereDatacenterConfig")))
 }
 
 func TestClusterValidateUpdateSuccess(t *testing.T) {
@@ -1094,7 +1094,7 @@ func TestClusterValidateUpdateSuccess(t *testing.T) {
 	c.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(10)
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterCreateManagementCluster(t *testing.T) {
@@ -1347,7 +1347,7 @@ func TestClusterUpdateEtcdEncryption(t *testing.T) {
 			newCluster.Spec.EtcdEncryption = tt.encryptionConfig
 
 			g := NewWithT(t)
-			warnings, err := newCluster.ValidateUpdate(context.TODO(), newCluster, baseCluster)
+			warnings, err := newCluster.ValidateUpdate(context.TODO(), baseCluster, newCluster)
 			g.Expect(warnings).To(BeEmpty())
 			if tt.expectedErr == nil {
 				g.Expect(err).ToNot(HaveOccurred())
@@ -1418,7 +1418,7 @@ func TestClusterUpdateWorkerNodeGroupTaintsAndLabelsSuccess(t *testing.T) {
 	c.Spec.WorkerNodeGroupConfigurations[0].Labels["test"] = "val2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterUpdateWorkerNodeGroupTaintsInvalid(t *testing.T) {
@@ -1438,7 +1438,7 @@ func TestClusterUpdateWorkerNodeGroupTaintsInvalid(t *testing.T) {
 	c.Spec.WorkerNodeGroupConfigurations[0].Taints[0].Effect = "NoSchedule"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("at least one WorkerNodeGroupConfiguration must not have NoExecute and/or NoSchedule taints")))
 }
 
 func TestClusterUpdateWorkerNodeGroupNameInvalid(t *testing.T) {
@@ -1447,7 +1447,7 @@ func TestClusterUpdateWorkerNodeGroupNameInvalid(t *testing.T) {
 	c.Spec.WorkerNodeGroupConfigurations[0].Name = ""
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("must specify name for worker nodes")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("must specify name for worker nodes")))
 }
 
 func TestClusterUpdateWorkerNodeGroupLabelsInvalid(t *testing.T) {
@@ -1465,7 +1465,7 @@ func TestClusterUpdateWorkerNodeGroupLabelsInvalid(t *testing.T) {
 	c.Spec.WorkerNodeGroupConfigurations[0].Labels["test"] = "val1/val2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(MatchError(ContainSubstring("labels for worker node group test not valid: found following errors with labels: spec.workerNodeGroupConfigurations[0].labels: Invalid value:")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("labels for worker node group test not valid: found following errors with labels: spec.workerNodeGroupConfigurations[0].labels: Invalid value:")))
 }
 
 func TestClusterUpdateControlPlaneTaintsAndLabelsSuccess(t *testing.T) {
@@ -1485,7 +1485,7 @@ func TestClusterUpdateControlPlaneTaintsAndLabelsSuccess(t *testing.T) {
 	c.Spec.ControlPlaneConfiguration.Labels["test"] = "val2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterUpdateControlPlaneLabelsInvalid(t *testing.T) {
@@ -1503,7 +1503,7 @@ func TestClusterUpdateControlPlaneLabelsInvalid(t *testing.T) {
 	c.Spec.ControlPlaneConfiguration.Labels["test"] = "val1/val2"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, cluster)).Error().To(MatchError(ContainSubstring("spec.controlPlaneConfiguration.labels: Invalid value")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cluster, c)).Error().To(MatchError(ContainSubstring("spec.controlPlaneConfiguration.labels: Invalid value")))
 }
 
 func TestClusterValidateCreateSelfManagedUnpaused(t *testing.T) {
@@ -1593,7 +1593,7 @@ func TestClusterValidateUpdateInvalidManagementCluster(t *testing.T) {
 			}}
 
 			g := NewWithT(t)
-			warnings, err := tt.clusterNew.ValidateUpdate(context.TODO(), tt.clusterNew, clusterOld)
+			warnings, err := tt.clusterNew.ValidateUpdate(context.TODO(), clusterOld, tt.clusterNew)
 			g.Expect(warnings).To(BeEmpty())
 			g.Expect(err).To(MatchError(ContainSubstring("worker node count must be >= 0")))
 		})
@@ -1638,7 +1638,7 @@ func TestClusterValidateUpdateInvalidWorkloadCluster(t *testing.T) {
 			}
 
 			g := NewWithT(t)
-			warnings, err := tt.clusterNew.ValidateUpdate(context.TODO(), tt.clusterNew, clusterOld)
+			warnings, err := tt.clusterNew.ValidateUpdate(context.TODO(), clusterOld, tt.clusterNew)
 			g.Expect(warnings).To(BeEmpty())
 			g.Expect(err).To(MatchError(ContainSubstring("control plane node count must be positive")))
 		})
@@ -1760,7 +1760,7 @@ func TestClusterValidateUpdateValidWorkloadCluster(t *testing.T) {
 			}}
 
 			g := NewWithT(t)
-			warnings, err := tt.clusterNew.ValidateUpdate(context.TODO(), tt.clusterNew, clusterOld)
+			warnings, err := tt.clusterNew.ValidateUpdate(context.TODO(), clusterOld, tt.clusterNew)
 			g.Expect(warnings).To(BeEmpty())
 			g.Expect(err).To(Succeed())
 		})
@@ -1775,7 +1775,7 @@ func TestClusterValidateUpdateValidRequest(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.ControlPlaneConfiguration.Count = cNew.Spec.ControlPlaneConfiguration.Count + 2
 	g := NewWithT(t)
-	_, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	_, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(err).To(Succeed())
 }
 
@@ -1789,7 +1789,7 @@ func TestClusterValidateUpdateRollingAndScalingTinkerbellRequest(t *testing.T) {
 	cNew.Spec.KubernetesVersion = "1.23"
 	cNew.Spec.ControlPlaneConfiguration.Count = cNew.Spec.ControlPlaneConfiguration.Count + 1
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("cannot perform scale up or down during rolling upgrades. Previous control plane node count")))
 }
@@ -1808,7 +1808,7 @@ func TestClusterValidateUpdateAddWNConfig(t *testing.T) {
 	}
 	cNew.Spec.WorkerNodeGroupConfigurations = append(cNew.Spec.WorkerNodeGroupConfigurations, addWNC)
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("cannot perform scale up or down during rolling upgrades. Please remove the new worker node group")))
 }
@@ -1823,7 +1823,7 @@ func TestClusterValidateUpdateAddWNCount(t *testing.T) {
 	cNew.Spec.KubernetesVersion = "1.23"
 	cNew.Spec.WorkerNodeGroupConfigurations[0].Count = ptr.Int(3)
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("cannot perform scale up or down during rolling upgrades. Previous worker node count")))
 }
@@ -1837,7 +1837,7 @@ func TestClusterValidateUpdateRollingTinkerbellRequest(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.KubernetesVersion = "1.23"
 	g := NewWithT(t)
-	g.Expect(cNew.ValidateUpdate(context.TODO(), cNew, cOld)).Error().To(Succeed())
+	g.Expect(cNew.ValidateUpdate(context.TODO(), cOld, cNew)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateLabelTaintsCPTinkerbellRequest(t *testing.T) {
@@ -1856,7 +1856,7 @@ func TestClusterValidateUpdateLabelTaintsCPTinkerbellRequest(t *testing.T) {
 	cNew.Spec.ControlPlaneConfiguration.Labels = map[string]string{}
 	cNew.Spec.ControlPlaneConfiguration.Taints = []v1.Taint{}
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.labels: Forbidden: field is immutable")))
 	g.Expect(err).To(MatchError(ContainSubstring("spec.ControlPlaneConfiguration.taints: Forbidden: field is immutable")))
@@ -1881,7 +1881,7 @@ func TestClusterValidateUpdateLabelTaintsWNTinkerbellRequest(t *testing.T) {
 	cNew.Spec.WorkerNodeGroupConfigurations[0].Taints = []v1.Taint{}
 
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("spec.WorkerNodeConfiguration.labels: Forbidden: field is immutable")))
 	g.Expect(err).To(MatchError(ContainSubstring("spec.WorkerNodeConfiguration.taints: Forbidden: field is immutable")))
@@ -1914,7 +1914,7 @@ func TestClusterValidateUpdateLabelTaintsMultiWNTinkerbellRequest(t *testing.T) 
 	cNew.Spec.WorkerNodeGroupConfigurations[0].Taints = []v1.Taint{{Key: "key1", Value: "val1", Effect: "NoSchedule", TimeAdded: nil}}
 
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(BeNil())
 }
@@ -1988,7 +1988,7 @@ func TestClusterValidateUpdateSkipUpgradeImmutability(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			warnings, err := tc.New.ValidateUpdate(context.TODO(), tc.New, tc.Old)
+			warnings, err := tc.New.ValidateUpdate(context.TODO(), tc.Old, tc.New)
 			g.Expect(warnings).To(BeEmpty())
 			if !tc.Error {
 				g.Expect(err).To(Succeed())
@@ -2011,7 +2011,7 @@ func TestClusterValidateUpdateVersionSkew(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.KubernetesVersion = "1.24"
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("only +1 minor version skew is supported")))
 }
@@ -2025,7 +2025,7 @@ func TestClusterValidateUpdateVersionSkewDecrement(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.KubernetesVersion = "1.23"
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("kubernetes version downgrade is not supported")))
 }
@@ -2039,7 +2039,7 @@ func TestClusterValidateUpdateVersionInvalidNew(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.KubernetesVersion = "test"
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("parsing comparison version: could not parse \"test\" as version")))
 }
@@ -2053,7 +2053,7 @@ func TestClusterValidateUpdateVersionInvalidOld(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.KubernetesVersion = "1.24"
 	g := NewWithT(t)
-	warnings, err := cNew.ValidateUpdate(context.TODO(), cNew, cOld)
+	warnings, err := cNew.ValidateUpdate(context.TODO(), cOld, cNew)
 	g.Expect(warnings).To(BeEmpty())
 	g.Expect(err).To(MatchError(ContainSubstring("parsing cluster version: could not parse \"test\" as version")))
 }
@@ -2067,7 +2067,7 @@ func TestClusterValidateUpdateVersionMinorVersionBump(t *testing.T) {
 	cNew := cOld.DeepCopy()
 	cNew.Spec.KubernetesVersion = "1.25"
 	g := NewWithT(t)
-	g.Expect(cNew.ValidateUpdate(context.TODO(), cNew, cOld)).Error().To(Succeed())
+	g.Expect(cNew.ValidateUpdate(context.TODO(), cOld, cNew)).Error().To(Succeed())
 }
 
 func newCluster(opts ...func(*v1alpha1.Cluster)) *v1alpha1.Cluster {
@@ -2264,7 +2264,7 @@ func TestValidateWorkerVersionSkew(t *testing.T) {
 			oldCluster.Spec.KubernetesVersion = tc.oldVersion
 			oldCluster.Spec.WorkerNodeGroupConfigurations[0].KubernetesVersion = tc.oldWorkerVersion
 
-			warnings, err := newCluster.ValidateUpdate(context.TODO(), newCluster, oldCluster)
+			warnings, err := newCluster.ValidateUpdate(context.TODO(), oldCluster, newCluster)
 			g := NewWithT(t)
 			g.Expect(warnings).To(BeEmpty())
 			if err != nil && !strings.Contains(err.Error(), tc.wantErr.Error()) {
@@ -2345,7 +2345,7 @@ func TestClusterValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.Cluster{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.Cluster{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.Cluster{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/fluxconfig_webhook.go
+++ b/pkg/api/v1alpha1/fluxconfig_webhook.go
@@ -62,7 +62,7 @@ func (r *FluxConfig) ValidateCreate(_ context.Context, obj runtime.Object) (admi
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *FluxConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *FluxConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	fluxConfig, ok := obj.(*FluxConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a FluxConfig but got %T", obj)

--- a/pkg/api/v1alpha1/fluxconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/fluxconfig_webhook_test.go
@@ -21,7 +21,7 @@ func TestClusterValidateUpdateFluxRepoImmutable(t *testing.T) {
 
 	c.Spec.Github.Repository = "fancyNewRepo"
 	f := NewWithT(t)
-	f.Expect(c.ValidateUpdate(ctx, c, &fOld)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
+	f.Expect(c.ValidateUpdate(ctx, &fOld, c)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
 }
 
 func TestClusterValidateUpdateFluxRepoUrlImmutable(t *testing.T) {
@@ -34,7 +34,7 @@ func TestClusterValidateUpdateFluxRepoUrlImmutable(t *testing.T) {
 
 	c.Spec.Git.RepositoryUrl = "https://test.git/test2"
 	f := NewWithT(t)
-	f.Expect(c.ValidateUpdate(ctx, c, &fOld)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
+	f.Expect(c.ValidateUpdate(ctx, &fOld, c)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
 }
 
 func TestClusterValidateUpdateFluxSshKeyAlgoImmutable(t *testing.T) {
@@ -48,7 +48,7 @@ func TestClusterValidateUpdateFluxSshKeyAlgoImmutable(t *testing.T) {
 
 	c.Spec.Git.SshKeyAlgorithm = "rsa2"
 	f := NewWithT(t)
-	f.Expect(c.ValidateUpdate(ctx, c, &fOld)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
+	f.Expect(c.ValidateUpdate(ctx, &fOld, c)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
 }
 
 func TestClusterValidateUpdateFluxBranchImmutable(t *testing.T) {
@@ -59,7 +59,7 @@ func TestClusterValidateUpdateFluxBranchImmutable(t *testing.T) {
 
 	c.Spec.Branch = "newMain"
 	f := NewWithT(t)
-	f.Expect(c.ValidateUpdate(ctx, c, &fOld)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
+	f.Expect(c.ValidateUpdate(ctx, &fOld, c)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
 }
 
 func TestClusterValidateUpdateFluxSubtractionImmutable(t *testing.T) {
@@ -72,7 +72,7 @@ func TestClusterValidateUpdateFluxSubtractionImmutable(t *testing.T) {
 
 	c.Spec = v1alpha1.FluxConfigSpec{}
 	f := NewWithT(t)
-	f.Expect(c.ValidateUpdate(ctx, c, &fOld)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
+	f.Expect(c.ValidateUpdate(ctx, &fOld, c)).Error().To(MatchError(ContainSubstring("Forbidden: config is immutable")))
 }
 
 func TestValidateCreateHasValidatedSpec(t *testing.T) {
@@ -99,7 +99,7 @@ func TestValidateUpdateHasValidatedSpec(t *testing.T) {
 	c.Spec.Git = &v1alpha1.GitProviderConfig{}
 
 	f := NewWithT(t)
-	warnings, err := c.ValidateUpdate(ctx, c, &fOld)
+	warnings, err := c.ValidateUpdate(ctx, &fOld, c)
 	f.Expect(warnings).To(BeEmpty())
 	f.Expect(apierrors.IsInvalid(err)).Error().To(BeTrue())
 	f.Expect(err).To(MatchError(ContainSubstring("must specify only one provider")))

--- a/pkg/api/v1alpha1/gitopsconfig_webhook.go
+++ b/pkg/api/v1alpha1/gitopsconfig_webhook.go
@@ -41,7 +41,7 @@ func (r *GitOpsConfig) ValidateCreate(_ context.Context, obj runtime.Object) (ad
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *GitOpsConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *GitOpsConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	gitopsConfig, ok := obj.(*GitOpsConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a GitOpsConfig but got %T", obj)

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook.go
@@ -63,7 +63,7 @@ func (r *NutanixDatacenterConfig) ValidateCreate(_ context.Context, obj runtime.
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *NutanixDatacenterConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *NutanixDatacenterConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	nutanixConfig, ok := obj.(*NutanixDatacenterConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a NutanixDatacenterConfig but got %T", obj)

--- a/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixdatacenterconfig_webhook_test.go
@@ -83,7 +83,7 @@ func TestNutanixDatacenterConfigWebhooksValidateUpdateInvalidOldObject(t *testin
 	g := NewWithT(t)
 	newConf := nutanixDatacenterConfig()
 	newConf.Spec.CredentialRef = nil
-	_, err := newConf.ValidateUpdate(ctx, newConf, &v1alpha1.NutanixMachineConfig{})
+	_, err := newConf.ValidateUpdate(ctx, &v1alpha1.NutanixMachineConfig{}, newConf)
 	g.Expect(err).To(MatchError(ContainSubstring("expected a NutanixDatacenterConfig but got a *v1alpha1.NutanixMachineConfig")))
 }
 
@@ -94,7 +94,7 @@ func TestNutanixDatacenterConfigWebhooksValidateUpdateCredentialRefRemoved(t *te
 	g.Expect(oldConf.ValidateCreate(ctx, oldConf)).Error().To(Succeed())
 	newConf := nutanixDatacenterConfig()
 	newConf.Spec.CredentialRef = nil
-	_, err := newConf.ValidateUpdate(ctx, newConf, oldConf)
+	_, err := newConf.ValidateUpdate(ctx, oldConf, newConf)
 	g.Expect(err).To(MatchError(ContainSubstring("credentialRef cannot be removed from an existing NutanixDatacenterConfig")))
 }
 

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook.go
@@ -50,7 +50,7 @@ func (in *NutanixMachineConfig) ValidateCreate(_ context.Context, obj runtime.Ob
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (in *NutanixMachineConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (in *NutanixMachineConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	nutanixConfig, ok := obj.(*NutanixMachineConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a NutanixMachineConfig but got %T", obj)

--- a/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/nutanixmachineconfig_webhook_test.go
@@ -210,7 +210,7 @@ func TestNutanixMachineConfigWebhooksValidateUpdateReconcilePaused(t *testing.T)
 	oldConfig.Annotations = map[string]string{
 		"anywhere.eks.amazonaws.com/paused": "true",
 	}
-	g.Expect(newConfig.ValidateUpdate(ctx, newConfig, oldConfig)).Error().To(Succeed())
+	g.Expect(newConfig.ValidateUpdate(ctx, oldConfig, newConfig)).Error().To(Succeed())
 }
 
 func TestValidateUpdate(t *testing.T) {
@@ -219,15 +219,15 @@ func TestValidateUpdate(t *testing.T) {
 	oldConfig := nutanixMachineConfig()
 	newConfig := nutanixMachineConfig()
 	newConfig.Spec.VCPUSockets = 8
-	g.Expect(newConfig.ValidateUpdate(ctx, newConfig, oldConfig)).Error().To(Succeed())
+	g.Expect(newConfig.ValidateUpdate(ctx, oldConfig, newConfig)).Error().To(Succeed())
 
 	oldConfig = nutanixMachineConfig()
 	oldConfig.SetManagedBy("mgmt-cluster")
-	g.Expect(newConfig.ValidateUpdate(ctx, newConfig, oldConfig)).Error().To(Succeed())
+	g.Expect(newConfig.ValidateUpdate(ctx, oldConfig, newConfig)).Error().To(Succeed())
 
 	oldConfig = nutanixMachineConfig()
 	oldConfig.SetControlPlane()
-	g.Expect(newConfig.ValidateUpdate(ctx, newConfig, oldConfig)).Error().To(HaveOccurred())
+	g.Expect(newConfig.ValidateUpdate(ctx, oldConfig, newConfig)).Error().To(HaveOccurred())
 }
 
 func TestValidateUpdate_Invalid(t *testing.T) {
@@ -332,7 +332,7 @@ func TestValidateUpdate_Invalid(t *testing.T) {
 			oldConfig := nutanixMachineConfig()
 			newConfig := nutanixMachineConfig()
 			tt.fn(newConfig, oldConfig)
-			_, err := newConfig.ValidateUpdate(ctx, newConfig, oldConfig)
+			_, err := newConfig.ValidateUpdate(ctx, oldConfig, newConfig)
 			g.Expect(err).To(HaveOccurred(), "expected error for %s", tt.name)
 		})
 	}
@@ -343,7 +343,7 @@ func TestValidateUpdate_OldObjectNotMachineConfig(t *testing.T) {
 	g := NewWithT(t)
 	oldConfig := nutanixDatacenterConfig()
 	newConfig := nutanixMachineConfig()
-	_, err := newConfig.ValidateUpdate(ctx, newConfig, oldConfig)
+	_, err := newConfig.ValidateUpdate(ctx, oldConfig, newConfig)
 	g.Expect(err).To(HaveOccurred())
 }
 

--- a/pkg/api/v1alpha1/oidcconfig_webhook.go
+++ b/pkg/api/v1alpha1/oidcconfig_webhook.go
@@ -47,7 +47,7 @@ func (r *OIDCConfig) ValidateCreate(_ context.Context, obj runtime.Object) (admi
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *OIDCConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *OIDCConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	oidcConfig, ok := obj.(*OIDCConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected an OIDCConfig but got %T", obj)

--- a/pkg/api/v1alpha1/oidcconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/oidcconfig_webhook_test.go
@@ -103,7 +103,7 @@ func TestValidateUpdateOIDCClientIdMgmtCluster(t *testing.T) {
 
 	c.Spec.ClientId = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCGroupsClaimMgmtCluster(t *testing.T) {
@@ -114,7 +114,7 @@ func TestValidateUpdateOIDCGroupsClaimMgmtCluster(t *testing.T) {
 
 	c.Spec.GroupsClaim = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCGroupsPrefixMgmtCluster(t *testing.T) {
@@ -125,7 +125,7 @@ func TestValidateUpdateOIDCGroupsPrefixMgmtCluster(t *testing.T) {
 
 	c.Spec.GroupsPrefix = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCIssuerUrlMgmtCluster(t *testing.T) {
@@ -136,7 +136,7 @@ func TestValidateUpdateOIDCIssuerUrlMgmtCluster(t *testing.T) {
 
 	c.Spec.IssuerUrl = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCUsernameClaimMgmtCluster(t *testing.T) {
@@ -147,7 +147,7 @@ func TestValidateUpdateOIDCUsernameClaimMgmtCluster(t *testing.T) {
 
 	c.Spec.UsernameClaim = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCUsernamePrefixMgmtCluster(t *testing.T) {
@@ -158,7 +158,7 @@ func TestValidateUpdateOIDCUsernamePrefixMgmtCluster(t *testing.T) {
 
 	c.Spec.UsernamePrefix = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCRequiredClaimsMgmtCluster(t *testing.T) {
@@ -169,7 +169,7 @@ func TestValidateUpdateOIDCRequiredClaimsMgmtCluster(t *testing.T) {
 
 	c.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value2"}}
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestValidateUpdateOIDCRequiredClaimsMultipleMgmtCluster(t *testing.T) {
@@ -183,7 +183,7 @@ func TestValidateUpdateOIDCRequiredClaimsMultipleMgmtCluster(t *testing.T) {
 		Value: "value2",
 	})
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(MatchError(ContainSubstring("OIDCConfig: Forbidden: config is immutable")))
 }
 
 func TestClusterValidateUpdateOIDCclientIdMutableUpdateNameWorkloadCluster(t *testing.T) {
@@ -195,7 +195,7 @@ func TestClusterValidateUpdateOIDCclientIdMutableUpdateNameWorkloadCluster(t *te
 
 	c.Spec.ClientId = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCClientIdWorkloadCluster(t *testing.T) {
@@ -208,7 +208,7 @@ func TestValidateUpdateOIDCClientIdWorkloadCluster(t *testing.T) {
 
 	c.Spec.ClientId = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCGroupsClaimWorkloadCluster(t *testing.T) {
@@ -221,7 +221,7 @@ func TestValidateUpdateOIDCGroupsClaimWorkloadCluster(t *testing.T) {
 
 	c.Spec.GroupsClaim = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCGroupsPrefixWorkloadCluster(t *testing.T) {
@@ -234,7 +234,7 @@ func TestValidateUpdateOIDCGroupsPrefixWorkloadCluster(t *testing.T) {
 
 	c.Spec.GroupsPrefix = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCIssuerUrlWorkloadCluster(t *testing.T) {
@@ -247,7 +247,7 @@ func TestValidateUpdateOIDCIssuerUrlWorkloadCluster(t *testing.T) {
 
 	c.Spec.IssuerUrl = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCUsernameClaimWorkloadCluster(t *testing.T) {
@@ -260,7 +260,7 @@ func TestValidateUpdateOIDCUsernameClaimWorkloadCluster(t *testing.T) {
 
 	c.Spec.UsernameClaim = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCUsernamePrefixWorkloadCluster(t *testing.T) {
@@ -273,7 +273,7 @@ func TestValidateUpdateOIDCUsernamePrefixWorkloadCluster(t *testing.T) {
 
 	c.Spec.UsernamePrefix = "test2"
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCRequiredClaimsWorkloadCluster(t *testing.T) {
@@ -286,7 +286,7 @@ func TestValidateUpdateOIDCRequiredClaimsWorkloadCluster(t *testing.T) {
 
 	c.Spec.RequiredClaims = []v1alpha1.OIDCConfigRequiredClaim{{Claim: "test", Value: "value2"}}
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func TestValidateUpdateOIDCRequiredClaimsMultipleWorkloadCluster(t *testing.T) {
@@ -302,7 +302,7 @@ func TestValidateUpdateOIDCRequiredClaimsMultipleWorkloadCluster(t *testing.T) {
 		Value: "value2",
 	})
 	o := NewWithT(t)
-	o.Expect(c.ValidateUpdate(ctx, c, &ocOld)).Error().To(Succeed())
+	o.Expect(c.ValidateUpdate(ctx, &ocOld, c)).Error().To(Succeed())
 }
 
 func oidcConfig() v1alpha1.OIDCConfig {
@@ -342,7 +342,7 @@ func TestOIDCConfigValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.OIDCConfig{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.OIDCConfig{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.OIDCConfig{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/snowdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig_webhook.go
@@ -53,7 +53,7 @@ func (r *SnowDatacenterConfig) ValidateCreate(_ context.Context, obj runtime.Obj
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *SnowDatacenterConfig) ValidateUpdate(_ context.Context, obj, _ runtime.Object) (admission.Warnings, error) {
+func (r *SnowDatacenterConfig) ValidateUpdate(_ context.Context, _, obj runtime.Object) (admission.Warnings, error) {
 	snowConfig, ok := obj.(*SnowDatacenterConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a SnowDatacenterConfig but got %T", obj)

--- a/pkg/api/v1alpha1/snowdatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/snowdatacenterconfig_webhook_test.go
@@ -57,7 +57,7 @@ func TestSnowDatacenterConfigValidateValidateEmptyIdentityRef(t *testing.T) {
 
 	snowDCOld := snowDatacenterConfig()
 	snowDCNew := snowDCOld.DeepCopy()
-	g.Expect(snowDCNew.ValidateUpdate(ctx, snowDCNew, &snowDCOld)).Error().To(MatchError(ContainSubstring("IdentityRef name must not be empty")))
+	g.Expect(snowDCNew.ValidateUpdate(ctx, &snowDCOld, snowDCNew)).Error().To(MatchError(ContainSubstring("IdentityRef name must not be empty")))
 }
 
 func TestSnowDatacenterConfigValidateValidateEmptyIdentityKind(t *testing.T) {
@@ -68,7 +68,7 @@ func TestSnowDatacenterConfigValidateValidateEmptyIdentityKind(t *testing.T) {
 	snowDCNew := snowDCOld.DeepCopy()
 	snowDCNew.Spec.IdentityRef.Name = "refName"
 
-	g.Expect(snowDCNew.ValidateUpdate(ctx, snowDCNew, &snowDCOld)).Error().To(MatchError(ContainSubstring("IdentityRef kind must not be empty")))
+	g.Expect(snowDCNew.ValidateUpdate(ctx, &snowDCOld, snowDCNew)).Error().To(MatchError(ContainSubstring("IdentityRef kind must not be empty")))
 }
 
 func TestSnowDatacenterConfigValidateValidateIdentityKindNotSnow(t *testing.T) {
@@ -80,7 +80,7 @@ func TestSnowDatacenterConfigValidateValidateIdentityKindNotSnow(t *testing.T) {
 	snowDCNew.Spec.IdentityRef.Name = "refName"
 	snowDCNew.Spec.IdentityRef.Kind = v1alpha1.OIDCConfigKind
 
-	g.Expect(snowDCNew.ValidateUpdate(ctx, snowDCNew, &snowDCOld)).Error().To(MatchError(ContainSubstring("is invalid, the only supported kind is Secret")))
+	g.Expect(snowDCNew.ValidateUpdate(ctx, &snowDCOld, snowDCNew)).Error().To(MatchError(ContainSubstring("is invalid, the only supported kind is Secret")))
 }
 
 func snowDatacenterConfig() v1alpha1.SnowDatacenterConfig {
@@ -120,7 +120,7 @@ func TestSnowDatacenterConfigValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.SnowDatacenterConfig{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.SnowDatacenterConfig{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.SnowDatacenterConfig{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/snowippool_webhook.go
+++ b/pkg/api/v1alpha1/snowippool_webhook.go
@@ -41,7 +41,7 @@ func (r *SnowIPPool) ValidateCreate(_ context.Context, obj runtime.Object) (admi
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *SnowIPPool) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *SnowIPPool) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	snowIPPool, ok := obj.(*SnowIPPool)
 	if !ok {
 		return nil, fmt.Errorf("expected a SnowIPPool but got %T", obj)

--- a/pkg/api/v1alpha1/snowippool_webhook_test.go
+++ b/pkg/api/v1alpha1/snowippool_webhook_test.go
@@ -30,7 +30,7 @@ func TestSnowIPPoolValidateUpdate(t *testing.T) {
 	g := NewWithT(t)
 	new := snowIPPool()
 	old := new.DeepCopy()
-	g.Expect(new.ValidateUpdate(ctx, &new, old)).Error().To(Succeed())
+	g.Expect(new.ValidateUpdate(ctx, old, &new)).Error().To(Succeed())
 }
 
 func TestSnowIPPoolValidateUpdateInvalidIPPool(t *testing.T) {
@@ -39,7 +39,7 @@ func TestSnowIPPoolValidateUpdateInvalidIPPool(t *testing.T) {
 	new := snowIPPool()
 	new.Spec.Pools[0].IPStart = "invalid"
 	old := new.DeepCopy()
-	g.Expect(new.ValidateUpdate(ctx, &new, old)).Error().To(MatchError(ContainSubstring("SnowIPPool Pools[0].IPStart is invalid")))
+	g.Expect(new.ValidateUpdate(ctx, old, &new)).Error().To(MatchError(ContainSubstring("SnowIPPool Pools[0].IPStart is invalid")))
 }
 
 func TestSnowIPPoolValidateUpdateInvalidObjectType(t *testing.T) {
@@ -47,7 +47,7 @@ func TestSnowIPPoolValidateUpdateInvalidObjectType(t *testing.T) {
 	g := NewWithT(t)
 	new := snowIPPool()
 	old := &v1alpha1.SnowDatacenterConfig{}
-	g.Expect(new.ValidateUpdate(ctx, &new, old)).Error().To(MatchError(ContainSubstring("expected a SnowIPPool but got a *v1alpha1.SnowDatacenterConfig")))
+	g.Expect(new.ValidateUpdate(ctx, old, &new)).Error().To(MatchError(ContainSubstring("expected a SnowIPPool but got a *v1alpha1.SnowDatacenterConfig")))
 }
 
 func TestSnowIPPoolValidateUpdateIPPoolsSame(t *testing.T) {

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook.go
@@ -75,7 +75,7 @@ func (r *SnowMachineConfig) ValidateCreate(_ context.Context, obj runtime.Object
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *SnowMachineConfig) ValidateUpdate(_ context.Context, obj, _ runtime.Object) (admission.Warnings, error) {
+func (r *SnowMachineConfig) ValidateUpdate(_ context.Context, _, obj runtime.Object) (admission.Warnings, error) {
 	snowConfig, ok := obj.(*SnowMachineConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a SnowMachineConfig but got %T", obj)

--- a/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/snowmachineconfig_webhook_test.go
@@ -132,7 +132,7 @@ func TestSnowMachineConfigValidateUpdate(t *testing.T) {
 		},
 	}
 
-	g.Expect(sNew.ValidateUpdate(ctx, sNew, &sOld)).Error().To(Succeed())
+	g.Expect(sNew.ValidateUpdate(ctx, &sOld, sNew)).Error().To(Succeed())
 }
 
 func TestSnowMachineConfigValidateUpdateNoDevices(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSnowMachineConfigValidateUpdateNoDevices(t *testing.T) {
 	sNew.Spec.PhysicalNetworkConnector = v1alpha1.SFPPlus
 	sNew.Spec.OSFamily = v1alpha1.Bottlerocket
 
-	g.Expect(sNew.ValidateUpdate(ctx, sNew, &sOld)).Error().To(MatchError(ContainSubstring("Devices must contain at least one device IP")))
+	g.Expect(sNew.ValidateUpdate(ctx, &sOld, sNew)).Error().To(MatchError(ContainSubstring("Devices must contain at least one device IP")))
 }
 
 func TestSnowMachineConfigValidateUpdateEmptySSHKeyName(t *testing.T) {
@@ -226,7 +226,7 @@ func TestSnowMachineConfigValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.SnowMachineConfig{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.SnowMachineConfig{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.SnowMachineConfig{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachine_webhook.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachine_webhook.go
@@ -48,7 +48,7 @@ func (m *TinkerbellMachine) ValidateCreate(_ context.Context, obj runtime.Object
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (m *TinkerbellMachine) ValidateUpdate(_ context.Context, obj, oldRaw runtime.Object) (admission.Warnings, error) {
+func (m *TinkerbellMachine) ValidateUpdate(_ context.Context, oldRaw, obj runtime.Object) (admission.Warnings, error) {
 	machine, ok := obj.(*TinkerbellMachine)
 	if !ok {
 		return nil, fmt.Errorf("expected a TinkerbellMachine but got %T", obj)

--- a/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachinetemplate_webhook.go
+++ b/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1/tinkerbellmachinetemplate_webhook.go
@@ -61,7 +61,7 @@ func (m *TinkerbellMachineTemplate) ValidateCreate(_ context.Context, obj runtim
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (m *TinkerbellMachineTemplate) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (m *TinkerbellMachineTemplate) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	template, ok := obj.(*TinkerbellMachineTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected a TinkerbellMachineTemplate but got %T", obj)

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook.go
@@ -74,7 +74,7 @@ func (r *TinkerbellDatacenterConfig) ValidateCreate(_ context.Context, obj runti
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *TinkerbellDatacenterConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *TinkerbellDatacenterConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	tinkerbellConfig, ok := obj.(*TinkerbellDatacenterConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a TinkerbellDatacenterConfig but got %T", obj)

--- a/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbelldatacenterconfig_webhook_test.go
@@ -55,7 +55,7 @@ func TestTinkerbellDatacenterValidateUpdateFailBadReq(t *testing.T) {
 	c := &v1alpha1.TinkerbellDatacenterConfig{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, cOld)).Error().To(MatchError(ContainSubstring("expected a TinkerbellDatacenterConfig but got a *v1alpha1.Cluster")))
+	g.Expect(c.ValidateUpdate(ctx, cOld, c)).Error().To(MatchError(ContainSubstring("expected a TinkerbellDatacenterConfig but got a *v1alpha1.Cluster")))
 }
 
 func TestTinkerbellDatacenterValidateUpdateImmutable(t *testing.T) {
@@ -124,7 +124,7 @@ func TestTinkerbellDatacenterValidateUpdateImmutable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			_, err := tt.new.ValidateUpdate(ctx, &tt.new, &tt.old)
+			_, err := tt.new.ValidateUpdate(ctx, &tt.old, &tt.new)
 			if tt.wantErr == "" {
 				g.Expect(err).To(BeNil())
 			} else {

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook.go
@@ -99,7 +99,7 @@ func (r *TinkerbellMachineConfig) ValidateCreate(_ context.Context, obj runtime.
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *TinkerbellMachineConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *TinkerbellMachineConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	tinkerbellConfig, ok := obj.(*TinkerbellMachineConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a TinkerbellMachineConfig but got %T", obj)

--- a/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/tinkerbellmachineconfig_webhook_test.go
@@ -73,7 +73,7 @@ func TestTinkerbellMachineConfigValidateUpdateSucceed(t *testing.T) {
 	machineConfigNew := machineConfigOld.DeepCopy()
 
 	g := NewWithT(t)
-	g.Expect(machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)).Error().To(Succeed())
+	g.Expect(machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)).Error().To(Succeed())
 }
 
 func TestTinkerbellMachineConfigValidateUpdateFailOldMachineConfig(t *testing.T) {
@@ -82,7 +82,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailOldMachineConfig(t *testing.T)
 	machineConfigNew := v1alpha1.CreateTinkerbellMachineConfig()
 
 	g := NewWithT(t)
-	g.Expect(machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)).Error().To(MatchError(ContainSubstring("expected a TinkerbellMachineConfig but got a *v1alpha1.TinkerbellDatacenterConfig")))
+	g.Expect(machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)).Error().To(MatchError(ContainSubstring("expected a TinkerbellMachineConfig but got a *v1alpha1.TinkerbellDatacenterConfig")))
 }
 
 func TestTinkerbellMachineConfigValidateUpdateFailOSFamily(t *testing.T) {
@@ -93,7 +93,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailOSFamily(t *testing.T) {
 	})
 
 	g := NewWithT(t)
-	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)
+	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(HaveField("spec.OSFamily", err))
 }
@@ -109,7 +109,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailLenSshAuthorizedKeys(t *testin
 	})
 
 	g := NewWithT(t)
-	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)
+	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(HaveField("Users[0].SshAuthorizedKeys", err))
 }
@@ -125,7 +125,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailSshAuthorizedKeys(t *testing.T
 	})
 
 	g := NewWithT(t)
-	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)
+	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(HaveField("Users[0].SshAuthorizedKeys[0]", err))
 }
@@ -147,7 +147,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailUsersLen(t *testing.T) {
 	})
 
 	g := NewWithT(t)
-	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)
+	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(HaveField("Users", err))
 }
@@ -211,7 +211,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailUsers(t *testing.T) {
 	})
 
 	g := NewWithT(t)
-	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)
+	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(HaveField("Users[0].Name", err))
 }
@@ -226,7 +226,7 @@ func TestTinkerbellMachineConfigValidateUpdateFailHardwareSelector(t *testing.T)
 	})
 
 	g := NewWithT(t)
-	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigNew, machineConfigOld)
+	_, err := machineConfigNew.ValidateUpdate(ctx, machineConfigOld, machineConfigNew)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(HaveField("HardwareSelector", err))
 }

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook.go
@@ -90,7 +90,7 @@ func (r *VSphereDatacenterConfig) ValidateCreate(_ context.Context, obj runtime.
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *VSphereDatacenterConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *VSphereDatacenterConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	vsphereConfig, ok := obj.(*VSphereDatacenterConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a VSphereDatacenterConfig but got %T", obj)

--- a/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheredatacenterconfig_webhook_test.go
@@ -18,7 +18,7 @@ func TestVSphereDatacenterValidateUpdateServerImmutable(t *testing.T) {
 
 	c.Spec.Server = "https://newFancyServer.newFancyCloud.io"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(MatchError(ContainSubstring("spec.server: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(MatchError(ContainSubstring("spec.server: Forbidden: field is immutable")))
 }
 
 func TestVSphereDatacenterValidateUpdateDataCenterImmutable(t *testing.T) {
@@ -30,7 +30,7 @@ func TestVSphereDatacenterValidateUpdateDataCenterImmutable(t *testing.T) {
 	c.Spec.Datacenter = "/shinyNewDatacenter"
 	c.Spec.Network = "/shinyNewDatacenter/network"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(MatchError(ContainSubstring("spec.datacenter: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(MatchError(ContainSubstring("spec.datacenter: Forbidden: field is immutable")))
 }
 
 func TestVSphereDatacenterValidateUpdateNetworkImmutable(t *testing.T) {
@@ -42,7 +42,7 @@ func TestVSphereDatacenterValidateUpdateNetworkImmutable(t *testing.T) {
 	c.Spec.Network = "/datacenter/network"
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(MatchError(ContainSubstring("spec.network: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(MatchError(ContainSubstring("spec.network: Forbidden: field is immutable")))
 }
 
 func TestVSphereDatacenterValidateUpdateTLSInsecureMutable(t *testing.T) {
@@ -53,7 +53,7 @@ func TestVSphereDatacenterValidateUpdateTLSInsecureMutable(t *testing.T) {
 
 	c.Spec.Insecure = false
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereDatacenterValidateUpdateTlsThumbprintMutable(t *testing.T) {
@@ -64,7 +64,7 @@ func TestVSphereDatacenterValidateUpdateTlsThumbprintMutable(t *testing.T) {
 
 	c.Spec.Thumbprint = "B3D1C464976E725E599D3548180CB56311818F224E701F9D56F22E8079A7B396"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereDatacenterValidateUpdateWithPausedAnnotation(t *testing.T) {
@@ -78,7 +78,7 @@ func TestVSphereDatacenterValidateUpdateWithPausedAnnotation(t *testing.T) {
 	vOld.PauseReconcile()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereDatacenterValidateUpdateInvalidType(t *testing.T) {
@@ -87,7 +87,7 @@ func TestVSphereDatacenterValidateUpdateInvalidType(t *testing.T) {
 	c := &v1alpha1.VSphereDatacenterConfig{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, vOld)).Error().To(MatchError(ContainSubstring("expected a VSphereDataCenterConfig but got a *v1alpha1.Cluster")))
+	g.Expect(c.ValidateUpdate(ctx, vOld, c)).Error().To(MatchError(ContainSubstring("expected a VSphereDataCenterConfig but got a *v1alpha1.Cluster")))
 }
 
 func TestVSphereDatacenterValidateUpdateInvalidServer(t *testing.T) {
@@ -98,7 +98,7 @@ func TestVSphereDatacenterValidateUpdateInvalidServer(t *testing.T) {
 	c.Spec.Server = ""
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(MatchError(ContainSubstring("VSphereDatacenterConfig server is not set or is empty")))
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(MatchError(ContainSubstring("VSphereDatacenterConfig server is not set or is empty")))
 }
 
 func TestVSphereDatacenterValidateUpdateInvalidDatacenter(t *testing.T) {
@@ -109,7 +109,7 @@ func TestVSphereDatacenterValidateUpdateInvalidDatacenter(t *testing.T) {
 	c.Spec.Datacenter = ""
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(MatchError(ContainSubstring("VSphereDatacenterConfig datacenter is not set or is empty")))
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(MatchError(ContainSubstring("VSphereDatacenterConfig datacenter is not set or is empty")))
 }
 
 func TestVSphereDatacenterValidateUpdateInvalidNetwork(t *testing.T) {
@@ -120,7 +120,7 @@ func TestVSphereDatacenterValidateUpdateInvalidNetwork(t *testing.T) {
 	c.Spec.Network = ""
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(ctx, c, &vOld)).Error().To(MatchError(ContainSubstring("VSphereDatacenterConfig VM network is not set or is empty")))
+	g.Expect(c.ValidateUpdate(ctx, &vOld, c)).Error().To(MatchError(ContainSubstring("VSphereDatacenterConfig VM network is not set or is empty")))
 }
 
 func TestVSphereDatacenterConfigSetDefaults(t *testing.T) {
@@ -220,7 +220,7 @@ func TestVSphereDatacenterConfigValidateUpdateCastFail(t *testing.T) {
 	config := &v1alpha1.VSphereDatacenterConfig{}
 
 	// Call ValidateUpdate with the wrong type
-	warnings, err := config.ValidateUpdate(context.TODO(), wrongType, &v1alpha1.VSphereDatacenterConfig{})
+	warnings, err := config.ValidateUpdate(context.TODO(), &v1alpha1.VSphereDatacenterConfig{}, wrongType)
 
 	// Verify that an error is returned
 	g.Expect(warnings).To(BeNil())

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook.go
@@ -78,7 +78,7 @@ func (r *VSphereMachineConfig) ValidateCreate(_ context.Context, obj runtime.Obj
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *VSphereMachineConfig) ValidateUpdate(_ context.Context, obj, old runtime.Object) (admission.Warnings, error) {
+func (r *VSphereMachineConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	vsphereConfig, ok := obj.(*VSphereMachineConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a VSphereMachineConfig but got %T", obj)

--- a/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/vspheremachineconfig_webhook_test.go
@@ -18,7 +18,7 @@ func TestManagementCPVSphereMachineValidateUpdateTemplateMutableManagement(t *te
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
@@ -30,7 +30,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
@@ -40,7 +40,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
@@ -51,7 +51,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateTemplateSuccess(t *testing.T
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateEtcdUpdateTemplateMutable(t *testing.T) {
@@ -62,7 +62,7 @@ func TestManagementEtcdVSphereMachineValidateEtcdUpdateTemplateMutable(t *testin
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
@@ -74,7 +74,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateTemplateSuccess(t *testing.T) {
 
 	c.Spec.Template = "newTemplate"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateOSFamilyImmutable(t *testing.T) {
@@ -85,7 +85,7 @@ func TestVSphereMachineValidateUpdateOSFamilyImmutable(t *testing.T) {
 	c.Spec.OSFamily = v1alpha1.Bottlerocket
 	c.Spec.Users[0].Name = "ec2-user"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(MatchError(ContainSubstring("spec.osFamily: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(MatchError(ContainSubstring("spec.osFamily: Forbidden: field is immutable")))
 }
 
 func TestManagementCPVSphereMachineValidateUpdateMemoryMiBMutableManagement(t *testing.T) {
@@ -96,7 +96,7 @@ func TestManagementCPVSphereMachineValidateUpdateMemoryMiBMutableManagement(t *t
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
@@ -108,7 +108,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
@@ -118,7 +118,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateMemoryMiBSuccess(t *testin
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
@@ -129,7 +129,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing.T) {
@@ -141,7 +141,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateMemoryMiBImmutable(t *testing
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) {
@@ -153,7 +153,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateMemoryMiBSuccess(t *testing.T) 
 
 	c.Spec.MemoryMiB = 2000000
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementCPVSphereMachineValidateUpdateNumCPUsMutableManagement(t *testing.T) {
@@ -164,7 +164,7 @@ func TestManagementCPVSphereMachineValidateUpdateNumCPUsMutableManagement(t *tes
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
@@ -176,7 +176,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
@@ -186,7 +186,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
@@ -197,7 +197,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T)
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateNumCPUsMmutableManagement(t *testing.T) {
@@ -208,7 +208,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateNumCPUsMmutableManagement(t *
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
@@ -220,7 +220,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateNumCPUsSuccess(t *testing.T) {
 
 	c.Spec.NumCPUs = 16
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementCPVSphereMachineValidateUpdateDiskGiBMutableManagement(t *testing.T) {
@@ -231,7 +231,7 @@ func TestManagementCPVSphereMachineValidateUpdateDiskGiBMutableManagement(t *tes
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
@@ -243,7 +243,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
@@ -253,7 +253,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
@@ -264,7 +264,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T)
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateDiskGiBMmutableManagement(t *testing.T) {
@@ -276,7 +276,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateDiskGiBMmutableManagement(t *
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
@@ -288,7 +288,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateDiskGiBSuccess(t *testing.T) {
 
 	c.Spec.DiskGiB = 160
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementControlPlaneSphereMachineValidateUpdateSshAuthorizedKeyMutableManagement(t *testing.T) {
@@ -300,7 +300,7 @@ func TestManagementControlPlaneSphereMachineValidateUpdateSshAuthorizedKeyMutabl
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
@@ -313,7 +313,7 @@ func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshAuthorizedKeyMutable
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementControlPlaneVSphereMachineValidateUpdateSshUsernameImmutable(t *testing.T) {
@@ -324,7 +324,7 @@ func TestManagementControlPlaneVSphereMachineValidateUpdateSshUsernameImmutable(
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
@@ -336,7 +336,7 @@ func TestWorkloadControlPlaneVSphereMachineValidateUpdateSshUsernameMutable(t *t
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateWithPausedAnnotation(t *testing.T) {
@@ -352,7 +352,7 @@ func TestVSphereMachineValidateUpdateWithPausedAnnotation(t *testing.T) {
 	vOld.PauseReconcile()
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdSphereMachineValidateUpdateSshAuthorizedKeyMutableManagement(t *testing.T) {
@@ -364,7 +364,7 @@ func TestManagementEtcdSphereMachineValidateUpdateSshAuthorizedKeyMutableManagem
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *testing.T) {
@@ -377,7 +377,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateSshAuthorizedKeyImmutable(t *te
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
@@ -388,7 +388,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateSshUsernameMutable(t *testing
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
@@ -400,7 +400,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkerNodeSphereMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
@@ -411,7 +411,7 @@ func TestManagementWorkerNodeSphereMachineValidateUpdateSshAuthorizedKeyMutable(
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshAuthorizedKeyMutable(t *testing.T) {
@@ -423,7 +423,7 @@ func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshAuthorizedKeyMutable(t
 
 	c.Spec.Users[0].SshAuthorizedKeys[0] = "rsa-laDeLala"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkerNodeVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
@@ -433,7 +433,7 @@ func TestManagementWorkerNodeVSphereMachineValidateUpdateSshUsernameMutable(t *t
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshUsernameMutable(t *testing.T) {
@@ -444,7 +444,7 @@ func TestWorkloadWorkerNodeVSphereMachineValidateUpdateSshUsernameMutable(t *tes
 
 	c.Spec.Users[0].Name = "Andy"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateInvalidType(t *testing.T) {
@@ -452,7 +452,7 @@ func TestVSphereMachineValidateUpdateInvalidType(t *testing.T) {
 	c := &v1alpha1.VSphereMachineConfig{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, vOld)).Error().To(MatchError(ContainSubstring("expected a VSphereMachineConfig but got a *v1alpha1.Cluster")))
+	g.Expect(c.ValidateUpdate(context.TODO(), vOld, c)).Error().To(MatchError(ContainSubstring("expected a VSphereMachineConfig but got a *v1alpha1.Cluster")))
 }
 
 func TestVSphereMachineValidateUpdateSuccess(t *testing.T) {
@@ -463,7 +463,7 @@ func TestVSphereMachineValidateUpdateSuccess(t *testing.T) {
 	c.Spec.NumCPUs = 16
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateBottleRocketInvalidUserName(t *testing.T) {
@@ -478,7 +478,7 @@ func TestVSphereMachineValidateUpdateBottleRocketInvalidUserName(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().ToNot(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().ToNot(Succeed())
 }
 
 func TestManagementCPVSphereMachineValidateUpdateDatastoreMutableSuccess(t *testing.T) {
@@ -489,7 +489,7 @@ func TestManagementCPVSphereMachineValidateUpdateDatastoreMutableSuccess(t *test
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
@@ -501,7 +501,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateDatastoreMutableManagement(t *testing.T) {
@@ -512,7 +512,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateDatastoreMutableManagement(t 
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
@@ -524,7 +524,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) 
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
@@ -534,7 +534,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateDatastoreSuccess(t *testin
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateDatastoreSuccess(t *testing.T) {
@@ -545,7 +545,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateDatastoreSuccess(t *testing.
 
 	c.Spec.Datastore = "NewDataStore"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementCPVSphereMachineValidateUpdateFolderMutableManagement(t *testing.T) {
@@ -556,7 +556,7 @@ func TestManagementCPVSphereMachineValidateUpdateFolderMutableManagement(t *test
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
@@ -568,7 +568,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateFolderMutableManagement(t *testing.T) {
@@ -579,7 +579,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateFolderMutableManagement(t *te
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
@@ -591,7 +591,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
@@ -601,7 +601,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateFolderSuccess(t *testing.T
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateFolderSuccess(t *testing.T) {
@@ -612,7 +612,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateFolderSuccess(t *testing.T) 
 
 	c.Spec.Folder = "/tmp"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementCPVSphereMachineValidateUpdateResourcePoolMutableManagemenmt(t *testing.T) {
@@ -623,7 +623,7 @@ func TestManagementCPVSphereMachineValidateUpdateResourcePoolMutableManagemenmt(
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadCPVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {
@@ -635,7 +635,7 @@ func TestWorkloadCPVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T)
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementEtcdVSphereMachineValidateUpdateResourcePoolMutableManagement(t *testing.T) {
@@ -646,7 +646,7 @@ func TestManagementEtcdVSphereMachineValidateUpdateResourcePoolMutableManagement
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadEtcdVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {
@@ -658,7 +658,7 @@ func TestWorkloadEtcdVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestManagementWorkersVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {
@@ -668,7 +668,7 @@ func TestManagementWorkersVSphereMachineValidateUpdateResourcePoolSuccess(t *tes
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestWorkloadWorkersVSphereMachineValidateUpdateResourcePoolSuccess(t *testing.T) {
@@ -679,7 +679,7 @@ func TestWorkloadWorkersVSphereMachineValidateUpdateResourcePoolSuccess(t *testi
 
 	c.Spec.ResourcePool = "IngroundPool"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(Succeed())
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(Succeed())
 }
 
 func TestVSphereMachineValidateUpdateStoragePolicyImmutable(t *testing.T) {
@@ -689,7 +689,7 @@ func TestVSphereMachineValidateUpdateStoragePolicyImmutable(t *testing.T) {
 
 	c.Spec.StoragePolicyName = "Space-Efficient"
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), c, &vOld)).Error().To(MatchError(ContainSubstring("spec.storagePolicyName: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), &vOld, c)).Error().To(MatchError(ContainSubstring("spec.storagePolicyName: Forbidden: field is immutable")))
 }
 
 func TestVSphereMachineConfigValidateCreateSuccess(t *testing.T) {

--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -159,7 +159,7 @@ func (p *cloudstackProvider) validateMachineConfigImmutability(ctx context.Conte
 		return err
 	}
 
-	_, err = newConfig.ValidateUpdate(ctx, newConfig, prevMachineConfig)
+	_, err = newConfig.ValidateUpdate(ctx, prevMachineConfig, newConfig)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (p *cloudstackProvider) ValidateNewSpec(ctx context.Context, cluster *types
 
 	prevDatacenter.SetDefaults()
 
-	if _, err = clusterSpec.CloudStackDatacenter.ValidateUpdate(ctx, clusterSpec.CloudStackDatacenter, prevDatacenter); err != nil {
+	if _, err = clusterSpec.CloudStackDatacenter.ValidateUpdate(ctx, prevDatacenter, clusterSpec.CloudStackDatacenter); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In https://github.com/aws/eks-anywhere/pull/9744 we added changes to accomodate new interface for webhook ValidateUpdate method. The args (old, new obj) are defined in wrong order and this is failing the upgrade scenarios.

 In this PR, I am fixing the method signature by updating the correct order of the arguments old, new

*Testing (if applicable):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



