### PR TITLE
doc fixes for packages copy into airgapped registry

### DIFF
--- a/docs/content/en/docs/getting-started/airgapped/airgap-steps.md
+++ b/docs/content/en/docs/getting-started/airgapped/airgap-steps.md
@@ -27,24 +27,4 @@ toc_hide: true
       --bundles ./eks-anywhere-downloads/bundle-release.yaml
    ```
 
-1. Optionally import curated packages to your registry mirror. The curated packages images are copied from Amazon ECR to your local registry mirror in a single step, as opposed to separate download and import steps. For post-cluster creation steps, reference the [Curated Packages documentation.]({{< relref "../../packages/prereq/#prepare-for-using-curated-packages-for-airgapped-environments" >}})
-   
-   <details>
-      <summary>Expand for curated packages instructions</summary>
-
-      If your EKS Anywhere cluster is running in an airgapped environment, and you set up a local registry mirror, you can copy curated packages from Amazon ECR to your local registry mirror with the following command.
-      
-      Set `$KUBEVERSION` to be equal to the `spec.kubernetesVersion` of your EKS Anywhere cluster specification.
-      
-      The `copy packages` command uses the credentials in your docker config file. So you must `docker login` to the source registries and the destination registry before running the command.
-      
-      When using self-signed certificates for your registry, you should run with the `--dst-insecure` command line argument to indicate skipping TLS verification while copying curated packages.
-
-      ```bash
-      eksctl anywhere copy packages \
-        ${REGISTRY_MIRROR_URL}/curated-packages \
-        --kube-version $KUBEVERSION \
-        --src-chart-registry public.ecr.aws/eks-anywhere \
-        --src-image-registry 783794618700.dkr.ecr.us-west-2.amazonaws.com
-      ```
-   </details>
+1. Optionally import curated packages to your registry mirror. The curated packages images are copied from Amazon ECR to your local registry mirror in a single step, as opposed to separate download and import steps. Follow the [Curated Packages documentation.]({{< relref "../../packages/prereq/#identify-aws-account-id-for-ecr-packages-registry" >}})

--- a/docs/content/en/docs/getting-started/optional/registrymirror.md
+++ b/docs/content/en/docs/getting-started/optional/registrymirror.md
@@ -122,6 +122,7 @@ eks-anywhere
 eks-distro
 isovalent
 cilium-chart
+curated-packages
 ```
 
 For example, if a registry is available at `private-registry.local`, then the following projects must be created.
@@ -132,6 +133,7 @@ https://private-registry.local/eks-anywhere
 https://private-registry.local/eks-distro
 https://private-registry.local/isovalent
 https://private-registry.local/cilium-chart
+https://private-registry.local/curated-packages
 ```
 
 ### Admin machine configuration
@@ -140,7 +142,7 @@ You must configure the Admin machine with the information it needs to communicat
 Add the registry's CA certificate to the list of CA certificates on the Admin machine if your registry uses self-signed certificates.
 
 - For [Linux](https://docs.docker.com/engine/security/certificates/), you can place your certificate here: `/etc/docker/certs.d/<private-registry-endpoint>/ca.crt`
-- For [Mac](https://docs.docker.com/desktop/mac/#add-tls-certificates), you can follow this guide to add the certificate to your keychain: https://docs.docker.com/desktop/mac/#add-tls-certificates
+- For [Mac](https://docs.docker.com/desktop/troubleshoot-and-support/faqs/macfaqs/#how-do-i-add-tls-certificates), you can follow this guide to add the certificate to your keychain: https://docs.docker.com/desktop/troubleshoot-and-support/faqs/macfaqs/#how-do-i-add-tls-certificates
 
 If your registry uses authentication, the following environment variables must be set on the Admin machine before running the `eksctl anywhere import images` command.
 ```bash

--- a/docs/content/en/docs/packages/prereq.md
+++ b/docs/content/en/docs/packages/prereq.md
@@ -126,13 +126,14 @@ If the image downloads successfully, it worked!
 
 If you are running in an airgapped environment and you set up a local registry mirror, you can copy curated packages from Amazon ECR to your local registry mirror with the following command. 
 
-The `$BUNDLE_RELEASE_YAML_PATH` should be set to the `eks-anywhere-downloads/bundle-release.yaml` location where you unpacked the tarball from the`eksctl anywhere download artifacts` command. The `$REGISTRY_MIRROR_CERT_PATH` and `$REGISTRY_MIRROR_URL` values must be the same as the `registryMirrorConfiguration` in your EKS Anywhere cluster specification.
+The `$KUBEVERSION` should be set to the same as the Kubernetes version in `spec.kubernetesVersion` of your EKS Anywhere cluster specification. When using self-signed certificates for your registry, you should run with the `--dst-insecure` command line argument to indicate skipping TLS verification while copying curated packages. 
 
 ```bash
 eksctl anywhere copy packages \
-  --bundle ${BUNDLE_RELEASE_YAML_PATH} \
-  --dst-cert ${REGISTRY_MIRROR_CERT_PATH} \
-  ${REGISTRY_MIRROR_URL}
+  ${REGISTRY_MIRROR_URL}/curated-packages \
+  --kube-version $KUBEVERSION \
+  --src-chart-registry public.ecr.aws/eks-anywhere \
+  --src-image-registry ${ECR_PACKAGES_ACCOUNT}.dkr.ecr.${EKSA_AWS_REGION}.amazonaws.com
 ```
 
 Once the curated packages images are in your local registry mirror, you must configure the curated packages controller to use your local registry mirror post-cluster creation. Configure the `defaultImageRegistry` and `defaultRegistry` settings for the `PackageBundleController` to point to your local registry mirror by applying a similar `yaml` definition as the one below to your standalone or management cluster. Existing `PackageBundleController` can be changed, and you do not need to deploy a new `PackageBundleController`. See the [Packages configuration documentation]({{< relref "./packages/#packagebundlecontrollerspec" >}}) for more information.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3337

*Description of changes:*
Removed wrong packages copy command under Package Management -> Prerequisites and centralised packages copy documentation under package management. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

