### PR TITLE
Fix e2e test TestVSphereKubernetes132MulticlusterWorkloadClusterAPI

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -6554,7 +6554,7 @@ func TestVSphereKubernetes132MulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken)
+				api.WithLicenseToken(licenseToken),
 			),
 			vsphere.WithUbuntu128(),
 		),
@@ -6566,7 +6566,7 @@ func TestVSphereKubernetes132MulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2)
+				api.WithLicenseToken(licenseToken2),
 			),
 			vsphere.WithUbuntu129(),
 		),


### PR DESCRIPTION
*Description of changes:*
The e2e test `TestVSphereKubernetes132MulticlusterWorkloadClusterAPI` is failing with error `Failed waiting for cluster kubeconfig: failed to get kubeconfig for cluster: secret "main-i-05e94-740e773-w-2-kubeconfig" not found` in workload cluster with k8s version 1.28 and 1.29. Add license token to solve this issue.

*Testing (if applicable):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

