### PR TITLE
Fix hardware application sequence in Tinkerbell upgrade flow

### DIFF
--- a/pkg/providers/cloudstack/cloudstack.go
+++ b/pkg/providers/cloudstack/cloudstack.go
@@ -78,14 +78,7 @@ func (p *cloudstackProvider) PostBootstrapSetup(ctx context.Context, clusterConf
 	return nil
 }
 
-// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
-func (p *cloudstackProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
-	return nil
-}
 
-func (p *cloudstackProvider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
-	return nil
-}
 
 func (p *cloudstackProvider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	return nil

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -107,16 +107,6 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	return nil
 }
 
-// PostBootstrapDeleteForUpgrade is a no-op. It implements providers.Provider.
-func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
-	return nil
-}
-
-// PostBootstrapSetupUpgrade is a no-op. It implements providers.Provider.
-func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
-	return nil
-}
-
 // PostWorkloadInit is a no-op. It implements providers.Provider.
 func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	return nil

--- a/pkg/providers/mocks/providers.go
+++ b/pkg/providers/mocks/providers.go
@@ -241,20 +241,6 @@ func (mr *MockProviderMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockProvider)(nil).Name))
 }
 
-// PostBootstrapDeleteForUpgrade mocks base method.
-func (m *MockProvider) PostBootstrapDeleteForUpgrade(arg0 context.Context, arg1 *types.Cluster) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostBootstrapDeleteForUpgrade", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PostBootstrapDeleteForUpgrade indicates an expected call of PostBootstrapDeleteForUpgrade.
-func (mr *MockProviderMockRecorder) PostBootstrapDeleteForUpgrade(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBootstrapDeleteForUpgrade", reflect.TypeOf((*MockProvider)(nil).PostBootstrapDeleteForUpgrade), arg0, arg1)
-}
-
 // PostBootstrapSetup mocks base method.
 func (m *MockProvider) PostBootstrapSetup(arg0 context.Context, arg1 *v1alpha1.Cluster, arg2 *types.Cluster) error {
 	m.ctrl.T.Helper()
@@ -267,20 +253,6 @@ func (m *MockProvider) PostBootstrapSetup(arg0 context.Context, arg1 *v1alpha1.C
 func (mr *MockProviderMockRecorder) PostBootstrapSetup(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBootstrapSetup", reflect.TypeOf((*MockProvider)(nil).PostBootstrapSetup), arg0, arg1, arg2)
-}
-
-// PostBootstrapSetupUpgrade mocks base method.
-func (m *MockProvider) PostBootstrapSetupUpgrade(arg0 context.Context, arg1 *v1alpha1.Cluster, arg2 *types.Cluster) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostBootstrapSetupUpgrade", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PostBootstrapSetupUpgrade indicates an expected call of PostBootstrapSetupUpgrade.
-func (mr *MockProviderMockRecorder) PostBootstrapSetupUpgrade(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBootstrapSetupUpgrade", reflect.TypeOf((*MockProvider)(nil).PostBootstrapSetupUpgrade), arg0, arg1, arg2)
 }
 
 // PostClusterDeleteValidate mocks base method.

--- a/pkg/providers/nutanix/provider.go
+++ b/pkg/providers/nutanix/provider.go
@@ -122,17 +122,6 @@ func (p *Provider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1alph
 	return nil
 }
 
-// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
-func (p *Provider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
-	// TODO(nutanix): figure out if we need something else here
-	return nil
-}
-
-func (p *Provider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
-	// TODO(nutanix): figure out if we need something else here
-	return nil
-}
-
 func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	// TODO(nutanix): figure out if we need something else here
 	return nil

--- a/pkg/providers/nutanix/provider_test.go
+++ b/pkg/providers/nutanix/provider_test.go
@@ -208,18 +208,6 @@ func TestNutanixProviderPostBootstrapSetup(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNutanixProviderPostBootstrapDeleteForUpgrade(t *testing.T) {
-	provider := testDefaultNutanixProvider(t)
-	err := provider.PostBootstrapDeleteForUpgrade(context.Background(), &types.Cluster{Name: "eksa-unit-test"})
-	assert.NoError(t, err)
-}
-
-func TestNutanixProviderPostBootstrapSetupUpgrade(t *testing.T) {
-	provider := testDefaultNutanixProvider(t)
-	err := provider.PostBootstrapSetupUpgrade(context.Background(), provider.clusterConfig, &types.Cluster{Name: "eksa-unit-test"})
-	assert.NoError(t, err)
-}
-
 func TestNutanixProviderPostWorkloadInit(t *testing.T) {
 	provider := testDefaultNutanixProvider(t)
 	clusterSpec := test.NewFullClusterSpec(t, "testdata/eksa-cluster.yaml")

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -21,8 +21,6 @@ type Provider interface {
 	// PreCAPIInstallOnBootstrap is called after the bootstrap cluster is setup but before CAPI resources are installed on it. This allows us to do provider specific configuration on the bootstrap cluster.
 	PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	PostBootstrapSetup(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error
-	PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error
-	PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error
 	// PostWorkloadInit is called after the workload cluster is created and initialized with a CNI. This allows us to do provider specific configuration on the workload cluster.
 	PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error
 	BootstrapClusterOpts(clusterSpec *cluster.Spec) ([]bootstrapper.BootstrapClusterOption, error)

--- a/pkg/providers/snow/snow.go
+++ b/pkg/providers/snow/snow.go
@@ -165,15 +165,6 @@ func (p *SnowProvider) PostBootstrapSetup(ctx context.Context, clusterConfig *v1
 	return nil
 }
 
-// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
-func (p *SnowProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
-	return nil
-}
-
-func (p *SnowProvider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
-	return nil
-}
-
 func (p *SnowProvider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	return nil
 }

--- a/pkg/providers/vsphere/vsphere.go
+++ b/pkg/providers/vsphere/vsphere.go
@@ -1003,10 +1003,6 @@ func (p *vsphereProvider) PostBootstrapSetup(ctx context.Context, clusterConfig 
 	return nil
 }
 
-func (p *vsphereProvider) PostBootstrapSetupUpgrade(ctx context.Context, clusterConfig *v1alpha1.Cluster, cluster *types.Cluster) error {
-	return nil
-}
-
 func (p *vsphereProvider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster, clusterSpec *cluster.Spec) error {
 	return nil
 }
@@ -1282,11 +1278,6 @@ func machineDeploymentName(clusterName, nodeGroupName string) string {
 }
 
 func (p *vsphereProvider) InstallCustomProviderComponents(ctx context.Context, kubeconfigFile string) error {
-	return nil
-}
-
-// PostBootstrapDeleteForUpgrade runs any provider-specific operations after bootstrap cluster has been deleted.
-func (p *vsphereProvider) PostBootstrapDeleteForUpgrade(ctx context.Context, cluster *types.Cluster) error {
 	return nil
 }
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

There is an issue in the EKS-A bare metal upgrade flow where hardware was being applied with a new schema before the CRDs were updated, causing validation failures.

Key changes:
- Move hardware application logic from SetupAndValidateUpgradeCluster to PreCoreComponentsUpgrade to ensure hardware is applied after CRDs are updated
- Remove redundant PostBootstrapSetupUpgrade and PostBootstrapDeleteForUpgrade methods from the provider interface and all provider implementations

The issue was occurring because hardware was being generated and applied based on a new schema in the upgrade flow before the CRDs were actually updated, resulting in validation errors with messages like 
`unknown field 'spec.connection.providerOptions.preferredOrder'`.

This change ensures the correct sequence: first update CRDs, then apply hardware with the new schema.

*Testing (if applicable):*
Manually tested upgrade with above changes and the flow doesn't break. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

