### PR TITLE
Fix BMC checks to honor --no-timeouts flag

### DIFF
--- a/pkg/dependencies/factory.go
+++ b/pkg/dependencies/factory.go
@@ -516,6 +516,12 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 			}
 			logger.V(4).Info("Tinkerbell IP", "tinkerbell-ip", tinkerbellIP)
 
+			// Set BMC timeout based on noTimeouts flag
+			bmcTimeout := 5 * time.Minute // Default 5 minutes
+			if f.config.noTimeouts {
+				bmcTimeout = 168 * time.Hour // 1 week, effectively no timeout
+			}
+
 			provider, err := tinkerbell.NewProvider(
 				datacenterConfig,
 				machineConfigs,
@@ -529,6 +535,7 @@ func (f *Factory) WithProvider(clusterConfigFile string, clusterConfig *v1alpha1
 				time.Now,
 				force,
 				skipIPCheck,
+				bmcTimeout,
 			)
 			if err != nil {
 				return err

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -760,6 +760,26 @@ func TestFactoryBuildWithEksdInstallerNoTimeout(t *testing.T) {
 	tt.Expect(deps.EksdInstaller).NotTo(BeNil())
 }
 
+// TestFactoryBuildWithProviderTinkerbellWithNoTimeouts tests that the BMC timeout is set correctly
+// when the noTimeouts flag is used with the Tinkerbell provider.
+func TestFactoryBuildWithProviderTinkerbellWithNoTimeouts(t *testing.T) {
+	tt := newTest(t, tinkerbell)
+	
+	// Test with noTimeouts = true
+	deps, err := dependencies.NewFactory().
+		WithLocalExecutables().
+		WithNoTimeouts().
+		WithProvider(tt.clusterConfigFile, tt.clusterSpec.Cluster, false, tt.hardwareConfigFile, false, tt.tinkerbellBootstrapIP, map[string]bool{}, tt.providerOptions).
+		Build(context.Background())
+
+	tt.Expect(err).To(BeNil())
+	tt.Expect(deps.Provider).NotTo(BeNil())
+	
+	// The test passes if we can create a provider with NoTimeouts
+	// The actual BMC timeout value is set to 168 hours (1 week) when noTimeouts is true
+	// as defined in factory.go line 538
+}
+
 type dummyDockerClient struct{}
 
 func (b dummyDockerClient) PullImage(ctx context.Context, image string) error {

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -77,7 +77,9 @@ func (p *Provider) applyHardware(ctx context.Context, cluster *types.Cluster) er
 		return fmt.Errorf("applying hardware yaml: %v", err)
 	}
 	if len(p.catalogue.AllBMCs()) > 0 {
-		err = p.providerKubectlClient.WaitForRufioMachines(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
+		bmcTimeoutStr := p.bmcTimeout.String()
+
+		err = p.providerKubectlClient.WaitForRufioMachines(ctx, cluster, bmcTimeoutStr, "Contactable", constants.EksaSystemNamespace)
 		if err != nil {
 			return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 		}

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -70,6 +70,7 @@ type Provider struct {
 
 	forceCleanup bool
 	skipIpCheck  bool
+	bmcTimeout   time.Duration
 	retrier      *retrier.Retrier
 }
 
@@ -116,6 +117,7 @@ func NewProvider(
 	now types.NowFunc,
 	forceCleanup bool,
 	skipIpCheck bool,
+	bmcTimeout time.Duration,
 ) (*Provider, error) {
 	var controlPlaneMachineSpec, workerNodeGroupMachineSpec, etcdMachineSpec *v1alpha1.TinkerbellMachineConfigSpec
 
@@ -191,6 +193,7 @@ func NewProvider(
 		// Behavioral flags.
 		forceCleanup: forceCleanup,
 		skipIpCheck:  skipIpCheck,
+		bmcTimeout:   bmcTimeout,
 	}, nil
 }
 

--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -117,6 +118,8 @@ func newProviderTest(t *testing.T) *providerTest {
 
 func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, docker stack.Docker, helm stack.Helm, kubectl ProviderKubectlClient, forceCleanup bool) *Provider {
 	hardwareFile := "./testdata/hardware.csv"
+	// Default BMC timeout is 5 minutes
+	bmcTimeout := 5 * time.Minute
 	provider, err := NewProvider(
 		datacenterConfig,
 		machineConfigs,
@@ -130,6 +133,7 @@ func newProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineC
 		test.FakeNow,
 		forceCleanup,
 		false,
+		bmcTimeout,
 	)
 	if err != nil {
 		panic(err)
@@ -2183,6 +2187,7 @@ func TestTinkerbellProviderGetMachineConfigsWithMismatchedAndExternalEtcd(t *tes
 	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
 
 	hardwareFile := "./testdata/hardware.csv"
+	bmcTimeout := 5 * time.Minute
 	_, err := NewProvider(
 		datacenterConfig,
 		machineConfigs,
@@ -2196,6 +2201,7 @@ func TestTinkerbellProviderGetMachineConfigsWithMismatchedAndExternalEtcd(t *tes
 		test.FakeNow,
 		forceCleanup,
 		false,
+		bmcTimeout,
 	)
 
 	expectedErrorMessage := fmt.Sprintf(referrencedMachineConfigsAvailabilityErrMsg, "test-etcd")
@@ -2247,6 +2253,7 @@ func TestTinkerbellProviderGetMachineConfigsWithMismatchedMachineConfig(t *testi
 	machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
 
 	hardwareFile := "./testdata/hardware.csv"
+	bmcTimeout := 5 * time.Minute
 	_, err := NewProvider(
 		datacenterConfig,
 		machineConfigs,
@@ -2260,6 +2267,7 @@ func TestTinkerbellProviderGetMachineConfigsWithMismatchedMachineConfig(t *testi
 		test.FakeNow,
 		forceCleanup,
 		false,
+		bmcTimeout,
 	)
 
 	expectedErrorMessage := fmt.Sprintf(referrencedMachineConfigsAvailabilityErrMsg, "single-node-cp")

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -140,8 +140,10 @@ func (p *Provider) SetupAndValidateUpgradeCluster(ctx context.Context, cluster *
 	// Check if the hardware in the catalogue have a BMCRef. Since we only allow either all hardware with bmc
 	// or no hardware with bmc, its sufficient to check the first hardware.
 	if p.catalogue.TotalHardware() > 0 && p.catalogue.AllHardware()[0].Spec.BMCRef != nil {
+		bmcTimeoutStr := p.bmcTimeout.String()
+
 		// Waiting to ensure all the new and exisiting baseboardmanagement connections are valid.
-		err = p.providerKubectlClient.WaitForRufioMachines(ctx, cluster, "5m", "Contactable", constants.EksaSystemNamespace)
+		err = p.providerKubectlClient.WaitForRufioMachines(ctx, cluster, bmcTimeoutStr, "Contactable", constants.EksaSystemNamespace)
 		if err != nil {
 			return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 		}
@@ -278,8 +280,11 @@ func (p *Provider) PostMoveManagementToBootstrap(ctx context.Context, bootstrapC
 	// Check if the hardware in the catalogue have a BMCRef. Since we only allow either all hardware with bmc
 	// or no hardware with bmc, its sufficient to check the first hardware.
 	if p.catalogue.TotalHardware() > 0 && p.catalogue.AllHardware()[0].Spec.BMCRef != nil {
+		// Convert bmcTimeout duration to string format for WaitForRufioMachines
+		bmcTimeoutStr := p.bmcTimeout.String()
+
 		// Waiting to ensure all the new and exisiting baseboardmanagement connections are valid.
-		err := p.providerKubectlClient.WaitForRufioMachines(ctx, bootstrapCluster, "5m", "Contactable", constants.EksaSystemNamespace)
+		err := p.providerKubectlClient.WaitForRufioMachines(ctx, bootstrapCluster, bmcTimeoutStr, "Contactable", constants.EksaSystemNamespace)
 		if err != nil {
 			return fmt.Errorf("waiting for baseboard management to be contactable: %v", err)
 		}

--- a/pkg/providers/tinkerbell/upgrade_test.go
+++ b/pkg/providers/tinkerbell/upgrade_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	tinkv1 "github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
@@ -704,6 +705,9 @@ func NewPreCoreComponentsUpgradeTestConfig(t *testing.T) *PreCoreComponentsUpgra
 // GetProvider retrieves a new Tinkerbell provider instance build using the mocks initialized
 // in t.
 func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
+	// Default BMC timeout is 5 minutes
+	bmcTimeout := 5 * time.Minute
+	
 	p, err := NewProvider(
 		t.DatacenterConfig,
 		t.MachineConfigs,
@@ -717,6 +721,7 @@ func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
 		test.FakeNow,
 		false,
 		false,
+		bmcTimeout,
 	)
 	if err != nil {
 		return nil, err
@@ -728,6 +733,8 @@ func (t *PreCoreComponentsUpgradeTestConfig) GetProvider() (*Provider, error) {
 func newTinkerbellProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig, machineConfigs map[string]*v1alpha1.TinkerbellMachineConfig, clusterConfig *v1alpha1.Cluster, writer filewriter.FileWriter, docker stack.Docker, helm stack.Helm, kubectl ProviderKubectlClient) *Provider {
 	hardwareFile := "./testdata/hardware.csv"
 	forceCleanup := false
+	// Default BMC timeout is 5 minutes
+	bmcTimeout := 5 * time.Minute
 
 	provider, err := NewProvider(
 		datacenterConfig,
@@ -742,6 +749,7 @@ func newTinkerbellProvider(datacenterConfig *v1alpha1.TinkerbellDatacenterConfig
 		test.FakeNow,
 		forceCleanup,
 		false,
+		bmcTimeout,
 	)
 	if err != nil {
 		panic(err)
@@ -1327,6 +1335,91 @@ func TestProviderValidateAvailableHardwareOnlyWorkerOSImageURLUpgradeError(t *te
 	err := provider.validateAvailableHardwareForUpgrade(ctx, clusterSpec, newCluster)
 	if err == nil || !strings.Contains(err.Error(), "for node rollout, minimum hardware count not met for selector '{\"type\":\"worker\"}'") {
 		t.Fatal(err)
+	}
+}
+
+func TestProviderBMCTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		bmcTimeout time.Duration
+		expected   string
+	}{
+		{
+			name:       "default timeout",
+			bmcTimeout: 5 * time.Minute,
+			expected:   "5m0s",
+		},
+		{
+			name:       "no timeouts",
+			bmcTimeout: 168 * time.Hour, // 1 week
+			expected:   "168h0m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			clusterSpecManifest := "cluster_tinkerbell_stacked_etcd.yaml"
+			datacenterConfig := givenDatacenterConfig(t, clusterSpecManifest)
+			machineConfigs := givenMachineConfigs(t, clusterSpecManifest)
+			clusterSpec := givenClusterSpec(t, clusterSpecManifest)
+			docker := stackmocks.NewMockDocker(mockCtrl)
+			helm := stackmocks.NewMockHelm(mockCtrl)
+			kubectl := mocks.NewMockProviderKubectlClient(mockCtrl)
+			writer := filewritermocks.NewMockFileWriter(mockCtrl)
+
+			// Create a provider with the specified BMC timeout
+			provider, err := NewProvider(
+				datacenterConfig,
+				machineConfigs,
+				clusterSpec.Cluster,
+				"",
+				writer,
+				docker,
+				helm,
+				kubectl,
+				testIP,
+				test.FakeNow,
+				false,
+				false,
+				tt.bmcTimeout,
+			)
+			if err != nil {
+				t.Fatalf("Failed to create provider: %v", err)
+			}
+
+			// Verify the BMC timeout is set correctly
+			if provider.bmcTimeout != tt.bmcTimeout {
+				t.Errorf("Expected BMC timeout %v, got %v", tt.bmcTimeout, provider.bmcTimeout)
+			}
+
+			// Create a mock cluster for testing
+			cluster := &types.Cluster{KubeconfigFile: "kubeconfig-file"}
+
+			// Mock the catalogue to have hardware with BMC references
+			catalogue := hardware.NewCatalogue()
+			hardware := &tinkv1.Hardware{
+				Spec: tinkv1.HardwareSpec{
+					BMCRef: &v1.TypedLocalObjectReference{
+						Kind: "Machine",
+						Name: "test-machine",
+					},
+				},
+			}
+			_ = catalogue.InsertHardware(hardware)
+			provider.catalogue = catalogue
+
+			// Mock the kubectl client to expect a call with the correct timeout string
+			kubectl.EXPECT().
+				WaitForRufioMachines(gomock.Any(), cluster, tt.expected, "Contactable", constants.EksaSystemNamespace).
+				Return(nil)
+
+			// Call the method that uses the BMC timeout
+			err = provider.applyHardware(context.Background(), cluster)
+			if err != nil {
+				t.Errorf("applyHardware failed: %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -415,6 +416,7 @@ func givenTinkerbellMachineConfigs(t *testing.T) map[string]*anywherev1.Tinkerbe
 
 func newProvider(datacenterConfig anywherev1.TinkerbellDatacenterConfig, machineConfigs map[string]*anywherev1.TinkerbellMachineConfig, clusterConfig *anywherev1.Cluster, writer filewriter.FileWriter, docker stack.Docker, helm stack.Helm, kubectl tinkerbell.ProviderKubectlClient, forceCleanup bool) *tinkerbell.Provider {
 	hardwareFile := "./testdata/hardware.csv"
+	bmcTimeout := 5 * time.Minute
 	provider, err := tinkerbell.NewProvider(
 		&datacenterConfig,
 		machineConfigs,
@@ -428,6 +430,7 @@ func newProvider(datacenterConfig anywherev1.TinkerbellDatacenterConfig, machine
 		test.FakeNow,
 		forceCleanup,
 		false,
+		bmcTimeout,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3390 

*Description of changes:*
The baremetal checks specific to BMCs being contactable had a hard coded "5m" timeout configured and didn't factor in the `no-timeouts` flag if it was set during CLI. This change makes the check to wait for highest time that is possible in 'Kubectl wait' when the flag is set. 

*Testing (if applicable):*
Built a CLI and controller with this change and tested the check when no-timeout flags was passed in.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

