### PR TITLE
Configuration Structure For Certificate Renewal (Part 1 of the certificate renewal command feature)

### DIFF
--- a/cmd/eksctl-anywhere/cmd/renew.go
+++ b/cmd/eksctl-anywhere/cmd/renew.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var renewCmd = &cobra.Command{
+	Use:   "renew",
+	Short: "renew resources",
+	Long:  "Use eksctl anywhere renew to renew resources, such as clusters",
+}
+
+func init() {
+	rootCmd.AddCommand(renewCmd)
+}

--- a/cmd/eksctl-anywhere/cmd/renewcertificates.go
+++ b/cmd/eksctl-anywhere/cmd/renewcertificates.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/eks-anywhere/pkg/certificates"
+	"github.com/aws/eks-anywhere/pkg/types"
+)
+
+type renewCertificatesOptions struct {
+	configFile  string
+	clusterName string
+	component   string
+	sshKey      string
+}
+
+var rc = &renewCertificatesOptions{}
+
+var renewCertificatesCmd = &cobra.Command{
+	Use:   "certificates",
+	Short: "Renew certificates for cluster components",
+	Long: `Renew certificates for etcd and control plane nodes in EKS Anywhere cluster.
+
+This command supports certificate renewal for both etcd and control plane components.
+You can choose to renew certificates for all components or specify a single component.
+
+The command can be used in two modes:
+
+1. Using cluster name (--cluster-name):
+   For functional clusters with expiring certificates, provide the cluster name and SSH key.
+   The command will automatically:
+   - Get node information from the cluster
+   - Detect node operating systems
+   - Get SSH username from cluster configuration
+
+   Required:
+   - KUBECONFIG environment variable must be set
+   - Cluster configuration file must exist in ./<cluster-name>/<cluster-name>-eks-a-cluster.yaml
+   - SSH private key must be provided via --ssh-key flag
+
+   Example:
+     export CLUSTER_NAME=my-cluster
+     export KUBECONFIG=${PWD}/${CLUSTER_NAME}/${CLUSTER_NAME}-eks-a-cluster.kubeconfig
+     eksctl anywhere certificates renew --cluster-name ${CLUSTER_NAME} --ssh-key ~/.ssh/id_ed25519
+
+2. Using config file (--config):
+   For clusters with expired certificates, provide a YAML file with node and SSH information.
+
+   Example config file:
+     clusterName: my-cluster
+     controlPlane:
+       nodes:
+       - 192.168.1.10
+       - 192.168.1.11
+       - 192.168.1.12
+       os: ubuntu    # ubuntu, rhel, or bottlerocket
+       sshKey: /path/to/ssh/private-key
+       sshUser: ec2-user
+     etcd:
+       nodes:
+       - 192.168.1.20
+       - 192.168.1.21
+       - 192.168.1.22
+       os: ubuntu    # ubuntu, rhel, or bottlerocket
+       sshKey: /path/to/ssh/private-key
+       sshUser: ec2-user`,
+	PreRunE:      bindFlagsToViper,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return rc.renewCertificates(cmd)
+	},
+}
+
+func init() {
+	renewCmd.AddCommand(renewCertificatesCmd)
+
+	renewCertificatesCmd.Flags().StringVarP(&rc.configFile, "config", "f", "", "Config file containing node and SSH information")
+	renewCertificatesCmd.Flags().StringVarP(&rc.clusterName, "cluster-name", "n", "", "Name of the cluster to renew certificates for")
+	renewCertificatesCmd.Flags().StringVarP(&rc.component, "component", "c", "", "Component to renew certificates for (etcd or control-plane). If not specified, renews both.")
+	renewCertificatesCmd.Flags().StringVar(&rc.sshKey, "ssh-key", "", "SSH private key file (required when using --cluster-name)")
+}
+
+func validateComponent(component string) error {
+	if component != "" && component != "etcd" && component != "control-plane" {
+		return fmt.Errorf("invalid component %q, must be either 'etcd' or 'control-plane'", component)
+	}
+	return nil
+}
+
+func (rc *renewCertificatesOptions) renewCertificates(cmd *cobra.Command) error {
+	if err := validateComponent(rc.component); err != nil {
+		return err
+	}
+
+	if (rc.configFile == "") == (rc.clusterName == "") {
+		return fmt.Errorf("must specify exactly one of --config or --cluster-name")
+	}
+
+	if rc.clusterName != "" && rc.sshKey == "" {
+		return fmt.Errorf("--ssh-key is required when using --cluster-name")
+	}
+
+	var config *certificates.RenewalConfig
+	var err error
+
+	if rc.configFile != "" {
+		config, err = certificates.ParseConfig(rc.configFile)
+		if err != nil {
+			return fmt.Errorf("failed to parse config file: %v", err)
+		}
+	} else {
+		if os.Getenv("KUBECONFIG") == "" {
+			return fmt.Errorf("KUBECONFIG environment variable must be set when using --cluster-name")
+		}
+		config, err = certificates.BuildConfigFromCluster(rc.clusterName, rc.sshKey)
+		if err != nil {
+			return fmt.Errorf("failed to build config from cluster: %v", err)
+		}
+	}
+
+	cluster := &types.Cluster{
+		Name: rc.clusterName,
+	}
+	if rc.configFile != "" {
+		cluster.Name = config.ClusterName
+	}
+
+	renewer, err := certificates.NewRenewer()
+	if err != nil {
+		return fmt.Errorf("failed to create renewer: %v", err)
+	}
+	return renewer.RenewCertificates(cmd.Context(), cluster, config, rc.component)
+}

--- a/pkg/certificates/cluster_config.go
+++ b/pkg/certificates/cluster_config.go
@@ -1,0 +1,157 @@
+package certificates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
+)
+
+// SSH configuration for the cluster
+type clusterSSHConfig struct {
+	SSHKeyPath  string
+	SSHUsername string
+}
+
+// get SSH configuration from the cluster's configuration
+func getClusterConfig(clusterName string) (*clusterSSHConfig, error) {
+	clusterDir := filepath.Join(".", clusterName)
+	clusterConfigPath := filepath.Join(clusterDir, fmt.Sprintf("%s-eks-a-cluster.yaml", clusterName))
+
+	data, err := os.ReadFile(clusterConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cluster config file: %v", err)
+	}
+
+	var config struct {
+		Spec struct {
+			ControlPlaneConfiguration struct {
+				SSHKeyPath string `yaml:"sshKeyPath"`
+				Users      []struct {
+					Name string `yaml:"name"`
+				} `yaml:"users"`
+			} `yaml:"controlPlaneConfiguration"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse cluster config: %v", err)
+	}
+
+	sshConfig := &clusterSSHConfig{
+		SSHKeyPath: config.Spec.ControlPlaneConfiguration.SSHKeyPath,
+	}
+
+	// get SSH username
+	if len(config.Spec.ControlPlaneConfiguration.Users) > 0 {
+		sshConfig.SSHUsername = config.Spec.ControlPlaneConfiguration.Users[0].Name
+	} else {
+		// if no usernamr, set it to default ec2-user
+		sshConfig.SSHUsername = "ec2-user"
+	}
+
+	return sshConfig, nil
+}
+
+// the RenewalConfig from a running cluster
+func BuildConfigFromCluster(clusterName, sshKeyPath string) (*RenewalConfig, error) {
+	if _, err := os.Stat(sshKeyPath); err != nil {
+		return nil, fmt.Errorf("SSH key file not found: %v", err)
+	}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubeconfig: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
+	}
+
+	// get kubeadm-config ConfigMap
+	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "kubeadm-config", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeadm-config: %v", err)
+	}
+
+	var clusterConfig struct {
+		Etcd struct {
+			External struct {
+				Endpoints []string `yaml:"endpoints"`
+			} `yaml:"external"`
+		} `yaml:"etcd"`
+	}
+
+	if err := yaml.Unmarshal([]byte(cm.Data["ClusterConfiguration"]), &clusterConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse cluster configuration: %v", err)
+	}
+
+	// get nodes
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	renewalConfig := &RenewalConfig{
+		ClusterName: clusterName,
+		ControlPlane: NodeConfig{
+			Nodes: []string{},
+		},
+		Etcd: NodeConfig{
+			Nodes: []string{},
+		},
+	}
+
+	// for control plane nodes
+	for _, node := range nodes.Items {
+		if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
+			renewalConfig.ControlPlane.Nodes = append(renewalConfig.ControlPlane.Nodes, node.Status.Addresses[0].Address)
+
+			osImage := strings.ToLower(node.Status.NodeInfo.OSImage)
+			if strings.Contains(osImage, "bottlerocket") {
+				renewalConfig.ControlPlane.OS = "bottlerocket"
+			} else if strings.Contains(osImage, "ubuntu") {
+				renewalConfig.ControlPlane.OS = "ubuntu"
+			} else if strings.Contains(osImage, "rhel") {
+				renewalConfig.ControlPlane.OS = "rhel"
+			}
+		}
+	}
+
+	// process etcd nodes if external etcd is configured
+	if len(clusterConfig.Etcd.External.Endpoints) > 0 {
+		for _, endpoint := range clusterConfig.Etcd.External.Endpoints {
+			parts := strings.Split(endpoint, "://")
+			if len(parts) != 2 {
+				continue
+			}
+			ip := strings.Split(parts[1], ":")[0]
+			renewalConfig.Etcd.Nodes = append(renewalConfig.Etcd.Nodes, ip)
+		}
+		// for external etcd, we assume the same OS type as control plane
+		// user can override this using the config file if needed
+		renewalConfig.Etcd.OS = renewalConfig.ControlPlane.OS
+	}
+
+	// find SSH user
+	sshConfig, err := getClusterConfig(clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster configuration: %v", err)
+	}
+
+	// SSH configuration
+	renewalConfig.ControlPlane.SSHKey = sshKeyPath
+	renewalConfig.ControlPlane.SSHUser = sshConfig.SSHUsername
+	renewalConfig.Etcd.SSHKey = sshKeyPath
+	renewalConfig.Etcd.SSHUser = sshConfig.SSHUsername
+
+	return renewalConfig, nil
+}

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -1,0 +1,88 @@
+package certificates
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// NodeConfig holds SSH configuration for a node group
+type NodeConfig struct {
+	Nodes     []string `yaml:"nodes"`
+	OS        string   `yaml:"os"`
+	SSHKey    string   `yaml:"sshKey"`
+	SSHUser   string   `yaml:"sshUser"`
+	SSHPasswd string   `yaml:"sshPasswd,omitempty"` // Optional SSH key passphrase
+}
+
+type RenewalConfig struct {
+	ClusterName  string     `yaml:"clusterName"`
+	ControlPlane NodeConfig `yaml:"controlPlane"`
+	Etcd         NodeConfig `yaml:"etcd"`
+}
+
+func ParseConfig(path string) (*RenewalConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %v", err)
+	}
+
+	config := &RenewalConfig{}
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("parsing config file: %v", err)
+	}
+
+	if err := validateConfig(config); err != nil {
+		return nil, fmt.Errorf("validating config: %v", err)
+	}
+
+	return config, nil
+}
+
+func validateConfig(config *RenewalConfig) error {
+	if config.ClusterName == "" {
+		return fmt.Errorf("cluster name is required")
+	}
+
+	if len(config.ControlPlane.Nodes) == 0 {
+		return fmt.Errorf("at least one control plane node is required")
+	}
+
+	if err := validateNodeConfig(&config.ControlPlane, "control plane"); err != nil {
+		return err
+	}
+
+	// Etcd nodes are optional (could be embedded in control plane)
+	if len(config.Etcd.Nodes) > 0 {
+		if err := validateNodeConfig(&config.Etcd, "etcd"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNodeConfig(config *NodeConfig, component string) error {
+	if len(config.Nodes) == 0 {
+		return fmt.Errorf("%s nodes are required", component)
+	}
+	if config.OS == "" {
+		return fmt.Errorf("%s OS is required", component)
+	}
+	if config.OS != "ubuntu" && config.OS != "rhel" && config.OS != "bottlerocket" {
+		return fmt.Errorf("unsupported OS %q for %s", config.OS, component)
+	}
+	if config.SSHKey == "" {
+		return fmt.Errorf("%s SSH key is required", component)
+	}
+	if config.SSHUser == "" {
+		return fmt.Errorf("%s SSH user is required", component)
+	}
+
+	if _, err := os.Stat(config.SSHKey); err != nil {
+		return fmt.Errorf("SSH key file for %s: %v", component, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes add core configuration structures and validation for the certificate renewal command. This includes:
- RenewalConfig structure for cluster and node configuration
- Config file parsing and validation logic
- Basic command framework for certificate renewal
- Add cluster-name based certificate renewal mode with automatic configuration:
  - Support `--cluster-name` flag for functional clusters
  - Automatically discover nodes and their OS from cluster
  - Get SSH username from cluster configuration
  - Require SSH private key via `--ssh-key` flag
  - Support both etcd and control-plane components

This is part 1 of the certificate renewal feature, focusing on configuration handling. The actual certificate renewal implementation will follow in a separate PR.

The command now supports two modes:

1. Using cluster name (new):  eksctl anywhere certificates renew --cluster-name ${CLUSTER_NAME} --ssh-key /path/to/ssh/private-key [--component <etcd|control-plane>]

2. Using config file (existing):  eksctl anywhere renew certificates [--config <file-path>] [--component <etcd|control-plane>]

Example Config file:
clusterName: my-cluster controlPlane: nodes: - 100.000.0.11 - 100.000.0.12 - 100.000.0.13 os: ubuntu # rhel or bottlerocket sshKey: /path/to/ssh/private-key sshUser: ec2-user etcd: nodes: - 100.000.0.14 - 100.000.0.15 - 100.000.0.16 os: ubuntu # rhels or bottlerocket sshKey: /path/to/ssh/private-key sshUser: ec2-user


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

