### PR TITLE
Add unit tests for certificate renewal functionality

### DIFF
--- a/pkg/certificates/mocks/ssh.go
+++ b/pkg/certificates/mocks/ssh.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	certificates "github.com/aws/eks-anywhere/pkg/certificates"
 	gomock "github.com/golang/mock/gomock"
 	ssh "golang.org/x/crypto/ssh"
 )
@@ -88,16 +89,21 @@ func (m *MockSSHRunner) EXPECT() *MockSSHRunnerMockRecorder {
 }
 
 // RunCommand mocks base method.
-func (m *MockSSHRunner) RunCommand(ctx context.Context, node, cmd string) (string, error) {
+func (m *MockSSHRunner) RunCommand(ctx context.Context, node, cmd string, opts ...certificates.SSHOption) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunCommand", ctx, node, cmd)
+	varargs := []interface{}{ctx, node, cmd}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunCommand", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunCommand indicates an expected call of RunCommand.
-func (mr *MockSSHRunnerMockRecorder) RunCommand(ctx, node, cmd interface{}) *gomock.Call {
+func (mr *MockSSHRunnerMockRecorder) RunCommand(ctx, node, cmd interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommand", reflect.TypeOf((*MockSSHRunner)(nil).RunCommand), ctx, node, cmd)
+	varargs := append([]interface{}{ctx, node, cmd}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommand", reflect.TypeOf((*MockSSHRunner)(nil).RunCommand), varargs...)
 }

--- a/pkg/certificates/renewer_test.go
+++ b/pkg/certificates/renewer_test.go
@@ -1,4 +1,4 @@
-package certificates
+package certificates_test
 
 import (
 	"context"
@@ -12,29 +12,35 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/aws/eks-anywhere/pkg/certificates"
 	"github.com/aws/eks-anywhere/pkg/certificates/mocks"
 	kubemocks "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
+)
+
+const (
+	tempLocalEtcdCertsDir = "etcd-client-certs"
+	backupDirStr          = "certificate_backup_"
 )
 
 func TestNewRenewerSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		ControlPlane: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		ControlPlane: certificates.NodeConfig{
 			Nodes: []string{
 				"0.0.0.0",
 			},
-			SSH: SSHConfig{
+			SSH: certificates.SSHConfig{
 				User:    "XXXX",
 				KeyPath: "test",
 			},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshCP := mocks.NewMockSSHRunner(ctrl)
@@ -55,12 +61,12 @@ func TestNewRenewerSuccess(t *testing.T) {
 		Return(apierrors.NewNotFound(schema.GroupResource{}, "")).
 		AnyTimes()
 
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		kubectl:         kubeClient,
-		os:              osRenewer,
-		sshEtcd:         sshEtcd,
-		sshControlPlane: sshCP,
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		Os:              osRenewer,
+		SshEtcd:         sshEtcd,
+		SshControlPlane: sshCP,
 	}
 
 	if err := renewer.RenewCertificates(context.Background(), cfg, "etcd"); err != nil {
@@ -72,24 +78,24 @@ func TestRenewEtcdCerts_BackupError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		Etcd: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
 			Nodes: []string{"etcd-1"},
 		},
-		ControlPlane: NodeConfig{
+		ControlPlane: certificates.NodeConfig{
 			Nodes: []string{
 				"0.0.0.0",
 			},
-			SSH: SSHConfig{
+			SSH: certificates.SSHConfig{
 				User:    "XXXX",
 				KeyPath: "test",
 			},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshEtcd.EXPECT().
@@ -100,14 +106,14 @@ func TestRenewEtcdCerts_BackupError(t *testing.T) {
 	sshCP := mocks.NewMockSSHRunner(ctrl)
 	kubeClient := kubemocks.NewMockClient(ctrl)
 
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		kubectl:         kubeClient,
-		os:              osRenewer,
-		sshEtcd:         sshEtcd,
-		sshControlPlane: sshCP,
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		Os:              osRenewer,
+		SshEtcd:         sshEtcd,
+		SshControlPlane: sshCP,
 	}
-	if err := renewer.renewEtcdCerts(context.Background(), cfg); err == nil {
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err == nil {
 		t.Fatalf("renewEtcdCerts() expected error, got nil")
 	}
 }
@@ -116,15 +122,15 @@ func TestRenewEtcdCerts_RenewError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		Etcd: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
 			Nodes: []string{"etcd-1"},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshEtcd.EXPECT().
@@ -132,13 +138,13 @@ func TestRenewEtcdCerts_RenewError(t *testing.T) {
 		Return("", fmt.Errorf("renew etcd error")).
 		AnyTimes()
 
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		os:        osRenewer,
-		sshEtcd:   sshEtcd,
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Os:        osRenewer,
+		SshEtcd:   sshEtcd,
 	}
 
-	if err := renewer.renewEtcdCerts(context.Background(), cfg); err == nil {
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err == nil {
 		t.Fatalf("renewEtcdCerts() expected error, got nil")
 	}
 }
@@ -147,94 +153,41 @@ func TestRenewEtcdCerts_SuccessfulRenewal(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		Etcd: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
 			Nodes: []string{"etcd-1"},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshEtcd.EXPECT().
 		RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string) (string, error) {
+		DoAndReturn(func(_ context.Context, _, _ string, opts ...certificates.SSHOption) (string, error) {
 			return "dummy-cert-content", nil
 		}).
 		AnyTimes()
 
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		os:        osRenewer,
-		sshEtcd:   sshEtcd,
-	}
-
-	if err := renewer.renewEtcdCerts(context.Background(), cfg); err != nil {
-		t.Fatalf("renewEtcdCerts() expected no error, got: %v", err)
-	}
-}
-
-func TestRenewControlPlaneCerts_SuccessfulRenewal(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	cfg := &RenewalConfig{
-		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		ControlPlane: NodeConfig{
-			Nodes: []string{"cp-1"},
-		},
-	}
-
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
-
-	sshCP := mocks.NewMockSSHRunner(ctrl)
-	sshCP.EXPECT().
-		RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", nil).
+	kubeClient := kubemocks.NewMockClient(ctrl)
+	kubeClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(apierrors.NewNotFound(schema.GroupResource{}, "")).
 		AnyTimes()
 
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		os:              osRenewer,
-		sshControlPlane: sshCP,
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Os:        osRenewer,
+		SshEtcd:   sshEtcd,
+		Kubectl:   kubeClient,
 	}
 
-	if err := renewer.renewControlPlaneCerts(context.Background(), cfg, "control-plane"); err != nil {
-		t.Fatalf("renewControlPlaneCerts() expected no error, got: %v", err)
-	}
-}
+	writeDummyEtcdCerts(t, renewer.BackupDir)
 
-func TestRenewControlPlaneCerts_RenewError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	cfg := &RenewalConfig{
-		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		ControlPlane: NodeConfig{
-			Nodes: []string{"cp-1"},
-		},
-	}
-
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
-
-	sshCP := mocks.NewMockSSHRunner(ctrl)
-	sshCP.EXPECT().
-		RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", fmt.Errorf("renew control plane error")).
-		AnyTimes()
-
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		os:              osRenewer,
-		sshControlPlane: sshCP,
-	}
-
-	if err := renewer.renewControlPlaneCerts(context.Background(), cfg, "control-plane"); err == nil {
-		t.Fatalf("renewControlPlaneCerts() expected error, got nil")
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("RenewCertificates() expected no error, got: %v", err)
 	}
 }
 
@@ -242,21 +195,21 @@ func TestRenewCertificates_RenewControlPlaneCertsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		ControlPlane: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		ControlPlane: certificates.NodeConfig{
 			Nodes: []string{
 				"0.0.0.0",
 			},
-			SSH: SSHConfig{
+			SSH: certificates.SSHConfig{
 				User:    "XXXX",
 				KeyPath: "test",
 			},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshCP := mocks.NewMockSSHRunner(ctrl)
@@ -267,12 +220,12 @@ func TestRenewCertificates_RenewControlPlaneCertsError(t *testing.T) {
 		Return("", fmt.Errorf("backing up control plane certs error")).
 		AnyTimes()
 
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		kubectl:         kubeClient,
-		os:              osRenewer,
-		sshEtcd:         sshEtcd,
-		sshControlPlane: sshCP,
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		Os:              osRenewer,
+		SshEtcd:         sshEtcd,
+		SshControlPlane: sshCP,
 	}
 
 	if err := renewer.RenewCertificates(context.Background(), cfg, "control-plane"); err == nil {
@@ -284,26 +237,26 @@ func TestRenewCertificates_UpdateAPIServerEtcdClientSecretError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		Etcd: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
 			Nodes: []string{
 				"etcd-1",
 			},
 		},
-		ControlPlane: NodeConfig{
+		ControlPlane: certificates.NodeConfig{
 			Nodes: []string{
 				"0.0.0.0",
 			},
-			SSH: SSHConfig{
+			SSH: certificates.SSHConfig{
 				User:    "XXXX",
 				KeyPath: "test",
 			},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshCP := mocks.NewMockSSHRunner(ctrl)
@@ -311,7 +264,7 @@ func TestRenewCertificates_UpdateAPIServerEtcdClientSecretError(t *testing.T) {
 
 	sshEtcd.EXPECT().
 		RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string) (string, error) {
+		DoAndReturn(func(_ context.Context, _, _ string, opts ...certificates.SSHOption) (string, error) {
 			return "certificate or key content", nil
 		}).
 		AnyTimes()
@@ -335,15 +288,15 @@ func TestRenewCertificates_UpdateAPIServerEtcdClientSecretError(t *testing.T) {
 		Return(fmt.Errorf("updating secret error")).
 		AnyTimes()
 
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		kubectl:         kubeClient,
-		os:              osRenewer,
-		sshEtcd:         sshEtcd,
-		sshControlPlane: sshCP,
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		Os:              osRenewer,
+		SshEtcd:         sshEtcd,
+		SshControlPlane: sshCP,
 	}
 
-	writeDummyEtcdCerts(t, renewer.backupDir)
+	writeDummyEtcdCerts(t, renewer.BackupDir)
 
 	if err := renewer.RenewCertificates(context.Background(), cfg, "etcd"); err == nil {
 		t.Fatalf("RenewCertificates() expected error, got nil")
@@ -354,26 +307,26 @@ func TestRenewCertificates_CopyEtcdCertsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
-	cfg := &RenewalConfig{
+	cfg := &certificates.RenewalConfig{
 		ClusterName: "test-cluster",
-		OS:          string(OSTypeLinux),
-		Etcd: NodeConfig{
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
 			Nodes: []string{
 				"etcd-1",
 			},
 		},
-		ControlPlane: NodeConfig{
+		ControlPlane: certificates.NodeConfig{
 			Nodes: []string{
 				"0.0.0.0",
 			},
-			SSH: SSHConfig{
+			SSH: certificates.SSHConfig{
 				User:    "XXXX",
 				KeyPath: "test",
 			},
 		},
 	}
 
-	osRenewer := BuildOSRenewer(cfg.OS, t.TempDir())
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
 
 	sshEtcd := mocks.NewMockSSHRunner(ctrl)
 	sshCP := mocks.NewMockSSHRunner(ctrl)
@@ -398,144 +351,17 @@ func TestRenewCertificates_CopyEtcdCertsError(t *testing.T) {
 		Return("", fmt.Errorf("copy etcd certs error")).
 		After(thirdCall)
 
-	renewer := &Renewer{
-		backupDir:       t.TempDir(),
-		kubectl:         kubeClient,
-		os:              osRenewer,
-		sshEtcd:         sshEtcd,
-		sshControlPlane: sshCP,
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		Os:              osRenewer,
+		SshEtcd:         sshEtcd,
+		SshControlPlane: sshCP,
 	}
 
 	if err := renewer.RenewCertificates(context.Background(), cfg, "etcd"); err == nil {
 		t.Fatalf("RenewCertificates() expected error, got nil")
 	}
-}
-
-func TestUpdateAPIServerEtcdClientSecret_ReadCertificateFileError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	kubeClient := kubemocks.NewMockClient(ctrl)
-
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		kubectl:   kubeClient,
-	}
-
-	if err := renewer.updateAPIServerEtcdClientSecret(context.Background(), "test-cluster"); err == nil {
-		t.Fatalf("updateAPIServerEtcdClientSecret() expected error, got nil")
-	}
-}
-
-func TestUpdateAPIServerEtcdClientSecret_SecretNotFound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	kubeClient := kubemocks.NewMockClient(ctrl)
-
-	kubeClient.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(apierrors.NewNotFound(schema.GroupResource{}, "")).
-		AnyTimes()
-
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		kubectl:   kubeClient,
-	}
-
-	writeDummyEtcdCerts(t, renewer.backupDir)
-
-	if err := renewer.updateAPIServerEtcdClientSecret(context.Background(), "test-cluster"); err != nil {
-		t.Fatalf("updateAPIServerEtcdClientSecret() expected no error, got: %v", err)
-	}
-}
-
-func TestUpdateAPIServerEtcdClientSecret_GetError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	kubeClient := kubemocks.NewMockClient(ctrl)
-
-	kubeClient.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(fmt.Errorf("get error")).
-		AnyTimes()
-
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		kubectl:   kubeClient,
-	}
-
-	writeDummyEtcdCerts(t, renewer.backupDir)
-
-	if err := renewer.updateAPIServerEtcdClientSecret(context.Background(), "test-cluster"); err != nil {
-		t.Fatalf("updateAPIServerEtcdClientSecret() expected no error, got: %v", err)
-	}
-}
-
-func TestUpdateAPIServerEtcdClientSecret_ReadKeyFileError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	kubeClient := kubemocks.NewMockClient(ctrl)
-
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		kubectl:   kubeClient,
-	}
-
-	dir := filepath.Join(renewer.backupDir, tempLocalEtcdCertsDir)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("creating directory: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "apiserver-etcd-client.crt"), []byte("cert"), 0o644); err != nil {
-		t.Fatalf("writing crt: %v", err)
-	}
-
-	if err := renewer.updateAPIServerEtcdClientSecret(context.Background(), "test-cluster"); err == nil {
-		t.Fatalf("updateAPIServerEtcdClientSecret() expected error, got nil")
-	}
-}
-
-func TestUpdateAPIServerEtcdClientSecret_SuccessfulUpdate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	kubeClient := kubemocks.NewMockClient(ctrl)
-
-	kubeClient.EXPECT().
-		Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, obj interface{}) error {
-			secret := obj.(*corev1.Secret)
-			secret.Data = map[string][]byte{}
-			return nil
-		})
-
-	kubeClient.EXPECT().
-		Update(gomock.Any(), gomock.Any()).
-		Return(nil)
-
-	renewer := &Renewer{
-		backupDir: t.TempDir(),
-		kubectl:   kubeClient,
-	}
-
-	writeDummyEtcdCerts(t, renewer.backupDir)
-
-	if err := renewer.updateAPIServerEtcdClientSecret(context.Background(), "test-cluster"); err != nil {
-		t.Fatalf("updateAPIServerEtcdClientSecret() expected no error, got: %v", err)
-	}
-}
-
-func TestCleanup_NonExistentDirectoryError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	renewer := &Renewer{
-		backupDir: "/non-existent-dir",
-	}
-
-	renewer.cleanup()
 }
 
 func writeDummyEtcdCerts(t *testing.T, backupDir string) {
@@ -553,61 +379,239 @@ func writeDummyEtcdCerts(t *testing.T, backupDir string) {
 	}
 }
 
-func TestValidateRenewalConfig(t *testing.T) {
-	tests := []struct {
-		name      string
-		config    *RenewalConfig
-		component string
-		wantEtcd  bool
-		wantCP    bool
-		wantErr   string
-	}{
-		{
-			name:      "valid etcd",
-			component: "etcd",
-			config: &RenewalConfig{
-				Etcd: NodeConfig{Nodes: []string{"etcd-1"}},
-			},
-			wantEtcd: true,
-			wantCP:   true,
-		},
-		{
-			name:      "valid control-plane",
-			component: "control-plane",
-			config: &RenewalConfig{
-				ControlPlane: NodeConfig{Nodes: []string{"cp-1"}},
-			},
-			wantEtcd: false,
-			wantCP:   true,
-		},
-		{
-			name:      "no etcd nodes",
-			component: "etcd",
-			config:    &RenewalConfig{},
-			wantEtcd:  false,
-			wantCP:    true,
+func TestRenewCertificates_ReadCertificateFileError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			renewer := &Renewer{}
-			processEtcd, processControlPlane, err := renewer.validateRenewalConfig(tt.config, tt.component)
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("expected no error, got: %v", err)
-			}
-			if processEtcd != tt.wantEtcd {
-				t.Fatalf("expected processEtcd=%v, got: %v", tt.wantEtcd, processEtcd)
-			}
-			if processControlPlane != tt.wantCP {
-				t.Fatalf("expected processControlPlane=%v, got: %v", tt.wantCP, processControlPlane)
-			}
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	sshEtcd := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	sshEtcd.EXPECT().RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, cmd string, opts ...certificates.SSHOption) (string, error) {
+			return "certificate-content", nil
+		}).AnyTimes()
+
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Os:        osRenewer,
+		SshEtcd:   sshEtcd,
+		Kubectl:   kubeClient,
+	}
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err == nil {
+		t.Fatalf("RenewCertificates() expected read certificate file error, got nil")
+	}
+}
+
+func TestRenewCertificates_ReadKeyFileError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	sshEtcd := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	sshEtcd.EXPECT().RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, cmd string, opts ...certificates.SSHOption) (string, error) {
+			return "certificate-content", nil
+		}).AnyTimes()
+
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Os:        osRenewer,
+		SshEtcd:   sshEtcd,
+		Kubectl:   kubeClient,
+	}
+
+	dir := filepath.Join(renewer.BackupDir, tempLocalEtcdCertsDir)
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "apiserver-etcd-client.crt"), []byte("cert"), 0o644)
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err == nil {
+		t.Fatalf("RenewCertificates() expected read key file error, got nil")
+	}
+}
+
+func TestRenewCertificates_KubernetesAPIUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	sshEtcd := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	sshEtcd.EXPECT().RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, opts ...certificates.SSHOption) (string, error) {
+			return "certificate-content", nil
+		}).AnyTimes()
+
+	kubeClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fmt.Errorf("connection refused")).
+		AnyTimes()
+
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Os:        osRenewer,
+		SshEtcd:   sshEtcd,
+		Kubectl:   kubeClient,
+	}
+
+	writeDummyEtcdCerts(t, renewer.BackupDir)
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("RenewCertificates() expected no error when API unavailable, got: %v", err)
+	}
+}
+
+func TestRenewCertificates_SuccessfulSecretUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	sshEtcd := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	sshEtcd.EXPECT().RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, opts ...certificates.SSHOption) (string, error) {
+			return "certificate-content", nil
+		}).AnyTimes()
+
+	kubeClient.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, obj interface{}) error {
+			secret := obj.(*corev1.Secret)
+			secret.Data = map[string][]byte{}
+			return nil
 		})
+
+	kubeClient.EXPECT().
+		Update(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Os:        osRenewer,
+		SshEtcd:   sshEtcd,
+		Kubectl:   kubeClient,
+	}
+
+	writeDummyEtcdCerts(t, renewer.BackupDir)
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("RenewCertificates() expected no error, got: %v", err)
+	}
+}
+
+func TestRenewCertificates_CleanupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	sshCP := mocks.NewMockSSHRunner(ctrl)
+
+	sshCP.EXPECT().RunCommand(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	renewer := &certificates.Renewer{
+		BackupDir:       "/non-existent-path/cannot-delete",
+		Os:              osRenewer,
+		SshControlPlane: sshCP,
+	}
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("RenewCertificates() expected no error even with cleanup failure, got: %v", err)
+	}
+}
+
+func TestNewRenewerEtcdSSHError(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+			SSH: certificates.SSHConfig{
+				User:    "",
+				KeyPath: "/non-existent-path",
+			},
+		},
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+			SSH: certificates.SSHConfig{
+				User:    "user",
+				KeyPath: "key-path",
+			},
+		},
+	}
+
+	kubeClient := kubemocks.NewMockClient(nil)
+
+	_, err := certificates.NewRenewer(kubeClient, cfg.OS, cfg)
+	if err == nil {
+		t.Fatal("NewRenewer() expected error, got nil")
+	}
+}
+
+func TestNewRenewerControlPlaneSSHError(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{},
+		},
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+			SSH: certificates.SSHConfig{
+				User:    "",
+				KeyPath: "/non-existent-path",
+			},
+		},
+	}
+
+	kubeClient := kubemocks.NewMockClient(nil)
+
+	_, err := certificates.NewRenewer(kubeClient, cfg.OS, cfg)
+	if err == nil {
+		t.Fatal("NewRenewer() expected error, got nil")
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds comprehensive unit tests for the certificate renewal functionality in renewer.go. The tests cover various scenarios including:

- Successful certificate renewal for both etcd and control plane components
- Error handling for various failure scenarios (backup errors, renewal errors, etc.)
- API server etcd client secret updates
- Configuration validation

The implementation uses mock objects for SSH runners and Kubernetes clients to simulate different behaviors and verify the correct handling of success and error cases. This improves test coverage and ensures the certificate renewal process works as expected across different environments and failure modes.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

