### PR TITLE
Removes wrongly added redhat8 tests for newer k8s versions

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3822,24 +3822,6 @@ func TestVSphereKubernetes131RedHatSimpleFlow(t *testing.T) {
 	runSimpleFlow(test)
 }
 
-func TestVSphereKubernetes132RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat132VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat133VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
 func TestVSphereKubernetes128RedHat9SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
@@ -3888,7 +3870,7 @@ func TestVSphereKubernetes132RedHat9SimpleFlow(t *testing.T) {
 func TestVSphereKubernetes133RedHat9SimpleFlow(t *testing.T) {
 	test := framework.NewClusterE2ETest(
 		t,
-		framework.NewVSphere(t, framework.WithRedHat133VSphere()),
+		framework.NewVSphere(t, framework.WithRedHat9133VSphere()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
 	)
 	runSimpleFlow(test)

--- a/test/framework/vsphere.go
+++ b/test/framework/vsphere.go
@@ -160,16 +160,6 @@ func WithRedHat131VSphere() VSphereOpt {
 	return withVSphereKubeVersionAndOS(anywherev1.Kube131, RedHat8, nil)
 }
 
-// WithRedHat132VSphere vsphere test with Redhat 8 for Kubernetes 1.32.
-func WithRedHat132VSphere() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube132, RedHat8, nil)
-}
-
-// WithRedHat133VSphere vsphere test with Redhat 8 for Kubernetes 1.33.
-func WithRedHat133VSphere() VSphereOpt {
-	return withVSphereKubeVersionAndOS(anywherev1.Kube133, RedHat8, nil)
-}
-
 // WithRedHat9128VSphere vsphere test with Redhat 9 for Kubernetes 1.28.
 func WithRedHat9128VSphere() VSphereOpt {
 	return withVSphereKubeVersionAndOS(anywherev1.Kube128, RedHat9, nil)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

