### PR TITLE
Add certificates component renewal and improve OS interface readability

### DIFF
--- a/pkg/certificates/os.go
+++ b/pkg/certificates/os.go
@@ -18,8 +18,8 @@ const (
 type OSRenewer interface {
 	RenewControlPlaneCerts(ctx context.Context, node string, config *RenewalConfig, component string, sshRunner SSHRunner) error
 	RenewEtcdCerts(ctx context.Context, node string, sshRunner SSHRunner) error
-	CopyEtcdCerts(ctx context.Context, node string, sshRunner SSHRunner) error
-	TransferCertsToControlPlane(ctx context.Context, node string, sshRunner SSHRunner) error
+	CopyEtcdCertsToLocal(ctx context.Context, node string, sshRunner SSHRunner) error
+	TransferCertsToControlPlaneFromLocal(ctx context.Context, node string, sshRunner SSHRunner) error
 }
 
 // BuildOSRenewer creates a new OSRenewer based on the OS type.

--- a/pkg/certificates/renewer.go
+++ b/pkg/certificates/renewer.go
@@ -179,7 +179,7 @@ func (r *Renewer) validateRenewalConfig(
 
 func (r *Renewer) processEtcdCertificateTransfer(ctx context.Context, cfg *RenewalConfig) error {
 	firstNode := cfg.Etcd.Nodes[0]
-	logger.V(4).Info("Copying certificates from node", "node", firstNode)
+	logger.V(4).Info("Transferring external ETCD certificate to control plane nodes")
 
 	if err := r.OS.CopyEtcdCertsToLocal(ctx, firstNode, r.SSHEtcd); err != nil {
 		return fmt.Errorf("copying certificates from etcd node %s: %v", firstNode, err)

--- a/pkg/certificates/renewerbottlerocket.go
+++ b/pkg/certificates/renewerbottlerocket.go
@@ -87,9 +87,6 @@ func (b *BottlerocketRenewer) TransferCertsToControlPlaneFromLocal(
 		return fmt.Errorf("transfering certificates to control plane: %v", err)
 	}
 
-	// if _, err := ssh.RunCommand(ctx, node, b.copyExternalEtcdCerts()); err != nil {
-	// 	return fmt.Errorf("copying etcd client certs: %v", err)
-	// }
 	return nil
 }
 
@@ -118,7 +115,6 @@ func (b *BottlerocketRenewer) RenewEtcdCerts(ctx context.Context, node string, s
 
 // CopyEtcdCertsToLocal copies the etcd certificates from the specified node to the local machine.
 func (b *BottlerocketRenewer) CopyEtcdCertsToLocal(ctx context.Context, node string, ssh SSHRunner) error {
-
 	if _, err := ssh.RunCommand(ctx, node, b.sheltie(
 		b.copyEtcdCertsToTemp(brTempDir),
 	)); err != nil {
@@ -181,7 +177,6 @@ ctr image pull ${IMAGE_ID}`
 }
 
 func (b *BottlerocketRenewer) backupControlPlaneCerts(_ string, hasExternalEtcd bool, certDir string) string {
-
 	backupPath := fmt.Sprintf("/var/lib/kubeadm/pki.bak_%s", b.backup)
 
 	if hasExternalEtcd {

--- a/pkg/certificates/renewerbottlerocket.go
+++ b/pkg/certificates/renewerbottlerocket.go
@@ -45,18 +45,11 @@ func (b *BottlerocketRenewer) RenewControlPlaneCerts(
 
 	hasExternalEtcd := cfg != nil && len(cfg.Etcd.Nodes) > 0
 
-	if hasExternalEtcd {
-		if err := b.TransferCertsToControlPlane(ctx, node, ssh); err != nil {
-			return fmt.Errorf("transferring certificates to control plane node: %v", err)
-		}
-	}
-
 	shellCommands := b.sheltie(
 		b.pullContainerImage(),
 		b.backupControlPlaneCerts(component, hasExternalEtcd, brControlPlaneCertDir),
 		b.renewControlPlaneCerts(),
 		b.checkControlPlaneCerts(),
-		b.copyExternalEtcdCerts(),
 		b.restartControlPlaneStaticPods(),
 	)
 
@@ -68,8 +61,8 @@ func (b *BottlerocketRenewer) RenewControlPlaneCerts(
 	return nil
 }
 
-// TransferCertsToControlPlane transfers etcd client certificates to a control plane node.
-func (b *BottlerocketRenewer) TransferCertsToControlPlane(
+// TransferCertsToControlPlaneFromLocal transfers etcd client certificates to a control plane node.
+func (b *BottlerocketRenewer) TransferCertsToControlPlaneFromLocal(
 	ctx context.Context, node string, ssh SSHRunner,
 ) error {
 	certificateBytes, err := os.ReadFile(filepath.Join(
@@ -87,12 +80,16 @@ func (b *BottlerocketRenewer) TransferCertsToControlPlane(
 		b.createTempDirectory(tempLocalEtcdCertsDir),
 		b.writeCertToTemp(base64.StdEncoding.EncodeToString(certificateBytes)),
 		b.writeKeyToTemp(base64.StdEncoding.EncodeToString(keyBytes)),
+		b.copyExternalEtcdCerts(),
 	)
 
-	if _, err := ssh.RunCommand(ctx, node, shellCommands); err != nil {
+	if _, err := ssh.RunCommand(ctx, node, shellCommands, WithSSHLogging(false)); err != nil {
 		return fmt.Errorf("transfering certificates to control plane: %v", err)
 	}
 
+	// if _, err := ssh.RunCommand(ctx, node, b.copyExternalEtcdCerts()); err != nil {
+	// 	return fmt.Errorf("copying etcd client certs: %v", err)
+	// }
 	return nil
 }
 
@@ -119,7 +116,8 @@ func (b *BottlerocketRenewer) RenewEtcdCerts(ctx context.Context, node string, s
 	return nil
 }
 
-func (b *BottlerocketRenewer) CopyEtcdCerts(ctx context.Context, node string, ssh SSHRunner) error {
+// CopyEtcdCertsToLocal copies the etcd certificates from the specified node to the local machine.
+func (b *BottlerocketRenewer) CopyEtcdCertsToLocal(ctx context.Context, node string, ssh SSHRunner) error {
 
 	if _, err := ssh.RunCommand(ctx, node, b.sheltie(
 		b.copyEtcdCertsToTemp(brTempDir),
@@ -128,7 +126,7 @@ func (b *BottlerocketRenewer) CopyEtcdCerts(ctx context.Context, node string, ss
 	}
 
 	certificatePath := filepath.Join(brTempDir, "apiserver-etcd-client.crt")
-	certificateContent, err := ssh.RunCommand(ctx, node, b.readTempFile(certificatePath))
+	certificateContent, err := ssh.RunCommand(ctx, node, b.readTempFile(certificatePath), WithSSHLogging(false))
 	if err != nil {
 		return fmt.Errorf("reading etcd certificate file: %v", err)
 	}
@@ -138,7 +136,7 @@ func (b *BottlerocketRenewer) CopyEtcdCerts(ctx context.Context, node string, ss
 	}
 
 	keyFilePath := filepath.Join(brTempDir, "apiserver-etcd-client.key")
-	keyContent, err := ssh.RunCommand(ctx, node, b.readTempFile(keyFilePath))
+	keyContent, err := ssh.RunCommand(ctx, node, b.readTempFile(keyFilePath), WithSSHLogging(false))
 	if err != nil {
 		return fmt.Errorf("reading etcd key file: %v", err)
 	}
@@ -213,11 +211,12 @@ func (b *BottlerocketRenewer) checkControlPlaneCerts() string {
 }
 
 func (b *BottlerocketRenewer) copyExternalEtcdCerts() string {
-	copyCerts := fmt.Sprintf(`if [ -d "/tmp/%[1]s" ]; then
-    cp /tmp/%[1]s/apiserver-etcd-client.crt %[2]s/server-etcd-client.crt
-    cp /tmp/%[1]s/apiserver-etcd-client.key %[2]s/apiserver-etcd-client.key
-    rm -rf /tmp/%[1]s
-fi`, tempLocalEtcdCertsDir, brControlPlaneCertDir)
+	copyCerts := fmt.Sprintf(`
+		mkdir -p %[2]s
+		cp /tmp/%[1]s/apiserver-etcd-client.crt %[2]s/server-etcd-client.crt
+		cp /tmp/%[1]s/apiserver-etcd-client.key %[2]s/apiserver-etcd-client.key
+		rm -rf /tmp/%[1]s
+		`, tempLocalEtcdCertsDir, brControlPlaneCertDir)
 	return copyCerts
 }
 

--- a/pkg/certificates/renewerubuntu.go
+++ b/pkg/certificates/renewerubuntu.go
@@ -160,7 +160,6 @@ func (l *LinuxRenewer) validateEtcdCerts() string {
 func (l *LinuxRenewer) TransferCertsToControlPlaneFromLocal(
 	ctx context.Context, node string, ssh SSHRunner,
 ) error {
-
 	localCertificatePath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.crt")
 	localKeyFilePath := filepath.Join(l.backup, tempLocalEtcdCertsDir, "apiserver-etcd-client.key")
 

--- a/pkg/certificates/ssh.go
+++ b/pkg/certificates/ssh.go
@@ -35,6 +35,7 @@ type DefaultSSHRunner struct {
 	sshPasswd  string
 }
 
+// SSHOption represents a configuration option for SSH operations.
 type SSHOption func(*sshConfigOption)
 
 type sshConfigOption struct {
@@ -47,6 +48,7 @@ func defaultSSHConfig() *sshConfigOption {
 	}
 }
 
+// WithSSHLogging configures whether SSH command output should be displayed in logs.
 func WithSSHLogging(display bool) SSHOption {
 	return func(c *sshConfigOption) {
 		c.displayLogs = display


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the ability to renew certificates by component (etcd or control-plane) and improves the OS interface naming for better readability. Added `WithSSHLogging(false)` for Linux systems to prevent displaying sensitive information in logs.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

