### PR TITLE
Configuration Structure For Certificate Renewal (Part 1 of the certificate renewal command feature) 

### DIFF
--- a/cmd/eksctl-anywhere/cmd/renew.go
+++ b/cmd/eksctl-anywhere/cmd/renew.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var renewCmd = &cobra.Command{
+	Use:   "renew",
+	Short: "renew resources",
+	Long:  "Use eksctl anywhere renew to renew resources, such as clusters",
+}
+
+func init() {
+	rootCmd.AddCommand(renewCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/renewcertificates.go
+++ b/cmd/eksctl-anywhere/cmd/renewcertificates.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/certificates"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type renewCertificatesOptions struct {
+	configFile string
+	component  string
+}
+
+var rc = &renewCertificatesOptions{}
+
+var renewCertificatesCmd = &cobra.Command{
+	Use:   "certificates",
+	Short: "Renew certificates for cluster components",
+	Long: `Renew certificates for etcd and control plane nodes in EKS Anywhere cluster.
+
+This command supports certificate renewal for both etcd and control plane components.
+You can choose to renew certificates for all components or specify a single component.
+
+Example config file (yaml):
+  clusterName: my-cluster
+  controlPlane:
+    nodes:
+    - 192.168.1.10
+    - 192.168.1.11
+    - 192.168.1.12
+    os: ubuntu    # ubuntu, rhel, or bottlerocket
+    sshKey: /path/to/ssh/private-key
+    sshUser: ec2-user
+  etcd:
+    nodes:
+    - 192.168.1.20
+    - 192.168.1.21
+    - 192.168.1.22
+    os: ubuntu    # ubuntu, rhel, or bottlerocket
+    sshKey: /path/to/ssh/private-key
+    sshUser: ec2-user`,
+	PreRunE:      bindFlagsToViper,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rc.renewCertificates(cmd)
+	},
+}
+
+func init() {
+	renewCmd.AddCommand(renewCertificatesCmd)
+
+	renewCertificatesCmd.Flags().StringVarP(&rc.configFile, "config", "f", "", "Config file containing node and SSH information")
+	renewCertificatesCmd.Flags().StringVarP(&rc.component, "component", "c", "", "Component to renew certificates for (etcd or control-plane). If not specified, renews both.")
+
+	if err := renewCertificatesCmd.MarkFlagRequired("config"); err != nil {
+		panic(err)
+	}
+}
+
+func validateComponent(component string) error {
+	if component != "" && component != "etcd" && component != "control-plane" {
+		return fmt.Errorf("invalid component %q, must be either 'etcd' or 'control-plane'", component)
+	}
+	return nil
+}
+
+func (rc *renewCertificatesOptions) renewCertificates(cmd *cobra.Command) error {
+	if err := validateComponent(rc.component); err != nil {
+		return err
+	}
+
+	config, err := certificates.ParseConfig(rc.configFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse config file: %v", err)
+	}
+
+	cluster := &types.Cluster{
+		Name: config.ClusterName,
+	}
+
+	renewer, err := certificates.NewRenewer()
+	if err != nil {
+		return fmt.Errorf("failed to create renewer: %v", err)
+	}
+	return renewer.RenewCertificates(cmd.Context(), cluster, config, rc.component)
+}

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -1,0 +1,88 @@
+package certificates
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// NodeConfig holds SSH configuration for a node group
+type NodeConfig struct {
+	Nodes     []string `yaml:"nodes"`
+	OS        string   `yaml:"os"`
+	SSHKey    string   `yaml:"sshKey"`
+	SSHUser   string   `yaml:"sshUser"`
+	SSHPasswd string   `yaml:"sshPasswd,omitempty"` // Optional SSH key passphrase
+}
+
+type RenewalConfig struct {
+	ClusterName  string     `yaml:"clusterName"`
+	ControlPlane NodeConfig `yaml:"controlPlane"`
+	Etcd         NodeConfig `yaml:"etcd"`
+}
+
+func ParseConfig(path string) (*RenewalConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %v", err)
+	}
+
+	config := &RenewalConfig{}
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("parsing config file: %v", err)
+	}
+
+	if err := validateConfig(config); err != nil {
+		return nil, fmt.Errorf("validating config: %v", err)
+	}
+
+	return config, nil
+}
+
+func validateConfig(config *RenewalConfig) error {
+	if config.ClusterName == "" {
+		return fmt.Errorf("cluster name is required")
+	}
+
+	if len(config.ControlPlane.Nodes) == 0 {
+		return fmt.Errorf("at least one control plane node is required")
+	}
+
+	if err := validateNodeConfig(&config.ControlPlane, "control plane"); err != nil {
+		return err
+	}
+
+	// Etcd nodes are optional (could be embedded in control plane)
+	if len(config.Etcd.Nodes) > 0 {
+		if err := validateNodeConfig(&config.Etcd, "etcd"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNodeConfig(config *NodeConfig, component string) error {
+	if len(config.Nodes) == 0 {
+		return fmt.Errorf("%s nodes are required", component)
+	}
+	if config.OS == "" {
+		return fmt.Errorf("%s OS is required", component)
+	}
+	if config.OS != "ubuntu" && config.OS != "rhel" && config.OS != "bottlerocket" {
+		return fmt.Errorf("unsupported OS %q for %s", config.OS, component)
+	}
+	if config.SSHKey == "" {
+		return fmt.Errorf("%s SSH key is required", component)
+	}
+	if config.SSHUser == "" {
+		return fmt.Errorf("%s SSH user is required", component)
+	}
+
+	if _, err := os.Stat(config.SSHKey); err != nil {
+		return fmt.Errorf("SSH key file for %s: %v", component, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes add core configuration structures and validation for the certificate renewal command. This includes:

- RenewalConfig structure for cluster and node configuration 
- Config file parsing and validation logic 
- Basic command framework for certificate renewal 

This is part 1 of the certificate renewal feature, focusing on configuration handling. The actual certificate renewal implementation will follow in a separate PR.

Example Config file

clusterName: my-cluster
controlPlane: 
    nodes: 
    - 100.000.0.11
    - 100.000.0.12
    - 100.000.0.13 
    os: ubuntu # rhel or bottlerocket
    sshKey: /path/to/ssh/private-key
    sshUser: ec2-user
etcd: 
    nodes: 
    - 100.000.0.14
    - 100.000.0.15
    - 100.000.0.16
    os: ubuntu # rhels or bottlerocket
    sshKey: /path/to/ssh/private-key
    sshUser: ec2-user



*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

