### PR TITLE
Set concurrent reconciliation in Rufio

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -32,20 +32,21 @@ const (
 	enabled           = "enabled"
 	kubevipInterface  = "interface"
 
-	boots        = "boots"
-	smee         = "smee"
-	hegel        = "hegel"
-	tink         = "tink"
-	controller   = "controller"
-	server       = "server"
-	rufio        = "rufio"
-	grpcPort     = "42113"
-	kubevip      = "kubevip"
-	stack        = "stack"
-	hook         = "hook"
-	service      = "service"
-	relay        = "relay"
-	smeeHTTPPort = "7171"
+	boots                        = "boots"
+	smee                         = "smee"
+	hegel                        = "hegel"
+	tink                         = "tink"
+	controller                   = "controller"
+	server                       = "server"
+	rufio                        = "rufio"
+	rufioMaxConcurrentReconciles = 10
+	grpcPort                     = "42113"
+	kubevip                      = "kubevip"
+	stack                        = "stack"
+	hook                         = "hook"
+	service                      = "service"
+	relay                        = "relay"
+	smeeHTTPPort                 = "7171"
 )
 
 type Docker interface {
@@ -597,6 +598,7 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 			image: bundle.TinkerbellStack.Rufio.URI,
 			"additionalArgs": []string{
 				"-metrics-bind-address=127.0.0.1:8080",
+				fmt.Sprintf("-max-concurrent-reconciles=%v", rufioMaxConcurrentReconciles),
 			},
 		},
 		stack: map[string]interface{}{

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: false

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -5,6 +5,7 @@ hegel:
 rufio:
   additionalArgs:
   - -metrics-bind-address=127.0.0.1:8080
+  - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
 smee:
   deploy: true


### PR DESCRIPTION
*Description of changes:*
Current [version](https://github.com/aws/eks-anywhere-build-tooling/pull/4632) of Rufio supports [concurrent reconciliation](https://github.com/tinkerbell/rufio/issues/311) to be configured at the time of deployment. When provisioning higher number of nodes at the same time, a concurrent reconciliation of the queue helps in processing the BMC operations faster. 

*Testing (if applicable):*
Built cli and controller and verified that the bmc interactions for 20 nodes parallel provisioning  was way faster than the one without  any concurrent reconciliation.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

