### PR TITLE
Deprecates cilium manifest from bundle as it's unused

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -563,6 +563,7 @@ spec:
                               type: string
                           type: object
                         manifest:
+                          description: This field has been deprecated
                           properties:
                             uri:
                               description: URI points to the manifest yaml file
@@ -601,7 +602,6 @@ spec:
                           type: string
                       required:
                       - cilium
-                      - manifest
                       - operator
                       type: object
                     cloudStack:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -729,6 +729,7 @@ spec:
                               type: string
                           type: object
                         manifest:
+                          description: This field has been deprecated
                           properties:
                             uri:
                               description: URI points to the manifest yaml file
@@ -767,7 +768,6 @@ spec:
                           type: string
                       required:
                       - cilium
-                      - manifest
                       - operator
                       type: object
                     cloudStack:

--- a/release/api/v1alpha1/artifacts.go
+++ b/release/api/v1alpha1/artifacts.go
@@ -60,9 +60,6 @@ func (vb *VersionsBundle) Manifests() map[string][]*string {
 			&vb.Nutanix.ClusterTemplate.URI,
 			&vb.Nutanix.Metadata.URI,
 		},
-		"cilium": {
-			&vb.Cilium.Manifest.URI,
-		},
 		"kindnetd": {
 			&vb.Kindnetd.Manifest.URI,
 		},

--- a/release/api/v1alpha1/bundle_types.go
+++ b/release/api/v1alpha1/bundle_types.go
@@ -244,11 +244,12 @@ type CloudStackBundle struct {
 
 // CiliumBundle defines the Cilium version and images used for CNI in this bundle.
 type CiliumBundle struct {
-	Version   string   `json:"version,omitempty"`
-	Cilium    Image    `json:"cilium"`
-	Operator  Image    `json:"operator"`
-	Manifest  Manifest `json:"manifest"`
-	HelmChart Image    `json:"helmChart,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Cilium   Image  `json:"cilium"`
+	Operator Image  `json:"operator"`
+	// This field has been deprecated
+	Manifest  *Manifest `json:"manifest,omitempty"`
+	HelmChart Image     `json:"helmChart,omitempty"`
 }
 
 // KindnetdBundle defines the Kindnetd version and manifest for this bundle.

--- a/release/api/v1alpha1/zz_generated.deepcopy.go
+++ b/release/api/v1alpha1/zz_generated.deepcopy.go
@@ -277,7 +277,11 @@ func (in *CiliumBundle) DeepCopyInto(out *CiliumBundle) {
 	*out = *in
 	in.Cilium.DeepCopyInto(&out.Cilium)
 	in.Operator.DeepCopyInto(&out.Operator)
-	out.Manifest = in.Manifest
+	if in.Manifest != nil {
+		in, out := &in.Manifest, &out.Manifest
+		*out = new(Manifest)
+		**out = **in
+	}
 	in.HelmChart.DeepCopyInto(&out.HelmChart)
 }
 

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -98,17 +98,6 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			},
 		},
 	},
-	// Cilium artifacts
-	{
-		ProjectName: "cilium",
-		ProjectPath: "projects/cilium/cilium",
-		Manifests: []*assettypes.ManifestComponent{
-			{
-				Name:          "cilium",
-				ManifestFiles: []string{"cilium.yaml"},
-			},
-		},
-	},
 	// Cloud-provider-nutanix artifacts
 	{
 		ProjectName: "cloud-provider-nutanix",

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -121,8 +121,6 @@ spec:
         imageDigest: sha256:f9786d17903ecb26caecd58137271cef3a7d25ecbb30a4d7396542096d158362
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.15.16-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.15.16-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
@@ -948,8 +946,6 @@ spec:
         imageDigest: sha256:f9786d17903ecb26caecd58137271cef3a7d25ecbb30a4d7396542096d158362
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.15.16-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.15.16-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
@@ -1775,8 +1771,6 @@ spec:
         imageDigest: sha256:f9786d17903ecb26caecd58137271cef3a7d25ecbb30a4d7396542096d158362
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.15.16-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.15.16-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
@@ -2602,8 +2596,6 @@ spec:
         imageDigest: sha256:f9786d17903ecb26caecd58137271cef3a7d25ecbb30a4d7396542096d158362
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.15.16-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.15.16-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
@@ -3429,8 +3421,6 @@ spec:
         imageDigest: sha256:f9786d17903ecb26caecd58137271cef3a7d25ecbb30a4d7396542096d158362
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.15.16-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.15.16-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
@@ -4256,8 +4246,6 @@ spec:
         imageDigest: sha256:f9786d17903ecb26caecd58137271cef3a7d25ecbb30a4d7396542096d158362
         name: cilium-chart
         uri: public.ecr.aws/isovalent/cilium:1.15.16-eksa.1
-      manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cilium/manifests/cilium/v1.15.16-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64

--- a/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
+++ b/release/config/crd/bases/anywhere.eks.amazonaws.com_bundles.yaml
@@ -563,6 +563,7 @@ spec:
                               type: string
                           type: object
                         manifest:
+                          description: This field has been deprecated
                           properties:
                             uri:
                               description: URI points to the manifest yaml file
@@ -601,7 +602,6 @@ spec:
                           type: string
                       required:
                       - cilium
-                      - manifest
                       - operator
                       type: object
                     cloudStack:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

