### PR TITLE
Update installation docs to specify supported yq version

### DIFF
--- a/docs/content/en/docs/getting-started/install/_index.md
+++ b/docs/content/en/docs/getting-started/install/_index.md
@@ -43,7 +43,7 @@ Here are a few other things to keep in mind:
 #### Tools
 - [Docker](https://docs.docker.com/engine/install/) 20.x.x or above
 - [`curl`](https://everything.curl.dev/get)
-- [`yq`](https://github.com/mikefarah/yq/#install)
+- [`yq`](https://github.com/mikefarah/yq/#install) 4.x.x or above
 
 ### Install EKS Anywhere CLI tools
 


### PR DESCRIPTION
*Issue #, if available:*
The installation prerequisites [docs](https://anywhere.eks.amazonaws.com/docs/getting-started/install/) does not specify the required version of the yq dependency. A customer encountered issues with yq version 3.1.0-3 and upon investigating further, there are some significant syntax changes from minor version 3 to 4.

Ref:- https://t.corp.amazon.com/V1852316742

*Description of changes:*
This PR updates the prerequisites docs to explicitly specify using version 4 or above for yq.

*Testing (if applicable):*
```
make -C docs build
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

