### PR TITLE
stops cilium operator from blocking draining of nodes

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -221,6 +221,20 @@ func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) 
 			"prometheus": values{
 				"enabled": true,
 			},
+			"tolerations": []values{
+				{
+					"key":      "node-role.kubernetes.io/control-plane",
+					"operator": "Exists",
+				},
+				{
+					"key":      "node.kubernetes.io/not-ready",
+					"operator": "Exists",
+				},
+				{
+					"key":      "node.cilium.io/agent-not-ready",
+					"operator": "Exists",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replaces cilium-operator tolerations from tolerations: [{operator: Exists}] to
tolerations: [{key: "[node-role.kubernetes.io/control-plane](http://node-role.kubernetes.io/control-plane)", operator: "Exists"}, {key: "[node.kubernetes.io/not-ready](http://node.kubernetes.io/not-ready)", operator: "Exists"}, {key: "[node.cilium.io/agent-not-ready](http://node.cilium.io/agent-not-ready)", operator: "Exists"},]

Worker node upgrade workflow sometimes fail due to cilium operator getting scheduled onto the nodes marked for deletion as they have wildcard tolerations by default.

*Testing (if applicable):*
Performed manual testing by creating cluster with the change and verified that cilium-operator schedules similarly with the added tolerations.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

