### PR TITLE
Remove 1.33 feature flag and make 1.33 as default version

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -229,7 +229,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster.
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube132
+	return Kube133
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -4043,7 +4043,7 @@ func TestValidateEksaVersion(t *testing.T) {
 
 func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
-	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube132))
+	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube133))
 }
 
 func TestClusterWorkerNodeConfigCount(t *testing.T) {

--- a/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
@@ -17,7 +17,7 @@ spec:
     upgradeRolloutStrategy:
       type: InPlace
   datacenterRef: {}
-  kubernetesVersion: "1.32"
+  kubernetesVersion: "1.33"
   managementCluster:
     name: test-cluster
   workerNodeGroupConfigurations:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -9,7 +9,6 @@ const (
 	VSphereInPlaceEnvVar              = "VSPHERE_IN_PLACE_UPGRADE"
 	APIServerExtraArgsEnabledEnvVar   = "API_SERVER_EXTRA_ARGS_ENABLED"
 	VSphereFailureDomainEnabledEnvVar = "VSPHERE_FAILURE_DOMAIN_ENABLED"
-	K8s133SupportEnvVar               = "K8S_1_33_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -72,13 +71,5 @@ func VsphereFailureDomainEnabled() Feature {
 	return Feature{
 		Name:     "Vsphere Failure Domains Enabled",
 		IsActive: globalFeatures.isActiveForEnvVar(VSphereFailureDomainEnabledEnvVar),
-	}
-}
-
-// K8s133Support is the feature flag for Kubernetes 1.33 support.
-func K8s133Support() Feature {
-	return Feature{
-		Name:     "Kubernetes version 1.33 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s133SupportEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -93,11 +93,3 @@ func TestWithVsphereFailureDomainsFeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(VSphereFailureDomainEnabledEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(VsphereFailureDomainEnabled())).To(BeTrue())
 }
-
-func TestWithK8s133FeatureFlag(t *testing.T) {
-	g := NewWithT(t)
-	setupContext(t)
-
-	g.Expect(os.Setenv(K8s133SupportEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(K8s133Support())).To(BeTrue())
-}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
@@ -335,16 +334,6 @@ func ValidateExtendedKubernetesVersionSupport(ctx context.Context, clusterSpec v
 	}
 
 	return ValidateExtendedK8sVersionSupport(ctx, clusterSpec, b, releaseManifest, k)
-}
-
-// ValidateK8s133Support checks if the 1.33 feature flag is set when using k8s 1.33.
-func ValidateK8s133Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s133Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube133 {
-			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube133, features.K8s133SupportEnvVar)
-		}
-	}
-	return nil
 }
 
 // getReleaseManifestFromBundle retrieves the EKS Distro release manifest from the bundle.

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -20,7 +20,6 @@ import (
 	internalmocks "github.com/aws/eks-anywhere/internal/test/mocks"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/releases"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -1188,21 +1187,6 @@ spec:
 			}
 		})
 	}
-}
-
-func TestValidateK8s133Support(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube133
-	tt.Expect(validations.ValidateK8s133Support(tt.clusterSpec)).To(
-		MatchError(ContainSubstring("kubernetes version 1.33 is not enabled. Please set the env variable K8S_1_33_SUPPORT")))
-}
-
-func TestValidateK8s133SupportActive(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube133
-	features.ClearCache()
-	os.Setenv(features.K8s133SupportEnvVar, "true")
-	tt.Expect(validations.ValidateK8s133Support(tt.clusterSpec)).To(Succeed())
 }
 
 func TestValidateExtendedKubernetesVersionSupportAirgappedSuccess(t *testing.T) {

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -7,7 +7,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -55,14 +54,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
 				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient, v.Opts.BundlesOverride),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.33 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s133SupportEnvVar),
-				Err:         validations.ValidateK8s133Support(v.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,7 +9,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -128,14 +127,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
 				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient, u.Opts.BundlesOverride),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.33 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s133SupportEnvVar),
-				Err:         validations.ValidateK8s133Support(u.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -36,7 +36,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -2278,12 +2277,11 @@ func dumpFile(description, path string, t T) {
 func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
 	// Update this variable to equal the feature flagged k8s version when applicable.
 	// For example, if k8s 1.31 is under a feature flag, we would set this to v1alpha1.Kube131
-	unreleasedK8sVersion := v1alpha1.Kube133
+	var unreleasedK8sVersion v1alpha1.KubernetesVersion
 
 	if version == unreleasedK8sVersion {
 		// Set feature flag for the unreleased k8s version when applicable
 		e.T.Logf("Setting k8s version support feature flag...")
-		os.Setenv(features.K8s133SupportEnvVar, "true")
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove 1.33 feature flag and make 1.33 as default version

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

