### PR TITLE
fix custom workflow to use dynamic tinkerbell ip

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -2980,11 +2980,6 @@ func TestTinkerbellKubernetes133KubeletConfigurationSimpleFlow(t *testing.T) {
 }
 
 func TestTinkerbellCustomTemplateRefSimpleFlow(t *testing.T) {
-	// Get the custom template config
-	customTemplateConfig, err := framework.GetCustomTinkerbellConfig()
-	if err != nil {
-		t.Fatalf("Failed to get custom template config: %v", err)
-	}
 
 	// Get license token for Ubuntu 2204
 	licenseToken := framework.GetLicenseToken()
@@ -3002,6 +2997,12 @@ func TestTinkerbellCustomTemplateRefSimpleFlow(t *testing.T) {
 			api.WithLicenseToken(licenseToken),
 		),
 	)
+
+	// Get the custom template config
+	customTemplateConfig, err := framework.GetCustomTinkerbellConfig(provider.GetTinkerbellLBIP())
+	if err != nil {
+		t.Fatalf("Failed to get custom template config: %v", err)
+	}
 
 	// Add the custom template config to the cluster
 	test.UpdateClusterConfig(

--- a/test/framework/testdata/tinkerbell/custom_config.yaml
+++ b/test/framework/testdata/tinkerbell/custom_config.yaml
@@ -54,7 +54,7 @@ spec:
           CONTENTS: |
             datasource:
               Ec2:
-                metadata_urls: [http://10.80.18.102:50061,http://<tinkerbellIP-from-cluster-config>:50061]
+                metadata_urls: [http://__TINKERBELL_LOCAL_IP__:50061,http://__TINKERBELL_LB_IP__:50061]
                 strict_id: false
             manage_etc_hosts: localhost
             warnings:

--- a/test/framework/tinkerbell.go
+++ b/test/framework/tinkerbell.go
@@ -150,6 +150,11 @@ func (t *Tinkerbell) Name() string {
 	return tinkerbellProviderName
 }
 
+// GetTinkerbellLBIP returns the configured tinkerbell ip for the provider.
+func (t *Tinkerbell) GetTinkerbellLBIP() string {
+	return t.serverIP
+}
+
 func (t *Tinkerbell) Setup() {}
 
 // UpdateKubeConfig customizes generated kubeconfig for the provider.

--- a/test/framework/tinkerbell_template_config.go
+++ b/test/framework/tinkerbell_template_config.go
@@ -2,22 +2,34 @@ package framework
 
 import (
 	_ "embed"
+	"fmt"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/networkutils"
 )
 
 //go:embed testdata/tinkerbell/custom_config.yaml
 var customTinkerbellConfigYAML []byte
 
-// GetCustomTinkerbellConfig is a public wrapper for getCustomTinkerbellConfig.
-func GetCustomTinkerbellConfig() (*anywherev1.TinkerbellTemplateConfig, error) {
-	// Parse the YAML into a TinkerbellTemplateConfig object
-	config := &anywherev1.TinkerbellTemplateConfig{}
-	if err := yaml.Unmarshal(customTinkerbellConfigYAML, config); err != nil {
+// GetCustomTinkerbellConfig returns a custom TinkerbellTemplateConfig.
+func GetCustomTinkerbellConfig(tinkerbellLBIP string) (*anywherev1.TinkerbellTemplateConfig, error) {
+	// Replace placeholders with actual values using string replacement
+	configContent := string(customTinkerbellConfigYAML)
+	localIP, err := networkutils.GetLocalIP()
+	if err != nil {
 		return nil, err
 	}
+	configContent = strings.ReplaceAll(configContent, "__TINKERBELL_LOCAL_IP__", localIP.String())
+	configContent = strings.ReplaceAll(configContent, "__TINKERBELL_LB_IP__", tinkerbellLBIP)
 
-	return config, nil
+	// Parse the YAML into TinkerbellTemplateConfig
+	var config anywherev1.TinkerbellTemplateConfig
+	if err := yaml.Unmarshal([]byte(configContent), &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal template config: %v", err)
+	}
+
+	return &config, nil
 }


### PR DESCRIPTION
*Description of changes:*
Fixes the recently added e2e test for tinkerbell custom provisioning workflow by replacing the hardcoded ips for metadata urls withe dynamically fetched ips from the environment

*Testing (if applicable):*
Ran the test manually


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

