### PR TITLE
Fix wrong k8s version in some 1.33 tests template

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2537,7 +2537,7 @@ func TestVSphereKubernetes132To133OIDCUpgrade(t *testing.T) {
 		test,
 		v1alpha1.Kube133,
 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
 	)
 }
 
@@ -9203,7 +9203,7 @@ func TestVSphereKubernetes133BottlerocketEtcdScaleDown(t *testing.T) {
 		t,
 		framework.NewVSphere(t, framework.WithBottleRocket133()),
 		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
+			api.WithKubernetesVersion(v1alpha1.Kube133),
 			api.WithExternalEtcdTopology(3),
 			api.WithControlPlaneCount(1),
 			api.WithWorkerNodeCount(1),


### PR DESCRIPTION
*Description of changes:*
Fix the wrong k8s version in TestVSphereKubernetes132To133OIDCUpgrade and TestVSphereKubernetes133BottlerocketEtcdScaleDown

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

