### PR TITLE
Fetch Control-Plane and etcd IPs for certificates renewal when API server is reachable

### DIFF
--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -2,13 +2,17 @@
 package certificates
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/types"
 )
 
 // VerbosityLevel controls the detail level of logging output.
@@ -47,11 +51,8 @@ func ParseConfig(path string) (*RenewalConfig, error) {
 		return nil, fmt.Errorf("parsing config file: %v", err)
 	}
 
-	// get password from env varibales
-	if len(config.Etcd.Nodes) > 0 {
-		if pass := os.Getenv("EKSA_SSH_KEY_PASSPHRASE_ETCD"); pass != "" {
-			config.Etcd.SSH.Password = pass
-		}
+	if pass := os.Getenv("EKSA_SSH_KEY_PASSPHRASE_ETCD"); pass != "" {
+		config.Etcd.SSH.Password = pass
 	}
 
 	if pass := os.Getenv("EKSA_SSH_KEY_PASSPHRASE_CP"); pass != "" {
@@ -129,7 +130,95 @@ func ValidateComponentWithConfig(component string, config *RenewalConfig) error 
 	return nil
 }
 
-// shouldProcessComponent checks if the specified component should be processed.
-func shouldProcessComponent(requestedComponent, targetComponent string) bool {
-	return requestedComponent == "" || requestedComponent == targetComponent
+func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernetes.Client, cluster *types.Cluster) error {
+
+	if len(cfg.ControlPlane.Nodes) > 0 {
+		return nil
+	}
+
+	controlPlaneIPs, err := getControlPlaneIPs(ctx, kubeClient, cluster)
+	if err != nil {
+		return fmt.Errorf("cluster is not reachable please provide control plane and/or external etcd IP addresses: %w", err)
+	}
+
+	cfg.ControlPlane.Nodes = controlPlaneIPs
+
+	etcdIPs, err := getEtcdIPs(ctx, kubeClient, cluster)
+	if err != nil {
+		fmt.Printf("Warning: Failed to get etcd IPs: %v\n", err)
+	} else {
+		cfg.Etcd.Nodes = etcdIPs
+	}
+
+	return nil
+}
+
+func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
+	fmt.Printf("getControlPlaneIPs \n")
+	var controlPlaneIPs []string
+
+	machineList := &clusterv1.MachineList{}
+
+	namespaceOpt := kubernetes.ListOptions{
+		Namespace: constants.EksaSystemNamespace,
+	}
+
+	if err := kubeClient.List(ctx, machineList, namespaceOpt); err != nil {
+		return nil, fmt.Errorf("listing machines: %w", err)
+	}
+
+	for _, machine := range machineList.Items {
+		if machine.Labels["cluster.x-k8s.io/cluster-name"] == cluster.Name {
+			_, hasControlPlaneLabel := machine.Labels["cluster.x-k8s.io/control-plane"]
+			if hasControlPlaneLabel {
+				for _, address := range machine.Status.Addresses {
+					if address.Type == clusterv1.MachineExternalIP {
+						controlPlaneIPs = append(controlPlaneIPs, address.Address)
+						break
+					}
+				}
+
+				if len(machine.Status.Addresses) == 0 {
+					fmt.Printf("  No addresses found for this machine\n")
+				}
+			}
+		}
+	}
+
+	if len(controlPlaneIPs) == 0 {
+		return nil, fmt.Errorf("no control plane IPs found")
+	}
+
+	return controlPlaneIPs, nil
+}
+
+func getEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
+	var etcdIPs []string
+
+	machineList := &clusterv1.MachineList{}
+
+	namespaceOpt := kubernetes.ListOptions{
+		Namespace: constants.EksaSystemNamespace,
+	}
+
+	if err := kubeClient.List(ctx, machineList, namespaceOpt); err != nil {
+		return nil, fmt.Errorf("listing machines: %w", err)
+	}
+
+	for _, machine := range machineList.Items {
+		if machine.Labels[clusterNameLabel] == cluster.Name && machine.Labels[externalEtcdLabel] == cluster.Name+"-etcd" {
+			for _, address := range machine.Status.Addresses {
+				if address.Type == clusterv1.MachineExternalIP {
+					etcdIPs = append(etcdIPs, address.Address)
+					break
+				}
+			}
+		}
+	}
+
+	if len(etcdIPs) == 0 {
+		return nil, fmt.Errorf("no etcd IPs found")
+	}
+
+	return etcdIPs, nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the ability to renew certificates by cluster name, discovering control plane and etcd node IPs using kubectl when the Kubernetes API server is reachable. When the API server is unreachable (which can happen during certificate expiration), it gracefully falls back to prompting users to provide node IPs in the configuration file. This improves user experience by reducing manual configuration steps when possible, while maintaining compatibility with scenarios where the API server is unavailable.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

