### PR TITLE
update in ubuntu

### DIFF
--- a/pkg/certificates/os.go
+++ b/pkg/certificates/os.go
@@ -32,7 +32,6 @@ var osRenewerBuilders = map[string]func(backupDir string) OSRenewer{
 	string(OSTypeLinux): func(backupDir string) OSRenewer {
 		return NewLinuxRenewer(backupDir)
 	},
-	// comment for focus ubuntu pr
 	string(OSTypeBottlerocket): func(backupDir string) OSRenewer {
 		return NewBottlerocketRenewer(backupDir)
 	},

--- a/pkg/certificates/os.go
+++ b/pkg/certificates/os.go
@@ -19,6 +19,7 @@ type OSRenewer interface {
 	RenewControlPlaneCerts(ctx context.Context, node string, config *RenewalConfig, component string, sshRunner SSHRunner) error
 	RenewEtcdCerts(ctx context.Context, node string, sshRunner SSHRunner) error
 	CopyEtcdCerts(ctx context.Context, node string, sshRunner SSHRunner) error
+	TransferCertsToControlPlane(ctx context.Context, node string, sshRunner SSHRunner) error
 }
 
 // BuildOSRenewer creates a new OSRenewer based on the OS type.
@@ -30,5 +31,9 @@ func BuildOSRenewer(osType string, backupDir string) OSRenewer {
 var osRenewerBuilders = map[string]func(backupDir string) OSRenewer{
 	string(OSTypeLinux): func(backupDir string) OSRenewer {
 		return NewLinuxRenewer(backupDir)
+	},
+	// comment for focus ubuntu pr
+	string(OSTypeBottlerocket): func(backupDir string) OSRenewer {
+		return NewBottlerocketRenewer(backupDir)
 	},
 }

--- a/pkg/certificates/renewerubuntu.go
+++ b/pkg/certificates/renewerubuntu.go
@@ -166,7 +166,7 @@ func (l *LinuxRenewer) validateEtcdCerts() string {
 func (l *LinuxRenewer) TransferCertsToControlPlane(
 	ctx context.Context, node string, ssh SSHRunner,
 ) error {
-	logger.V(4).Info("Transferring certificates to control-plane node", "node", node)
+	logger.V(4).Info("Certificates transferred", "node", node)
 
 	crtPath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
 	keyPath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")

--- a/pkg/certificates/renewerubuntu.go
+++ b/pkg/certificates/renewerubuntu.go
@@ -55,7 +55,7 @@ func (l *LinuxRenewer) RenewControlPlaneCerts(
 	}
 
 	if hasExternalEtcd {
-		if err := l.transferCertsToControlPlane(ctx, node, ssh); err != nil {
+		if err := l.TransferCertsToControlPlane(ctx, node, ssh); err != nil {
 			return fmt.Errorf("transferring certificates to control plane node: %v", err)
 		}
 		if _, err := ssh.RunCommand(ctx, node, l.copyExternalEtcdCerts(hasExternalEtcd)); err != nil {
@@ -162,7 +162,8 @@ func (l *LinuxRenewer) validateEtcdCerts() string {
 		linuxEtcdCertDir)
 }
 
-func (l *LinuxRenewer) transferCertsToControlPlane(
+// TransferCertsToControlPlane transfers etcd client certificates to a control plane node.
+func (l *LinuxRenewer) TransferCertsToControlPlane(
 	ctx context.Context, node string, ssh SSHRunner,
 ) error {
 	logger.V(4).Info("Transferring certificates to control-plane node", "node", node)

--- a/pkg/certificates/renewerubuntu.go
+++ b/pkg/certificates/renewerubuntu.go
@@ -50,8 +50,6 @@ func (l *LinuxRenewer) RenewControlPlaneCerts(
 		if _, err := ssh.RunCommand(ctx, node, "sudo kubeadm certs check-expiration"); err != nil {
 			return fmt.Errorf("validating control plane certs: %v", err)
 		}
-	} else {
-		logger.V(4).Info("Skipping kubeadm cert validation for external etcd setup", "node", node)
 	}
 
 	if hasExternalEtcd {
@@ -77,7 +75,7 @@ func (l *LinuxRenewer) RenewEtcdCerts(
 	node string,
 	ssh SSHRunner,
 ) error {
-	logger.V(0).Info("Processing etcd node", "os", l.osType, "node", node)
+	logger.V(0).Info("Renewing etcd certificates", "node", node)
 
 	if _, err := ssh.RunCommand(ctx, node, l.backupEtcdCerts()); err != nil {
 		return fmt.Errorf("backing up etcd certs: %v", err)
@@ -99,35 +97,38 @@ func (l *LinuxRenewer) CopyEtcdCerts(
 	node string,
 	ssh SSHRunner,
 ) error {
-	cat := func(file string) (string, error) {
+	readFile := func(file string) (string, error) {
 		return ssh.RunCommand(ctx, node,
 			fmt.Sprintf("sudo cat %s", filepath.Join(linuxEtcdCertDir, file)))
 	}
 
-	crt, err := cat("pki/apiserver-etcd-client.crt")
+	certificateContent, err := readFile("pki/apiserver-etcd-client.crt")
 	if err != nil {
-		return fmt.Errorf("read crt: %v", err)
+		return fmt.Errorf("reading etcd certificate file: %v", err)
 	}
-	key, err := cat("pki/apiserver-etcd-client.key")
+	keyContent, err := readFile("pki/apiserver-etcd-client.key")
 	if err != nil {
-		return fmt.Errorf("read key: %v", err)
+		return fmt.Errorf("reading etcd key file: %v", err)
 	}
-	if crt == "" || key == "" {
+	if certificateContent == "" || keyContent == "" {
 		return fmt.Errorf("etcd client cert or key is empty")
 	}
 
-	dstDir := filepath.Join(l.backup, tempLocalEtcdCertsDir)
-	if err := os.MkdirAll(dstDir, 0o700); err != nil {
-		return fmt.Errorf("creating etcd backup direcotry %s: %v", dstDir, err)
-	}
-	if err := os.WriteFile(filepath.Join(dstDir, "apiserver-etcd-client.crt"), []byte(crt), 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(dstDir, "apiserver-etcd-client.key"), []byte(key), 0o600); err != nil {
-		return err
+	localCertificateDir := filepath.Join(l.backup, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(localCertificateDir, 0o700); err != nil {
+		return fmt.Errorf("creating etcd backup direcotry %s: %v", localCertificateDir, err)
 	}
 
-	logger.V(4).Info("Copied etcd client certs", "path", dstDir)
+	localCertificatePath := filepath.Join(localCertificateDir, "apiserver-etcd-client.crt")
+	localKeyFilePath := filepath.Join(localCertificateDir, "apiserver-etcd-client.key")
+
+	if err := os.WriteFile(localCertificatePath, []byte(certificateContent), 0o600); err != nil {
+		return fmt.Errorf("writing etcd certificate file: %v", err)
+	}
+	if err := os.WriteFile(localKeyFilePath, []byte(keyContent), 0o600); err != nil {
+		return fmt.Errorf("writing etcd key file: %v", err)
+	}
+
 	return nil
 }
 
@@ -166,31 +167,29 @@ func (l *LinuxRenewer) validateEtcdCerts() string {
 func (l *LinuxRenewer) TransferCertsToControlPlane(
 	ctx context.Context, node string, ssh SSHRunner,
 ) error {
-	logger.V(4).Info("Certificates transferred", "node", node)
 
-	crtPath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
-	keyPath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
+	localCertificatePath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
+	localKeyFilePath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
 
-	crtData, err := os.ReadFile(crtPath)
+	certificateBytes, err := os.ReadFile(localCertificatePath)
 	if err != nil {
-		return fmt.Errorf("reading certificate file: %v", err)
+		return fmt.Errorf("reading certificate file from the admin machine: %v", err)
 	}
-	keyData, err := os.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(localKeyFilePath)
 	if err != nil {
-		return fmt.Errorf("reading key file: %v", err)
+		return fmt.Errorf("reading key file from the admin machine: %v", err)
 	}
 
-	crtCmd := fmt.Sprintf("sudo tee %s/apiserver-etcd-client.crt > /dev/null << 'EOF'\n%s\nEOF", linuxTempDir, string(crtData))
-	if _, err := ssh.RunCommand(ctx, node, crtCmd); err != nil {
-		return fmt.Errorf("copying certificate: %v", err)
+	certificateCommand := fmt.Sprintf("sudo tee %s/apiserver-etcd-client.crt > /dev/null << 'EOF'\n%s\nEOF", linuxTempDir, string(certificateBytes))
+	if _, err := ssh.RunCommand(ctx, node, certificateCommand); err != nil {
+		return fmt.Errorf("copying certificate to control plane: %v", err)
 	}
 
-	keyCmd := fmt.Sprintf("sudo tee %s/apiserver-etcd-client.key > /dev/null << 'EOF'\n%s\nEOF", linuxTempDir, string(keyData))
-	if _, err := ssh.RunCommand(ctx, node, keyCmd); err != nil {
-		return fmt.Errorf("copying key: %v", err)
+	keyCommand := fmt.Sprintf("sudo tee %s/apiserver-etcd-client.key > /dev/null << 'EOF'\n%s\nEOF", linuxTempDir, string(keyBytes))
+	if _, err := ssh.RunCommand(ctx, node, keyCommand); err != nil {
+		return fmt.Errorf("copying key to control plane: %v", err)
 	}
 
-	logger.V(4).Info("Certificates transferred", "node", node)
 	return nil
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enhances the certificate renewal functionality for EKS Anywhere clusters with external etcd configurations. The implementation removes the component parameter and now performs comprehensive certificate renewal for both etcd and control plane nodes when external etcd is present. Key improvements include skipping kubeadm certificate validation for external etcd setups to handle expired certificate scenarios, and deferring the API server etcd client secret update until after all control plane certificates are renewed. This ensures proper certificate propagation and cluster stability during the renewal process.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

