### PR TITLE
Bump golangci-lint version to latest

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0.1
+          version: v2.1.6
           only-new-issues: true
           args: --timeout 10m


### PR DESCRIPTION
*Issue #, if available:*
The `golangci-lint` Github action workflow failed on [#9801](https://github.com/aws/eks-anywhere/pull/9801) with the following error:
```
Error: Failed to run: Error: requested golangci-lint version 'v2.0.1' isn't supported: we support only v2.1.0 and later versions, Error: requested golangci-lint version 'v2.0.1' isn't supported: we support only v2.1.0 and later versions
```
This is because we just bumped golangci-lint-action version to the latest v8.0.0 in [#9712](https://github.com/aws/eks-anywhere/pull/9712).

*Description of changes:*
This PR bumps the `golangci-lint` version to latest v2.1.6 to fix the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

