### PR TITLE
Fix CloudstackDataCenter and awsiamconfig webhook update issue

### DIFF
--- a/pkg/api/v1alpha1/awsiamconfig_webhook.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook.go
@@ -59,7 +59,7 @@ func (r *AWSIamConfig) ValidateCreate(_ context.Context, obj runtime.Object) (ad
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *AWSIamConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
+func (*AWSIamConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
 	awsIamConfig, ok := obj.(*AWSIamConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected an AWSIamConfig but got %T", obj)
@@ -74,9 +74,9 @@ func (r *AWSIamConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object
 
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, validateImmutableAWSIamFields(r, oldAWSIamConfig)...)
-	if err := r.Validate(); err != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("AWSIamConfig"), r, err.Error()))
+	allErrs = append(allErrs, validateImmutableAWSIamFields(awsIamConfig, oldAWSIamConfig)...)
+	if err := awsIamConfig.Validate(); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("AWSIamConfig"), awsIamConfig, err.Error()))
 	}
 
 	if len(allErrs) == 0 {

--- a/pkg/api/v1alpha1/awsiamconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/awsiamconfig_webhook_test.go
@@ -35,7 +35,7 @@ func TestValidateUpdateAWSIamConfigSuccess(t *testing.T) {
 		},
 	}
 	g := NewWithT(t)
-	g.Expect(aiNew.ValidateUpdate(ctx, &aiOld, aiNew)).Error().To(Succeed())
+	g.Expect((&v1alpha1.AWSIamConfig{}).ValidateUpdate(ctx, &aiOld, aiNew)).Error().To(Succeed())
 }
 
 func TestValidateCreateAWSIamConfigSuccess(t *testing.T) {

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook.go
@@ -80,13 +80,13 @@ func (r *CloudStackDatacenterConfig) ValidateCreate(_ context.Context, obj runti
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
-func (r *CloudStackDatacenterConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
-	cloudstackConfig, ok := obj.(*CloudStackDatacenterConfig)
+func (*CloudStackDatacenterConfig) ValidateUpdate(_ context.Context, old, obj runtime.Object) (admission.Warnings, error) {
+	newDatacenterConfig, ok := obj.(*CloudStackDatacenterConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected a CloudStackDatacenterConfig but got %T", obj)
 	}
 
-	cloudstackdatacenterconfiglog.Info("validate update", "name", cloudstackConfig.Name)
+	cloudstackdatacenterconfiglog.Info("validate update", "name", newDatacenterConfig.Name)
 
 	oldDatacenterConfig, ok := old.(*CloudStackDatacenterConfig)
 	if !ok {
@@ -100,13 +100,13 @@ func (r *CloudStackDatacenterConfig) ValidateUpdate(_ context.Context, old, obj 
 
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, validateImmutableFieldsCloudStackCluster(r, oldDatacenterConfig)...)
+	allErrs = append(allErrs, validateImmutableFieldsCloudStackCluster(newDatacenterConfig, oldDatacenterConfig)...)
 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(CloudStackDatacenterKind).GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(CloudStackDatacenterKind).GroupKind(), newDatacenterConfig.Name, allErrs)
 }
 
 func isValidAzConversionName(uuid string) bool {

--- a/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook_test.go
+++ b/pkg/api/v1alpha1/cloudstackdatacenterconfig_webhook_test.go
@@ -46,6 +46,17 @@ func TestCloudStackDatacenterDatacenterConfigSetDefaults(t *testing.T) {
 	g.Expect(originalDatacenter).To(Equal(*expectedDatacenter))
 }
 
+func TestCloudStackDatacenterValidateUpdateSuccessful(t *testing.T) {
+	ctx := context.Background()
+	vOld := cloudstackDatacenterConfig()
+	vOld.Spec.AvailabilityZones[0].Domain = "oldCruftyDomain"
+	c := vOld.DeepCopy()
+
+	c.Spec.Account = "123"
+	g := NewWithT(t)
+	g.Expect((&v1alpha1.CloudStackDatacenterConfig{}).ValidateUpdate(ctx, &vOld, c)).Error().To(Succeed())
+}
+
 func TestCloudStackDatacenterValidateUpdateDomainImmutable(t *testing.T) {
 	ctx := context.Background()
 	vOld := cloudstackDatacenterConfig()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudstack E2E tests are failing with below error. This is because in the webhook validate method, code is still using receiver as new object but the receiver will be empty in the new webhook implementation in controller runtime.

In this PR I am fixing the issue to use new object instead of the receiver.

```
denied the request: CloudStackDatacenterConfig.anywhere.eks.amazonaws.com \"\" is invalid: spec.availabilityZone: Invalid value: []v1alpha1.CloudStackAvailabilityZone(nil): at least one AvailabilityZone must be shared between new and old CloudStackDatacenterConfig specs","errVerbose":"admission webhook \"validation.cloudstackdatacenterconfig.anywhere.amazonaws.com\" denied the request: CloudStackDatacenterConfig.anywhere.eks.amazonaws.com \"\" is invalid: spec.availabilityZone: Invalid value: []v1alpha1.CloudStackAvailabilityZone(nil): at least one AvailabilityZone must be shared between new and old CloudStackDatacenterConfig specs\nupdating object 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


