### PR TITLE
[release-0.22] Validate eksd manifest signature for extended kubernetes version support

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4700,20 +4700,20 @@ spec:
                       description: |-
                         The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                        This field may be empty.
                       type: string
                     severity:
                       description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
                       description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
@@ -5660,20 +5660,20 @@ spec:
                       description: |-
                         The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                        This field may be empty.
                       type: string
                     severity:
                       description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
                       description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
@@ -5924,6 +5924,13 @@ spec:
                   - value
                   type: object
                 type: array
+              bootType:
+                description: 'BootType defines the boot type of the VM. Allowed values:
+                  legacy, uefi'
+                enum:
+                - legacy
+                - uefi
+                type: string
               cluster:
                 description: |-
                   cluster is to identify the cluster (the Prism Element under management
@@ -6136,20 +6143,20 @@ spec:
                       description: |-
                         The reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                        This field may be empty.
                       type: string
                     severity:
                       description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
+                      description: status of the condition, one of True, False, Unknown.
                       type: string
                     type:
                       description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string

--- a/controllers/cluster_controller_test_test.go
+++ b/controllers/cluster_controller_test_test.go
@@ -489,7 +489,8 @@ func TestClusterReconcilerFailSignatureValidation(t *testing.T) {
 
 	clusterValidator := mocks.NewMockClusterValidator(controller)
 	registry := newRegistryMock(providerReconciler)
-	c := fake.NewClientBuilder().WithRuntimeObjects(cluster, kcp, eksaReleaseV022, bundles).
+	eksdRelease := createEKSDRelease()
+	c := fake.NewClientBuilder().WithRuntimeObjects(cluster, kcp, eksaReleaseV022, bundles, eksdRelease).
 		WithStatusSubresource(cluster).
 		Build()
 	mockPkgs := mocks.NewMockPackagesClient(controller)

--- a/pkg/signature/manifest.go
+++ b/pkg/signature/manifest.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"text/template"
 
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/itchyny/gojq"
 	"sigs.k8s.io/yaml"
@@ -38,7 +39,7 @@ import (
 func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid bool, err error) {
 	bundleSig := bundle.Annotations[constants.SignatureAnnotation]
 	if bundleSig == "" {
-		return false, errors.New("missing signature annotation")
+		return false, errors.New("missing bundle signature annotation")
 	}
 
 	digest, _, err := getBundleDigest(bundle)
@@ -48,7 +49,7 @@ func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid b
 
 	sig, err := base64.StdEncoding.DecodeString(bundleSig)
 	if err != nil {
-		return false, fmt.Errorf("signature in metadata isn't base64 encoded: %w", err)
+		return false, fmt.Errorf("bundle signature in metadata isn't base64 encoded: %w", err)
 	}
 
 	pubkey, err := parsePublicKey(pubKey)
@@ -57,6 +58,59 @@ func ValidateSignature(bundle *anywherev1alpha1.Bundles, pubKey string) (valid b
 	}
 
 	return ecdsa.VerifyASN1(pubkey, digest[:], sig), nil
+}
+
+// ValidateEKSDistroManifestSignature validates the signature annotation of the bundles object using KMS public key.
+func ValidateEKSDistroManifestSignature(release *eksdv1alpha1.Release, signature, pubKey, releaseChannel string) (valid bool, err error) {
+	if signature == "" {
+		return false, fmt.Errorf("missing %s eks distro manifest signature annotation", releaseChannel)
+	}
+
+	digest, _, err := getEKSDistroReleaseDigest(release)
+	if err != nil {
+		return false, err
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false, fmt.Errorf("eks distro manifest signature in metadata for %s release channel isn't base64 encoded: %w", releaseChannel, err)
+	}
+
+	pubkey, err := parsePublicKey(pubKey)
+	if err != nil {
+		return false, err
+	}
+
+	return ecdsa.VerifyASN1(pubkey, digest[:], sig), nil
+}
+
+// getEksdDigest computes the SHA256 digest for an EKS Distro release object.
+// It follows similar steps as getBundleDigest() for Bundles by marshalling the object,
+// converting it to JSON, filtering out undesired fields, and then computing the hash.
+func getEKSDistroReleaseDigest(release *eksdv1alpha1.Release) ([32]byte, []byte, error) {
+	var zero [32]byte
+
+	// Marshal the eks-distro release object to YAML.
+	yamlBytes, err := yaml.Marshal(release)
+	if err != nil {
+		return zero, nil, fmt.Errorf("marshalling eks distro release to YAML: %v", err)
+	}
+
+	// Convert the YAML to JSON for easier gojq processing.
+	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
+	if err != nil {
+		return zero, nil, fmt.Errorf("converting eks distro release YAML to JSON: %v", err)
+	}
+
+	// Build and execute the gojq filter that deletes excluded fields.
+	filtered, err := filterExcludes(jsonBytes, constants.EKSDistroExcludes)
+	if err != nil {
+		return zero, nil, fmt.Errorf("filtering excluded fields: %v", err)
+	}
+
+	// Compute the SHA256 digest of the filtered JSON.
+	digest := sha256.Sum256(filtered)
+	return digest, filtered, nil
 }
 
 // getBundleDigest converts the Bundles manifest to JSON, excludes certain fields, then
@@ -78,7 +132,7 @@ func getBundleDigest(bundle *anywherev1alpha1.Bundles) ([32]byte, []byte, error)
 	}
 
 	// Build and execute the gojq filter that deletes excluded fields
-	filtered, err := filterExcludes(jsonBytes)
+	filtered, err := filterExcludes(jsonBytes, constants.Excludes)
 	if err != nil {
 		return zero, nil, fmt.Errorf("filtering excluded fields: %w", err)
 	}
@@ -91,18 +145,20 @@ func getBundleDigest(bundle *anywherev1alpha1.Bundles) ([32]byte, []byte, error)
 
 // filterExcludes applies the default and user-specified excludes to the JSON
 // representation of the Bundles object using gojq.
-// This function has dependency on constants.AlwaysExcludedFields and constants.Excludes fields.
-func filterExcludes(jsonBytes []byte) ([]byte, error) {
+func filterExcludes(jsonBytes []byte, excludes string) ([]byte, error) {
 	// Decode the base64-encoded excludes
-	exclBytes, err := base64.StdEncoding.DecodeString(constants.Excludes)
+	exclBytes, err := base64.StdEncoding.DecodeString(excludes)
 	if err != nil {
-		return nil, fmt.Errorf("decoding Excludes: %w", err)
+		return nil, fmt.Errorf("decoding Excludes: %v", err)
 	}
 	// Convert them into slice of strings
 	userExcludes := strings.Split(string(exclBytes), "\n")
 
 	// Combine AlwaysExcluded with userExcludes
-	allExcludes := append(constants.AlwaysExcludedFields, userExcludes...)
+	allExcludes := constants.AlwaysExcludedFields
+	if userExcludes[0] != "" {
+		allExcludes = append(allExcludes, userExcludes...)
+	}
 
 	// Build the argument to the gojq template
 	var tmplBuf bytes.Buffer
@@ -121,19 +177,19 @@ func filterExcludes(jsonBytes []byte) ([]byte, error) {
 	if err := gojqTemplate.Execute(&tmplBuf, map[string]interface{}{
 		"Excludes": allExcludes,
 	}); err != nil {
-		return nil, fmt.Errorf("executing gojq template: %w", err)
+		return nil, fmt.Errorf("executing gojq template: %v", err)
 	}
 
 	// Parse the final gojq query
 	query, err := gojq.Parse(tmplBuf.String())
 	if err != nil {
-		return nil, fmt.Errorf("gojq parse error: %w", err)
+		return nil, fmt.Errorf("gojq parse error: %v", err)
 	}
 
 	// Unmarshal the JSON into a generic interface so gojq can operate
 	var input interface{}
 	if err := json.Unmarshal(jsonBytes, &input); err != nil {
-		return nil, fmt.Errorf("unmarshalling JSON: %w", err)
+		return nil, fmt.Errorf("unmarshalling JSON: %v", err)
 	}
 
 	// Run the query
@@ -143,13 +199,13 @@ func filterExcludes(jsonBytes []byte) ([]byte, error) {
 		return nil, errors.New("gojq produced no result")
 	}
 	if errVal, ok := finalVal.(error); ok {
-		return nil, fmt.Errorf("gojq execution error: %w", errVal)
+		return nil, fmt.Errorf("gojq execution error: %v", errVal)
 	}
 
 	// Marshal the filtered result back to JSON
 	filtered, err := json.Marshal(finalVal)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling final result to JSON: %w", err)
+		return nil, fmt.Errorf("marshalling final result to JSON: %v", err)
 	}
 	return filtered, nil
 }

--- a/pkg/signature/manifest_test.go
+++ b/pkg/signature/manifest_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +50,7 @@ func TestValidateSignature(t *testing.T) {
 				},
 			},
 			valid:   false,
-			wantErr: fmt.Errorf("missing signature annotation"),
+			wantErr: fmt.Errorf("missing bundle signature annotation"),
 		},
 		{
 			name: "invalid signature",
@@ -69,7 +70,7 @@ func TestValidateSignature(t *testing.T) {
 				},
 			},
 			valid:   false,
-			wantErr: fmt.Errorf("signature in metadata isn't base64 encoded"),
+			wantErr: fmt.Errorf("bundle signature in metadata isn't base64 encoded"),
 		},
 		{
 			name: "invalid public key",
@@ -174,6 +175,114 @@ func TestValidateSignature(t *testing.T) {
 	}
 }
 
+func TestValidateEKSDistroManifestSignature(t *testing.T) {
+	// Create a dummy release with some nonempty Spec (so filtering produces a valid JSON payload).
+	testRelease := &eksdv1alpha1.Release{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Release",
+			APIVersion: eksdv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "kubernetes-1-28-46",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: eksdv1alpha1.ReleaseSpec{
+			Channel: "1-28",
+			Number:  46,
+		},
+		Status: eksdv1alpha1.ReleaseStatus{
+			Components: []eksdv1alpha1.Component{
+				{
+					Name:   "metrics-server",
+					GitTag: "v0.7.2",
+					Assets: []eksdv1alpha1.Asset{
+						{
+							Name: "metrics-server-image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		release        *eksdv1alpha1.Release
+		signature      string
+		publicKey      string
+		releaseChannel string
+		valid          bool
+		wantErr        error
+	}{
+		{
+			name:           "no eks distro manifest signature",
+			release:        testRelease,
+			signature:      "",
+			publicKey:      constants.EKSDistroKMSPublicKey,
+			releaseChannel: "1-28",
+			valid:          false,
+			wantErr:        fmt.Errorf("missing 1-28 eks distro manifest signature annotation"),
+		},
+		{
+			name:           "invalid signature",
+			release:        testRelease,
+			signature:      "invalid",
+			publicKey:      constants.EKSDistroKMSPublicKey,
+			releaseChannel: "1-29",
+			valid:          false,
+			wantErr:        fmt.Errorf("eks distro manifest signature in metadata for 1-29 release channel isn't base64 encoded"),
+		},
+		{
+			name:           "invalid public key",
+			release:        testRelease,
+			signature:      "MEUCICV1iiNA4owIUdZBIowSgWjTKx+JT5/CE8PzmF2CBD5+AiEAk8Fcc1X/LNGm0YCyZISWFhbh4qdc7ENyYCU3DB0u4b0=",
+			publicKey:      "invalid",
+			releaseChannel: "test-channel",
+			valid:          false,
+			wantErr:        fmt.Errorf("decoding the public key as string"),
+		},
+		{
+			name:           "invalid encoded public key",
+			release:        testRelease,
+			signature:      "MEUCICV1iiNA4owIUdZBIowSgWjTKx+JT5/CE8PzmF2CBD5+AiEAk8Fcc1X/LNGm0YCyZISWFhbh4qdc7ENyYCU3DB0u4b0=",
+			publicKey:      "TUVVQ0lDVjFpaU5BNG93SVVkWkJJb3dTZ1dqVEt4K0pUNS9DRThQem1GMkNCRDUrQWlFQWs4RmNjMVgvTE5HbTBZQ3laSVNXRmhiaDRxZGM3RU55WUNVM0RCMHU0YjA9Cg==",
+			releaseChannel: "test-channel",
+			valid:          false,
+			wantErr:        fmt.Errorf("parsing the public key (not PKIX)"),
+		},
+		{
+			name:           "signature verification fail",
+			release:        testRelease,
+			signature:      "MEUCICV1iiNA4owIUdZBIowSgWjTKx+JT5/CE8PzmF2CBD5+AiEAk8Fcc1X/LNGm0YCyZISWFhbh4qdc7ENyYCU3DB0u4b0=",
+			publicKey:      constants.EKSDistroKMSPublicKey,
+			releaseChannel: "test-channel",
+			valid:          false,
+			wantErr:        nil,
+		},
+		{
+			name:           "signature verification succeeded",
+			release:        testRelease,
+			signature:      "MEUCIQC3uP3Dhfb/nhCeir0Hwtf4bddKVfVIauFWBidT18XZOwIgHjzH1mOxBm1N2l2w9wBVy9W1o6CQXpdDz7UcbCszZYc=",
+			publicKey:      constants.EKSDistroKMSPublicKey,
+			releaseChannel: "1-28",
+			valid:          true,
+			wantErr:        nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			valid, err := ValidateEKSDistroManifestSignature(tc.release, tc.signature, tc.publicKey, tc.releaseChannel)
+			if err != nil && (tc.wantErr == nil || !strings.Contains(err.Error(), tc.wantErr.Error())) {
+				t.Errorf("%v got = %v, \nwant %v", tc.name, err, tc.wantErr)
+			}
+			if valid != tc.valid {
+				t.Errorf("%v got = %v, \nwant %v", tc.name, valid, tc.valid)
+			}
+		})
+	}
+}
+
 func TestGetBundleDigest(t *testing.T) {
 	testCases := []struct {
 		testName        string
@@ -220,17 +329,101 @@ func TestGetBundleDigest(t *testing.T) {
 
 			digest, filtered, err := getBundleDigest(tt.bundle)
 			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(gomega.HaveOccurred(), "Expected success but got error")
-				g.Expect(digest).NotTo(gomega.BeZero(),
-					"Expected digest to be non-zero array")
-				g.Expect(filtered).NotTo(gomega.BeEmpty(),
-					"Expected filtered bytes to be non-empty")
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "Expected success but got error: %v", err)
+				g.Expect(digest).NotTo(gomega.BeZero(), "Expected digest to be non-zero")
+				g.Expect(filtered).NotTo(gomega.BeEmpty(), "Expected filtered bytes to be non-empty")
 			} else {
-				g.Expect(err).To(gomega.HaveOccurred(),
-					"Expected error but got none")
-				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectErrSubstr),
-					"Error message should contain substring %q, got: %v",
-					tt.expectErrSubstr, err)
+				g.Expect(err).To(gomega.HaveOccurred(), "Expected error but got none")
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(digest).To(gomega.BeZero())
+				g.Expect(filtered).To(gomega.BeNil())
+			}
+		})
+	}
+}
+
+func TestGetEKSDistroReleaseDigest(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		release         *eksdv1alpha1.Release
+		expectErrSubstr string
+	}{
+		{
+			testName: "Simple valid release",
+			release: &eksdv1alpha1.Release{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Release",
+					APIVersion: eksdv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kubernetes-1-28-46",
+					Namespace: constants.EksaSystemNamespace,
+				},
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number:  46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "metrics-server",
+							GitTag: "v0.7.2",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "metrics-server-image",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErrSubstr: "",
+		},
+		{
+			testName: "Release with unmarshalable content",
+			release: &eksdv1alpha1.Release{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Release",
+					APIVersion: eksdv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "invalid-release",
+					Namespace: constants.EksaSystemNamespace,
+				},
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number:  46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "test-component",
+							GitTag: "v1.0.0",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "test-asset",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErrSubstr: "",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			digest, filtered, err := getEKSDistroReleaseDigest(tt.release)
+			if tt.expectErrSubstr == "" {
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "Expected success but got error: %v", err)
+				g.Expect(digest).NotTo(gomega.BeZero(), "Expected digest to be non-zero")
+				g.Expect(filtered).NotTo(gomega.BeEmpty(), "Expected filtered bytes to be non-empty")
+			} else {
+				g.Expect(err).To(gomega.HaveOccurred(), "Expected error but got none")
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
 				g.Expect(digest).To(gomega.BeZero())
 				g.Expect(filtered).To(gomega.BeNil())
 			}
@@ -242,6 +435,7 @@ func TestFilterExcludes(t *testing.T) {
 	testCases := []struct {
 		testName        string
 		jsonPayload     string
+		excludes        string
 		expectErrSubstr string
 		expectExclude   []string // substrings we expect to NOT be present
 		expectInclude   []string // substrings we expect to be present
@@ -273,6 +467,7 @@ func TestFilterExcludes(t *testing.T) {
 					"otherField": "otherValue"
 				}
 			}`,
+			excludes:        constants.Excludes,
 			expectErrSubstr: "",
 			expectExclude: []string{
 				"creationTimestamp",
@@ -289,11 +484,13 @@ func TestFilterExcludes(t *testing.T) {
 		{
 			testName:        "Invalid JSON payload",
 			jsonPayload:     `{"unclosed": [`,
+			excludes:        constants.Excludes,
 			expectErrSubstr: "unmarshalling JSON:",
 		},
 		{
 			testName:        "empty JSON payload",
 			jsonPayload:     `{}`,
+			excludes:        constants.Excludes,
 			expectErrSubstr: "gojq execution error",
 		},
 		{
@@ -306,9 +503,22 @@ func TestFilterExcludes(t *testing.T) {
 					}]
 				}
 			}`,
+			excludes:        constants.Excludes,
 			expectErrSubstr: "",
 			expectExclude:   []string{"creationTimestamp"},
 			expectInclude:   []string{"spec"},
+		},
+		{
+			testName:        "Invalid base64 excludes string",
+			jsonPayload:     `{"spec": {"field": "value"}}`,
+			excludes:        "invalid-base64!@#$",
+			expectErrSubstr: "decoding Excludes:",
+		},
+		{
+			testName:        "Invalid gojq template syntax",
+			jsonPayload:     `{"spec": {"field": "value"}}`,
+			excludes:        base64.StdEncoding.EncodeToString([]byte("invalid.[gojq..syntax")),
+			expectErrSubstr: "gojq parse error:",
 		},
 	}
 
@@ -316,7 +526,7 @@ func TestFilterExcludes(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
-			filtered, err := filterExcludes([]byte(tt.jsonPayload))
+			filtered, err := filterExcludes([]byte(tt.jsonPayload), tt.excludes)
 
 			if tt.expectErrSubstr == "" {
 				g.Expect(err).NotTo(gomega.HaveOccurred(),
@@ -380,6 +590,41 @@ func TestParseLicense(t *testing.T) {
 	}
 }
 
+func TestParsePublicKeyErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr string
+	}{
+		{
+			name:    "invalid base64 public key",
+			key:     "invalid-base64!@#$",
+			wantErr: "decoding the public key as string",
+		},
+		{
+			name:    "valid base64 but invalid PKIX format",
+			key:     base64.StdEncoding.EncodeToString([]byte("not-a-valid-pkix-key")),
+			wantErr: "parsing the public key (not PKIX)",
+		},
+		{
+			name:    "valid PKIX but not ECDSA key",
+			key:     "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7XtGi5M5nUyoXZpZWg5e9YgQaVbUq4DbxFkGn7yM9rIg+45dQ1pJwYQd/Z9RDZ3umTZHfdmVfaMT8E/2jpa6vYh5AroOn75tN8qaGmG2OqEBoA8k84zK98qNdOJow7CcIWjHQGk6Tr/dSfdTC6ydmBdRMX/7bBYcKylOFf2P65HOMQCB5YdZJAYzvlXEXzoc1o7DD3pT68BOHHTJp6h7+GGXZoNlHJeq1+AKq38Ra6tuI8EUV2S/5+75FFJzMTLVlJ20Jlhh3fuWJtn6a2hGeD/fbZ1w6CMi0dCTGEX6wUOmL5FJ4RFSVthqZCZ7Ap0G2/5Mu3pxVR9glAxThOw61QIDAQAB",
+			wantErr: "parsing the public key (not ECDSA)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parsePublicKey(tc.key)
+			if err == nil {
+				t.Errorf("Expected error but got none")
+			} else if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
 func generateTestKeys() (string, *ecdsa.PrivateKey, error) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -416,5 +661,235 @@ func TestParseLicense_Success(t *testing.T) {
 	_, err = ParseLicense(signedToken, publicKeyBase64)
 	if err != nil {
 		t.Errorf("ParseLicense failed: %v", err)
+	}
+}
+
+func TestGetEKSDistroReleaseDigest_YAMLMarshalError(t *testing.T) {
+	// Create a release with unmarshalable content (containing a channel)
+	type problematicRelease struct {
+		*eksdv1alpha1.Release
+		ProblematicField chan int `yaml:"problematicField,omitempty"`
+	}
+
+	release := &problematicRelease{
+		Release: &eksdv1alpha1.Release{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "Release",
+				APIVersion: eksdv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-release",
+				Namespace: constants.EksaSystemNamespace,
+			},
+			Spec: eksdv1alpha1.ReleaseSpec{
+				Channel: "1-28",
+				Number:  46,
+			},
+		},
+		ProblematicField: make(chan int),
+	}
+
+	_, _, err := getEKSDistroReleaseDigest(release.Release)
+	// Note: Since we can't easily create a YAML marshal error with a standard eksdv1alpha1.Release,
+	// we'll test this indirectly by ensuring the function handles normal releases correctly
+	// The actual marshal error is difficult to trigger in practice with valid struct types
+	if err != nil {
+		// If we get an error here, it should be a YAML marshal error or downstream error
+		if !strings.Contains(err.Error(), "marshalling eks distro release to YAML") &&
+			!strings.Contains(err.Error(), "converting eks distro release YAML to JSON") &&
+			!strings.Contains(err.Error(), "filtering excluded fields") {
+			t.Errorf("Unexpected error type: %v", err)
+		}
+	}
+}
+
+func TestFilterExcludes_GojqNoResult(t *testing.T) {
+	// Create a query that would produce no results by using an impossible filter
+	jsonPayload := `{"spec": {"field": "value"}}`
+
+	// Create an excludes string that would cause gojq to produce no result
+	// This is a complex scenario to trigger, but we can simulate it with an invalid query
+	impossibleExcludes := base64.StdEncoding.EncodeToString([]byte("impossible.nonexistent.deeply.nested.field.that.does.not.exist"))
+
+	_, err := filterExcludes([]byte(jsonPayload), impossibleExcludes)
+	// The actual error might be different, but we're testing the error handling path
+	if err != nil {
+		// Accept various error types that could occur in the filterExcludes function
+		if !strings.Contains(err.Error(), "gojq") &&
+			!strings.Contains(err.Error(), "filtering") &&
+			!strings.Contains(err.Error(), "execution") {
+			t.Errorf("Expected gojq-related error, got: %v", err)
+		}
+	}
+}
+
+func TestFilterExcludes_JSONUnmarshalError(t *testing.T) {
+	// Test with invalid JSON to trigger unmarshaling error
+	invalidJSON := `{"unclosed": [}`
+	validExcludes := constants.EKSDistroExcludes
+
+	_, err := filterExcludes([]byte(invalidJSON), validExcludes)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "unmarshalling JSON") {
+		t.Errorf("Expected JSON unmarshaling error, got: %v", err)
+	}
+}
+
+func TestFilterExcludes_TemplateExecutionError(t *testing.T) {
+	// This test covers potential template execution errors within filterExcludes
+	validJSON := `{"spec": {"field": "value"}}`
+
+	// Create excludes that could potentially cause template execution issues
+	// Using a very long field name to test edge cases
+	longFieldName := strings.Repeat("verylongfieldname", 100)
+	problematicExcludes := base64.StdEncoding.EncodeToString([]byte(longFieldName))
+
+	_, err := filterExcludes([]byte(validJSON), problematicExcludes)
+	// This may or may not error depending on the template implementation
+	// but we're testing the error handling paths
+	if err != nil {
+		// Accept various error types
+		validErrorParts := []string{"gojq", "template", "execution", "filtering"}
+		hasValidError := false
+		for _, part := range validErrorParts {
+			if strings.Contains(err.Error(), part) {
+				hasValidError = true
+				break
+			}
+		}
+		if !hasValidError {
+			t.Errorf("Unexpected error type: %v", err)
+		}
+	}
+}
+
+func TestValidateEKSDistroManifestSignature_MissingSignature(t *testing.T) {
+	release := &eksdv1alpha1.Release{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Release",
+			APIVersion: eksdv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-release",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: eksdv1alpha1.ReleaseSpec{
+			Channel: "test-channel",
+			Number:  1,
+		},
+	}
+
+	// Test with empty signature
+	valid, err := ValidateEKSDistroManifestSignature(release, "", constants.EKSDistroKMSPublicKey, "test-channel")
+	if valid {
+		t.Error("Expected validation to fail with empty signature")
+	}
+	if err == nil {
+		t.Error("Expected error for empty signature")
+	}
+	expectedError := "missing test-channel eks distro manifest signature annotation"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Expected error containing '%s', got: %v", expectedError, err)
+	}
+}
+
+func TestValidateEKSDistroManifestSignature_Base64DecodeError(t *testing.T) {
+	release := &eksdv1alpha1.Release{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Release",
+			APIVersion: eksdv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-release",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: eksdv1alpha1.ReleaseSpec{
+			Channel: "test-channel",
+			Number:  1,
+		},
+	}
+
+	// Test with invalid base64 signature
+	valid, err := ValidateEKSDistroManifestSignature(release, "invalid-base64!@#", constants.EKSDistroKMSPublicKey, "test-channel")
+	if valid {
+		t.Error("Expected validation to fail with invalid base64 signature")
+	}
+	if err == nil {
+		t.Error("Expected error for invalid base64 signature")
+	}
+	expectedError := "eks distro manifest signature in metadata for test-channel release channel isn't base64 encoded"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Expected error containing '%s', got: %v", expectedError, err)
+	}
+}
+
+func TestGetEKSDistroReleaseDigest_YAMLToJSONError(t *testing.T) {
+	// Create a release that could potentially cause YAML to JSON conversion issues
+	// This is difficult to trigger directly with normal structs, so we test the normal path
+	// and verify that errors would be handled correctly
+	release := &eksdv1alpha1.Release{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Release",
+			APIVersion: eksdv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-release",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: eksdv1alpha1.ReleaseSpec{
+			Channel: "test-channel",
+			Number:  1,
+		},
+	}
+
+	// Normal case should work - this tests that the function path is correct
+	_, _, err := getEKSDistroReleaseDigest(release)
+	if err != nil {
+		// If we get an error, it should be from the filtering step, not YAML/JSON conversion
+		if strings.Contains(err.Error(), "converting eks distro release YAML to JSON") {
+			t.Logf("Successfully caught YAML to JSON conversion error: %v", err)
+		} else if strings.Contains(err.Error(), "filtering excluded fields") {
+			// This is expected for the empty release
+			t.Logf("Got expected filtering error: %v", err)
+		} else {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+
+func TestGetEKSDistroReleaseDigest_FilteringError(t *testing.T) {
+	// Create a minimal release that will trigger filtering error
+	release := &eksdv1alpha1.Release{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Release",
+			APIVersion: eksdv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "empty-release",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		// Empty Spec to trigger filtering issues
+	}
+
+	_, _, err := getEKSDistroReleaseDigest(release)
+	if err != nil {
+		if !strings.Contains(err.Error(), "filtering excluded fields") {
+			t.Errorf("Expected filtering error, got: %v", err)
+		}
+	}
+}
+
+func TestParsePublicKey_NotECDSAError(t *testing.T) {
+	rsaPublicKeyPEM := "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7XtGi5M5nUyoXZpZWg5e9YgQaVbUq4DbxFkGn7yM9rIg+45dQ1pJwYQd/Z9RDZ3umTZHfdmVfaMT8E/2jpa6vYh5AroOn75tN8qaGmG2OqEBoA8k84zK98qNdOJow7CcIWjHQGk6Tr/dSfdTC6ydmBdRMX/7bBYcKylOFf2P65HOMQCB5YdZJAYzvlXEXzoc1o7DD3pT68BOHHTJp6h7+GGXZoNlHJeq1+AKq38Ra6tuI8EUV2S/5+75FFJzMTLVlJ20Jlhh3fuWJtn6a2hGeD/fbZ1w6CMi0dCTGEX6wUOmL5FJ4RFSVthqZCZ7Ap0G2/5Mu3pxVR9glAxThOw61QIDAQAB"
+
+	_, err := parsePublicKey(rsaPublicKeyPEM)
+	if err == nil {
+		t.Error("Expected error for non-ECDSA key")
+	}
+
+	if !strings.Contains(err.Error(), "parsing the public key (not ECDSA)") {
+		t.Errorf("Expected 'parsing the public key (not ECDSA)' error, got: %v", err)
 	}
 }

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -160,10 +162,10 @@ func TestValidateAuthenticationForRegistryMirrorAuthInvalid(t *testing.T) {
 	tt := newTest(t, withTLS())
 	tt.clusterSpec.Cluster.Spec.RegistryMirrorConfiguration.Authenticate = true
 	if err := os.Unsetenv("REGISTRY_USERNAME"); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if err := os.Unsetenv("REGISTRY_PASSWORD"); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	tt.Expect(validations.ValidateAuthenticationForRegistryMirror(tt.clusterSpec)).To(
@@ -874,7 +876,7 @@ func TestValidateExtendedKubernetesVersionSupportCLINoError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	reader := internalmocks.NewMockReader(ctrl)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
 	if err != nil {
 		t.Errorf("got = %v, \nwant nil", err)
 	}
@@ -886,12 +888,14 @@ func TestValidateExtendedKubernetesVersionSupportCLIError(t *testing.T) {
 	cluster := &anywherev1.Cluster{
 		Spec: anywherev1.ClusterSpec{
 			EksaVersion:       &version,
-			KubernetesVersion: anywherev1.Kube130,
+			KubernetesVersion: anywherev1.Kube131,
 		},
 	}
 
 	objs := []client.Object{}
 	objs = append(objs, cluster)
+	// Add the EKS Distro release object that the bundle references
+	objs = append(objs, test.EksdRelease("1-31"))
 	fakeClient := test.NewFakeKubeClient(objs...)
 
 	ctrl := gomock.NewController(t)
@@ -919,11 +923,15 @@ metadata:
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 	reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
 	if err == nil {
 		t.Errorf("got = nil, \nwant error: validating bundle signature")
 	} else if !strings.Contains(err.Error(), "validating bundle signature") {
@@ -937,12 +945,14 @@ func TestValidateExtendedKubernetesVersionSupportCLICheckExtendedSupport(t *test
 	cluster := &anywherev1.Cluster{
 		Spec: anywherev1.ClusterSpec{
 			EksaVersion:       &version,
-			KubernetesVersion: anywherev1.Kube130,
+			KubernetesVersion: anywherev1.Kube131,
 		},
 	}
 
 	objs := []client.Object{}
 	objs = append(objs, cluster)
+	// Add the EKS Distro release object that the bundle references
+	objs = append(objs, test.EksdRelease("1-31"))
 	fakeClient := test.NewFakeKubeClient(objs...)
 
 	ctrl := gomock.NewController(t)
@@ -959,21 +969,24 @@ spec:
 	reader.EXPECT().ReadFile(releasesURL).Return([]byte(releasesManifest), nil)
 
 	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Bundles
 metadata:
   annotations:
-    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
   name: bundles-1
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 
 	reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, manifests.NewReader(reader), fakeClient, "")
 	if err != nil {
 		t.Errorf("got = %v, \nwant nil", err)
 	}
@@ -986,30 +999,35 @@ func TestValidateExtendedKubernetesSupportWithBundlesOverrideSuccess(t *testing.
 	cluster := &anywherev1.Cluster{
 		Spec: anywherev1.ClusterSpec{
 			EksaVersion:       &version,
-			KubernetesVersion: anywherev1.Kube130,
+			KubernetesVersion: anywherev1.Kube131,
 		},
 	}
 
 	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Bundles
 metadata:
   annotations:
-    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
   name: bundles-1
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 
 	fr := &fakeFileReader{content: bundlesManifest}
 	reader := manifests.NewReader(fr)
 	bundlesOverride := "bundles-override.yaml"
 
-	fakeClient := test.NewFakeKubeClient(cluster)
+	// Add the EKS Distro release object that the bundle references
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, reader, fakeClient, bundlesOverride)
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, bundlesOverride)
 	g.Expect(err).To(BeNil())
 }
 
@@ -1027,7 +1045,7 @@ func TestValidateExtendedKubernetesSupportWithBundlesOverrideError(t *testing.T)
 	bundlesOverride := "bundles-override.yaml"
 	fakeClient := test.NewFakeKubeClient(cluster)
 
-	err := validations.ValidateExtendedKubernetesSupport(ctx, *cluster, reader, fakeClient, bundlesOverride)
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, bundlesOverride)
 	g.Expect(err).To(MatchError(ContainSubstring("getting bundle for cluster:")))
 }
 
@@ -1079,7 +1097,7 @@ func TestValidateExtendedKubernetesSupport(t *testing.T) {
 			cluster: &anywherev1.Cluster{
 				Spec: anywherev1.ClusterSpec{
 					EksaVersion:       &eksaVersionV023,
-					KubernetesVersion: anywherev1.Kube130,
+					KubernetesVersion: anywherev1.Kube131,
 				},
 			},
 			readerSetup: func(reader *internalmocks.MockReader) {
@@ -1098,13 +1116,17 @@ spec:
 kind: Bundles
 metadata:
   annotations:
-    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
   name: bundles-1
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 				reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
 			},
 			wantErr: false,
@@ -1114,7 +1136,7 @@ spec:
 			cluster: &anywherev1.Cluster{
 				Spec: anywherev1.ClusterSpec{
 					EksaVersion:       &eksaVersionV023,
-					KubernetesVersion: anywherev1.Kube130,
+					KubernetesVersion: anywherev1.Kube131,
 				},
 			},
 			bundlesOverride: "bundles-override.yaml",
@@ -1123,13 +1145,17 @@ spec:
 kind: Bundles
 metadata:
   annotations:
-    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
   name: bundles-1
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 				reader.EXPECT().ReadFile("bundles-override.yaml").Return([]byte(bundlesManifest), nil)
 			},
 			wantErr: false,
@@ -1144,9 +1170,14 @@ spec:
 				tt.readerSetup(reader)
 			}
 
-			fakeClient := test.NewFakeKubeClient(tt.cluster)
+			// Add EKS Distro release object for tests that need it
+			objs := []client.Object{tt.cluster}
+			if tt.readerSetup != nil {
+				objs = append(objs, test.EksdRelease("1-31"))
+			}
+			fakeClient := test.NewFakeKubeClient(objs...)
 
-			err := validations.ValidateExtendedKubernetesSupport(ctx, *tt.cluster, manifests.NewReader(reader), fakeClient, tt.bundlesOverride)
+			err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *tt.cluster, manifests.NewReader(reader), fakeClient, tt.bundlesOverride)
 
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -1156,4 +1187,285 @@ spec:
 			}
 		})
 	}
+}
+
+func TestValidateExtendedKubernetesVersionSupportAirgappedSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := anywherev1.EksaVersion("v0.23.0")
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube131,
+		},
+	}
+
+	// Create a temp file for airgapped case
+	tempFile, err := os.CreateTemp("", "eks-anywhere-downloads-*.yaml")
+	g.Expect(err).To(BeNil())
+	defer os.Remove(tempFile.Name())
+
+	releaseManifest := `apiVersion: distro.eks.amazonaws.com/v1alpha1
+kind: Release
+metadata:
+  name: kubernetes-1-31-eks-1
+spec:
+  channel: "1-31"`
+
+	_, err = tempFile.WriteString(releaseManifest)
+	g.Expect(err).To(BeNil())
+	tempFile.Close()
+
+	bundlesManifest := fmt.Sprintf(`apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "%s"`, tempFile.Name())
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+
+	// Add the EKS Distro release object that the bundle references
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
+
+	err = validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, "bundles-override.yaml")
+	g.Expect(err).To(BeNil())
+}
+
+func TestValidateExtendedKubernetesVersionSupportAirgappedFileReadError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := anywherev1.EksaVersion("v0.23.0")
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube131,
+		},
+	}
+
+	// Use non-existent file path for airgapped case
+	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "/nonexistent/eks-anywhere-downloads/file.yaml"`
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
+
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, "bundles-override.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("reading eksd release manifest file"))
+}
+
+func TestValidateExtendedKubernetesVersionSupportAirgappedUnmarshalError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := anywherev1.EksaVersion("v0.23.0")
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube131,
+		},
+	}
+
+	// Create a temp file with invalid YAML
+	tempFile, err := os.CreateTemp("", "eks-anywhere-downloads-*.yaml")
+	g.Expect(err).To(BeNil())
+	defer os.Remove(tempFile.Name())
+
+	// Invalid YAML content
+	_, err = tempFile.WriteString("invalid: yaml: content: [")
+	g.Expect(err).To(BeNil())
+	tempFile.Close()
+
+	bundlesManifest := fmt.Sprintf(`apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "%s"`, tempFile.Name())
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
+
+	err = validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, "bundles-override.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("unmarshalling eksd release manifest file"))
+}
+
+func TestValidateExtendedKubernetesVersionSupportNonAirgappedHTTPSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := anywherev1.EksaVersion("v0.23.0")
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube131,
+		},
+	}
+
+	// Create HTTP test server for non-airgapped case
+	releaseManifest := `apiVersion: distro.eks.amazonaws.com/v1alpha1
+kind: Release
+metadata:
+  name: kubernetes-1-31-eks-1
+spec:
+  channel: "1-31"`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(releaseManifest))
+	}))
+	defer server.Close()
+
+	bundlesManifest := fmt.Sprintf(`apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "%s"`, server.URL)
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
+
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, "bundles-override.yaml")
+	g.Expect(err).To(BeNil())
+}
+
+func TestValidateExtendedKubernetesVersionSupportNonAirgappedHTTPError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := anywherev1.EksaVersion("v0.23.0")
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube131,
+		},
+	}
+
+	// Create HTTP test server that returns 404
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	bundlesManifest := fmt.Sprintf(`apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "%s"`, server.URL)
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
+
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, "bundles-override.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("received status code 404"))
+}
+
+func TestValidateExtendedKubernetesVersionSupportNonAirgappedHTTPInvalidYAML(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	version := anywherev1.EksaVersion("v0.23.0")
+	cluster := &anywherev1.Cluster{
+		Spec: anywherev1.ClusterSpec{
+			EksaVersion:       &version,
+			KubernetesVersion: anywherev1.Kube131,
+		},
+	}
+
+	// Create HTTP test server with invalid YAML
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("invalid: yaml: content: ["))
+	}))
+	defer server.Close()
+
+	bundlesManifest := fmt.Sprintf(`apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Bundles
+metadata:
+  annotations:
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
+  name: bundles-1
+spec:
+  number: 1
+  versionsBundles:
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "%s"`, server.URL)
+
+	fr := &fakeFileReader{content: bundlesManifest}
+	reader := manifests.NewReader(fr)
+
+	objs := []client.Object{cluster, test.EksdRelease("1-31")}
+	fakeClient := test.NewFakeKubeClient(objs...)
+
+	err := validations.ValidateExtendedKubernetesVersionSupport(ctx, *cluster, reader, fakeClient, "bundles-override.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("unmarshalling eksd release manifest from URL"))
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -54,7 +54,7 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 			return &validations.ValidationResult{
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
-				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient, v.Opts.BundlesOverride),
+				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient, v.Opts.BundlesOverride),
 			}
 		},
 	}

--- a/pkg/validations/createvalidations/preflightvalidations_test.go
+++ b/pkg/validations/createvalidations/preflightvalidations_test.go
@@ -44,7 +44,7 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 	clusterSpec := test.NewClusterSpec(func(s *cluster.Spec) {
 		s.Cluster = &anywherev1.Cluster{
 			Spec: anywherev1.ClusterSpec{
-				KubernetesVersion: "1.30",
+				KubernetesVersion: "1.31",
 				GitOpsRef: &anywherev1.Ref{
 					Name: "gitops",
 				},
@@ -57,7 +57,9 @@ func newPreflightValidationsTest(t *testing.T) *preflightValidationsTest {
 	eksaReleaseV022.Name = "eksa-v0-22-0"
 	eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
 
-	objects := []client.Object{eksaReleaseV022}
+	eksdRelease := test.EksdRelease("1-31")
+
+	objects := []client.Object{eksaReleaseV022, eksdRelease}
 	opts := &validations.Opts{
 		Kubectl:           k,
 		Spec:              clusterSpec,
@@ -90,17 +92,20 @@ spec:
 	reader.EXPECT().ReadFile(releasesURL).Return([]byte(releasesManifest), nil)
 
 	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Bundles
 metadata:
   annotations:
-    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
   name: bundles-1
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 
 	reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
 

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -126,7 +126,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 			return &validations.ValidationResult{
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
-				Err:         validations.ValidateExtendedKubernetesSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient, u.Opts.BundlesOverride),
+				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient, u.Opts.BundlesOverride),
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations_test.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations_test.go
@@ -55,8 +55,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 	}{
 		{
 			name:               "ValidationSucceeds",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -66,8 +66,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsClusterDoesNotExist",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: []types.CAPICluster{{Metadata: types.Metadata{Name: "thisIsNotTheClusterYourLookingFor"}}},
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -77,8 +77,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsNoClusters",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: []types.CAPICluster{},
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -88,8 +88,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsCpNotReady",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         errors.New("control plane nodes are not ready"),
 			workerResponse:     nil,
@@ -99,8 +99,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsWorkerNodesNotReady",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     errors.New("2 worker nodes are not ready"),
@@ -110,8 +110,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsNodesNotReady",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -121,8 +121,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsNoCrds",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -132,8 +132,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsExplodingCluster",
-			clusterVersion:     "1.28",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.29",
+			upgradeVersion:     "1.31",
 			getClusterResponse: []types.CAPICluster{{Metadata: types.Metadata{Name: "thisIsNotTheClusterYourLookingFor"}}},
 			cpResponse:         errors.New("control plane nodes are not ready"),
 			workerResponse:     errors.New("2 worker nodes are not ready"),
@@ -143,8 +143,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationControlPlaneImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -157,8 +157,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationClusterNetworkPodsImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -171,8 +171,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationClusterNetworkServicesImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -185,8 +185,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationManagementImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -199,8 +199,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationTinkerbellIPImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -213,8 +213,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationOSImageURLMutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -227,8 +227,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationHookImageURLImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -241,8 +241,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationSSHUsernameImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -255,8 +255,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationSSHAuthorizedKeysImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -269,8 +269,8 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 		},
 		{
 			name:               "ValidationHardwareSelectorImmutable",
-			clusterVersion:     "1.30",
-			upgradeVersion:     "1.30",
+			clusterVersion:     "1.31",
+			upgradeVersion:     "1.31",
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -358,6 +358,15 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 			tlsValidator := mocks.NewMockTlsValidator(mockCtrl)
 			version := anywherev1.EksaVersion("v0.22.0")
 			provider := newProvider(defaultDatacenterSpec, givenTinkerbellMachineConfigs(t), clusterSpec.Cluster, writer, docker, helm, kubectl, false)
+
+			eksaReleaseV022 := test.EKSARelease()
+			eksaReleaseV022.Name = "eksa-v0-22-0"
+			eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
+
+			eksdRelease := test.EksdRelease("1-31")
+
+			objects := []client.Object{eksaReleaseV022, eksdRelease}
+
 			opts := &validations.Opts{
 				Kubectl:           k,
 				Spec:              clusterSpec,
@@ -366,6 +375,7 @@ func TestPreflightValidationsTinkerbell(t *testing.T) {
 				Provider:          provider,
 				TLSValidator:      tlsValidator,
 				CliVersion:        string(version),
+				KubeClient:        test.NewFakeKubeClient(objects...),
 				ManifestReader:    addManifestReaderMock(t, version),
 			}
 
@@ -453,8 +463,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 	}{
 		{
 			name:               "ValidationBottlerocketKC",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -501,8 +511,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationSucceeds",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -512,8 +522,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsClusterDoesNotExist",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: []types.CAPICluster{{Metadata: types.Metadata{Name: "thisIsNotTheClusterYourLookingFor"}}},
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -523,8 +533,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsNoClusters",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: []types.CAPICluster{},
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -534,8 +544,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsCpNotReady",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         errors.New("control plane nodes are not ready"),
 			workerResponse:     nil,
@@ -545,8 +555,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsWorkerNodesNotReady",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     errors.New("2 worker nodes are not ready"),
@@ -556,8 +566,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsNodesNotReady",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -567,8 +577,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsNoCrds",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -578,8 +588,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationFailsExplodingCluster",
-			clusterVersion:     string(anywherev1.Kube128),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube129),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: []types.CAPICluster{{Metadata: types.Metadata{Name: "thisIsNotTheClusterYourLookingFor"}}},
 			cpResponse:         errors.New("control plane nodes are not ready"),
 			workerResponse:     errors.New("2 worker nodes are not ready"),
@@ -589,8 +599,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationControlPlaneImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -603,8 +613,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationAwsIamRegionImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -617,8 +627,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationAwsIamBackEndModeImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -631,8 +641,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationAwsIamPartitionImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -645,8 +655,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationAwsIamNameImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -662,8 +672,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationAwsIamKindImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -679,8 +689,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationAwsIamKindImmutableSwapOrder",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -700,8 +710,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationGitOpsNamespaceImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -714,8 +724,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationGitOpsBranchImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -728,8 +738,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationGitOpsOwnerImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -742,8 +752,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationGitOpsRepositoryImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -756,8 +766,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationGitOpsPathImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -770,8 +780,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationGitOpsPersonalImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -784,8 +794,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCClientIdMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -798,8 +808,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCGroupsClaimMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -812,8 +822,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCGroupsPrefixMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -826,8 +836,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCIssuerUrlMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -840,8 +850,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCUsernameClaimMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -854,8 +864,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCUsernamePrefixMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -868,8 +878,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationOIDCRequiredClaimsMutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -882,8 +892,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationClusterNetworkPodsImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -896,8 +906,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationClusterNetworkServicesImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -910,8 +920,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationClusterNetworkDNSImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -924,8 +934,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationProxyConfigurationImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -944,8 +954,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationEtcdConfigPreviousSpecEmpty",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -962,8 +972,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationManagementImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -976,8 +986,8 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 		},
 		{
 			name:               "ValidationManagementClusterNameImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -1145,7 +1155,9 @@ func TestPreflightValidationsVsphere(t *testing.T) {
 			eksaReleaseV022.Name = "eksa-v0-22-0"
 			eksaReleaseV022.Spec.Version = "eksa-v0-22-0"
 
-			objects := []client.Object{eksaReleaseV022}
+			eksdRelease := test.EksdRelease("1-31")
+
+			objects := []client.Object{eksaReleaseV022, eksdRelease}
 			version := anywherev1.EksaVersion("v0.22.0")
 			opts := &validations.Opts{
 				Kubectl:           k,
@@ -1204,7 +1216,7 @@ var explodingClusterError = composeError(
 	"node test-node is not ready, currently in Unknown state",
 	"error getting clusters crd: crd not found",
 	"couldn't find CAPI cluster object for cluster with name testcluster",
-	"spec: Invalid value: \"1.30\": only +1 minor version skew is supported, minor version skew detected 2",
+	"spec: Invalid value: \"1.31\": only +1 minor version skew is supported, minor version skew detected 2",
 )
 
 func TestPreFlightValidationsGit(t *testing.T) {
@@ -1222,8 +1234,8 @@ func TestPreFlightValidationsGit(t *testing.T) {
 	}{
 		{
 			name:               "ValidationFluxSshKeyAlgoImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -1236,8 +1248,8 @@ func TestPreFlightValidationsGit(t *testing.T) {
 		},
 		{
 			name:               "ValidationFluxRepoUrlImmutable",
-			clusterVersion:     string(anywherev1.Kube130),
-			upgradeVersion:     string(anywherev1.Kube130),
+			clusterVersion:     string(anywherev1.Kube131),
+			upgradeVersion:     string(anywherev1.Kube131),
 			getClusterResponse: goodClusterResponse,
 			cpResponse:         nil,
 			workerResponse:     nil,
@@ -1445,17 +1457,20 @@ spec:
 	reader.EXPECT().ReadFile(releasesURL).Return([]byte(releasesManifest), nil)
 
 	bundlesManifest := `apiVersion: anywhere.eks.amazonaws.com/v1alpha1
-apiVersion: anywhere.eks.amazonaws.com/v1alpha1
 kind: Bundles
 metadata:
   annotations:
-    anywhere.eks.amazonaws.com/signature: MEYCIQDgmE8oY9xUyFO3uOHRkpRWjTxoej8Wf7Ty5HQcbs9ouQIhANV2kylPXjcpLY2xu7vD6ktXqm7yrnLUgiehSdbL8JUJ
+    anywhere.eks.amazonaws.com/signature: MEQCICjq1rZmhH0FYOlruZmh6QADCrr5ccrN6hE7Lu0vaXGrAiBhV+kfh64sqLblBt98DvIfHMerEqJVhHzpGy1YJthZQw==
   name: bundles-1
 spec:
   number: 1
   versionsBundles:
-  - kubeversion: "1.30"
-    endOfStandardSupport: "2026-12-31"`
+  - kubeVersion: "1.31"
+    endOfStandardSupport: "2026-12-31"
+    eksD:
+      name: "test"
+      channel: "1-31"
+      manifestUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml"`
 
 	reader.EXPECT().ReadFile("https://bundles/bundles.yaml").Return([]byte(bundlesManifest), nil)
 

--- a/release/cli/pkg/signature/manifest_test.go
+++ b/release/cli/pkg/signature/manifest_test.go
@@ -16,6 +16,7 @@ package signature
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -23,6 +24,9 @@ import (
 	anywherev1constants "github.com/aws/eks-anywhere/pkg/constants"
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eksdv1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 )
 
 func TestGetBundleSignature(t *testing.T) {
@@ -106,6 +110,38 @@ func TestGetBundleSignature(t *testing.T) {
 			key:             constants.BundlesKmsKey,
 			expectErrSubstr: "",
 		},
+		{
+			testName: "get bundle signature",
+			bundle: &anywherev1alpha1.Bundles{
+				TypeMeta: v1.TypeMeta{
+					Kind:       "Bundles",
+					APIVersion: anywherev1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						anywherev1constants.SignatureAnnotation: "MEUCIBQSvgIhP+DWxZABtdXznRHd3pDoFLeNqi+LcvysJlclAiEAsFCH222IZ1u5hJ0dLdu0NJd2rsJnhKNhxpE+Qg3L7qQ=",
+						anywherev1constants.EKSDistroSignatureAnnotation: "",
+					},
+					Name: "bundles-1",
+				},
+				Spec: anywherev1alpha1.BundlesSpec{
+					Number: 1,
+					VersionsBundles: []anywherev1alpha1.VersionsBundle{
+						{
+							KubeVersion:          "1.31",
+							EndOfStandardSupport: "2026-12-31",
+							EksD: anywherev1alpha1.EksDRelease{
+								Name: "test",
+								ReleaseChannel: "1-31",
+								EksDReleaseUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml",
+							},
+						},
+					},
+				},
+			},
+			key:             constants.BundlesKmsKey,
+			expectErrSubstr: "",
+		},
 	}
 
 	for _, tt := range testCases {
@@ -114,21 +150,60 @@ func TestGetBundleSignature(t *testing.T) {
 
 			ctx := context.Background()
 			sig, err := GetBundleSignature(ctx, tt.bundle, tt.key)
+			if tt.testName == "get bundle signature" {
+				fmt.Println(sig)
+			}
 
 			if tt.expectErrSubstr == "" {
-				// Expecting no particular error substring -> test for success
-				g.Expect(err).NotTo(HaveOccurred(),
-					"Expected no error but got error: %v", err)
-				g.Expect(sig).NotTo(BeEmpty(),
-					"Expected signature string to be non-empty on success")
+				g.Expect(err).NotTo(HaveOccurred(), "Expected no error but got: %v", err)
+				g.Expect(sig).NotTo(BeEmpty(), "Expected non-empty signature on success")
 			} else {
-				// Expecting an error substring -> test for error presence
-				g.Expect(err).To(HaveOccurred(),
-					"Expected an error but got none")
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr),
-					"Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
-				g.Expect(sig).To(BeEmpty(),
-					"Expected signature to be empty when error occurs")
+				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(sig).To(BeEmpty(), "Expected empty signature when error occurs")
+			}
+		})
+	}
+}
+
+func TestGetEKSDistroManifestSignature(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		bundle          *anywherev1alpha1.Bundles
+		key             string
+		releaseUrl      string
+		expectErrSubstr string
+	}{
+		{
+			testName:        "Invalid release URL",
+			bundle:          &anywherev1alpha1.Bundles{},
+			key:             constants.EKSDistroManifestKmsKey,
+			releaseUrl:      "invalid-test-url",
+			expectErrSubstr: "getting eks distro release",
+		},
+		{
+			testName:        "Valid eks distro manifest signature generation",
+			bundle:          &anywherev1alpha1.Bundles{},
+			key:             constants.EKSDistroManifestKmsKey,
+			releaseUrl:      "https://distro.eks.amazonaws.com/kubernetes-1-28/kubernetes-1-28-eks-46.yaml",
+			expectErrSubstr: "",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx := context.Background()
+			sig, err := GetEKSDistroManifestSignature(ctx, tt.bundle, tt.key, tt.releaseUrl)
+			
+			if tt.expectErrSubstr == "" {
+				g.Expect(err).NotTo(HaveOccurred(), "Expected no error but got: %v", err)
+				g.Expect(sig).NotTo(BeEmpty(), "Expected non-empty signature on success")
+			} else {
+				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(sig).To(BeEmpty(), "Expected empty signature when error occurs")
 			}
 		})
 	}
@@ -180,17 +255,67 @@ func TestGetBundleDigest(t *testing.T) {
 
 			digest, filtered, err := getBundleDigest(tt.bundle)
 			if tt.expectErrSubstr == "" {
-				g.Expect(err).NotTo(HaveOccurred(), "Expected success but got error")
-				g.Expect(digest).NotTo(BeZero(),
-					"Expected digest to be non-zero array")
-				g.Expect(filtered).NotTo(BeEmpty(),
-					"Expected filtered bytes to be non-empty")
+				g.Expect(err).NotTo(HaveOccurred(), "Expected success but got error: %v", err)
+				g.Expect(digest).NotTo(BeZero(), "Expected non-zero digest")
+				g.Expect(filtered).NotTo(BeEmpty(), "Expected non-empty filtered output")
 			} else {
-				g.Expect(err).To(HaveOccurred(),
-					"Expected error but got none")
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr),
-					"Error message should contain substring %q, got: %v",
-					tt.expectErrSubstr, err)
+				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
+				g.Expect(digest).To(BeZero())
+				g.Expect(filtered).To(BeNil())
+			}
+		})
+	}
+}
+
+func TestGetEKSDistroReleaseDigest(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		release         *eksdv1alpha1.Release
+		expectErrSubstr string
+	}{
+		{
+			testName:        "Simple valid eks distro release",
+			release:         &eksdv1alpha1.Release{},
+			expectErrSubstr: "",
+		},
+		{
+			testName: "Populated eks distro release",
+			release: &eksdv1alpha1.Release{
+				Spec: eksdv1alpha1.ReleaseSpec{
+					Channel: "1-28",
+					Number: 46,
+				},
+				Status: eksdv1alpha1.ReleaseStatus{
+					Components: []eksdv1alpha1.Component{
+						{
+							Name:   "metrics-server",
+							GitTag: "v0.7.2",
+							Assets: []eksdv1alpha1.Asset{
+								{
+									Name: "metrics-server-image",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErrSubstr: "",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			g := NewWithT(t)
+
+			digest, filtered, err := getEKSDistroReleaseDigest(tt.release)
+			if tt.expectErrSubstr == "" {
+				g.Expect(err).NotTo(HaveOccurred(), "Expected success but got error: %v", err)
+				g.Expect(digest).NotTo(BeZero(), "Expected non-zero digest")
+				g.Expect(filtered).NotTo(BeEmpty(), "Expected non-empty filtered output")
+			} else {
+				g.Expect(err).To(HaveOccurred(), "Expected error but got none")
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubstr), "Error message should contain substring %q, got: %v", tt.expectErrSubstr, err)
 				g.Expect(digest).To(BeZero())
 				g.Expect(filtered).To(BeNil())
 			}


### PR DESCRIPTION
*Description of changes:*
This is a manual cherry-pick of [#9801](https://github.com/aws/eks-anywhere/pull/9801).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

