### PR TITLE
Allow aws iam config mutation for an existing cluster

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -8007,24 +8007,8 @@ rules:
   - anywhere.eks.amazonaws.com
   resources:
   - awsiamconfigs
-  - cloudstackdatacenterconfigs
-  - cloudstackmachineconfigs
-  - clusters
-  - dockerdatacenterconfigs
-  - fluxconfigs
-  - gitopsconfigs
-  - nutanixdatacenterconfigs
-  - nutanixmachineconfigs
-  - oidcconfigs
-  - snowdatacenterconfigs
-  - snowippools
-  - snowmachineconfigs
-  - tinkerbelldatacenterconfigs
-  - tinkerbellmachineconfigs
-  - tinkerbelltemplateconfigs
-  - vspheredatacenterconfigs
-  - vspheremachineconfigs
   verbs:
+  - delete
   - get
   - list
   - patch
@@ -8081,6 +8065,32 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - anywhere.eks.amazonaws.com
+  resources:
+  - cloudstackdatacenterconfigs
+  - cloudstackmachineconfigs
+  - clusters
+  - dockerdatacenterconfigs
+  - fluxconfigs
+  - gitopsconfigs
+  - nutanixdatacenterconfigs
+  - nutanixmachineconfigs
+  - oidcconfigs
+  - snowdatacenterconfigs
+  - snowippools
+  - snowmachineconfigs
+  - tinkerbelldatacenterconfigs
+  - tinkerbellmachineconfigs
+  - tinkerbelltemplateconfigs
+  - vspheredatacenterconfigs
+  - vspheremachineconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - anywhere.eks.amazonaws.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,24 +73,8 @@ rules:
   - anywhere.eks.amazonaws.com
   resources:
   - awsiamconfigs
-  - cloudstackdatacenterconfigs
-  - cloudstackmachineconfigs
-  - clusters
-  - dockerdatacenterconfigs
-  - fluxconfigs
-  - gitopsconfigs
-  - nutanixdatacenterconfigs
-  - nutanixmachineconfigs
-  - oidcconfigs
-  - snowdatacenterconfigs
-  - snowippools
-  - snowmachineconfigs
-  - tinkerbelldatacenterconfigs
-  - tinkerbellmachineconfigs
-  - tinkerbelltemplateconfigs
-  - vspheredatacenterconfigs
-  - vspheremachineconfigs
   verbs:
+  - delete
   - get
   - list
   - patch
@@ -147,6 +131,32 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - anywhere.eks.amazonaws.com
+  resources:
+  - cloudstackdatacenterconfigs
+  - cloudstackmachineconfigs
+  - clusters
+  - dockerdatacenterconfigs
+  - fluxconfigs
+  - gitopsconfigs
+  - nutanixdatacenterconfigs
+  - nutanixmachineconfigs
+  - oidcconfigs
+  - snowdatacenterconfigs
+  - snowippools
+  - snowmachineconfigs
+  - tinkerbelldatacenterconfigs
+  - tinkerbellmachineconfigs
+  - tinkerbelltemplateconfigs
+  - vspheredatacenterconfigs
+  - vspheremachineconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - anywhere.eks.amazonaws.com

--- a/controllers/mocks/cluster_controller.go
+++ b/controllers/mocks/cluster_controller.go
@@ -195,6 +195,20 @@ func (mr *MockAWSIamConfigReconcilerMockRecorder) ReconcileDelete(ctx, logger, c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDelete", reflect.TypeOf((*MockAWSIamConfigReconciler)(nil).ReconcileDelete), ctx, logger, cluster)
 }
 
+// ReconcileWorkloadClusterDelete mocks base method.
+func (m *MockAWSIamConfigReconciler) ReconcileWorkloadClusterDelete(ctx context.Context, logger logr.Logger, cluster *v1alpha1.Cluster, awsIamConfig *v1alpha1.AWSIamConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileWorkloadClusterDelete", ctx, logger, cluster, awsIamConfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileWorkloadClusterDelete indicates an expected call of ReconcileWorkloadClusterDelete.
+func (mr *MockAWSIamConfigReconcilerMockRecorder) ReconcileWorkloadClusterDelete(ctx, logger, cluster, awsIamConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileWorkloadClusterDelete", reflect.TypeOf((*MockAWSIamConfigReconciler)(nil).ReconcileWorkloadClusterDelete), ctx, logger, cluster, awsIamConfig)
+}
+
 // MockMachineHealthCheckReconciler is a mock of MachineHealthCheckReconciler interface.
 type MockMachineHealthCheckReconciler struct {
 	ctrl     *gomock.Controller

--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -426,7 +426,7 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 		}
 	}
 
-	if !oldAWSIamConfig.Equal(newAWSIamConfig) {
+	if !oldAWSIamConfig.IsEmpty() && !newAWSIamConfig.IsEmpty() && !oldAWSIamConfig.Equal(newAWSIamConfig) {
 		allErrs = append(
 			allErrs,
 			field.Forbidden(specPath.Child("identityProviderRefs", AWSIamConfigKind), fmt.Sprintf("field is immutable %v", newAWSIamConfig.Kind)))

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -753,7 +753,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableUpdateName(t *testing.T) {
 	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
 }
 
-func TestClusterValidateUpdateAWSIamNameImmutableEmpty(t *testing.T) {
+func TestClusterValidateUpdateAWSIamConfigRemoveSuccess(t *testing.T) {
 	cOld := baseCluster()
 	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{
 		{
@@ -765,10 +765,10 @@ func TestClusterValidateUpdateAWSIamNameImmutableEmpty(t *testing.T) {
 	c.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
-func TestClusterValidateUpdateAWSIamNameImmutableAddConfig(t *testing.T) {
+func TestClusterValidateUpdateAWSIamConfigAddSuccess(t *testing.T) {
 	cOld := baseCluster()
 	cOld.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
 	c := cOld.DeepCopy()
@@ -780,7 +780,7 @@ func TestClusterValidateUpdateAWSIamNameImmutableAddConfig(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(MatchError(ContainSubstring("spec.identityProviderRefs.AWSIamConfig: Forbidden: field is immutable")))
+	g.Expect(c.ValidateUpdate(context.TODO(), cOld, c)).Error().To(Succeed())
 }
 
 func TestClusterValidateUpdateUnsetBundlesRefImmutable(t *testing.T) {

--- a/pkg/awsiamauth/installer.go
+++ b/pkg/awsiamauth/installer.go
@@ -111,3 +111,16 @@ func (i *Installer) GenerateManagementKubeconfig(
 	logger.V(3).Info("Generated aws-iam-authenticator kubeconfig", "kubeconfig", path)
 	return nil
 }
+
+// CleanupKubeconfig removes an existing AWS IAM kubeconfig file when AWS IAM is removed from cluster.
+func (i *Installer) CleanupKubeconfig(clusterName string) error {
+	fileName := fmt.Sprintf("%s-aws.kubeconfig", clusterName)
+
+	err := i.writer.Delete(fileName)
+	if err != nil {
+		return fmt.Errorf("removing aws-iam-authenticator kubeconfig %s: %v", fileName, err)
+	}
+
+	logger.V(3).Info("Cleaned up aws-iam-authenticator kubeconfig", "file", fileName)
+	return nil
+}

--- a/pkg/awsiamauth/installer_test.go
+++ b/pkg/awsiamauth/installer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -92,5 +93,51 @@ func TestGenerateAWSIAMKubeconfigError(t *testing.T) {
 	err := installer.GenerateManagementKubeconfig(context.Background(), cluster)
 	if err == nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCleanupKubeconfigSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	k8s := NewMockKubernetesClient(ctrl)
+	writer := filewritermock.NewMockFileWriter(ctrl)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+
+	clusterName := "test-cluster"
+	fileName := fmt.Sprintf("%s-aws.kubeconfig", clusterName)
+
+	// Mock Delete to return success (no error)
+	writer.EXPECT().Delete(fileName).Return(nil)
+
+	installer := awsiamauth.NewInstaller(k8s, writer, kwriter)
+
+	err := installer.CleanupKubeconfig(clusterName)
+	if err != nil {
+		t.Fatalf("CleanupKubeconfig failed: %v", err)
+	}
+}
+
+func TestCleanupKubeconfigRemoveError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	k8s := NewMockKubernetesClient(ctrl)
+	writer := filewritermock.NewMockFileWriter(ctrl)
+	kwriter := kubeconfigmocks.NewMockWriter(ctrl)
+
+	clusterName := "test-cluster"
+	fileName := fmt.Sprintf("%s-aws.kubeconfig", clusterName)
+
+	// Mock Delete to return an error
+	writer.EXPECT().Delete(fileName).Return(errors.New("permission denied"))
+
+	installer := awsiamauth.NewInstaller(k8s, writer, kwriter)
+
+	err := installer.CleanupKubeconfig(clusterName)
+	if err == nil {
+		t.Fatal("CleanupKubeconfig should fail when file cannot be removed")
+	}
+
+	if !strings.Contains(err.Error(), "removing aws-iam-authenticator kubeconfig") {
+		t.Fatalf("Expected error message to contain 'removing aws-iam-authenticator kubeconfig', got: %v", err)
 	}
 }

--- a/pkg/controller/serverside/reconcile.go
+++ b/pkg/controller/serverside/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
@@ -45,6 +46,37 @@ func ReconcileObject(ctx context.Context, c client.Client, obj client.Object) er
 func UpdateObject(ctx context.Context, c client.Client, obj client.Object) error {
 	if err := c.Update(ctx, obj, client.FieldOwner(fieldManager)); err != nil {
 		return errors.Wrapf(err, "failed to reconcile object %s, %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	}
+
+	return nil
+}
+
+// DeleteYaml deletes Kubernetes objects from YAML content.
+func DeleteYaml(ctx context.Context, c client.Client, yaml []byte) error {
+	objs, err := clientutil.YamlToClientObjects(yaml)
+	if err != nil {
+		return err
+	}
+
+	return DeleteObjects(ctx, c, objs)
+}
+
+// DeleteObjects deletes multiple Kubernetes objects.
+func DeleteObjects(ctx context.Context, c client.Client, objs []client.Object) error {
+	for _, o := range objs {
+		if err := DeleteObject(ctx, c, o); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DeleteObject deletes a single Kubernetes object. It's idempotent - if the object doesn't exist, no error is returned.
+func DeleteObject(ctx context.Context, c client.Client, obj client.Object) error {
+	err := c.Delete(ctx, obj)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to delete object %s, %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 	}
 
 	return nil

--- a/pkg/controller/serverside/reconcile_test.go
+++ b/pkg/controller/serverside/reconcile_test.go
@@ -264,3 +264,305 @@ func updatedCluster(cluster *clusterapiv1.Cluster, f func(*clusterapiv1.Cluster)
 	f(copy)
 	return copy
 }
+
+func TestDeleteYaml(t *testing.T) {
+	cluster1 := newCluster("cluster-1")
+	cluster2 := newCluster("cluster-2")
+	tests := []struct {
+		name          string
+		initialObjs   []*clusterapiv1.Cluster
+		yaml          []byte
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "delete existing object",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#`),
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			expectError: false,
+		},
+		{
+			name: "delete non-existent object idempotent",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-nonexistent
+  namespace: #namespace#`),
+			expectError: false,
+		},
+		{
+			name: "delete multiple objects",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-2
+  namespace: #namespace#`),
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+				cluster2.DeepCopy(),
+			},
+			expectError: false,
+		},
+		{
+			name: "delete mixed existing and non-existing",
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-1
+  namespace: #namespace#
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-nonexistent
+  namespace: #namespace#`),
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			expectError: false,
+		},
+		{
+			name:          "invalid yaml",
+			yaml:          []byte(`invalid: yaml: content: [[[`),
+			expectError:   true,
+			errorContains: "failed to unmarshal",
+		},
+	}
+
+	c := env.Client()
+	reader := env.APIReader()
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ns := env.CreateNamespaceForTest(ctx, t)
+
+			// Create initial objects
+			for _, o := range tt.initialObjs {
+				o.SetNamespace(ns)
+				if err := c.Create(ctx, o); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Replace namespace placeholder in YAML
+			tt.yaml = []byte(strings.ReplaceAll(string(tt.yaml), "#namespace#", ns))
+
+			// Execute delete
+			err := serverside.DeleteYaml(ctx, c, tt.yaml)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Verify objects are deleted
+			for _, o := range tt.initialObjs {
+				key := client.ObjectKey{
+					Namespace: ns,
+					Name:      o.GetName(),
+				}
+				cluster := &clusterapiv1.Cluster{}
+				err := reader.Get(ctx, key, cluster)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("not found"))
+			}
+		})
+	}
+}
+
+func TestDeleteObjects(t *testing.T) {
+	cluster1 := newCluster("cluster-1")
+	cluster2 := newCluster("cluster-2")
+	tests := []struct {
+		name        string
+		initialObjs []*clusterapiv1.Cluster
+		deleteObjs  []*clusterapiv1.Cluster
+		expectError bool
+	}{
+		{
+			name: "delete existing objects",
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+				cluster2.DeepCopy(),
+			},
+			deleteObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+				cluster2.DeepCopy(),
+			},
+			expectError: false,
+		},
+		{
+			name: "delete non-existent objects idempotent",
+			deleteObjs: []*clusterapiv1.Cluster{
+				newCluster("nonexistent-1"),
+				newCluster("nonexistent-2"),
+			},
+			expectError: false,
+		},
+		{
+			name: "delete mixed existing and non-existing",
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			deleteObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+				newCluster("nonexistent"),
+			},
+			expectError: false,
+		},
+		{
+			name:        "delete empty object slice",
+			deleteObjs:  []*clusterapiv1.Cluster{},
+			expectError: false,
+		},
+		{
+			name: "delete single object",
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			deleteObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			expectError: false,
+		},
+	}
+
+	c := env.Client()
+	reader := env.APIReader()
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ns := env.CreateNamespaceForTest(ctx, t)
+
+			// Create initial objects
+			for _, o := range tt.initialObjs {
+				o.SetNamespace(ns)
+				if err := c.Create(ctx, o); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Set namespace for delete objects
+			var deleteObjs []client.Object
+			for _, o := range tt.deleteObjs {
+				o.SetNamespace(ns)
+				deleteObjs = append(deleteObjs, o)
+			}
+
+			// Execute delete
+			err := serverside.DeleteObjects(ctx, c, deleteObjs)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Verify initially existing objects are deleted
+			for _, o := range tt.initialObjs {
+				key := client.ObjectKey{
+					Namespace: ns,
+					Name:      o.GetName(),
+				}
+				cluster := &clusterapiv1.Cluster{}
+				err := reader.Get(ctx, key, cluster)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("not found"))
+			}
+		})
+	}
+}
+
+func TestDeleteObject(t *testing.T) {
+	cluster1 := newCluster("cluster-1")
+	tests := []struct {
+		name          string
+		initialObjs   []*clusterapiv1.Cluster
+		deleteObj     *clusterapiv1.Cluster
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "delete existing object",
+			initialObjs: []*clusterapiv1.Cluster{
+				cluster1.DeepCopy(),
+			},
+			deleteObj:   cluster1.DeepCopy(),
+			expectError: false,
+		},
+		{
+			name:        "delete non-existent object idempotent",
+			deleteObj:   newCluster("nonexistent"),
+			expectError: false,
+		},
+	}
+
+	c := env.Client()
+	reader := env.APIReader()
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ns := env.CreateNamespaceForTest(ctx, t)
+
+			// Create initial objects
+			for _, o := range tt.initialObjs {
+				o.SetNamespace(ns)
+				if err := c.Create(ctx, o); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Set namespace for delete object
+			tt.deleteObj.SetNamespace(ns)
+
+			// Execute delete
+			err := serverside.DeleteObject(ctx, c, tt.deleteObj)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// If there were initial objects, verify they are deleted
+			if len(tt.initialObjs) > 0 {
+				key := client.ObjectKey{
+					Namespace: ns,
+					Name:      tt.deleteObj.GetName(),
+				}
+				cluster := &clusterapiv1.Cluster{}
+				err := reader.Get(ctx, key, cluster)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("not found"))
+			}
+		})
+	}
+}

--- a/pkg/filewriter/filewriter.go
+++ b/pkg/filewriter/filewriter.go
@@ -13,6 +13,7 @@ type FileWriter interface {
 	Dir() string
 	TempDir() string
 	Create(name string, f ...FileOptionsFunc) (_ io.WriteCloser, path string, _ error)
+	Delete(fileName string) error
 }
 
 type FileOptions struct {

--- a/pkg/filewriter/mocks/filewriter.go
+++ b/pkg/filewriter/mocks/filewriter.go
@@ -80,6 +80,20 @@ func (mr *MockFileWriterMockRecorder) Create(arg0 interface{}, arg1 ...interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFileWriter)(nil).Create), varargs...)
 }
 
+// Delete mocks base method.
+func (m *MockFileWriter) Delete(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockFileWriterMockRecorder) Delete(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockFileWriter)(nil).Delete), arg0)
+}
+
 // Dir mocks base method.
 func (m *MockFileWriter) Dir() string {
 	m.ctrl.T.Helper()

--- a/pkg/filewriter/writer.go
+++ b/pkg/filewriter/writer.go
@@ -72,6 +72,18 @@ func (w *writer) Create(name string, opts ...FileOptionsFunc) (_ io.WriteCloser,
 	return fh, path, err
 }
 
+// Delete removes a file with the given name from w's base directory.
+func (w *writer) Delete(fileName string) error {
+	filePath := filepath.Join(w.dir, fileName)
+
+	// Check if file exists first
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil // File doesn't exist, nothing to delete
+	}
+
+	return os.Remove(filePath)
+}
+
 type options struct {
 	BasePath    string
 	Permissions fs.FileMode

--- a/pkg/validations/upgradevalidations/immutable_fields_test.go
+++ b/pkg/validations/upgradevalidations/immutable_fields_test.go
@@ -301,6 +301,43 @@ func TestValidateImmutableFields(t *testing.T) {
 			},
 			ExpectedError: "spec.clusterNetwork.cniConfig.cilium.skipUpgrade cannot be toggled off",
 		},
+		{
+			Name: "Add AWS IAM identity provider when none existed",
+			ConfigureCurrent: func(current *v1alpha1.Cluster) {
+				current.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
+			},
+			ConfigureDesired: func(desired *v1alpha1.Cluster) {
+				desired.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+					{
+						Kind: v1alpha1.AWSIamConfigKind,
+						Name: "aws-iam",
+					},
+				}
+			},
+		},
+		{
+			Name: "Remove AWS IAM identity provider when one existed",
+			ConfigureCurrent: func(current *v1alpha1.Cluster) {
+				current.Spec.IdentityProviderRefs = []v1alpha1.Ref{
+					{
+						Kind: v1alpha1.AWSIamConfigKind,
+						Name: "aws-iam",
+					},
+				}
+			},
+			ConfigureDesired: func(desired *v1alpha1.Cluster) {
+				desired.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
+			},
+		},
+		{
+			Name: "Both old and new clusters have no AWS IAM config",
+			ConfigureCurrent: func(current *v1alpha1.Cluster) {
+				current.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
+			},
+			ConfigureDesired: func(desired *v1alpha1.Cluster) {
+				desired.Spec.IdentityProviderRefs = []v1alpha1.Ref{}
+			},
+		},
 	}
 
 	clstr := &types.Cluster{}

--- a/pkg/workflows/interfaces/interfaces.go
+++ b/pkg/workflows/interfaces/interfaces.go
@@ -111,4 +111,5 @@ type ClusterMover interface {
 type AwsIamAuth interface {
 	GenerateWorkloadKubeconfig(ctx context.Context, management, workload *types.Cluster, spec *cluster.Spec) error
 	GenerateManagementKubeconfig(ctx context.Context, cluster *types.Cluster) error
+	CleanupKubeconfig(clusterName string) error
 }

--- a/pkg/workflows/interfaces/mocks/clients.go
+++ b/pkg/workflows/interfaces/mocks/clients.go
@@ -979,6 +979,20 @@ func (m *MockAwsIamAuth) EXPECT() *MockAwsIamAuthMockRecorder {
 	return m.recorder
 }
 
+// CleanupKubeconfig mocks base method.
+func (m *MockAwsIamAuth) CleanupKubeconfig(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupKubeconfig", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupKubeconfig indicates an expected call of CleanupKubeconfig.
+func (mr *MockAwsIamAuthMockRecorder) CleanupKubeconfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupKubeconfig", reflect.TypeOf((*MockAwsIamAuth)(nil).CleanupKubeconfig), arg0)
+}
+
 // GenerateManagementKubeconfig mocks base method.
 func (m *MockAwsIamAuth) GenerateManagementKubeconfig(arg0 context.Context, arg1 *types.Cluster) error {
 	m.ctrl.T.Helper()

--- a/pkg/workflows/management/write_cluster_config.go
+++ b/pkg/workflows/management/write_cluster_config.go
@@ -21,6 +21,29 @@ func (s *writeUpgradeClusterConfig) Run(ctx context.Context, commandContext *tas
 		commandContext.SetError(err)
 	}
 
+	// Handle AWS IAM kubeconfig generation/cleanup during management cluster upgrade
+	if commandContext.CurrentClusterSpec != nil {
+		hadAWSIam := commandContext.CurrentClusterSpec.AWSIamConfig != nil
+		hasAWSIam := commandContext.ClusterSpec.AWSIamConfig != nil
+
+		if !hadAWSIam && hasAWSIam {
+			// AWS IAM being added during upgrade
+			logger.Info("Generating AWS IAM kubeconfig file for management cluster upgrade (AWS IAM added)")
+			err = commandContext.IamAuth.GenerateManagementKubeconfig(ctx, commandContext.ManagementCluster)
+			if err != nil {
+				commandContext.SetError(err)
+				logger.Error(err, "Generating AWS IAM kubeconfig file for management cluster upgrade")
+			}
+		} else if hadAWSIam && !hasAWSIam {
+			// AWS IAM being removed during upgrade - cleanup existing kubeconfig
+			logger.Info("Cleaning up AWS IAM kubeconfig file (AWS IAM removed during management cluster upgrade)")
+			err = commandContext.IamAuth.CleanupKubeconfig(commandContext.ManagementCluster.Name)
+			if err != nil {
+				logger.Error(err, "Failed to cleanup AWS IAM kubeconfig file")
+			}
+		}
+	}
+
 	if commandContext.OriginalError == nil {
 		logger.MarkSuccess("Cluster upgraded!")
 	}

--- a/pkg/workflows/workload/upgrade_test.go
+++ b/pkg/workflows/workload/upgrade_test.go
@@ -139,11 +139,6 @@ func (c *upgradeTestSetup) expectWriteWorkloadClusterConfig(err error) {
 	)
 }
 
-func (c *upgradeTestSetup) expectWithoutAWSIAMAuthKubeconfig(err error) {
-	c.iamAuth.EXPECT().GenerateWorkloadKubeconfig(
-		c.ctx, c.clusterSpec.ManagementCluster, c.workloadCluster, c.clusterSpec).Return(err).Times(0)
-}
-
 func (c *upgradeTestSetup) expectDatacenterConfig() {
 	gomock.InOrder(
 		c.provider.EXPECT().DatacenterConfig(c.clusterSpec).Return(c.datacenterConfig).AnyTimes(),
@@ -192,26 +187,6 @@ func TestUpgradeRunSuccess(t *testing.T) {
 	test.expectBuildClientFromKubeconfig(nil)
 	test.expectWriteWorkloadClusterConfig(nil)
 
-	err := test.run()
-	if err != nil {
-		t.Fatalf("Upgrade.Run() err = %v, want err = nil", err)
-	}
-}
-
-func TestUpgradeRunWithAWSIAMSuccess(t *testing.T) {
-	features.ClearCache()
-	os.Setenv(features.UseControllerForCli, "true")
-	test := newUpgradeTest(t)
-	test.clusterSpec.AWSIamConfig = &v1alpha1.AWSIamConfig{}
-	test.expectSetup()
-	test.expectPreflightValidationsToPass()
-	test.expectDatacenterConfig()
-	test.expectMachineConfigs()
-	test.expectBackupWorkloadFromCluster(nil)
-	test.expectUpgradeWorkloadCluster(nil)
-	test.expectBuildClientFromKubeconfig(nil)
-	test.expectWriteWorkloadClusterConfig(nil)
-	test.expectWithoutAWSIAMAuthKubeconfig(nil)
 	err := test.run()
 	if err != nil {
 		t.Fatalf("Upgrade.Run() err = %v, want err = nil", err)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2455

*Description of changes:*
Allows addition or deletion of aws iam authentication to an existing cluster using upgrade workflow. 

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

