### PR TITLE
Revert "additionlTrustBundle using ConfigMag (#9747)"

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -35,9 +35,9 @@ spec:
   prismCentral:
 {{- if .nutanixAdditionalTrustBundle }}
     additionalTrustBundle:
-      kind: ConfigMap
-      name: "{{.clusterName}}-trust-bundle"
-      namespace: {{.eksaSystemNamespace}}
+      kind: String
+      data: |
+{{ .nutanixAdditionalTrustBundle | indent 8 }}
 {{- end }}
     address: "{{.nutanixEndpoint}}"
     port: {{.nutanixPort}}
@@ -616,8 +616,8 @@ data:
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: {{.clusterName}}-trust-bundle
-      namespace: {{.eksaSystemNamespace}}
+      name: user-ca-bundle
+      namespace: kube-system
     data:
       ca.crt: |
 {{ .nutanixAdditionalTrustBundle | indent 8 }}
@@ -648,8 +648,8 @@ data:
             }{{- if .nutanixAdditionalTrustBundle }},
             "additionalTrustBundle": {
               "kind": "ConfigMap",
-              "name": {{.clusterName}}-trust-bundle,
-              "namespace": {{.eksaSystemNamespace}}
+              "name": "user-ca-bundle",
+              "namespace": "kube-system"
             }{{- end }}
           },
           "enableCustomLabeling": false,
@@ -838,8 +838,7 @@ spec:
     name: {{.clusterName}}-nutanix-ccm-secret
 {{- if .nutanixAdditionalTrustBundle }}
   - kind: ConfigMap
-    name: {{.clusterName}}-trust-bundle
-    namespace: {{.eksaSystemNamespace}}
+    name: user-ca-bundle
 {{- end }}
   strategy: Reconcile
 ---

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -7,9 +7,29 @@ spec:
   failureDomains: []
   prismCentral:
     additionalTrustBundle:
-      kind: ConfigMap
-      name: "eksa-unit-test-trust-bundle"
-      namespace: eksa-system
+      kind: String
+      data: |
+        -----BEGIN CERTIFICATE-----
+        MIIDajCCAlKgAwIBAgIUZOD4pznfHyCO8gMvP87F+PnhGHMwDQYJKoZIhvcNAQEL
+        BQAwNDELMAkGA1UEBhMCREUxFDASBgNVBAgMC0xhbmQgQmVybGluMQ8wDQYDVQQH
+        DAZCZXJsaW4wHhcNMjIwODI1MTYxNzI5WhcNMzIwODIyMTYxNzI5WjA0MQswCQYD
+        VQQGEwJERTEUMBIGA1UECAwLTGFuZCBCZXJsaW4xDzANBgNVBAcMBkJlcmxpbjCC
+        ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAO280znVj6qLpCqAeNgpw7gw
+        0OE54gBW8Y9gBtEYxBux6hXBl+doj+JNZLcfIoDoqdTlgZX13Y//WakfMuvuhYUN
+        53fpwsiup3pqqL+JHhKy+Bq/BSQcHkLGi/aUGph7qK/wQMZBGBbbBXaCwnhjYovl
+        nRq4p+Cm5wm4S/QUhgyvqyoeNWAc6+2AHniuIzo6Q1MU9ktaSAdL8ZdW5g6el5iA
+        oHjDHNjTwyTeybKFScEQvFqO6qfzTRn8eV6dwH4gOYec1IdDwSp8PSv9R7J9AC+1
+        DtAjsYtqO4i6qRpgf0zyGQb+uNKXdz/ovOGa58twfMKYU7Z2crPj3K7NOJVelZEC
+        AwEAAaN0MHIwHQYDVR0OBBYEFPlcZspynb+2DwRN5K3slRyEV0nxMB8GA1UdIwQY
+        MBaAFPlcZspynb+2DwRN5K3slRyEV0nxMA4GA1UdDwEB/wQEAwIFoDAgBgNVHSUB
+        Af8EFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBACXY
+        FH72svBSALkqmTyU9rsh4rRK9yo7tmNJkFkRQ/cjYycpNKZ6Cg9+wGwN6o6pXdqb
+        JfeuePclDdGcgYe8SbGr0T7pFXdUIVmuO/jjatKCftXQQZK5zHCkUTLhVlAbnNpC
+        3NIU4wWjx/QLtk+zEqjl5kyDgXD5GwxXbgzzY+7wi4QZO8VRyLG5lawZVKer3gkt
+        +NGIOtoyz4RjnWIKV34Z6HUDhdgbVyX1uPG/a5mLmcbLjuSf39WdAgv9bFGkUHZk
+        2dU0bIXepIZ5Mz3aovl35EjbGAbpI8tpKWlsHNoiVNQm1vojfKvKVibVS2FNo0cD
+        gu45O/O1hxzezDKiKKU=
+        -----END CERTIFICATE-----
     address: "prism.nutanix.com"
     port: 9440
     insecure: false
@@ -380,8 +400,8 @@ data:
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: eksa-unit-test-trust-bundle
-      namespace: eksa-system
+      name: user-ca-bundle
+      namespace: kube-system
     data:
       ca.crt: |
         -----BEGIN CERTIFICATE-----
@@ -431,8 +451,8 @@ data:
             },
             "additionalTrustBundle": {
               "kind": "ConfigMap",
-              "name": eksa-unit-test-trust-bundle,
-              "namespace": eksa-system
+              "name": "user-ca-bundle",
+              "namespace": "kube-system"
             }
           },
           "enableCustomLabeling": false,
@@ -620,8 +640,7 @@ spec:
   - kind: Secret
     name: eksa-unit-test-nutanix-ccm-secret
   - kind: ConfigMap
-    name: eksa-unit-test-trust-bundle
-    namespace: eksa-system
+    name: user-ca-bundle
   strategy: Reconcile
 ---
 apiVersion: v1


### PR DESCRIPTION
This reverts commit fb4bedad3f47b061ccef0695222237336d16db41.

*Issue #, if available:*


*Description of changes:*

This commit is breaking the cluster creation (in all e2e tests) due to error in CAPX controller pod

```
2025-06-20T05:28:23Z    ERROR   error occurred while reconciling trust bundle ref for cluster main-i-04a29-7e06913  {"controller": "nutanixcluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "NutanixCluster", "NutanixCluster": {"name":"main-i-04a29-7e06913","namespace":"eksa-system"}, "namespace": "eksa-system", "name": "main-i-04a29-7e06913", "reconcileID": "1794dffc-3173-4b75-b010-6f3b1b779eec", "error": "ConfigMap \"main-i-04a29-7e06913-trust-bundle\" not found"}
```

Reverting the commit for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

