### PR TITLE
Add a new command to renew cluster certificates(Ubuntu/RHEL,Bottlerocket), config.yaml support for certificate renewal

### DIFF
--- a/cmd/eksctl-anywhere/cmd/renew.go
+++ b/cmd/eksctl-anywhere/cmd/renew.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var renewCmd = &cobra.Command{
+	Use:   "renew",
+	Short: "renew resources",
+	Long:  "Use eksctl anywhere renew to renew resources, such as clusters",
+}
+
+func init() {
+	rootCmd.AddCommand(renewCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/renewcertificates.go
+++ b/cmd/eksctl-anywhere/cmd/renewcertificates.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/certificates"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type renewCertificatesOptions struct {
+	configFile string
+	component  string
+}
+
+var rc = &renewCertificatesOptions{}
+
+var renewCertificatesCmd = &cobra.Command{
+	Use:   "certificates",
+	Short: "Renew certificates for cluster components",
+	Long: `Renew certificates for etcd and control plane nodes in EKS Anywhere cluster.
+
+This command supports certificate renewal for both etcd and control plane components.
+You can choose to renew certificates for all components or specify a single component.
+
+Example config file (yaml):
+  clusterName: my-cluster
+  controlPlane:
+    nodes:
+    - 192.168.1.10
+    - 192.168.1.11
+    - 192.168.1.12
+    os: ubuntu    # ubuntu, rhel, or bottlerocket
+    sshKey: /path/to/ssh/private-key
+    sshUser: ec2-user
+  etcd:
+    nodes:
+    - 192.168.1.20
+    - 192.168.1.21
+    - 192.168.1.22
+    os: ubuntu    # ubuntu, rhel, or bottlerocket
+    sshKey: /path/to/ssh/private-key
+    sshUser: ec2-user`,
+	PreRunE:      bindFlagsToViper,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rc.renewCertificates(cmd)
+	},
+}
+
+func init() {
+	renewCmd.AddCommand(renewCertificatesCmd)
+
+	renewCertificatesCmd.Flags().StringVarP(&rc.configFile, "config", "f", "", "Config file containing node and SSH information")
+	renewCertificatesCmd.Flags().StringVarP(&rc.component, "component", "c", "", "Component to renew certificates for (etcd or control-plane). If not specified, renews both.")
+
+	if err := renewCertificatesCmd.MarkFlagRequired("config"); err != nil {
+		panic(err)
+	}
+}
+
+func validateComponent(component string) error {
+	if component != "" && component != "etcd" && component != "control-plane" {
+		return fmt.Errorf("invalid component %q, must be either 'etcd' or 'control-plane'", component)
+	}
+	return nil
+}
+
+func (rc *renewCertificatesOptions) renewCertificates(cmd *cobra.Command) error {
+	if err := validateComponent(rc.component); err != nil {
+		return err
+	}
+
+	config, err := certificates.ParseConfig(rc.configFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse config file: %v", err)
+	}
+
+	cluster := &types.Cluster{
+		Name: config.ClusterName,
+	}
+
+	renewer, err := certificates.NewRenewer()
+	if err != nil {
+		return fmt.Errorf("failed to create renewer: %v", err)
+	}
+	return renewer.RenewCertificates(cmd.Context(), cluster, config, rc.component)
+}

--- a/pkg/certificates/bottlerocket/commands.go
+++ b/pkg/certificates/bottlerocket/commands.go
@@ -1,0 +1,355 @@
+package bottlerocket
+
+import "fmt"
+
+type ControlPlaneCommands struct {
+	ShelliePrefix string
+	BackupCerts   string
+	ImagePull     string
+	RenewCerts    string
+	CopyCerts     string
+	RestartPods   string
+}
+
+type ControlPlaneCommandBuilder struct {
+	BackupDir       string
+	CertDir         string
+	Component       string
+	HasExternalEtcd bool
+}
+
+func NewControlPlaneCommandBuilder(backupDir, certDir, component string, hasExternalEtcd bool) *ControlPlaneCommandBuilder {
+	return &ControlPlaneCommandBuilder{
+		BackupDir:       backupDir,
+		CertDir:         certDir,
+		Component:       component,
+		HasExternalEtcd: hasExternalEtcd,
+	}
+}
+
+func (b *ControlPlaneCommandBuilder) BuildCommands() *ControlPlaneCommands {
+	return &ControlPlaneCommands{
+		ShelliePrefix: b.buildShelliePrefix(),
+		BackupCerts:   b.buildBackupCerts(),
+		ImagePull:     b.buildImagePull(),
+		RenewCerts:    b.buildRenewCerts(),
+		CopyCerts:     b.buildCopyCerts(),
+		RestartPods:   b.buildRestartPods(),
+	}
+}
+
+type EtcdCommands struct {
+	ShelliePrefix string
+	ImagePull     string
+	BackupCerts   string
+	RenewCerts    string
+	CopyCerts     string
+	Cleanup       string
+}
+
+type EtcdCommandBuilder struct {
+	BackupDir string
+	TempDir   string
+}
+
+func NewEtcdCommandBuilder(backupDir, tempDir string) *EtcdCommandBuilder {
+	return &EtcdCommandBuilder{
+		BackupDir: backupDir,
+		TempDir:   tempDir,
+	}
+}
+
+// all etcd commands
+func (b *EtcdCommandBuilder) BuildCommands() *EtcdCommands {
+	return &EtcdCommands{
+		ShelliePrefix: b.buildShelliePrefix(),
+		ImagePull:     b.buildImagePull(),
+		BackupCerts:   b.buildBackupCerts(),
+		RenewCerts:    b.buildRenewCerts(),
+		CopyCerts:     b.buildCopyCerts(),
+		Cleanup:       b.buildCleanup(),
+	}
+}
+
+type CertTransferCommands struct {
+	ShelliePrefix    string
+	CreateDir        string
+	SetPermissions   string
+	WriteCertificate string
+	WriteKey         string
+}
+
+type CertTransferBuilder struct {
+	TempDir     string
+	Certificate string
+	Key         string
+}
+
+func NewCertTransferBuilder(tempDir, certificate, key string) *CertTransferBuilder {
+	return &CertTransferBuilder{
+		TempDir:     tempDir,
+		Certificate: certificate,
+		Key:         key,
+	}
+}
+
+// certificate transfer commands
+func (b *CertTransferBuilder) BuildCommands() *CertTransferCommands {
+	return &CertTransferCommands{
+		ShelliePrefix:    b.buildShelliePrefix(),
+		CreateDir:        b.buildCreateDir(),
+		SetPermissions:   b.buildSetPermissions(),
+		WriteCertificate: b.buildWriteCertificate(),
+		WriteKey:         b.buildWriteKey(),
+	}
+}
+
+type CertReadCommands struct {
+	ListFiles string
+	ReadCert  string
+	ReadKey   string
+}
+
+type CertReadBuilder struct {
+	TempDir string
+}
+
+func NewCertReadBuilder(tempDir string) *CertReadBuilder {
+	return &CertReadBuilder{
+		TempDir: tempDir,
+	}
+}
+
+// certificate read commands
+func (b *CertReadBuilder) BuildCommands() *CertReadCommands {
+	return &CertReadCommands{
+		ListFiles: b.buildListFiles(),
+		ReadCert:  b.buildReadCert(),
+		ReadKey:   b.buildReadKey(),
+	}
+}
+
+func (b *ControlPlaneCommandBuilder) buildShelliePrefix() string {
+	return `set -euo pipefail
+sudo sheltie << 'EOF'
+set -x`
+}
+
+func (b *ControlPlaneCommandBuilder) buildBackupCerts() string {
+	if b.Component == "control-plane" && b.HasExternalEtcd {
+		return fmt.Sprintf(`mkdir -p '/etc/kubernetes/pki.bak_%[1]s'
+cd %[2]s
+for f in $(find . -type f ! -path './etcd/*'); do
+    mkdir -p $(dirname '/etc/kubernetes/pki.bak_%[1]s/'$f)
+    cp $f '/etc/kubernetes/pki.bak_%[1]s/'$f
+done`, b.BackupDir, b.CertDir)
+	} else {
+		return fmt.Sprintf("cp -r '%s' '/etc/kubernetes/pki.bak_%s'",
+			b.CertDir, b.BackupDir)
+	}
+}
+
+func (b *ControlPlaneCommandBuilder) buildImagePull() string {
+	return `IMAGE_ID=$(apiclient get | apiclient exec admin jq -r '.settings["host-containers"]["kubeadm-bootstrap"].source')
+ctr image pull ${IMAGE_ID}`
+}
+
+func (b *ControlPlaneCommandBuilder) buildRenewCerts() string {
+	return `ctr run \
+--mount type=bind,src=/var/lib/kubeadm,dst=/var/lib/kubeadm,options=rbind:rw \
+--mount type=bind,src=/var/lib/kubeadm,dst=/etc/kubernetes,options=rbind:rw \
+--rm ${IMAGE_ID} tmp-cert-renew \
+/opt/bin/kubeadm certs renew all
+
+ctr run \
+--mount type=bind,src=/var/lib/kubeadm,dst=/var/lib/kubeadm,options=rbind:rw \
+--mount type=bind,src=/var/lib/kubeadm,dst=/etc/kubernetes,options=rbind:rw \
+--rm ${IMAGE_ID} tmp-cert-check \
+/opt/bin/kubeadm certs check-expiration`
+}
+
+func (b *ControlPlaneCommandBuilder) buildCopyCerts() string {
+	return `if [ -d "/run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/etcd-client-certs" ]; then
+    echo "Source certificates:"
+    ls -l /run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/etcd-client-certs/
+    
+    echo "Destination before copy:"
+    ls -l /var/lib/kubeadm/pki/server-etcd-client.crt || true
+    ls -l /var/lib/kubeadm/pki/apiserver-etcd-client.key || true
+    
+    cp -v /run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/etcd-client-certs/apiserver-etcd-client.crt /var/lib/kubeadm/pki/server-etcd-client.crt || {
+        echo "❌ Failed to copy certificate"
+        exit 1
+    }
+    cp -v /run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/etcd-client-certs/apiserver-etcd-client.key /var/lib/kubeadm/pki/apiserver-etcd-client.key || {
+        echo "❌ Failed to copy key"
+        exit 1
+    }
+    
+    chmod 600 /var/lib/kubeadm/pki/server-etcd-client.crt || {
+        echo "❌ Failed to set certificate permissions"
+        exit 1
+    }
+    chmod 600 /var/lib/kubeadm/pki/apiserver-etcd-client.key || {
+        echo "❌ Failed to set key permissions"
+        exit 1
+    }
+    
+    echo "Destination after copy:"
+    ls -l /var/lib/kubeadm/pki/server-etcd-client.crt
+    ls -l /var/lib/kubeadm/pki/apiserver-etcd-client.key
+    
+    echo "✅ Certificates copied successfully"
+else
+    echo "❌ Source directory does not exist"
+    ls -l /run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/
+    exit 1
+fi`
+}
+
+func (b *ControlPlaneCommandBuilder) buildRestartPods() string {
+	return `apiclient get | apiclient exec admin jq -r '.settings.kubernetes["static-pods"] | keys[]' \
+ | xargs -n1 -I{} apiclient set settings.kubernetes.static-pods.{}.enabled=false
+apiclient get | apiclient exec admin jq -r '.settings.kubernetes["static-pods"] | keys[]' \
+ | xargs -n1 -I{} apiclient set settings.kubernetes.static-pods.{}.enabled=true`
+}
+
+func (b *EtcdCommandBuilder) buildShelliePrefix() string {
+	return `set -euo pipefail
+sudo sheltie << 'EOF'
+set -x`
+}
+
+func (b *EtcdCommandBuilder) buildImagePull() string {
+	return `IMAGE_ID=$(apiclient get | apiclient exec admin jq -r '.settings["host-containers"]["kubeadm-bootstrap"].source')
+ctr image pull ${IMAGE_ID}`
+}
+
+func (b *EtcdCommandBuilder) buildBackupCerts() string {
+	return fmt.Sprintf(`cp -r /var/lib/etcd/pki /var/lib/etcd/pki.bak_%[1]s
+rm /var/lib/etcd/pki/*
+cp /var/lib/etcd/pki.bak_%[1]s/ca.* /var/lib/etcd/pki
+echo "✅ Certs backedup"`, b.BackupDir)
+}
+
+func (b *EtcdCommandBuilder) buildRenewCerts() string {
+	return `ctr run \
+--mount type=bind,src=/var/lib/etcd/pki,dst=/etc/etcd/pki,options=rbind:rw \
+--net-host \
+--rm \
+${IMAGE_ID} tmp-cert-renew \
+/opt/bin/etcdadm join phase certificates http://eks-a-etcd-dumb-url --init-system kubelet`
+}
+
+func (b *EtcdCommandBuilder) buildCopyCerts() string {
+	return fmt.Sprintf(`echo "Source files in /var/lib/etcd/pki/:"
+ls -l /var/lib/etcd/pki/apiserver-etcd-client.*
+
+echo "Copying certificates to %[1]s..."
+cp /var/lib/etcd/pki/apiserver-etcd-client.* %[1]s || { 
+    echo "❌ Failed to copy certs to tmp"
+    echo "Source files:"
+    ls -l /var/lib/etcd/pki/apiserver-etcd-client.*
+    echo "Destination directory:"
+    ls -l %[1]s
+    exit 1
+}
+
+echo "Setting permissions..."
+chmod 600 %[1]s/apiserver-etcd-client.crt || { 
+    echo "❌ Failed to chmod certificate"
+    ls -l %[1]s/apiserver-etcd-client.crt
+    exit 1
+}
+chmod 600 %[1]s/apiserver-etcd-client.key || { 
+    echo "❌ Failed to chmod key"
+    ls -l %[1]s/apiserver-etcd-client.key
+    exit 1
+}
+
+echo "Verifying copied files..."
+ls -l %[1]s/apiserver-etcd-client.*`, b.TempDir)
+}
+
+func (b *EtcdCommandBuilder) buildCleanup() string {
+	return fmt.Sprintf(`rm -f %s/apiserver-etcd-client.*`, b.TempDir)
+}
+
+func (b *CertTransferBuilder) buildShelliePrefix() string {
+	return `sudo sheltie << 'EOF'
+set -x`
+}
+
+func (b *CertTransferBuilder) buildCreateDir() string {
+	return fmt.Sprintf(`echo "Creating directory..."
+TARGET_DIR="/run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/%[1]s"
+mkdir -p "${TARGET_DIR}" || {
+    echo "❌ Failed to create directory"
+    exit 1
+}
+
+chmod 755 "${TARGET_DIR}" || {
+    echo "❌ Failed to set directory permissions"
+    exit 1
+}
+
+echo "Verifying directory:"
+ls -ld "${TARGET_DIR}"
+ls -l /run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp/`, b.TempDir)
+}
+
+func (b *CertTransferBuilder) buildSetPermissions() string {
+	return `echo "Setting permissions..."
+chmod 600 "${TARGET_DIR}/apiserver-etcd-client.crt" || {
+    echo "❌ Failed to set permissions on certificate"
+    exit 1
+}
+chmod 600 "${TARGET_DIR}/apiserver-etcd-client.key" || {
+    echo "❌ Failed to set permissions on key"
+    exit 1
+}`
+}
+
+func (b *CertTransferBuilder) buildWriteCertificate() string {
+	return fmt.Sprintf(`echo "Writing certificate file..."
+cat <<'CRT_END' | base64 -d > "${TARGET_DIR}/apiserver-etcd-client.crt"
+%s
+CRT_END
+if [ $? -ne 0 ]; then
+    echo "❌ Failed to write certificate file"
+    exit 1
+fi`, b.Certificate)
+}
+
+func (b *CertTransferBuilder) buildWriteKey() string {
+	return fmt.Sprintf(`echo "Writing key file..."
+cat <<'KEY_END' | base64 -d > "${TARGET_DIR}/apiserver-etcd-client.key"
+%s
+KEY_END
+if [ $? -ne 0 ]; then
+    echo "❌ Failed to write key file"
+    exit 1
+fi`, b.Key)
+}
+
+func (b *CertReadBuilder) buildListFiles() string {
+	return fmt.Sprintf(`sudo sheltie << 'EOF'
+echo "Checking source files:"
+ls -l %s/apiserver-etcd-client.*
+exit
+EOF`, b.TempDir)
+}
+
+func (b *CertReadBuilder) buildReadCert() string {
+	return fmt.Sprintf(`sudo sheltie << 'EOF'
+cat %s/apiserver-etcd-client.crt
+exit
+EOF`, b.TempDir)
+}
+
+func (b *CertReadBuilder) buildReadKey() string {
+	return fmt.Sprintf(`sudo sheltie << 'EOF'
+cat %s/apiserver-etcd-client.key
+exit
+EOF`, b.TempDir)
+}

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -1,0 +1,88 @@
+package certificates
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// NodeConfig holds SSH configuration for a node group
+type NodeConfig struct {
+	Nodes     []string `yaml:"nodes"`
+	OS        string   `yaml:"os"`
+	SSHKey    string   `yaml:"sshKey"`
+	SSHUser   string   `yaml:"sshUser"`
+	SSHPasswd string   `yaml:"sshPasswd,omitempty"` // Optional SSH key passphrase
+}
+
+type RenewalConfig struct {
+	ClusterName  string     `yaml:"clusterName"`
+	ControlPlane NodeConfig `yaml:"controlPlane"`
+	Etcd         NodeConfig `yaml:"etcd"`
+}
+
+func ParseConfig(path string) (*RenewalConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %v", err)
+	}
+
+	config := &RenewalConfig{}
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("parsing config file: %v", err)
+	}
+
+	if err := validateConfig(config); err != nil {
+		return nil, fmt.Errorf("validating config: %v", err)
+	}
+
+	return config, nil
+}
+
+func validateConfig(config *RenewalConfig) error {
+	if config.ClusterName == "" {
+		return fmt.Errorf("cluster name is required")
+	}
+
+	if len(config.ControlPlane.Nodes) == 0 {
+		return fmt.Errorf("at least one control plane node is required")
+	}
+
+	if err := validateNodeConfig(&config.ControlPlane, "control plane"); err != nil {
+		return err
+	}
+
+	// Etcd nodes are optional (could be embedded in control plane)
+	if len(config.Etcd.Nodes) > 0 {
+		if err := validateNodeConfig(&config.Etcd, "etcd"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNodeConfig(config *NodeConfig, component string) error {
+	if len(config.Nodes) == 0 {
+		return fmt.Errorf("%s nodes are required", component)
+	}
+	if config.OS == "" {
+		return fmt.Errorf("%s OS is required", component)
+	}
+	if config.OS != "ubuntu" && config.OS != "rhel" && config.OS != "bottlerocket" {
+		return fmt.Errorf("unsupported OS %q for %s", config.OS, component)
+	}
+	if config.SSHKey == "" {
+		return fmt.Errorf("%s SSH key is required", component)
+	}
+	if config.SSHUser == "" {
+		return fmt.Errorf("%s SSH user is required", component)
+	}
+
+	if _, err := os.Stat(config.SSHKey); err != nil {
+		return fmt.Errorf("SSH key file for %s: %v", component, err)
+	}
+
+	return nil
+}

--- a/pkg/certificates/config_test.go
+++ b/pkg/certificates/config_test.go
@@ -1,0 +1,221 @@
+package certificates
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configYaml  string
+		expectError bool
+	}{
+		{
+			name: "valid config with both etcd and control plane",
+			configYaml: `
+clusterName: test-cluster
+controlPlane:
+  nodes:
+  - 192.168.1.10
+  os: ubuntu
+  sshKey: /tmp/test-key
+  sshUser: ec2-user
+etcd:
+  nodes:
+  - 192.168.1.20
+  os: ubuntu
+  sshKey: /tmp/test-key
+  sshUser: ec2-user
+`,
+			expectError: false,
+		},
+		{
+			name: "valid config without etcd (embedded)",
+			configYaml: `
+clusterName: test-cluster
+controlPlane:
+  nodes:
+  - 192.168.1.10
+  os: ubuntu
+  sshKey: /tmp/test-key
+  sshUser: ec2-user
+`,
+			expectError: false,
+		},
+		{
+			name: "invalid config - missing cluster name",
+			configYaml: `
+controlPlane:
+  nodes:
+  - 192.168.1.10
+  os: ubuntu
+  sshKey: /tmp/test-key
+  sshUser: ec2-user
+`,
+			expectError: true,
+		},
+		{
+			name: "invalid config - missing control plane nodes",
+			configYaml: `
+clusterName: test-cluster
+controlPlane:
+  os: ubuntu
+  sshKey: /tmp/test-key
+  sshUser: ec2-user
+`,
+			expectError: true,
+		},
+		{
+			name: "invalid config - unsupported OS",
+			configYaml: `
+clusterName: test-cluster
+controlPlane:
+  nodes:
+  - 192.168.1.10
+  os: windows
+  sshKey: /tmp/test-key
+  sshUser: ec2-user
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary config file
+			tmpfile, err := os.CreateTemp("", "config-*.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.Write([]byte(tt.configYaml)); err != nil {
+				t.Fatal(err)
+			}
+			if err := tmpfile.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Create temporary SSH key file
+			keyFile := "/tmp/test-key"
+			if err := os.WriteFile(keyFile, []byte("test-key"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(keyFile)
+
+			// Test config parsing
+			_, err = ParseConfig(tmpfile.Name())
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateNodeConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      NodeConfig
+		component   string
+		expectError bool
+	}{
+		{
+			name: "valid ubuntu config",
+			config: NodeConfig{
+				Nodes:   []string{"192.168.1.10"},
+				OS:      "ubuntu",
+				SSHKey:  "/tmp/test-key",
+				SSHUser: "ec2-user",
+			},
+			component:   "control plane",
+			expectError: false,
+		},
+		{
+			name: "valid rhel config",
+			config: NodeConfig{
+				Nodes:   []string{"192.168.1.10"},
+				OS:      "rhel",
+				SSHKey:  "/tmp/test-key",
+				SSHUser: "ec2-user",
+			},
+			component:   "etcd",
+			expectError: false,
+		},
+		{
+			name: "valid bottlerocket config",
+			config: NodeConfig{
+				Nodes:   []string{"192.168.1.10"},
+				OS:      "bottlerocket",
+				SSHKey:  "/tmp/test-key",
+				SSHUser: "ec2-user",
+			},
+			component:   "control plane",
+			expectError: false,
+		},
+		{
+			name: "invalid - missing nodes",
+			config: NodeConfig{
+				OS:      "ubuntu",
+				SSHKey:  "/tmp/test-key",
+				SSHUser: "ec2-user",
+			},
+			component:   "control plane",
+			expectError: true,
+		},
+		{
+			name: "invalid - unsupported OS",
+			config: NodeConfig{
+				Nodes:   []string{"192.168.1.10"},
+				OS:      "windows",
+				SSHKey:  "/tmp/test-key",
+				SSHUser: "ec2-user",
+			},
+			component:   "control plane",
+			expectError: true,
+		},
+		{
+			name: "invalid - missing SSH key",
+			config: NodeConfig{
+				Nodes:   []string{"192.168.1.10"},
+				OS:      "ubuntu",
+				SSHUser: "ec2-user",
+			},
+			component:   "control plane",
+			expectError: true,
+		},
+		{
+			name: "invalid - missing SSH user",
+			config: NodeConfig{
+				Nodes:  []string{"192.168.1.10"},
+				OS:     "ubuntu",
+				SSHKey: "/tmp/test-key",
+			},
+			component:   "control plane",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary SSH key file
+			if tt.config.SSHKey != "" {
+				if err := os.WriteFile(tt.config.SSHKey, []byte("test-key"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				defer os.Remove(tt.config.SSHKey)
+			}
+
+			err := validateNodeConfig(&tt.config, tt.component)
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/certificates/renewer.go
+++ b/pkg/certificates/renewer.go
@@ -1,0 +1,332 @@
+package certificates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+const (
+	tempLocalEtcdCertsDir = "etcd-client-certs"
+
+	ubuntuEtcdCertDir           = "/etc/etcd"
+	ubuntuControlPlaneCertDir   = "/etc/kubernetes/pki"
+	ubuntuControlPlaneManifests = "/etc/kubernetes/manifests"
+
+	bottlerocketEtcdCertDir         = "/var/lib/etcd"
+	bottlerocketControlPlaneCertDir = "/var/lib/kubeadm/pki"
+	bottlerocketTmpDir              = "/run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs/tmp"
+
+	componentEtcd         = "etcd"
+	componentControlPlane = "control-plane"
+)
+
+type sshDialer func(network, addr string, config *ssh.ClientConfig) (sshClient, error)
+
+type Renewer struct {
+	backupDir  string
+	sshConfig  *ssh.ClientConfig
+	sshKeyPath string // store SSH key path from config
+	kubeClient kubernetes.Interface
+	sshDialer  sshDialer
+}
+
+func NewRenewer() (*Renewer, error) {
+	backupDate := time.Now().Format("20060102_150405")
+	backupDir := fmt.Sprintf("certificate_backup_%s", backupDate)
+	fmt.Printf("Creating backup directory: %s\n", backupDir)
+
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create backup directory: %v", err)
+	}
+
+	etcdCertsPath := filepath.Join(backupDir, tempLocalEtcdCertsDir)
+	fmt.Printf("Creating etcd certs directory: %s\n", etcdCertsPath)
+
+	if err := os.MkdirAll(etcdCertsPath, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create etcd certs directory: %v", err)
+	}
+
+	r := &Renewer{
+		backupDir: backupDir,
+		sshDialer: func(network, addr string, config *ssh.ClientConfig) (sshClient, error) {
+			return ssh.Dial(network, addr, config)
+		},
+	}
+	return r, nil
+}
+
+func (r *Renewer) RenewCertificates(ctx context.Context, cluster *types.Cluster, config *RenewalConfig, component string) error {
+	if component != "" && component != componentEtcd && component != componentControlPlane {
+		return fmt.Errorf("invalid component %q, must be either %q or %q", component, componentEtcd, componentControlPlane)
+	}
+
+	fmt.Printf("✅ Checking if Kubernetes API server is reachable...\n")
+	if err := r.initKubeClient(); err != nil {
+		return fmt.Errorf("failed to initialize kubernetes client: %v", err)
+	}
+
+	if err := r.checkAPIServerReachability(ctx); err != nil {
+		return fmt.Errorf("API server health check failed: %v", err)
+	}
+
+	fmt.Printf("✅ Backing up kubeadm-config ConfigMap...\n")
+	if err := r.backupKubeadmConfig(ctx); err != nil {
+		return fmt.Errorf("failed to backup kubeadm config: %v", err)
+	}
+
+	if component == componentEtcd || component == "" {
+		if len(config.Etcd.Nodes) > 0 {
+			fmt.Printf("Starting etcd certificate renewal process...\n")
+			if err := r.renewEtcdCerts(ctx, config); err != nil {
+				return fmt.Errorf("failed to renew etcd certificates: %v", err)
+			}
+			fmt.Printf("🎉 Etcd certificate renewal process completed successfully.\n")
+		} else {
+			fmt.Printf("Cluster does not have external ETCD.\n")
+		}
+	}
+
+	if component == componentControlPlane || component == "" {
+		if len(config.ControlPlane.Nodes) == 0 {
+			return fmt.Errorf("❌ Error: No control plane node IPs found")
+		}
+		fmt.Printf("Starting control plane certificate renewal process...\n")
+		if err := r.renewControlPlaneCerts(ctx, config, component); err != nil {
+			return fmt.Errorf("failed to renew control plane certificates: %v", err)
+		}
+		fmt.Printf("🎉 Control plane certificate renewal process completed successfully.\n")
+	}
+
+	fmt.Printf("✅ Cleaning up temporary files...\n")
+	if err := r.cleanup(); err != nil {
+		fmt.Printf("❌ API server unreachable — skipping cleanup to preserve debug data.\n")
+		return err
+	}
+	fmt.Printf("✅ All temporary files removed.\n")
+	return nil
+}
+
+func (r *Renewer) initKubeClient() error {
+	if r.kubeClient != nil {
+		return nil
+	}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	r.kubeClient = clientset
+	return nil
+}
+
+func (r *Renewer) checkAPIServerReachability(ctx context.Context) error {
+	for i := 0; i < 5; i++ {
+		_, err := r.kubeClient.Discovery().ServerVersion()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(10 * time.Second)
+	}
+	return fmt.Errorf("kubernetes API server is not reachable")
+}
+
+func (r *Renewer) backupKubeadmConfig(ctx context.Context) error {
+	cm, err := r.kubeClient.CoreV1().ConfigMaps("kube-system").Get(ctx, "kubeadm-config", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get kubeadm-config: %v", err)
+	}
+
+	backupPath := filepath.Join(r.backupDir, "kubeadm-config.yaml")
+	if err := os.WriteFile(backupPath, []byte(cm.Data["ClusterConfiguration"]), 0600); err != nil {
+		return fmt.Errorf("failed to write kubeadm config backup: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Renewer) renewEtcdCerts(ctx context.Context, config *RenewalConfig) error {
+
+	if err := r.initSSHConfig(config.Etcd.SSHUser, config.Etcd.SSHKey, config.Etcd.SSHPasswd); err != nil {
+		return fmt.Errorf("failed to initialize SSH config: %v", err)
+	}
+
+	for _, node := range config.Etcd.Nodes {
+		if err := r.renewEtcdNodeCerts(ctx, node, config.Etcd); err != nil {
+			return fmt.Errorf("failed to renew certificates for etcd node %s: %v", node, err)
+		}
+	}
+
+	if err := r.updateAPIServerEtcdClientSecret(ctx, config.ClusterName); err != nil {
+		return fmt.Errorf("failed to update apiserver-etcd-client secret: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Renewer) renewControlPlaneCerts(ctx context.Context, config *RenewalConfig, component string) error {
+	if err := r.initSSHConfig(config.ControlPlane.SSHUser, config.ControlPlane.SSHKey, config.ControlPlane.SSHPasswd); err != nil {
+		return fmt.Errorf("failed to initialize SSH config: %v", err)
+	}
+
+	// Renew certificate for each control plane node
+	for _, node := range config.ControlPlane.Nodes {
+		if err := r.renewControlPlaneNodeCerts(ctx, node, config, component); err != nil {
+			return fmt.Errorf("failed to renew certificates for control plane node %s: %v", node, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Renewer) initSSHConfig(user, keyPath string, passwd string) error {
+	r.sshKeyPath = keyPath // Store SSH key path
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read SSH key: %v", err)
+	}
+
+	var signer ssh.Signer
+	signer, err = ssh.ParsePrivateKey(key)
+	if err != nil {
+		if err.Error() == "ssh: this private key is passphrase protected" {
+			if passwd == "" {
+				fmt.Printf("Enter passphrase for SSH key '%s': ", keyPath)
+				var passphrase []byte
+				passphrase, err = term.ReadPassword(int(os.Stdin.Fd()))
+				if err != nil {
+					return fmt.Errorf("failed to read passphrase: %v", err)
+				}
+				fmt.Println() // Print newline after password input
+				passwd = string(passphrase)
+			}
+			signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(passwd))
+			if err != nil {
+				return fmt.Errorf("failed to parse SSH key with passphrase: %v", err)
+			}
+		} else {
+			return fmt.Errorf("failed to parse SSH key: %v", err)
+		}
+	}
+
+	r.sshConfig = &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         30 * time.Second,
+	}
+
+	return nil
+}
+
+func (r *Renewer) renewEtcdNodeCerts(ctx context.Context, node string, config NodeConfig) error {
+	switch config.OS {
+	case "ubuntu", "rhel":
+		return r.renewEtcdCertsLinux(ctx, node)
+	case "bottlerocket":
+		return r.renewEtcdCertsBottlerocket(ctx, node)
+	default:
+		return fmt.Errorf("unsupported OS: %s", config.OS)
+	}
+}
+
+func (r *Renewer) renewControlPlaneNodeCerts(ctx context.Context, node string, config *RenewalConfig, component string) error {
+	switch config.ControlPlane.OS {
+	case "ubuntu", "rhel":
+		return r.renewControlPlaneCertsLinux(ctx, node, config, component)
+	case "bottlerocket":
+		return r.renewControlPlaneCertsBottlerocket(ctx, node, config, component)
+	default:
+		return fmt.Errorf("unsupported OS: %s", config.ControlPlane.OS)
+	}
+}
+
+func (r *Renewer) runCommand(ctx context.Context, client sshClient, cmd string) error {
+	done := make(chan error, 1)
+	go func() {
+		session, err := client.NewSession()
+		if err != nil {
+			done <- fmt.Errorf("failed to create session: %v", err)
+			return
+		}
+		defer session.Close()
+		// print shell session progress
+		session.Stdout = os.Stdout
+		session.Stderr = os.Stderr
+
+		done <- session.Run(cmd)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("command cancelled: %v", ctx.Err())
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("command failed: %v", err)
+		}
+		return nil
+	}
+}
+
+func (r *Renewer) runCommandWithOutput(ctx context.Context, client sshClient, cmd string) (string, error) {
+	type result struct {
+		output string
+		err    error
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		session, err := client.NewSession()
+		if err != nil {
+			done <- result{"", fmt.Errorf("failed to create session: %v", err)}
+			return
+		}
+		defer session.Close()
+
+		output, err := session.Output(cmd)
+		if err != nil {
+			done <- result{"", fmt.Errorf("command failed: %v", err)}
+			return
+		}
+		done <- result{strings.TrimSpace(string(output)), nil}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return "", fmt.Errorf("command cancelled: %v", ctx.Err())
+	case res := <-done:
+		return res.output, res.err
+	}
+}
+
+func (r *Renewer) cleanup() error {
+	fmt.Printf("Cleaning up directory: %s\n", r.backupDir)
+
+	chmodCmd := exec.Command("chmod", "-R", "u+w", r.backupDir)
+	if err := chmodCmd.Run(); err != nil {
+		return fmt.Errorf("failed to change permissions: %v", err)
+	}
+
+	return os.RemoveAll(r.backupDir)
+}

--- a/pkg/certificates/renewerbottlerocket.go
+++ b/pkg/certificates/renewerbottlerocket.go
@@ -1,0 +1,341 @@
+package certificates
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/eks-anywhere/pkg/certificates/bottlerocket"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	persistentCertDir     = "/var/lib/eks-anywhere/certificates"
+	persistentEtcdCertDir = "etcd-certs"
+)
+
+func (r *Renewer) renewControlPlaneCertsBottlerocket(ctx context.Context, node string, config *RenewalConfig, component string) error {
+	fmt.Printf("Processing control plane node: %s...\n", node)
+
+	// for renew control panel only
+	if component == componentControlPlane && len(config.Etcd.Nodes) > 0 {
+		if err := r.loadCertsFromPersistentStorage(); err != nil {
+			return fmt.Errorf("failed to load certificates from persistent storage: %v", err)
+		}
+	}
+
+	client, err := r.sshDialer("tcp", fmt.Sprintf("%s:22", node), r.sshConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s: %v", node, err)
+	}
+	defer client.Close()
+
+	// If we have external etcd nodes, first transfer certificates to the node
+	if len(config.Etcd.Nodes) > 0 {
+		if err := r.transferCertsToControlPlane(ctx, node); err != nil {
+			return fmt.Errorf("failed to transfer certificates to control plane node: %v", err)
+		}
+	}
+
+	builder := bottlerocket.NewControlPlaneCommandBuilder(
+		r.backupDir,
+		bottlerocketControlPlaneCertDir,
+		component,
+		len(config.Etcd.Nodes) > 0,
+	)
+	commands := builder.BuildCommands()
+	session := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\nEOF",
+		commands.ShelliePrefix,
+		commands.BackupCerts,
+		commands.ImagePull,
+		commands.RenewCerts,
+		commands.CopyCerts,
+		commands.RestartPods)
+
+	if err := r.runCommand(ctx, client, session); err != nil {
+		return fmt.Errorf("failed to renew control panel node certificates: %v", err)
+	}
+
+	fmt.Printf("✅ Completed renewing certificate for the control node: %s.\n", node)
+	fmt.Printf("---------------------------------------------\n")
+	return nil
+}
+
+func (r *Renewer) transferCertsToControlPlane(ctx context.Context, node string) error {
+	fmt.Printf("Transferring certificates to control plane node: %s...\n", node)
+
+	client, err := r.sshDialer("tcp", fmt.Sprintf("%s:22", node), r.sshConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s: %v", node, err)
+	}
+	defer client.Close()
+
+	srcCrt := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
+	crtContent, err := os.ReadFile(srcCrt)
+	if err != nil {
+		return fmt.Errorf("failed to read certificate file: %v", err)
+	}
+
+	srcKey := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
+	keyContent, err := os.ReadFile(srcKey)
+	if err != nil {
+		return fmt.Errorf("failed to read key file: %v", err)
+	}
+
+	crtBase64 := base64.StdEncoding.EncodeToString(crtContent)
+	keyBase64 := base64.StdEncoding.EncodeToString(keyContent)
+
+	builder := bottlerocket.NewCertTransferBuilder(tempLocalEtcdCertsDir, crtBase64, keyBase64)
+	commands := builder.BuildCommands()
+	session := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\nEOF",
+		commands.ShelliePrefix,
+		commands.CreateDir,
+		commands.WriteCertificate,
+		commands.WriteKey,
+		commands.SetPermissions)
+
+	if err := r.runCommand(ctx, client, session); err != nil {
+		return fmt.Errorf("failed to transfer certificates: %v", err)
+	}
+
+	fmt.Printf("External certificates transferred to control plane node: %s.\n", node)
+	return nil
+}
+
+func (r *Renewer) renewEtcdCertsBottlerocket(ctx context.Context, node string) error {
+	fmt.Printf("Processing etcd node: %s...\n", node)
+
+	client, err := r.sshDialer("tcp", fmt.Sprintf("%s:22", node), r.sshConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s: %v", node, err)
+	}
+	defer client.Close()
+
+	builder := bottlerocket.NewEtcdCommandBuilder(r.backupDir, bottlerocketTmpDir)
+	commands := builder.BuildCommands()
+
+	// first session: backup and renew certificates
+	firstSession := fmt.Sprintf("%s\n%s\n%s\n%s\nEOF",
+		commands.ShelliePrefix,
+		commands.ImagePull,
+		commands.BackupCerts,
+		commands.RenewCerts)
+
+	if err := r.runCommand(ctx, client, firstSession); err != nil {
+		return fmt.Errorf("failed to renew certificates: %v", err)
+	}
+
+	// second sheltie session for copying certs
+	secondSession := fmt.Sprintf("%s\n%s\nEOF",
+		commands.ShelliePrefix,
+		commands.CopyCerts)
+
+	if err := r.runCommand(ctx, client, secondSession); err != nil {
+		return fmt.Errorf("failed to copy certificates2 to tmp: %v", err)
+	}
+
+	// copy certificates to local
+	fmt.Printf("Copying certificates from node %s...\n", node)
+	if err := r.copyEtcdCerts(ctx, client, node); err != nil {
+		return fmt.Errorf("failed to copy certificates3: %v", err)
+	}
+
+	// third sheltie session for cleanup
+	thirdSession := fmt.Sprintf("%s\n%s\nEOF",
+		commands.ShelliePrefix,
+		commands.Cleanup)
+
+	if err := r.runCommand(ctx, client, thirdSession); err != nil {
+		return fmt.Errorf("failed to cleanup temporary files: %v", err)
+	}
+
+	fmt.Printf("✅ Completed renewing certificate for the ETCD node: %s.\n", node)
+	fmt.Printf("---------------------------------------------\n")
+
+	// save etcd cert for control panel renew
+	if err := r.saveCertsToPersistentStorage(); err != nil {
+		return fmt.Errorf("failed to save certificates to persistent storage: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Renewer) copyEtcdCerts(ctx context.Context, client sshClient, node string) error {
+
+	fmt.Printf("Reading certificate from ETCD node %s...\n", node)
+	fmt.Printf("Using backup directory: %s\n", r.backupDir)
+
+	builder := bottlerocket.NewCertReadBuilder(bottlerocketTmpDir)
+	commands := builder.BuildCommands()
+
+	if err := r.runCommand(ctx, client, commands.ListFiles); err != nil {
+		return fmt.Errorf("failed to list certificate files: %v", err)
+	}
+
+	crtContent, err := r.runCommandWithOutput(ctx, client, commands.ReadCert)
+	if err != nil {
+		return fmt.Errorf("failed to read certificate file: %v", err)
+	}
+
+	if len(crtContent) == 0 {
+		return fmt.Errorf("certificate file is empty")
+	}
+
+	fmt.Printf("Reading key from ETCD node %s...\n", node)
+	keyContent, err := r.runCommandWithOutput(ctx, client, commands.ReadKey)
+	if err != nil {
+		return fmt.Errorf("failed to read key file: %v", err)
+	}
+
+	if len(keyContent) == 0 {
+		return fmt.Errorf("key file is empty")
+	}
+
+	crtPath := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
+	keyPath := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
+
+	fmt.Printf("Writing certificates to:\n")
+	fmt.Printf("Certificate: %s\n", crtPath)
+	fmt.Printf("Key: %s\n", keyPath)
+
+	if err := os.WriteFile(crtPath, []byte(crtContent), 0600); err != nil {
+		return fmt.Errorf("failed to write certificate file: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte(keyContent), 0600); err != nil {
+		return fmt.Errorf("failed to write key file: %v", err)
+	}
+
+	fmt.Printf("✅ Certificates copied successfully:\n")
+	fmt.Printf("Backup directory: %s\n", r.backupDir)
+	fmt.Printf("Certificate path: %s\n", crtPath)
+	fmt.Printf("Key path: %s\n", keyPath)
+
+	return nil
+}
+
+func (r *Renewer) updateAPIServerEtcdClientSecret(ctx context.Context, clusterName string) error {
+	fmt.Printf("Updating %s-apiserver-etcd-client secret...\n", clusterName)
+
+	crtPath := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
+	keyPath := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
+
+	crtData, err := os.ReadFile(crtPath)
+	if err != nil {
+		return fmt.Errorf("failed to read certificate file: %v", err)
+	}
+
+	keyData, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read key file: %v", err)
+	}
+
+	// get current sercet or create
+	secretName := fmt.Sprintf("%s-apiserver-etcd-client", clusterName)
+	secret, err := r.kubeClient.CoreV1().Secrets("eksa-system").Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get secret %s: %v", secretName, err)
+		}
+
+		// if sercet not exist, create
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: "eksa-system",
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": crtData,
+				"tls.key": keyData,
+			},
+		}
+
+		_, err = r.kubeClient.CoreV1().Secrets("eksa-system").Create(ctx, secret, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create secret %s: %v", secretName, err)
+		}
+	} else {
+		// if sercet exist, renew it
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+
+		secret.Data["tls.crt"] = crtData
+		secret.Data["tls.key"] = keyData
+
+		_, err = r.kubeClient.CoreV1().Secrets("eksa-system").Update(ctx, secret, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update secret %s: %v", secretName, err)
+		}
+	}
+
+	fmt.Printf("✅ Successfully updated %s secret.\n", secretName)
+	return nil
+}
+
+// for renew control panel only
+func (r *Renewer) saveCertsToPersistentStorage() error {
+	srcCrt := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
+	srcKey := filepath.Join(r.backupDir, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
+
+	destDir := filepath.Join(persistentCertDir, persistentEtcdCertDir)
+	if err := os.MkdirAll(destDir, 0700); err != nil {
+		return fmt.Errorf("failed to create persistent directory: %v", err)
+	}
+
+	destCrt := filepath.Join(destDir, "apiserver-etcd-client.crt")
+	destKey := filepath.Join(destDir, "apiserver-etcd-client.key")
+
+	if err := copyFile(srcCrt, destCrt); err != nil {
+		return fmt.Errorf("failed to copy certificate: %v", err)
+	}
+	if err := copyFile(srcKey, destKey); err != nil {
+		return fmt.Errorf("failed to copy key: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Renewer) loadCertsFromPersistentStorage() error {
+	srcDir := filepath.Join(persistentCertDir, persistentEtcdCertDir)
+	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+		return fmt.Errorf("no etcd certificates found in persistent storage. Please run etcd certificate renewal first")
+	}
+
+	destDir := filepath.Join(r.backupDir, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(destDir, 0700); err != nil {
+		return fmt.Errorf("failed to create temporary directory: %v", err)
+	}
+
+	srcCrt := filepath.Join(srcDir, "apiserver-etcd-client.crt")
+	srcKey := filepath.Join(srcDir, "apiserver-etcd-client.key")
+
+	destCrt := filepath.Join(destDir, "apiserver-etcd-client.crt")
+	destKey := filepath.Join(destDir, "apiserver-etcd-client.key")
+
+	if err := copyFile(srcCrt, destCrt); err != nil {
+		return fmt.Errorf("failed to copy certificate: %v", err)
+	}
+	if err := copyFile(srcKey, destKey); err != nil {
+		return fmt.Errorf("failed to copy key: %v", err)
+	}
+
+	return nil
+}
+
+func copyFile(src, dest string) error {
+	input, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile(dest, input, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/certificates/renewerubuntu.go
+++ b/pkg/certificates/renewerubuntu.go
@@ -1,0 +1,115 @@
+package certificates
+
+import (
+	"context"
+	"fmt"
+)
+
+func (r *Renewer) renewControlPlaneCertsLinux(ctx context.Context, node string, config *RenewalConfig, component string) error {
+	fmt.Printf("Processing control plane node: %s...\n", node)
+	client, err := r.sshDialer("tcp", fmt.Sprintf("%s:22", node), r.sshConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s: %v", node, err)
+	}
+	defer client.Close()
+
+	// Backup certificates, excluding etcd directory if component is control-plane
+	var backupCmd string
+	if component == componentControlPlane && len(config.Etcd.Nodes) > 0 {
+		// When only updating control plane with external etcd, exclude etcd directory
+		backupCmd = fmt.Sprintf(`
+sudo mkdir -p '/etc/kubernetes/pki.bak_%[1]s'
+cd %[2]s
+for f in $(find . -type f ! -path './etcd/*'); do
+    sudo mkdir -p $(dirname '/etc/kubernetes/pki.bak_%[1]s/'$f)
+    sudo cp $f '/etc/kubernetes/pki.bak_%[1]s/'$f
+done`, r.backupDir, ubuntuControlPlaneCertDir)
+	} else {
+		backupCmd = fmt.Sprintf("sudo cp -r '%s' '/etc/kubernetes/pki.bak_%s'",
+			ubuntuControlPlaneCertDir, r.backupDir)
+	}
+	if err := r.runCommand(ctx, client, backupCmd); err != nil {
+		return fmt.Errorf("failed to backup certificates: %v", err)
+	}
+
+	// Renew certificates
+	fmt.Printf("Renewing certificates on node %s...\n", node)
+	renewCmd := "sudo kubeadm certs renew all"
+	if component == componentControlPlane && len(config.Etcd.Nodes) > 0 {
+		// When only renewing control plane certs with external etcd,
+		// we need to skip the etcd directory to preserve certificates
+		renewCmd = `for cert in admin.conf apiserver apiserver-kubelet-client controller-manager.conf front-proxy-client scheduler.conf; do
+            sudo kubeadm certs renew $cert
+        done`
+	}
+	if err := r.runCommand(ctx, client, renewCmd); err != nil {
+		return fmt.Errorf("failed to renew certificates: %v", err)
+	}
+
+	// Validate certificates
+	fmt.Printf("Validating certificates on node %s...\n", node)
+	validateCmd := "sudo kubeadm certs check-expiration"
+	if err := r.runCommand(ctx, client, validateCmd); err != nil {
+		return fmt.Errorf("certificate validation failed: %v", err)
+	}
+
+	// Restart
+	fmt.Printf("Restarting control plane components on node %s...\n", node)
+	restartCmd := fmt.Sprintf("sudo mkdir -p /tmp/manifests && "+
+		"sudo mv %s/* /tmp/manifests/ && "+
+		"sleep 20 && "+
+		"sudo mv /tmp/manifests/* %s/",
+		ubuntuControlPlaneManifests, ubuntuControlPlaneManifests)
+	if err := r.runCommand(ctx, client, restartCmd); err != nil {
+		return fmt.Errorf("failed to restart control plane components: %v", err)
+	}
+
+	fmt.Printf("✅ Completed renewing certificate for the control node: %s.\n", node)
+	fmt.Printf("---------------------------------------------\n")
+	return nil
+}
+
+func (r *Renewer) renewEtcdCertsLinux(ctx context.Context, node string) error {
+	fmt.Printf("Processing etcd node: %s...\n", node)
+	client, err := r.sshDialer("tcp", fmt.Sprintf("%s:22", node), r.sshConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s: %v", node, err)
+	}
+	defer client.Close()
+
+	// Backup certificates
+	fmt.Printf("# Backup certificates\n")
+	backupCmd := fmt.Sprintf("cd %s && sudo cp -r pki pki.bak_%s && sudo rm -rf pki/* && sudo cp pki.bak_%s/ca.* pki/",
+		ubuntuEtcdCertDir, r.backupDir, r.backupDir)
+	if err := r.runCommand(ctx, client, backupCmd); err != nil {
+		return fmt.Errorf("failed to backup certificates: %v", err)
+	}
+
+	// Renew certificates
+	fmt.Printf("# Renew certificates\n")
+	renewCmd := "sudo etcdadm join phase certificates http://eks-a-etcd-dumb-url"
+	if err := r.runCommand(ctx, client, renewCmd); err != nil {
+		return fmt.Errorf("failed to renew certificates: %v", err)
+	}
+
+	// Validate certificates
+	fmt.Printf("# Validate certificates\n")
+	validateCmd := fmt.Sprintf("sudo etcdctl --cacert=%s/pki/ca.crt "+
+		"--cert=%s/pki/etcdctl-etcd-client.crt "+
+		"--key=%s/pki/etcdctl-etcd-client.key "+
+		"endpoint health",
+		ubuntuEtcdCertDir, ubuntuEtcdCertDir, ubuntuEtcdCertDir)
+	if err := r.runCommand(ctx, client, validateCmd); err != nil {
+		return fmt.Errorf("certificate validation failed: %v", err)
+	}
+
+	// Copy certificates to local
+	fmt.Printf("Copying certificates from node %s...\n", node)
+	if err := r.copyEtcdCerts(ctx, client, node); err != nil {
+		return fmt.Errorf("failed to copy certificates1: %v", err)
+	}
+
+	fmt.Printf("✅ Completed renewing certificate for the ETCD node: %s.\n", node)
+	fmt.Printf("---------------------------------------------\n")
+	return nil
+}

--- a/pkg/certificates/ssh.go
+++ b/pkg/certificates/ssh.go
@@ -1,0 +1,11 @@
+package certificates
+
+import (
+	"golang.org/x/crypto/ssh"
+)
+
+// sshClient interface defines the methods we need from ssh.Client
+type sshClient interface {
+	Close() error
+	NewSession() (*ssh.Session, error)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR introduces a new eksctl anywhere renew certificates command that implements certificate renewal for EKS Anywhere clusters. Key features:

Command Interface:
- New subcommand under eksctl anywhere renew
- Configurable via YAML for flexible deployment
- Component-specific renewal with --component flag

Core Implementation:
- OS-specific renewal strategies:
    - Bottlerocket: Uses sheltie for privileged operations, container based cert renewal
    - Ubuntu/RHEL: Direct certificate management
- Secure SSH-based deployment with optional key passphrase
- Automatic certificate backup and validation

Architecture:
- Modular command builders for Bottlerocket operations
- Unified configuration structure for all OS types
- Flexible component targeting (etcd/control-plane)


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

