### PR TITLE
Remove --insecure-skip-tls-verify flag from Helm uninstall command

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -258,7 +258,6 @@ func (h *Helm) Uninstall(ctx context.Context, chart, kubeconfigFilePath, namespa
 		opt(h.helmConfig)
 	}
 
-	params = h.addInsecureFlagIfProvided(params)
 	params = append(params, h.helmConfig.ExtraFlags...)
 
 	logger.Info("Uninstalling helm chart on cluster", "chart", chart)

--- a/pkg/executables/helm_test.go
+++ b/pkg/executables/helm_test.go
@@ -442,10 +442,10 @@ func TestHelmUninstall(s *testing.T) {
 		tt.Expect(err).NotTo(HaveOccurred())
 	})
 
-	s.Run("passes the insecure skip flag", func(t *testing.T) {
+	s.Run("ignores the insecure skip flag", func(t *testing.T) {
 		tt := newHelmTest(t, helm.WithInsecure())
 		installName := "test-install"
-		expectCommand(tt.e, tt.ctx, "uninstall", installName, "--kubeconfig", kubeconfig, "--wait", "--insecure-skip-tls-verify").withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
+		expectCommand(tt.e, tt.ctx, "uninstall", installName, "--kubeconfig", kubeconfig, "--wait").withEnvVars(tt.envVars).to().Return(bytes.Buffer{}, nil)
 		err := tt.h.Uninstall(tt.ctx, installName, kubeconfig, "")
 		tt.Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
*Description of changes:*
When moving from the legacy tinkerbell chart to upstream chart we uninstall the legacy chart. For some configurations such as airgapped with registry mirror configurations where tls is not setup this might end up breaking the upgrade workflow when passing in the '--insecure-skip-tls-verify' flag. Remove the flag from helm uninstall command as it is not supported.


*Testing (if applicable):*
Built the cli and tested an upgrade from legacy chart to the latest tink chart in our bundle.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

