### PR TITLE
Fix conflicts for concurrent git operations

### DIFF
--- a/release/cli/pkg/signature/manifest_test.go
+++ b/release/cli/pkg/signature/manifest_test.go
@@ -119,7 +119,7 @@ func TestGetBundleSignature(t *testing.T) {
 				},
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						anywherev1constants.SignatureAnnotation: "MEUCIBQSvgIhP+DWxZABtdXznRHd3pDoFLeNqi+LcvysJlclAiEAsFCH222IZ1u5hJ0dLdu0NJd2rsJnhKNhxpE+Qg3L7qQ=",
+						anywherev1constants.SignatureAnnotation:          "MEUCIBQSvgIhP+DWxZABtdXznRHd3pDoFLeNqi+LcvysJlclAiEAsFCH222IZ1u5hJ0dLdu0NJd2rsJnhKNhxpE+Qg3L7qQ=",
 						anywherev1constants.EKSDistroSignatureAnnotation: "",
 					},
 					Name: "bundles-1",
@@ -131,7 +131,7 @@ func TestGetBundleSignature(t *testing.T) {
 							KubeVersion:          "1.31",
 							EndOfStandardSupport: "2026-12-31",
 							EksD: anywherev1alpha1.EksDRelease{
-								Name: "test",
+								Name:           "test",
 								ReleaseChannel: "1-31",
 								EksDReleaseUrl: "https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-1.yaml",
 							},
@@ -196,7 +196,7 @@ func TestGetEKSDistroManifestSignature(t *testing.T) {
 
 			ctx := context.Background()
 			sig, err := GetEKSDistroManifestSignature(ctx, tt.bundle, tt.key, tt.releaseUrl)
-			
+
 			if tt.expectErrSubstr == "" {
 				g.Expect(err).NotTo(HaveOccurred(), "Expected no error but got: %v", err)
 				g.Expect(sig).NotTo(BeEmpty(), "Expected non-empty signature on success")
@@ -284,7 +284,7 @@ func TestGetEKSDistroReleaseDigest(t *testing.T) {
 			release: &eksdv1alpha1.Release{
 				Spec: eksdv1alpha1.ReleaseSpec{
 					Channel: "1-28",
-					Number: 46,
+					Number:  46,
 				},
 				Status: eksdv1alpha1.ReleaseStatus{
 					Components: []eksdv1alpha1.Component{


### PR DESCRIPTION
*Issue #, if available:*
CodeBuild Job Logs: https://tiny.amazon.com/evch7zbm/IsenLink

The dev-release failed for the `release-0.21` branch with the following error:
```
Execution aborted by retry policy
Artifact corresponding to release-0.21 branch not found for bottlerocket.img.gz archive.
Using artifact from main
Error happened during retry after 1 retries: requested object not found: 
projects/kubernetes-sigs/image-builder/1-27/ami/bottlerocket/1/release-0.21/bottlerocket.img.gz
Execution aborted by retry policy
Artifact corresponding to release-0.21 branch not found for bottlerocket.img.gz archive. 
Using artifact from main
fatal: Unable to create '/root/eks-a-source/eks-a-build/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```
A lot of operations in the release process were parallelized in [#7186](https://github.com/aws/eks-anywhere/pull/7186) to reduce the release execution time. The above issue happens when multiple goroutines simultaneously tries to checkout git repositories and read tags when artifacts aren't found for the release branch. Since the git `index.lock` files are not being cleaned up properly, this prevents any subsequent git operations.

*Description of changes:*
This PR fixes concurrent git lock issues in the release CLI during the artifacts download stage by implementing the following changes:
1. **Thread-Safe Git Operations:**
   - Added global `gitOperationMutex` to serialize all git operations
   - Created `readGitTagThreadSafe()` function with proper synchronization
   - Updated both `handleArchiveDownload()` and `handleManifestDownload()` to use thread-safe git operations

2. **Git Lock File Management:**
   - Added `cleanupGitLockFiles()` function to remove stale git index.lock files
   - Integrated cleanup at download process startup and before each git operation
   - Added proper error handling and logging for lock file operations

3. **Improved Error Handling:**
   - Enhanced logging for git lock file cleanup operations
   - Maintained existing fallback behavior while preventing race conditions 

*Testing (if applicable):*
```
make -C release build
make -C release dev-release
```
The dry-run of dev-release succeeded locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

