### PR TITLE
Skip BottleRocket auto-import integration tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -74,3 +74,13 @@ skipped_tests:
 - TestTinkerbellKubernetes130ThreeReplicasTwoWorkersConformanceFlow
 - TestTinkerbellKubernetes131ThreeReplicasTwoWorkersConformanceFlow
 - TestTinkerbellKubernetes132ThreeReplicasTwoWorkersConformanceFlow
+
+# Vsphere 
+# Auto import tests fail from time to time if the underlying template doesn't go well with the content library.
+# Currently there's no fix for this and issue has been brought up with the BR team multiple times.
+- TestVSphereKubernetes128BottlerocketAutoimport
+- TestVSphereKubernetes129BottlerocketAutoimport
+- TestVSphereKubernetes130BottlerocketAutoimport
+- TestVSphereKubernetes131BottlerocketAutoimport
+- TestVSphereKubernetes132BottlerocketAutoimport
+- TestVSphereKubernetes133BottlerocketAutoimport


### PR DESCRIPTION
*Description of changes:*
Time to time we see BR auto-import tests failing with the below pipe closed error. This is a well known issue and there's no way for eks-a fix it as the issue seem to stem from the underlying BR ova template being vended. Skip these tests to avoid noise in our e2e. 

```
2024-10-23T22:38:48.432Z	V0	❌ Validation failed	{"validation": "vsphere Provider setup is valid", "error": "failed setting default values for vsphere machine configs: failed importing template into library: importing template: govc: The import of library item ae9ef96d-1e1d-4316-abc0-f3153334a200 has failed. Reason: Error transferring file bottlerocket-v1.31.1-eks-d-1-31-5-eks-a-v0.21.0-dev-build.284-amd64.ova to ds:///vmfs/volumes/vsan:d553112fa66a4375-b38364b4fc9cf307//contentlib-01374ce1-f97d-4678-84f4-0bdd4df2ae71/ae9ef96d-1e1d-4316-abc0-f3153334a200/bottlerocket-v1.31.1-eks-d-1-31-5-eks-a-v0.21.0-dev-build.284-amd64_b7ea7fcd-01ce-407e-b080-40c750ae4ee4.ova?serverId=65cc6f41-4935-4140-b6c5-fa6370cad77d. Reason: Error during transfer of ds:///vmfs/volumes/vsan:d553112fa66a4375-b38364b4fc9cf307//contentlib-01374ce1-f97d-4678-84f4-0bdd4df2ae71/ae9ef96d-1e1d-4316-abc0-f3153334a200/bottlerocket-v1.31.1-eks-d-1-31-5-eks-a-v0.21.0-dev-build.284-amd64_b7ea7fcd-01ce-407e-b080-40c750ae4ee4.ova?serverId=65cc6f41-4935-4140-b6c5-fa6370cad77d: IO error during transfer of ds:/vmfs/volumes/vsan:d553112fa66a4375-b38364b4fc9cf307/contentlib-01374ce1-f97d-4678-84f4-0bdd4df2ae71/ae9ef96d-1e1d-4316-abc0-f3153334a200/bottlerocket-vmware-k8s-1.31-x86_64-1.25.0-388e1050_b7ea7fcd-01ce-407e-b080-40c750ae4ee4.vmdk: Pipe closed.\n", "remediation": ""}
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

