### PR TITLE
Add unit tests for bottlerocket/ubuntu/config/os

### DIFF
--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -76,13 +76,13 @@ func ValidateConfig(config *RenewalConfig, component string) error {
 		return fmt.Errorf("unsupported os %q", config.OS)
 	}
 
-	if err := validateNodeConfig(&config.ControlPlane); err != nil {
+	if err := ValidateNodeConfig(&config.ControlPlane); err != nil {
 		return fmt.Errorf("validating control plane config: %w", err)
 	}
 
 	// Etcd nodes are only required if using external etcd.
 	if len(config.Etcd.Nodes) > 0 {
-		if err := validateNodeConfig(&config.Etcd); err != nil {
+		if err := ValidateNodeConfig(&config.Etcd); err != nil {
 			return fmt.Errorf("validating etcd config: %w", err)
 		}
 	}
@@ -94,7 +94,7 @@ func ValidateConfig(config *RenewalConfig, component string) error {
 	return nil
 }
 
-func validateNodeConfig(config *NodeConfig) error {
+func ValidateNodeConfig(config *NodeConfig) error {
 	if len(config.Nodes) == 0 {
 		return fmt.Errorf("nodes list cannot be empty")
 	}
@@ -136,14 +136,14 @@ func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernet
 		return nil
 	}
 
-	controlPlaneIPs, err := getControlPlaneIPs(ctx, kubeClient, cluster)
+	controlPlaneIPs, err := GetControlPlaneIPs(ctx, kubeClient, cluster)
 	if err != nil {
 		return fmt.Errorf("cluster is not reachable, please provide control plane and/or external etcd IP addresses: %w", err)
 	}
 
 	cfg.ControlPlane.Nodes = controlPlaneIPs
 
-	etcdIPs, err := getEtcdIPs(ctx, kubeClient, cluster)
+	etcdIPs, err := GetEtcdIPs(ctx, kubeClient, cluster)
 	if err != nil {
 		return fmt.Errorf("retrieving external etcd IPs for the cluster: %w", err)
 	}
@@ -152,7 +152,7 @@ func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernet
 	return nil
 }
 
-func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
+func GetControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var controlPlaneIPs []string
 
 	machineList := &clusterv1.MachineList{}
@@ -182,7 +182,7 @@ func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, clust
 	return controlPlaneIPs, nil
 }
 
-func getEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
+func GetEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var etcdIPs []string
 
 	machineList := &clusterv1.MachineList{}

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -94,6 +94,7 @@ func ValidateConfig(config *RenewalConfig, component string) error {
 	return nil
 }
 
+// ValidateNodeConfig validates a node configuration.
 func ValidateNodeConfig(config *NodeConfig) error {
 	if len(config.Nodes) == 0 {
 		return fmt.Errorf("nodes list cannot be empty")
@@ -152,6 +153,7 @@ func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernet
 	return nil
 }
 
+// GetControlPlaneIPs retrieves the external IP addresses of all control plane nodes.
 func GetControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var controlPlaneIPs []string
 
@@ -182,6 +184,7 @@ func GetControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, clust
 	return controlPlaneIPs, nil
 }
 
+// GetEtcdIPs retrieves the external IP addresses of all etcd nodes.
 func GetEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var etcdIPs []string
 

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -76,13 +76,13 @@ func ValidateConfig(config *RenewalConfig, component string) error {
 		return fmt.Errorf("unsupported os %q", config.OS)
 	}
 
-	if err := ValidateNodeConfig(&config.ControlPlane); err != nil {
+	if err := validateNodeConfig(&config.ControlPlane); err != nil {
 		return fmt.Errorf("validating control plane config: %w", err)
 	}
 
 	// Etcd nodes are only required if using external etcd.
 	if len(config.Etcd.Nodes) > 0 {
-		if err := ValidateNodeConfig(&config.Etcd); err != nil {
+		if err := validateNodeConfig(&config.Etcd); err != nil {
 			return fmt.Errorf("validating etcd config: %w", err)
 		}
 	}
@@ -94,8 +94,7 @@ func ValidateConfig(config *RenewalConfig, component string) error {
 	return nil
 }
 
-// ValidateNodeConfig validates a node configuration.
-func ValidateNodeConfig(config *NodeConfig) error {
+func validateNodeConfig(config *NodeConfig) error {
 	if len(config.Nodes) == 0 {
 		return fmt.Errorf("nodes list cannot be empty")
 	}

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -137,14 +137,14 @@ func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernet
 		return nil
 	}
 
-	controlPlaneIPs, err := GetControlPlaneIPs(ctx, kubeClient, cluster)
+	controlPlaneIPs, err := getControlPlaneIPs(ctx, kubeClient, cluster)
 	if err != nil {
 		return fmt.Errorf("cluster is not reachable, please provide control plane and/or external etcd IP addresses: %w", err)
 	}
 
 	cfg.ControlPlane.Nodes = controlPlaneIPs
 
-	etcdIPs, err := GetEtcdIPs(ctx, kubeClient, cluster)
+	etcdIPs, err := getEtcdIPs(ctx, kubeClient, cluster)
 	if err != nil {
 		return fmt.Errorf("retrieving external etcd IPs for the cluster: %w", err)
 	}
@@ -153,8 +153,7 @@ func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernet
 	return nil
 }
 
-// GetControlPlaneIPs retrieves the external IP addresses of all control plane nodes.
-func GetControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
+func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var controlPlaneIPs []string
 
 	machineList := &clusterv1.MachineList{}
@@ -184,8 +183,7 @@ func GetControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, clust
 	return controlPlaneIPs, nil
 }
 
-// GetEtcdIPs retrieves the external IP addresses of all etcd nodes.
-func GetEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
+func getEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var etcdIPs []string
 
 	machineList := &clusterv1.MachineList{}

--- a/pkg/certificates/config_test.go
+++ b/pkg/certificates/config_test.go
@@ -576,29 +576,39 @@ func TestValidateConfig_EtcdMissingSSHUser(t *testing.T) {
 	}
 }
 
-func TestValidateNodeConfig_MissingSSHUser(t *testing.T) {
+func TestValidateConfig_MissingSSHUser(t *testing.T) {
 	key := "/tmp/key-no-user"
 	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
 		t.Fatalf("failed to write key file: %v", err)
 	}
 	defer os.Remove(key)
 
-	nc := &certificates.NodeConfig{
-		Nodes: []string{"1.1.1.1"},
-		SSH:   certificates.SSHConfig{KeyPath: key},
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"1.1.1.1"},
+			SSH:   certificates.SSHConfig{KeyPath: key},
+		},
 	}
-	if err := certificates.ValidateNodeConfig(nc); err == nil {
-		t.Fatalf("want sshUser required error, got %v", err)
+
+	if err := certificates.ValidateConfig(cfg, ""); err == nil {
+		t.Fatalf("want sshUser required error, got nil")
 	}
 }
 
-func TestValidateNodeConfig_MissingKeyPath(t *testing.T) {
-	nc := &certificates.NodeConfig{
-		Nodes: []string{"1.1.1.1"},
-		SSH:   certificates.SSHConfig{User: "test"},
+func TestValidateConfig_MissingKeyPath(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"1.1.1.1"},
+			SSH:   certificates.SSHConfig{User: "test"},
+		},
 	}
-	if err := certificates.ValidateNodeConfig(nc); err == nil {
-		t.Fatalf("want sshKey required error, got %v", err)
+
+	if err := certificates.ValidateConfig(cfg, ""); err == nil {
+		t.Fatalf("want sshKey required error, got nil")
 	}
 }
 

--- a/pkg/certificates/config_test.go
+++ b/pkg/certificates/config_test.go
@@ -51,6 +51,25 @@ func setupSSHKeyForTest(t *testing.T, path string) func() {
 	return func() { os.Remove(path) }
 }
 
+func createConfigFileFromYAML(t *testing.T, yamlContent string) (string, func()) {
+	t.Helper()
+
+	tmpfile, err := os.CreateTemp("", "config-*.yaml")
+	if err != nil {
+		t.Fatalf("create tmp: %v", err)
+	}
+
+	if _, err := tmpfile.Write([]byte(yamlContent)); err != nil {
+		tmpfile.Close()
+		t.Fatalf("write tmp: %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("close tmp: %v", err)
+	}
+
+	return tmpfile.Name(), func() { os.Remove(tmpfile.Name()) }
+}
+
 // TestParseConfigFileNotFound tests the ParseConfig function with a non-existent file.
 func TestParseConfigFileNotFound(t *testing.T) {
 	_, err := certificates.ParseConfig("non-existent-file.yaml")
@@ -59,103 +78,54 @@ func TestParseConfigFileNotFound(t *testing.T) {
 	}
 }
 
-// Testcertificates.ValidateConfig tests the certificates.ValidateConfig function directly.
-func TestValidateConfig(t *testing.T) {
-	// Setup SSH key once for all tests
-	keyFile := "/tmp/test-key"
-	cleanup := setupSSHKeyForTest(t, keyFile)
+func TestParseConfig_InvalidYAML(t *testing.T) {
+	bad := "clusterName: foo: bar"
+	file, cleanup := createConfigFileFromYAML(t, bad)
 	defer cleanup()
 
-	tests := []struct {
-		name        string
-		config      *certificates.RenewalConfig
-		expectError bool
-	}{
-		{
-			name: "valid config",
-			config: &certificates.RenewalConfig{
-				ClusterName: "test-cluster",
-				OS:          "ubuntu",
-				ControlPlane: certificates.NodeConfig{
-					Nodes: []string{"192.168.1.10"},
-					SSH: certificates.SSHConfig{
-						User:    "ec2-user",
-						KeyPath: keyFile,
-					},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "missing cluster name",
-			config: &certificates.RenewalConfig{
-				OS: "ubuntu",
-				ControlPlane: certificates.NodeConfig{
-					Nodes: []string{"192.168.1.10"},
-					SSH: certificates.SSHConfig{
-						User:    "ec2-user",
-						KeyPath: keyFile,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "missing control plane nodes",
-			config: &certificates.RenewalConfig{
-				ClusterName: "test-cluster",
-				OS:          "ubuntu",
-				ControlPlane: certificates.NodeConfig{
-					SSH: certificates.SSHConfig{
-						User:    "ec2-user",
-						KeyPath: keyFile,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "non-existent SSH key file",
-			config: &certificates.RenewalConfig{
-				ClusterName: "test-cluster",
-				OS:          "ubuntu",
-				ControlPlane: certificates.NodeConfig{
-					Nodes: []string{"192.168.1.10"},
-					SSH: certificates.SSHConfig{
-						User:    "ec2-user",
-						KeyPath: "/tmp/non-existent-key",
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "unsupported OS",
-			config: &certificates.RenewalConfig{
-				ClusterName: "test-cluster",
-				OS:          "windows",
-				ControlPlane: certificates.NodeConfig{
-					Nodes: []string{"192.168.1.10"},
-					SSH: certificates.SSHConfig{
-						User:    "ec2-user",
-						KeyPath: keyFile,
-					},
-				},
-			},
-			expectError: true,
-		},
+	if _, err := certificates.ParseConfig(file); err == nil {
+		t.Fatalf("ParseConfig(): want YAML error, got %v", err)
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := certificates.ValidateConfig(tt.config, "")
-			if tt.expectError && err == nil {
-				t.Error("expected error but got none")
-			}
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-		})
+func TestParseConfig_EnvPasswordsInjected(t *testing.T) {
+	key := "/tmp/test-key-pass"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	yml := fmt.Sprintf(
+		"clusterName: demo\n"+
+			"os: ubuntu\n"+
+			"controlPlane:\n"+
+			"  nodes:\n"+
+			"    - 1.2.3.4\n"+
+			"  ssh:\n"+
+			"    sshUser: u\n"+
+			"    sshKey: %s\n"+
+			"etcd:\n"+
+			"  nodes:\n"+
+			"    - 5.6.7.8\n"+
+			"  ssh:\n"+
+			"    sshUser: u\n"+
+			"    sshKey: %s\n",
+		key, key)
+
+	os.Setenv("EKSA_SSH_KEY_PASSPHRASE_CP", "pass-cp")
+	os.Setenv("EKSA_SSH_KEY_PASSPHRASE_ETCD", "pass-etcd")
+	defer func() {
+		os.Unsetenv("EKSA_SSH_KEY_PASSPHRASE_CP")
+		os.Unsetenv("EKSA_SSH_KEY_PASSPHRASE_ETCD")
+	}()
+
+	file, cleanup := createConfigFileFromYAML(t, yml)
+	defer cleanup()
+
+	if cfg, err := certificates.ParseConfig(file); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	} else if cfg.ControlPlane.SSH.Password != "pass-cp" || cfg.Etcd.SSH.Password != "pass-etcd" {
+		t.Fatalf("env passphrase not injected into cfg: %#v", cfg)
 	}
 }
 
@@ -301,6 +271,211 @@ controlPlane:
 				}
 			}
 		})
+	}
+}
+
+// Testcertificates.ValidateConfig tests the certificates.ValidateConfig function directly.
+func TestValidateConfig(t *testing.T) {
+	// Setup SSH key once for all tests
+	keyFile := "/tmp/test-key"
+	cleanup := setupSSHKeyForTest(t, keyFile)
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		config      *certificates.RenewalConfig
+		expectError bool
+	}{
+		{
+			name: "valid config",
+			config: &certificates.RenewalConfig{
+				ClusterName: "test-cluster",
+				OS:          "ubuntu",
+				ControlPlane: certificates.NodeConfig{
+					Nodes: []string{"192.168.1.10"},
+					SSH: certificates.SSHConfig{
+						User:    "ec2-user",
+						KeyPath: keyFile,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "missing cluster name",
+			config: &certificates.RenewalConfig{
+				OS: "ubuntu",
+				ControlPlane: certificates.NodeConfig{
+					Nodes: []string{"192.168.1.10"},
+					SSH: certificates.SSHConfig{
+						User:    "ec2-user",
+						KeyPath: keyFile,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing control plane nodes",
+			config: &certificates.RenewalConfig{
+				ClusterName: "test-cluster",
+				OS:          "ubuntu",
+				ControlPlane: certificates.NodeConfig{
+					SSH: certificates.SSHConfig{
+						User:    "ec2-user",
+						KeyPath: keyFile,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "non-existent SSH key file",
+			config: &certificates.RenewalConfig{
+				ClusterName: "test-cluster",
+				OS:          "ubuntu",
+				ControlPlane: certificates.NodeConfig{
+					Nodes: []string{"192.168.1.10"},
+					SSH: certificates.SSHConfig{
+						User:    "ec2-user",
+						KeyPath: "/tmp/non-existent-key",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "unsupported OS",
+			config: &certificates.RenewalConfig{
+				ClusterName: "test-cluster",
+				OS:          "windows",
+				ControlPlane: certificates.NodeConfig{
+					Nodes: []string{"192.168.1.10"},
+					SSH: certificates.SSHConfig{
+						User:    "ec2-user",
+						KeyPath: keyFile,
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := certificates.ValidateConfig(tt.config, "")
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateConfig_MissingOS(t *testing.T) {
+	key := "/tmp/key-missing-os"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	if err := certificates.ValidateConfig(&certificates.RenewalConfig{
+		ClusterName:  "c",
+		ControlPlane: certificates.NodeConfig{Nodes: []string{"n"}, SSH: certificates.SSHConfig{User: "u", KeyPath: key}},
+	}, ""); err == nil {
+		t.Fatalf("want missing os error, got %v", err)
+	}
+}
+
+func TestValidateConfig_MissingSSHUser(t *testing.T) {
+	key := "/tmp/key-no-user"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"1.1.1.1"},
+			SSH:   certificates.SSHConfig{KeyPath: key},
+		},
+	}
+
+	if err := certificates.ValidateConfig(cfg, ""); err == nil {
+		t.Fatalf("want sshUser required error, got nil")
+	}
+}
+
+func TestValidateConfig_MissingKeyPath(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"1.1.1.1"},
+			SSH:   certificates.SSHConfig{User: "test"},
+		},
+	}
+
+	if err := certificates.ValidateConfig(cfg, ""); err == nil {
+		t.Fatalf("want sshKey required error, got nil")
+	}
+}
+
+func TestValidateConfig_EtcdMissingSSHUser(t *testing.T) {
+	key := "/tmp/key-bad-etcd"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "c", OS: "ubuntu",
+		ControlPlane: certificates.NodeConfig{Nodes: []string{"n"}, SSH: certificates.SSHConfig{User: "u", KeyPath: key}},
+		Etcd:         certificates.NodeConfig{Nodes: []string{"e"}, SSH: certificates.SSHConfig{KeyPath: key}},
+	}
+	if err := certificates.ValidateConfig(cfg, ""); err == nil {
+		t.Fatalf("want nested etcd validation error, got %v", err)
+	}
+}
+
+func TestValidateComponentWithConfig_ValidControlPlane(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName:  "test",
+		OS:           "ubuntu",
+		ControlPlane: certificates.NodeConfig{Nodes: []string{"1.1.1.1"}},
+	}
+
+	if err := certificates.ValidateComponentWithConfig("control-plane", cfg); err != nil {
+		t.Fatalf("ValidateComponentWithConfig() expected no error for control-plane component, got: %v", err)
+	}
+}
+
+func TestValidateComponentWithConfig_ValidEtcdWithNodes(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName:  "test",
+		OS:           "ubuntu",
+		ControlPlane: certificates.NodeConfig{Nodes: []string{"1.1.1.1"}},
+		Etcd:         certificates.NodeConfig{Nodes: []string{"2.2.2.2"}},
+	}
+
+	if err := certificates.ValidateComponentWithConfig("etcd", cfg); err != nil {
+		t.Fatalf("ValidateComponentWithConfig() expected no error for etcd component with nodes, got: %v", err)
+	}
+}
+
+func TestValidateComponentWithConfig_EmptyComponent(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName:  "test",
+		OS:           "ubuntu",
+		ControlPlane: certificates.NodeConfig{Nodes: []string{"1.1.1.1"}},
+	}
+
+	if err := certificates.ValidateComponentWithConfig("", cfg); err != nil {
+		t.Fatalf("ValidateComponentWithConfig() expected no error for empty component, got: %v", err)
 	}
 }
 
@@ -493,162 +668,6 @@ func TestPopulateConfig_ControlPlaneListError(t *testing.T) {
 	}
 }
 
-func TestParseConfig_InvalidYAML(t *testing.T) {
-	bad := "clusterName: foo: bar"
-	file, cleanup := createConfigFileFromYAML(t, bad)
-	defer cleanup()
-
-	if _, err := certificates.ParseConfig(file); err == nil {
-		t.Fatalf("ParseConfig(): want YAML error, got %v", err)
-	}
-}
-
-func TestParseConfig_EnvPasswordsInjected(t *testing.T) {
-	key := "/tmp/test-key-pass"
-	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-	defer os.Remove(key)
-
-	yml := fmt.Sprintf(
-		"clusterName: demo\n"+
-			"os: ubuntu\n"+
-			"controlPlane:\n"+
-			"  nodes:\n"+
-			"    - 1.2.3.4\n"+
-			"  ssh:\n"+
-			"    sshUser: u\n"+
-			"    sshKey: %s\n"+
-			"etcd:\n"+
-			"  nodes:\n"+
-			"    - 5.6.7.8\n"+
-			"  ssh:\n"+
-			"    sshUser: u\n"+
-			"    sshKey: %s\n",
-		key, key)
-
-	os.Setenv("EKSA_SSH_KEY_PASSPHRASE_CP", "pass-cp")
-	os.Setenv("EKSA_SSH_KEY_PASSPHRASE_ETCD", "pass-etcd")
-	defer func() {
-		os.Unsetenv("EKSA_SSH_KEY_PASSPHRASE_CP")
-		os.Unsetenv("EKSA_SSH_KEY_PASSPHRASE_ETCD")
-	}()
-
-	file, cleanup := createConfigFileFromYAML(t, yml)
-	defer cleanup()
-
-	if cfg, err := certificates.ParseConfig(file); err != nil {
-		t.Fatalf("unexpected: %v", err)
-	} else if cfg.ControlPlane.SSH.Password != "pass-cp" || cfg.Etcd.SSH.Password != "pass-etcd" {
-		t.Fatalf("env passphrase not injected into cfg: %#v", cfg)
-	}
-}
-
-func TestValidateConfig_MissingOS(t *testing.T) {
-	key := "/tmp/key-missing-os"
-	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-	defer os.Remove(key)
-
-	if err := certificates.ValidateConfig(&certificates.RenewalConfig{
-		ClusterName:  "c",
-		ControlPlane: certificates.NodeConfig{Nodes: []string{"n"}, SSH: certificates.SSHConfig{User: "u", KeyPath: key}},
-	}, ""); err == nil {
-		t.Fatalf("want missing os error, got %v", err)
-	}
-}
-
-func TestValidateConfig_EtcdMissingSSHUser(t *testing.T) {
-	key := "/tmp/key-bad-etcd"
-	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-	defer os.Remove(key)
-
-	cfg := &certificates.RenewalConfig{
-		ClusterName: "c", OS: "ubuntu",
-		ControlPlane: certificates.NodeConfig{Nodes: []string{"n"}, SSH: certificates.SSHConfig{User: "u", KeyPath: key}},
-		Etcd:         certificates.NodeConfig{Nodes: []string{"e"}, SSH: certificates.SSHConfig{KeyPath: key}},
-	}
-	if err := certificates.ValidateConfig(cfg, ""); err == nil {
-		t.Fatalf("want nested etcd validation error, got %v", err)
-	}
-}
-
-func TestValidateConfig_MissingSSHUser(t *testing.T) {
-	key := "/tmp/key-no-user"
-	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-	defer os.Remove(key)
-
-	cfg := &certificates.RenewalConfig{
-		ClusterName: "test-cluster",
-		OS:          string(v1alpha1.Ubuntu),
-		ControlPlane: certificates.NodeConfig{
-			Nodes: []string{"1.1.1.1"},
-			SSH:   certificates.SSHConfig{KeyPath: key},
-		},
-	}
-
-	if err := certificates.ValidateConfig(cfg, ""); err == nil {
-		t.Fatalf("want sshUser required error, got nil")
-	}
-}
-
-func TestValidateConfig_MissingKeyPath(t *testing.T) {
-	cfg := &certificates.RenewalConfig{
-		ClusterName: "test-cluster",
-		OS:          string(v1alpha1.Ubuntu),
-		ControlPlane: certificates.NodeConfig{
-			Nodes: []string{"1.1.1.1"},
-			SSH:   certificates.SSHConfig{User: "test"},
-		},
-	}
-
-	if err := certificates.ValidateConfig(cfg, ""); err == nil {
-		t.Fatalf("want sshKey required error, got nil")
-	}
-}
-
-func TestValidateComponentWithConfig_ValidControlPlane(t *testing.T) {
-	cfg := &certificates.RenewalConfig{
-		ClusterName:  "test",
-		OS:           "ubuntu",
-		ControlPlane: certificates.NodeConfig{Nodes: []string{"1.1.1.1"}},
-	}
-
-	if err := certificates.ValidateComponentWithConfig("control-plane", cfg); err != nil {
-		t.Fatalf("ValidateComponentWithConfig() expected no error for control-plane component, got: %v", err)
-	}
-}
-
-func TestValidateComponentWithConfig_ValidEtcdWithNodes(t *testing.T) {
-	cfg := &certificates.RenewalConfig{
-		ClusterName:  "test",
-		OS:           "ubuntu",
-		ControlPlane: certificates.NodeConfig{Nodes: []string{"1.1.1.1"}},
-		Etcd:         certificates.NodeConfig{Nodes: []string{"2.2.2.2"}},
-	}
-
-	if err := certificates.ValidateComponentWithConfig("etcd", cfg); err != nil {
-		t.Fatalf("ValidateComponentWithConfig() expected no error for etcd component with nodes, got: %v", err)
-	}
-}
-
-func TestValidateComponentWithConfig_EmptyComponent(t *testing.T) {
-	cfg := &certificates.RenewalConfig{
-		ClusterName:  "test",
-		OS:           "ubuntu",
-		ControlPlane: certificates.NodeConfig{Nodes: []string{"1.1.1.1"}},
-	}
-
-	if err := certificates.ValidateComponentWithConfig("", cfg); err != nil {
-		t.Fatalf("ValidateComponentWithConfig() expected no error for empty component, got: %v", err)
-	}
-}
-
 func TestPopulateConfig_ExistingNodesEarlyReturn(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -667,23 +686,4 @@ func TestPopulateConfig_ExistingNodesEarlyReturn(t *testing.T) {
 	if err := certificates.PopulateConfig(context.Background(), cfg, k, &types.Cluster{Name: clusterLabel}); err != nil {
 		t.Fatalf("PopulateConfig() expected no error for early return, got: %v", err)
 	}
-}
-
-func createConfigFileFromYAML(t *testing.T, yamlContent string) (string, func()) {
-	t.Helper()
-
-	tmpfile, err := os.CreateTemp("", "config-*.yaml")
-	if err != nil {
-		t.Fatalf("create tmp: %v", err)
-	}
-
-	if _, err := tmpfile.Write([]byte(yamlContent)); err != nil {
-		tmpfile.Close()
-		t.Fatalf("write tmp: %v", err)
-	}
-	if err := tmpfile.Close(); err != nil {
-		t.Fatalf("close tmp: %v", err)
-	}
-
-	return tmpfile.Name(), func() { os.Remove(tmpfile.Name()) }
 }

--- a/pkg/certificates/config_test.go
+++ b/pkg/certificates/config_test.go
@@ -329,7 +329,6 @@ func Test_getControlPlaneIPs_Success(t *testing.T) {
 	if _, err := certificates.GetControlPlaneIPs(context.Background(), k, &types.Cluster{Name: clusterLabel}); err != nil {
 		t.Fatalf("GetControlPlaneIPs() expected no error, got: %v", err)
 	}
-
 }
 
 func Test_getEtcdIPs_Success(t *testing.T) {
@@ -357,7 +356,6 @@ func Test_getEtcdIPs_Success(t *testing.T) {
 	if _, err := certificates.GetEtcdIPs(context.Background(), k, &types.Cluster{Name: clusterLabel}); err != nil {
 		t.Fatalf("GetEtcdIPs() expected no error, got: %v", err)
 	}
-
 }
 
 func TestPopulateConfig_EtcdListError(t *testing.T) {

--- a/pkg/certificates/config_test.go
+++ b/pkg/certificates/config_test.go
@@ -1,18 +1,48 @@
 package certificates
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	kubemocks "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
+	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/types"
 )
+
+const (
+	clusterLabel = "demo"
+	cpIP         = "10.0.0.1"
+	etcdIP       = "10.0.0.2"
+	namespace    = constants.EksaSystemNamespace
+)
+
+// helper to generate a Machine with the given labels and external IP.
+func buildMachine(labels map[string]string, ip string) clusterv1.Machine {
+	return clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: labels,
+		},
+		Status: clusterv1.MachineStatus{
+			Addresses: []clusterv1.MachineAddress{
+				{Type: clusterv1.MachineExternalIP, Address: ip},
+			},
+		},
+	}
+}
 
 // setupSSHKeyForTest creates a temporary SSH key file for testing.
 func setupSSHKeyForTest(t *testing.T, path string) func() {
-	if path == "" {
-		return func() {}
-	}
-
+	t.Helper()
 	if err := os.WriteFile(path, []byte("test-key"), 0o600); err != nil {
-		t.Fatal(err)
+		t.Fatalf("setupSSHKeyForTest() failed to create key file: %v", err)
 	}
 	return func() { os.Remove(path) }
 }
@@ -268,4 +298,372 @@ controlPlane:
 			}
 		})
 	}
+}
+
+func Test_getControlPlaneIPs_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	machines := &clusterv1.MachineList{
+		Items: []clusterv1.Machine{
+			buildMachine(map[string]string{
+				clusterNameLabel:  clusterLabel,
+				controlPlaneLabel: "",
+			}, cpIP),
+		},
+	}
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, l interface{}, _ ...interface{}) error {
+			*l.(*clusterv1.MachineList) = *machines
+			return nil
+		})
+
+	if got, err := getControlPlaneIPs(context.Background(), k, &types.Cluster{Name: clusterLabel}); err != nil {
+		t.Fatalf("getControlPlaneIPs() expected no error, got: %v", err)
+	} else if len(got) != 1 || got[0] != cpIP {
+		t.Fatalf("getControlPlaneIPs() expected [%s], got: %v", cpIP, got)
+	}
+}
+
+func Test_getEtcdIPs_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	machines := &clusterv1.MachineList{
+		Items: []clusterv1.Machine{
+			buildMachine(map[string]string{
+				clusterNameLabel:  clusterLabel,
+				externalEtcdLabel: clusterLabel + "-etcd",
+			}, etcdIP),
+		},
+	}
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, l interface{}, _ ...interface{}) error {
+			*l.(*clusterv1.MachineList) = *machines
+			return nil
+		})
+
+	if got, err := getEtcdIPs(context.Background(), k, &types.Cluster{Name: clusterLabel}); err != nil {
+		t.Fatalf("getEtcdIPs() expected no error, got: %v", err)
+	} else if len(got) != 1 || got[0] != etcdIP {
+		t.Fatalf("getEtcdIPs() expected [%s], got: %v", etcdIP, got)
+	}
+}
+
+func TestPopulateConfig_EtcdListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	cpMachines := &clusterv1.MachineList{
+		Items: []clusterv1.Machine{
+			buildMachine(map[string]string{
+				clusterNameLabel:  clusterLabel,
+				controlPlaneLabel: "",
+			}, cpIP),
+		},
+	}
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, l interface{}, _ ...interface{}) error {
+			*l.(*clusterv1.MachineList) = *cpMachines
+			return nil
+		})
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("etcd list error"))
+
+	cfg := &RenewalConfig{
+		ClusterName: clusterLabel,
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: NodeConfig{
+			SSH: SSHConfig{User: "ec2-user", KeyPath: "/test"},
+		},
+	}
+
+	if err := PopulateConfig(context.Background(), cfg, k, &types.Cluster{Name: clusterLabel}); err == nil {
+		t.Fatalf("PopulateConfig() expected error, got nil")
+	}
+}
+
+func Test_getControlPlaneIPs_ListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("api server unavailable"))
+
+	if _, err := getControlPlaneIPs(context.Background(), k, &types.Cluster{Name: clusterLabel}); err == nil {
+		t.Fatalf("getControlPlaneIPs() expected error, got nil")
+	}
+}
+
+func TestPopulateConfig_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	all := &clusterv1.MachineList{
+		Items: []clusterv1.Machine{
+			buildMachine(map[string]string{
+				clusterNameLabel:  clusterLabel,
+				controlPlaneLabel: "",
+			}, cpIP),
+			buildMachine(map[string]string{
+				clusterNameLabel:  clusterLabel,
+				externalEtcdLabel: clusterLabel + "-etcd",
+			}, etcdIP),
+		},
+	}
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, l interface{}, _ ...interface{}) error {
+			*l.(*clusterv1.MachineList) = *all
+			return nil
+		}).Times(2)
+
+	cfg := &RenewalConfig{
+		ClusterName: clusterLabel,
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: NodeConfig{
+			SSH: SSHConfig{User: "ec2-user", KeyPath: "/test"},
+		},
+	}
+
+	if err := PopulateConfig(context.Background(), cfg, k, &types.Cluster{Name: clusterLabel}); err != nil {
+		t.Fatalf("PopulateConfig() expected no error, got: %v", err)
+	}
+	if len(cfg.ControlPlane.Nodes) != 1 || cfg.ControlPlane.Nodes[0] != cpIP {
+		t.Fatalf("PopulateConfig() expected ControlPlane.Nodes=[%s], got: %v", cpIP, cfg.ControlPlane.Nodes)
+	}
+	if len(cfg.Etcd.Nodes) != 1 || cfg.Etcd.Nodes[0] != etcdIP {
+		t.Fatalf("PopulateConfig() expected Etcd.Nodes=[%s], got: %v", etcdIP, cfg.Etcd.Nodes)
+	}
+}
+
+func TestPopulateConfig_ControlPlaneListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	k.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("api down"))
+
+	cfg := &RenewalConfig{
+		ClusterName: clusterLabel,
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: NodeConfig{
+			SSH: SSHConfig{User: "ec2-user", KeyPath: "/test"},
+		},
+	}
+
+	if err := PopulateConfig(context.Background(), cfg, k, &types.Cluster{Name: clusterLabel}); err == nil {
+		t.Fatalf("PopulateConfig() expected error, got nil")
+	}
+}
+
+func TestParseConfig_InvalidYAML(t *testing.T) {
+	bad := "clusterName: foo: bar"
+	file, cleanup := createConfigFileFromYAML(t, bad)
+	defer cleanup()
+
+	if _, err := ParseConfig(file); err == nil {
+		t.Fatalf("ParseConfig(): want YAML error, got %v", err)
+	}
+}
+
+func TestParseConfig_EnvPasswordsInjected(t *testing.T) {
+	key := "/tmp/test-key-pass"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	yml := fmt.Sprintf(
+		"clusterName: demo\n"+
+			"os: ubuntu\n"+
+			"controlPlane:\n"+
+			"  nodes:\n"+
+			"    - 1.2.3.4\n"+
+			"  ssh:\n"+
+			"    sshUser: u\n"+
+			"    sshKey: %s\n"+
+			"etcd:\n"+
+			"  nodes:\n"+
+			"    - 5.6.7.8\n"+
+			"  ssh:\n"+
+			"    sshUser: u\n"+
+			"    sshKey: %s\n",
+		key, key)
+
+	os.Setenv("EKSA_SSH_KEY_PASSPHRASE_CP", "pass-cp")
+	os.Setenv("EKSA_SSH_KEY_PASSPHRASE_ETCD", "pass-etcd")
+	defer func() {
+		os.Unsetenv("EKSA_SSH_KEY_PASSPHRASE_CP")
+		os.Unsetenv("EKSA_SSH_KEY_PASSPHRASE_ETCD")
+	}()
+
+	file, cleanup := createConfigFileFromYAML(t, yml)
+	defer cleanup()
+
+	if cfg, err := ParseConfig(file); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	} else if cfg.ControlPlane.SSH.Password != "pass-cp" || cfg.Etcd.SSH.Password != "pass-etcd" {
+		t.Fatalf("env passphrase not injected into cfg: %#v", cfg)
+	}
+}
+
+func TestValidateConfig_MissingOS(t *testing.T) {
+	key := "/tmp/key-missing-os"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	if err := ValidateConfig(&RenewalConfig{
+		ClusterName:  "c",
+		ControlPlane: NodeConfig{Nodes: []string{"n"}, SSH: SSHConfig{User: "u", KeyPath: key}},
+	}, ""); err == nil {
+		t.Fatalf("want missing os error, got %v", err)
+	}
+}
+
+func TestValidateConfig_EtcdMissingSSHUser(t *testing.T) {
+	key := "/tmp/key-bad-etcd"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	cfg := &RenewalConfig{
+		ClusterName: "c", OS: "ubuntu",
+		ControlPlane: NodeConfig{Nodes: []string{"n"}, SSH: SSHConfig{User: "u", KeyPath: key}},
+		Etcd:         NodeConfig{Nodes: []string{"e"}, SSH: SSHConfig{KeyPath: key}},
+	}
+	if err := ValidateConfig(cfg, ""); err == nil {
+		t.Fatalf("want nested etcd validation error, got %v", err)
+	}
+}
+
+func TestValidateNodeConfig_MissingSSHUser(t *testing.T) {
+	key := "/tmp/key-no-user"
+	if err := os.WriteFile(key, []byte("k"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+	defer os.Remove(key)
+
+	nc := &NodeConfig{
+		Nodes: []string{"1.1.1.1"},
+		SSH:   SSHConfig{KeyPath: key},
+	}
+	if err := validateNodeConfig(nc); err == nil {
+		t.Fatalf("want sshUser required error, got %v", err)
+	}
+}
+
+func TestValidateNodeConfig_MissingKeyPath(t *testing.T) {
+	nc := &NodeConfig{
+		Nodes: []string{"1.1.1.1"},
+		SSH:   SSHConfig{User: "test"},
+	}
+	if err := validateNodeConfig(nc); err == nil {
+		t.Fatalf("want sshKey required error, got %v", err)
+	}
+}
+
+func TestValidateComponentWithConfig_ValidControlPlane(t *testing.T) {
+	cfg := &RenewalConfig{
+		ClusterName:  "test",
+		OS:           "ubuntu",
+		ControlPlane: NodeConfig{Nodes: []string{"1.1.1.1"}},
+	}
+
+	if err := ValidateComponentWithConfig("control-plane", cfg); err != nil {
+		t.Fatalf("ValidateComponentWithConfig() expected no error for control-plane component, got: %v", err)
+	}
+}
+
+func TestValidateComponentWithConfig_ValidEtcdWithNodes(t *testing.T) {
+	cfg := &RenewalConfig{
+		ClusterName:  "test",
+		OS:           "ubuntu",
+		ControlPlane: NodeConfig{Nodes: []string{"1.1.1.1"}},
+		Etcd:         NodeConfig{Nodes: []string{"2.2.2.2"}},
+	}
+
+	if err := ValidateComponentWithConfig("etcd", cfg); err != nil {
+		t.Fatalf("ValidateComponentWithConfig() expected no error for etcd component with nodes, got: %v", err)
+	}
+}
+
+func TestValidateComponentWithConfig_EmptyComponent(t *testing.T) {
+	cfg := &RenewalConfig{
+		ClusterName:  "test",
+		OS:           "ubuntu",
+		ControlPlane: NodeConfig{Nodes: []string{"1.1.1.1"}},
+	}
+
+	if err := ValidateComponentWithConfig("", cfg); err != nil {
+		t.Fatalf("ValidateComponentWithConfig() expected no error for empty component, got: %v", err)
+	}
+}
+
+func TestPopulateConfig_ExistingNodesEarlyReturn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k := kubemocks.NewMockClient(ctrl)
+
+	cfg := &RenewalConfig{
+		ClusterName: clusterLabel,
+		OS:          string(v1alpha1.Ubuntu),
+		ControlPlane: NodeConfig{
+			Nodes: []string{cpIP},
+			SSH:   SSHConfig{User: "ec2-user", KeyPath: "/test"},
+		},
+	}
+
+	if err := PopulateConfig(context.Background(), cfg, k, &types.Cluster{Name: clusterLabel}); err != nil {
+		t.Fatalf("PopulateConfig() expected no error for early return, got: %v", err)
+	}
+	if len(cfg.ControlPlane.Nodes) != 1 || cfg.ControlPlane.Nodes[0] != cpIP {
+		t.Fatalf("PopulateConfig() should preserve existing ControlPlane.Nodes")
+	}
+}
+
+func createConfigFileFromYAML(t *testing.T, yamlContent string) (string, func()) {
+	t.Helper()
+
+	tmpfile, err := os.CreateTemp("", "config-*.yaml")
+	if err != nil {
+		t.Fatalf("create tmp: %v", err)
+	}
+
+	if _, err := tmpfile.Write([]byte(yamlContent)); err != nil {
+		tmpfile.Close()
+		t.Fatalf("write tmp: %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("close tmp: %v", err)
+	}
+
+	return tmpfile.Name(), func() { os.Remove(tmpfile.Name()) }
 }

--- a/pkg/certificates/os_test.go
+++ b/pkg/certificates/os_test.go
@@ -1,0 +1,36 @@
+package certificates
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildOSRenewer_Linux(t *testing.T) {
+	got := BuildOSRenewer(string(OSTypeLinux), t.TempDir())
+
+	wantType := reflect.TypeOf(&LinuxRenewer{})
+	gotType := reflect.TypeOf(got)
+	if gotType != wantType {
+		t.Fatalf("BuildOSRenewer() for linux expected type %v, got: %v", wantType, gotType)
+	}
+}
+
+func TestBuildOSRenewer_Bottlerocket(t *testing.T) {
+	got := BuildOSRenewer(string(OSTypeBottlerocket), t.TempDir())
+
+	wantType := reflect.TypeOf(&BottlerocketRenewer{})
+	gotType := reflect.TypeOf(got)
+	if gotType != wantType {
+		t.Fatalf("BuildOSRenewer() for bottlerocket expected type %v, got: %v", wantType, gotType)
+	}
+}
+
+func TestBuildOSRenewer_UnknownOSPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("BuildOSRenewer() expected panic for unknown OS type, got none")
+		}
+	}()
+
+	BuildOSRenewer("unknown", t.TempDir())
+}

--- a/pkg/certificates/os_test.go
+++ b/pkg/certificates/os_test.go
@@ -1,14 +1,16 @@
-package certificates
+package certificates_test
 
 import (
 	"reflect"
 	"testing"
+
+	"github.com/aws/eks-anywhere/pkg/certificates"
 )
 
 func TestBuildOSRenewer_Linux(t *testing.T) {
-	got := BuildOSRenewer(string(OSTypeLinux), t.TempDir())
+	got := certificates.BuildOSRenewer(string(certificates.OSTypeLinux), t.TempDir())
 
-	wantType := reflect.TypeOf(&LinuxRenewer{})
+	wantType := reflect.TypeOf(&certificates.LinuxRenewer{})
 	gotType := reflect.TypeOf(got)
 	if gotType != wantType {
 		t.Fatalf("BuildOSRenewer() for linux expected type %v, got: %v", wantType, gotType)
@@ -16,9 +18,9 @@ func TestBuildOSRenewer_Linux(t *testing.T) {
 }
 
 func TestBuildOSRenewer_Bottlerocket(t *testing.T) {
-	got := BuildOSRenewer(string(OSTypeBottlerocket), t.TempDir())
+	got := certificates.BuildOSRenewer(string(certificates.OSTypeBottlerocket), t.TempDir())
 
-	wantType := reflect.TypeOf(&BottlerocketRenewer{})
+	wantType := reflect.TypeOf(&certificates.BottlerocketRenewer{})
 	gotType := reflect.TypeOf(got)
 	if gotType != wantType {
 		t.Fatalf("BuildOSRenewer() for bottlerocket expected type %v, got: %v", wantType, gotType)
@@ -32,5 +34,5 @@ func TestBuildOSRenewer_UnknownOSPanics(t *testing.T) {
 		}
 	}()
 
-	BuildOSRenewer("unknown", t.TempDir())
+	certificates.BuildOSRenewer("unknown", t.TempDir())
 }

--- a/pkg/certificates/renewerbottlerocket_test.go
+++ b/pkg/certificates/renewerbottlerocket_test.go
@@ -322,31 +322,6 @@ func TestBR_RenewCP_WithEtcd_TransferFails(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_WriteCertFail(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	tmp := t.TempDir()
-	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
-	if err := os.MkdirAll(localDir, 0o500); err != nil {
-		t.Fatalf("prep: %v", err)
-	}
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(tmp)
-
-	ctx, node := context.Background(), "etcd"
-
-	gomock.InOrder(
-		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
-		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
-		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
-	)
-
-	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
-		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
-	}
-}
-
 func TestBR_CopyEtcdCertsToLocal_CleanupFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/certificates/renewerbottlerocket_test.go
+++ b/pkg/certificates/renewerbottlerocket_test.go
@@ -98,7 +98,7 @@ func TestBR_TransferCerts_SSHError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(context.Background(), "cp", gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", ssh); err == nil {
 		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
@@ -114,7 +114,7 @@ func TestBR_CopyEtcdCertsToLocal_CopyTmpFail(t *testing.T) {
 
 	ctx, node := context.Background(), "etcd"
 
-	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errBoomTest)
+	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errString)
 
 	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
 		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
@@ -132,7 +132,7 @@ func TestBR_CopyEtcdCertsToLocal_ReadCertFail(t *testing.T) {
 
 	gomock.InOrder(
 		ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", nil),
-		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errBoomTest),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errString),
 	)
 
 	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
@@ -171,7 +171,7 @@ func TestBR_CopyEtcdCertsToLocal_KeyReadFail(t *testing.T) {
 	gomock.InOrder(
 		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
 		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
-		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errBoomTest),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errString),
 	)
 
 	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
@@ -235,7 +235,7 @@ func TestBR_RenewEtcdCerts_BackupError(t *testing.T) {
 
 	ctx, node := context.Background(), "etcd"
 
-	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errBoomTest)
+	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errString)
 
 	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
 		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
@@ -253,7 +253,7 @@ func TestBR_RenewEtcdCerts_RenewError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
 		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
@@ -276,7 +276,7 @@ func TestBR_RenewEtcdCerts_ValidateError(t *testing.T) {
 	ssh.EXPECT().
 		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
 		After(first).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
 		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
@@ -296,7 +296,7 @@ func TestBR_RenewCP_NoEtcd_ShellCommandError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
 		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
@@ -315,7 +315,7 @@ func TestBR_RenewCP_WithEtcd_TransferFails(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
 		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
@@ -336,7 +336,7 @@ func TestBR_CopyEtcdCertsToLocal_CleanupFail(t *testing.T) {
 		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
 		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
 		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
-		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errBoomTest),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errString),
 	)
 
 	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {

--- a/pkg/certificates/renewerbottlerocket_test.go
+++ b/pkg/certificates/renewerbottlerocket_test.go
@@ -26,7 +26,65 @@ func prepareLocalEtcdFiles(t *testing.T, dir string) {
 	}
 }
 
-func TestBR_TransferCerts_Success(t *testing.T) {
+func TestBottlerocketRenewer_RenewControlPlaneCerts_NoEtcd_ShellCommandError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "cp"
+
+	cfg := &certificates.RenewalConfig{}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", errString)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBottlerocketRenewer_RenewControlPlaneCerts_WithEtcd_TransferFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "cp"
+	cfg := &certificates.RenewalConfig{Etcd: certificates.NodeConfig{Nodes: []string{"etcd"}}}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", errString)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBottlerocketRenewer_RenewControlPlaneCerts_NoEtcd_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "cp"
+	cfg := &certificates.RenewalConfig{}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err != nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBottlerocketRenewer_RenewControlPlaneCerts_WithEtcd_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -37,75 +95,97 @@ func TestBR_TransferCerts_Success(t *testing.T) {
 	r := certificates.NewBottlerocketRenewer(tmp)
 
 	ctx, node := context.Background(), "cp"
+	cfg := &certificates.RenewalConfig{Etcd: certificates.NodeConfig{Nodes: []string{"n"}}}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any()).
+		Return("", nil)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err != nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBottlerocketRenewer_RenewEtcdCerts_BackupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errString)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBottlerocketRenewer_RenewEtcdCerts_RenewError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
 
 	ssh.EXPECT().
 		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", nil)
-
-	if err := r.TransferCertsToControlPlaneFromLocal(ctx, node, ssh); err != nil {
-		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected no error, got: %v", err)
-	}
-}
-
-func TestBR_TransferCerts_ReadCertError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	tmp := t.TempDir()
-	local := filepath.Join(tmp, tempLocalEtcdCertsDir)
-	if err := os.MkdirAll(local, 0o700); err != nil {
-		t.Fatalf("failed to create directory: %v", err)
-	}
-
-	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.key"), []byte("key"), 0o600); err != nil {
-		t.Fatalf("failed to write key file: %v", err)
-	}
-
-	r := certificates.NewBottlerocketRenewer(tmp)
-	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", mocks.NewMockSSHRunner(ctrl)); err == nil {
-		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
-	}
-}
-
-func TestBR_TransferCerts_ReadKeyError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	tmp := t.TempDir()
-	local := filepath.Join(tmp, tempLocalEtcdCertsDir)
-	if err := os.MkdirAll(local, 0o700); err != nil {
-		t.Fatalf("failed to create directory: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.crt"), []byte("crt"), 0o600); err != nil {
-		t.Fatalf("failed to write certificate file: %v", err)
-	}
-
-	r := certificates.NewBottlerocketRenewer(tmp)
-	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", mocks.NewMockSSHRunner(ctrl)); err == nil {
-		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
-	}
-}
-
-func TestBR_TransferCerts_SSHError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	tmp := t.TempDir()
-	prepareLocalEtcdFiles(t, tmp)
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(tmp)
-
-	ssh.EXPECT().
-		RunCommand(context.Background(), "cp", gomock.Any(), gomock.Any()).
 		Return("", errString)
 
-	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", ssh); err == nil {
-		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_CopyTmpFail(t *testing.T) {
+func TestBottlerocketRenewer_RenewEtcdCerts_ValidateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	first := ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		After(first).
+		Return("", errString)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBottlerocketRenewer_RenewEtcdCerts_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	first := ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		After(first).
+		Return("", nil)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err != nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_CopyTmpFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -121,7 +201,7 @@ func TestBR_CopyEtcdCertsToLocal_CopyTmpFail(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_ReadCertFail(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_ReadCertFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -140,7 +220,7 @@ func TestBR_CopyEtcdCertsToLocal_ReadCertFail(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_CertEmpty(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_CertEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -159,7 +239,7 @@ func TestBR_CopyEtcdCertsToLocal_CertEmpty(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_KeyReadFail(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_KeyReadFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -179,7 +259,7 @@ func TestBR_CopyEtcdCertsToLocal_KeyReadFail(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_KeyEmpty(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_KeyEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -199,7 +279,7 @@ func TestBR_CopyEtcdCertsToLocal_KeyEmpty(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_LocalDirCreateFail(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_LocalDirCreateFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -226,103 +306,7 @@ func TestBR_CopyEtcdCertsToLocal_LocalDirCreateFail(t *testing.T) {
 	}
 }
 
-func TestBR_RenewEtcdCerts_BackupError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "etcd"
-
-	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errString)
-
-	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
-		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
-	}
-}
-
-func TestBR_RenewEtcdCerts_RenewError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "etcd"
-
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", errString)
-
-	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
-		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
-	}
-}
-
-func TestBR_RenewEtcdCerts_ValidateError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "etcd"
-
-	first := ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", nil)
-
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		After(first).
-		Return("", errString)
-
-	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
-		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
-	}
-}
-
-func TestBR_RenewCP_NoEtcd_ShellCommandError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "cp"
-
-	cfg := &certificates.RenewalConfig{}
-
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", errString)
-
-	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
-		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
-	}
-}
-
-func TestBR_RenewCP_WithEtcd_TransferFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "cp"
-	cfg := &certificates.RenewalConfig{Etcd: certificates.NodeConfig{Nodes: []string{"etcd"}}}
-
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", errString)
-
-	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
-		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
-	}
-}
-
-func TestBR_CopyEtcdCertsToLocal_CleanupFail(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_CleanupFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -344,70 +328,7 @@ func TestBR_CopyEtcdCertsToLocal_CleanupFail(t *testing.T) {
 	}
 }
 
-func TestBR_RenewEtcdCerts_Success(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "etcd"
-
-	first := ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", nil)
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		After(first).
-		Return("", nil)
-
-	if err := r.RenewEtcdCerts(ctx, node, ssh); err != nil {
-		t.Fatalf("RenewEtcdCertsOnOS() expected no error, got: %v", err)
-	}
-}
-
-func TestBR_RenewCP_NoEtcd_Success(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(t.TempDir())
-
-	ctx, node := context.Background(), "cp"
-	cfg := &certificates.RenewalConfig{}
-
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
-		Return("", nil)
-
-	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err != nil {
-		t.Fatalf("RenewControlPlaneCertsOnOS() expected no error, got: %v", err)
-	}
-}
-
-func TestBR_RenewCP_WithEtcd_Success(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	tmp := t.TempDir()
-	prepareLocalEtcdFiles(t, tmp)
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewBottlerocketRenewer(tmp)
-
-	ctx, node := context.Background(), "cp"
-	cfg := &certificates.RenewalConfig{Etcd: certificates.NodeConfig{Nodes: []string{"n"}}}
-
-	ssh.EXPECT().
-		RunCommand(ctx, node, gomock.Any()).
-		Return("", nil)
-
-	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err != nil {
-		t.Fatalf("RenewControlPlaneCertsOnOS() expected no error, got: %v", err)
-	}
-}
-
-func TestBR_CopyEtcdCertsToLocal_WriteKeyFail(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_WriteKeyFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -433,7 +354,7 @@ func TestBR_CopyEtcdCertsToLocal_WriteKeyFail(t *testing.T) {
 	}
 }
 
-func TestBR_CopyEtcdCertsToLocal_Success(t *testing.T) {
+func TestBottlerocketRenewer_CopyEtcdCertsToLocal_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -458,5 +379,84 @@ func TestBR_CopyEtcdCertsToLocal_Success(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(tmp, tempLocalEtcdCertsDir, f)); err != nil {
 			t.Fatalf("expect local %s: %v", f, err)
 		}
+	}
+}
+
+func TestBottlerocketRenewer_TransferCertsToControlPlaneFromLocal_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	prepareLocalEtcdFiles(t, tmp)
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "cp"
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	if err := r.TransferCertsToControlPlaneFromLocal(ctx, node, ssh); err != nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBottlerocketRenewer_TransferCertsToControlPlaneFromLocal_ReadCertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	local := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(local, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.key"), []byte("key"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	r := certificates.NewBottlerocketRenewer(tmp)
+	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", mocks.NewMockSSHRunner(ctrl)); err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
+	}
+}
+
+func TestBottlerocketRenewer_TransferCertsToControlPlaneFromLocal_ReadKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	local := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(local, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.crt"), []byte("crt"), 0o600); err != nil {
+		t.Fatalf("failed to write certificate file: %v", err)
+	}
+
+	r := certificates.NewBottlerocketRenewer(tmp)
+	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", mocks.NewMockSSHRunner(ctrl)); err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
+	}
+}
+
+func TestBottlerocketRenewer_TransferCertsToControlPlaneFromLocal_SSHError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	prepareLocalEtcdFiles(t, tmp)
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(context.Background(), "cp", gomock.Any(), gomock.Any()).
+		Return("", errString)
+
+	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", ssh); err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
 	}
 }

--- a/pkg/certificates/renewerbottlerocket_test.go
+++ b/pkg/certificates/renewerbottlerocket_test.go
@@ -1,0 +1,487 @@
+package certificates_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/aws/eks-anywhere/pkg/certificates"
+	"github.com/aws/eks-anywhere/pkg/certificates/mocks"
+)
+
+func prepareLocalEtcdFiles(t *testing.T, dir string) {
+	t.Helper()
+	local := filepath.Join(dir, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(local, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.crt"), []byte("crt"), 0o600); err != nil {
+		t.Fatalf("failed to write certificate file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.key"), []byte("key"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+}
+
+func TestBR_TransferCerts_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	prepareLocalEtcdFiles(t, tmp)
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "cp"
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	if err := r.TransferCertsToControlPlaneFromLocal(ctx, node, ssh); err != nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBR_TransferCerts_ReadCertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	local := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(local, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.key"), []byte("key"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	r := certificates.NewBottlerocketRenewer(tmp)
+	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", mocks.NewMockSSHRunner(ctrl)); err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
+	}
+}
+
+func TestBR_TransferCerts_ReadKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	local := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(local, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "apiserver-etcd-client.crt"), []byte("crt"), 0o600); err != nil {
+		t.Fatalf("failed to write certificate file: %v", err)
+	}
+
+	r := certificates.NewBottlerocketRenewer(tmp)
+	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", mocks.NewMockSSHRunner(ctrl)); err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
+	}
+}
+
+func TestBR_TransferCerts_SSHError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	prepareLocalEtcdFiles(t, tmp)
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(context.Background(), "cp", gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	if err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp", ssh); err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocalOS() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_CopyTmpFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errBoomTest)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_ReadCertFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errBoomTest),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_CertEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_KeyReadFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errBoomTest),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_KeyEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_LocalDirCreateFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+
+	bad := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.WriteFile(bad, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_RenewEtcdCerts_BackupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	ssh.EXPECT().RunCommand(ctx, node, gomock.Any()).Return("", errBoomTest)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBR_RenewEtcdCerts_RenewError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBR_RenewEtcdCerts_ValidateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	first := ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		After(first).
+		Return("", errBoomTest)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err == nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBR_RenewCP_NoEtcd_ShellCommandError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "cp"
+
+	cfg := &certificates.RenewalConfig{}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBR_RenewCP_WithEtcd_TransferFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "cp"
+	cfg := &certificates.RenewalConfig{Etcd: certificates.NodeConfig{Nodes: []string{"etcd"}}}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err == nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_WriteCertFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(localDir, 0o500); err != nil {
+		t.Fatalf("prep: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_CleanupFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", errBoomTest),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_RenewEtcdCerts_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "etcd"
+
+	first := ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		After(first).
+		Return("", nil)
+
+	if err := r.RenewEtcdCerts(ctx, node, ssh); err != nil {
+		t.Fatalf("RenewEtcdCertsOnOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBR_RenewCP_NoEtcd_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(t.TempDir())
+
+	ctx, node := context.Background(), "cp"
+	cfg := &certificates.RenewalConfig{}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err != nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBR_RenewCP_WithEtcd_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	prepareLocalEtcdFiles(t, tmp)
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "cp"
+	cfg := &certificates.RenewalConfig{Etcd: certificates.NodeConfig{Nodes: []string{"n"}}}
+
+	ssh.EXPECT().
+		RunCommand(ctx, node, gomock.Any()).
+		Return("", nil)
+
+	if err := r.RenewControlPlaneCerts(ctx, node, cfg, "", ssh); err != nil {
+		t.Fatalf("RenewControlPlaneCertsOnOS() expected no error, got: %v", err)
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_WriteKeyFail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(filepath.Join(localDir, "apiserver-etcd-client.key"), 0o700); err != nil {
+		t.Fatalf("prep: %v", err)
+	}
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestBR_CopyEtcdCertsToLocal_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewBottlerocketRenewer(tmp)
+
+	ctx, node := context.Background(), "etcd"
+
+	gomock.InOrder(
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("crt", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("key", nil),
+		ssh.EXPECT().RunCommand(ctx, node, gomock.Any(), gomock.Any()).Return("", nil),
+	)
+
+	if err := r.CopyEtcdCertsToLocal(ctx, node, ssh); err != nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected no error, got: %v", err)
+	}
+
+	for _, f := range []string{"apiserver-etcd-client.crt", "apiserver-etcd-client.key"} {
+		if _, err := os.Stat(filepath.Join(tmp, tempLocalEtcdCertsDir, f)); err != nil {
+			t.Fatalf("expect local %s: %v", f, err)
+		}
+	}
+}

--- a/pkg/certificates/renewerubuntu_test.go
+++ b/pkg/certificates/renewerubuntu_test.go
@@ -410,37 +410,6 @@ func TestCopyEtcdCertsToLocalWithMkdirError(t *testing.T) {
 	}
 }
 
-func TestCopyEtcdCertsToLocalWithWriteCertError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	tmp := t.TempDir()
-	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
-	if err := os.MkdirAll(localDir, 0o700); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	if err := os.Chmod(localDir, 0o500); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	ssh := mocks.NewMockSSHRunner(ctrl)
-	r := certificates.NewLinuxRenewer(tmp)
-
-	ssh.EXPECT().
-		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
-		Return("cert", nil)
-
-	ssh.EXPECT().
-		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
-		Return("key", nil)
-
-	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
-	if err == nil {
-		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
-	}
-}
-
 func TestTransferCertsToControlPlaneWithReadKeyError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/certificates/renewerubuntu_test.go
+++ b/pkg/certificates/renewerubuntu_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
 	"testing"
 
 	"github.com/golang/mock/gomock"

--- a/pkg/certificates/renewerubuntu_test.go
+++ b/pkg/certificates/renewerubuntu_test.go
@@ -14,59 +14,7 @@ import (
 	kubemocks "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
 )
 
-var errBoomTest = fmt.Errorf("boom-test")
-
-func TestNewRenewerWithEtcdSSHError(t *testing.T) {
-	cfg := &certificates.RenewalConfig{
-		ClusterName: "test-cluster",
-		OS:          string(certificates.OSTypeLinux),
-		Etcd: certificates.NodeConfig{
-			Nodes: []string{"etcd-1"},
-			SSH: certificates.SSHConfig{
-				User:    "",
-				KeyPath: "/non-existent-path",
-			},
-		},
-		ControlPlane: certificates.NodeConfig{
-			Nodes: []string{"cp-1"},
-			SSH: certificates.SSHConfig{
-				User:    "user",
-				KeyPath: "key-path",
-			},
-		},
-	}
-
-	kubeClient := kubemocks.NewMockClient(nil)
-
-	_, err := certificates.NewRenewer(kubeClient, cfg.OS, cfg)
-	if err == nil {
-		t.Fatal("NewRenewer() expected error, got nil")
-	}
-}
-
-func TestNewRenewerWithControlPlaneSSHError(t *testing.T) {
-	cfg := &certificates.RenewalConfig{
-		ClusterName: "test-cluster",
-		OS:          string(certificates.OSTypeLinux),
-		Etcd: certificates.NodeConfig{
-			Nodes: []string{},
-		},
-		ControlPlane: certificates.NodeConfig{
-			Nodes: []string{"cp-1"},
-			SSH: certificates.SSHConfig{
-				User:    "",
-				KeyPath: "/non-existent-path",
-			},
-		},
-	}
-
-	kubeClient := kubemocks.NewMockClient(nil)
-
-	_, err := certificates.NewRenewer(kubeClient, cfg.OS, cfg)
-	if err == nil {
-		t.Fatal("NewRenewer() expected error, got nil")
-	}
-}
+var errString = fmt.Errorf("error")
 
 func TestRenewControlPlaneCertsWithRenewError(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -90,7 +38,7 @@ func TestRenewControlPlaneCertsWithRenewError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	renewer := &certificates.Renewer{
 		BackupDir:       t.TempDir(),
@@ -130,7 +78,7 @@ func TestRenewControlPlaneCertsWithExternalEtcdValidationError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	renewer := &certificates.Renewer{
 		BackupDir:       t.TempDir(),
@@ -166,7 +114,7 @@ func TestRenewEtcdCertsWithJoinError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	renewer := &certificates.Renewer{
 		BackupDir: t.TempDir(),
@@ -206,7 +154,7 @@ func TestRenewEtcdCertsWithValidateError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	renewer := &certificates.Renewer{
 		BackupDir: t.TempDir(),
@@ -243,7 +191,7 @@ func TestRenewControlPlaneCertsWithExternalEtcdTransferError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	err := r.RenewControlPlaneCerts(context.Background(), "cp-1", cfg, "", ssh)
 	if err == nil {
@@ -323,7 +271,7 @@ func TestTransferCertsToControlPlaneWithCopyCertError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp-1", ssh)
 	if err == nil {
@@ -354,7 +302,7 @@ func TestRenewControlPlaneCertsWithRestartPodsError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	err := r.RenewControlPlaneCerts(context.Background(), "cp-1", cfg, "", ssh)
 	if err == nil {
@@ -375,7 +323,7 @@ func TestCopyEtcdCertsToLocalWithReadKeyError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
 	if err == nil {
@@ -449,7 +397,7 @@ func TestTransferCertsToControlPlaneWithCopyKeyError(t *testing.T) {
 
 	ssh.EXPECT().
 		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
-		Return("", errBoomTest)
+		Return("", errString)
 
 	err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp-1", ssh)
 	if err == nil {

--- a/pkg/certificates/renewerubuntu_test.go
+++ b/pkg/certificates/renewerubuntu_test.go
@@ -1,0 +1,527 @@
+package certificates_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/aws/eks-anywhere/pkg/certificates"
+	"github.com/aws/eks-anywhere/pkg/certificates/mocks"
+	kubemocks "github.com/aws/eks-anywhere/pkg/clients/kubernetes/mocks"
+)
+
+var errBoomTest = fmt.Errorf("boom-test")
+
+func TestNewRenewerWithEtcdSSHError(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+			SSH: certificates.SSHConfig{
+				User:    "",
+				KeyPath: "/non-existent-path",
+			},
+		},
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+			SSH: certificates.SSHConfig{
+				User:    "user",
+				KeyPath: "key-path",
+			},
+		},
+	}
+
+	kubeClient := kubemocks.NewMockClient(nil)
+
+	_, err := certificates.NewRenewer(kubeClient, cfg.OS, cfg)
+	if err == nil {
+		t.Fatal("NewRenewer() expected error, got nil")
+	}
+}
+
+func TestNewRenewerWithControlPlaneSSHError(t *testing.T) {
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{},
+		},
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+			SSH: certificates.SSHConfig{
+				User:    "",
+				KeyPath: "/non-existent-path",
+			},
+		},
+	}
+
+	kubeClient := kubemocks.NewMockClient(nil)
+
+	_, err := certificates.NewRenewer(kubeClient, cfg.OS, cfg)
+	if err == nil {
+		t.Fatal("NewRenewer() expected error, got nil")
+	}
+}
+
+func TestRenewControlPlaneCertsWithRenewError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		OS:              osRenewer,
+		SSHControlPlane: ssh,
+	}
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, "control-plane"); err == nil {
+		t.Fatalf("RenewCertificates() expected error, got nil")
+	}
+}
+
+func TestRenewControlPlaneCertsWithExternalEtcdValidationError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		ControlPlane: certificates.NodeConfig{
+			Nodes: []string{"cp-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	renewer := &certificates.Renewer{
+		BackupDir:       t.TempDir(),
+		Kubectl:         kubeClient,
+		OS:              osRenewer,
+		SSHControlPlane: ssh,
+	}
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, "control-plane"); err == nil {
+		t.Fatalf("RenewCertificates() expected error, got nil")
+	}
+}
+
+func TestRenewEtcdCertsWithJoinError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Kubectl:   kubeClient,
+		OS:        osRenewer,
+		SSHEtcd:   ssh,
+	}
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err == nil {
+		t.Fatalf("RenewCertificates() expected error, got nil")
+	}
+}
+
+func TestRenewEtcdCertsWithValidateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	cfg := &certificates.RenewalConfig{
+		ClusterName: "test-cluster",
+		OS:          string(certificates.OSTypeLinux),
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+		},
+	}
+
+	osRenewer := certificates.BuildOSRenewer(cfg.OS, t.TempDir())
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	kubeClient := kubemocks.NewMockClient(ctrl)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	renewer := &certificates.Renewer{
+		BackupDir: t.TempDir(),
+		Kubectl:   kubeClient,
+		OS:        osRenewer,
+		SSHEtcd:   ssh,
+	}
+
+	if err := renewer.RenewCertificates(context.Background(), cfg, ""); err == nil {
+		t.Fatalf("RenewCertificates() expected error, got nil")
+	}
+}
+
+func TestRenewControlPlaneCertsWithExternalEtcdTransferError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := &certificates.RenewalConfig{
+		Etcd: certificates.NodeConfig{
+			Nodes: []string{"etcd-1"},
+		},
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(t.TempDir())
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	err := r.RenewControlPlaneCerts(context.Background(), "cp-1", cfg, "", ssh)
+	if err == nil {
+		t.Fatalf("RenewControlPlaneCerts() expected error, got nil")
+	}
+}
+
+func TestCopyEtcdCertsToLocalWithEmptyCert(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(t.TempDir())
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
+	if err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestCopyEtcdCertsToLocalWithEmptyKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(t.TempDir())
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("cert", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
+	if err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestTransferCertsToControlPlaneWithReadCertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(t.TempDir())
+
+	err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp-1", ssh)
+	if err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocal() expected error, got nil")
+	}
+}
+
+func TestTransferCertsToControlPlaneWithCopyCertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "apiserver-etcd-client.crt"), []byte("crt"), 0o600); err != nil {
+		t.Fatalf("failed to write certificate file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "apiserver-etcd-client.key"), []byte("key"), 0o600); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp-1", ssh)
+	if err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocal() expected error, got nil")
+	}
+}
+
+func TestRenewControlPlaneCertsWithRestartPodsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := &certificates.RenewalConfig{}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(t.TempDir())
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	err := r.RenewControlPlaneCerts(context.Background(), "cp-1", cfg, "", ssh)
+	if err == nil {
+		t.Fatalf("RenewControlPlaneCerts() expected error, got nil")
+	}
+}
+
+func TestCopyEtcdCertsToLocalWithReadKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(t.TempDir())
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("cert", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
+	if err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestCopyEtcdCertsToLocalWithMkdirError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	badDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.WriteFile(badDir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("cert", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("key", nil)
+
+	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
+	if err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestCopyEtcdCertsToLocalWithWriteCertError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if err := os.Chmod(localDir, 0o500); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("cert", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("key", nil)
+
+	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
+	if err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}
+
+func TestTransferCertsToControlPlaneWithReadKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(localDir, "apiserver-etcd-client.crt"), []byte("crt"), 0o600); err != nil {
+		t.Fatalf("failed to write certificate file: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(tmp)
+
+	err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp-1", ssh)
+	if err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocal() expected error, got nil")
+	}
+}
+
+func TestTransferCertsToControlPlaneWithCopyKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	writeDummyEtcdCerts(t, tmp)
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "cp-1", gomock.Any(), gomock.Any()).
+		Return("", errBoomTest)
+
+	err := r.TransferCertsToControlPlaneFromLocal(context.Background(), "cp-1", ssh)
+	if err == nil {
+		t.Fatalf("TransferCertsToControlPlaneFromLocal() expected error, got nil")
+	}
+}
+
+func TestCopyEtcdCertsToLocalWithWriteKeyError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, tempLocalEtcdCertsDir)
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	certPath := filepath.Join(localDir, "apiserver-etcd-client.crt")
+	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
+		t.Fatalf("failed to write certificate file: %v", err)
+	}
+
+	keyPath := filepath.Join(localDir, "apiserver-etcd-client.key")
+	if err := os.Mkdir(keyPath, 0o755); err != nil {
+		t.Fatalf("setup key conflict: %v", err)
+	}
+
+	ssh := mocks.NewMockSSHRunner(ctrl)
+	r := certificates.NewLinuxRenewer(tmp)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("cert", nil)
+
+	ssh.EXPECT().
+		RunCommand(gomock.Any(), "etcd-1", gomock.Any(), gomock.Any()).
+		Return("key", nil)
+
+	err := r.CopyEtcdCertsToLocal(context.Background(), "etcd-1", ssh)
+	if err == nil {
+		t.Fatalf("CopyEtcdCertsToLocal() expected error, got nil")
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds unit tests for certificate renewal functionality, covering the implementation in renewerbottlerocket.go, renewerubuntu.go, config.go, and os.go files.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

