### PR TITLE
docs: update typos with incorrect command

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/overview.md
+++ b/docs/content/en/docs/getting-started/baremetal/overview.md
@@ -26,7 +26,7 @@ Create a hardware configuration file (`hardware.csv`) as described in [Prepare h
 
 #### 3. Launch the cluster creation
 
-Run the `eksctl anywhere cluster create` command, providing the cluster config and hardware CSV files.
+Run the `eksctl anywhere create cluster` command, providing the cluster config and hardware CSV files.
 To see details on the cluster creation process, increase verbosity (`-v=9` provides maximum verbosity).
 
 #### 4. Create bootstrap cluster and provision hardware

--- a/docs/content/en/docs/getting-started/nutanix/overview.md
+++ b/docs/content/en/docs/getting-started/nutanix/overview.md
@@ -26,7 +26,7 @@ Details about this config file can be found on the [Nutanix Config]({{< relref "
 
 #### 3. Launch the cluster creation
 
-After modifying the cluster configuration file, run the `eksctl anywhere cluster create` command, providing the cluster config. 
+After modifying the cluster configuration file, run the `eksctl anywhere create cluster` command, providing the cluster config. 
 The verbosity can be increased to see more details on the cluster creation process (-v=9 provides maximum verbosity).
 
 #### 4. Create bootstrap cluster


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The docs have the command arguments backwards

*Testing (if applicable):* N/A
 
*Documentation added/planned (if applicable):* N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

