### PR TITLE
Enable control plane tolerations for Tinkerbell stack components

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -553,15 +553,27 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 		tink: map[string]interface{}{
 			controller: map[string]interface{}{
 				image: bundle.TinkerbellStack.Tink.TinkController.URI,
+				"singleNodeClusterConfig": map[string]interface{}{
+					"controlPlaneTolerationsEnabled": true,
+					"nodeAffinityWeight":             1,
+				},
 			},
 			server: map[string]interface{}{
 				image: bundle.TinkerbellStack.Tink.TinkServer.URI,
+				"singleNodeClusterConfig": map[string]interface{}{
+					"controlPlaneTolerationsEnabled": true,
+					"nodeAffinityWeight":             1,
+				},
 			},
 		},
 		hegel: map[string]interface{}{
 			image: bundle.TinkerbellStack.Hegel.URI,
 			"trustedProxies": []string{
 				s.podCidrRange,
+			},
+			"singleNodeClusterConfig": map[string]interface{}{
+				"controlPlaneTolerationsEnabled": true,
+				"nodeAffinityWeight":             1,
 			},
 		},
 		smee: map[string]interface{}{
@@ -593,6 +605,10 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 				"staticIPAMEnabled": true,
 				"url":               isoURL,
 			},
+			"singleNodeClusterConfig": map[string]interface{}{
+				"controlPlaneTolerationsEnabled": true,
+				"nodeAffinityWeight":             1,
+			},
 		},
 		rufio: map[string]interface{}{
 			image: bundle.TinkerbellStack.Rufio.URI,
@@ -600,9 +616,17 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 				"-metrics-bind-address=127.0.0.1:8080",
 				fmt.Sprintf("-max-concurrent-reconciles=%v", rufioMaxConcurrentReconciles),
 			},
+			"singleNodeClusterConfig": map[string]interface{}{
+				"controlPlaneTolerationsEnabled": true,
+				"nodeAffinityWeight":             1,
+			},
 		},
 		stack: map[string]interface{}{
 			image: bundle.TinkerbellStack.Tink.Nginx.URI,
+			"singleNodeClusterConfig": map[string]interface{}{
+				"controlPlaneTolerationsEnabled": true,
+				"nodeAffinityWeight":             1,
+			},
 			kubevip: map[string]interface{}{
 				image:   bundle.KubeVip.URI,
 				enabled: s.loadBalancer,

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -17,15 +23,18 @@ smee:
       port: ""
       scheme: https
     tinkServer:
+      insecureTLS: true
       ip: 1.2.3.4
       port: "42113"
-      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   iso:
     enabled: true
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -20,15 +26,18 @@ smee:
       port: ""
       scheme: https
     tinkServer:
+      insecureTLS: true
       ip: 1.2.3.4
       port: "42113"
-      insecureTLS: true
   image: public.ecr.aws/eks-anywhere/boots:latest
   iso:
     enabled: true
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -52,8 +61,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: false
   http:
@@ -27,6 +33,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -50,8 +59,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: false
   http:
@@ -27,6 +33,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -50,8 +59,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://my-local-web-server/hook.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -49,8 +58,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -26,6 +32,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -50,8 +59,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -29,6 +35,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -52,8 +61,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -1,5 +1,8 @@
 hegel:
   image: public.ecr.aws/eks-anywhere/hegel:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   trustedProxies:
   - 192.168.0.0/16
 rufio:
@@ -7,6 +10,9 @@ rufio:
   - -metrics-bind-address=127.0.0.1:8080
   - -max-concurrent-reconciles=10
   image: public.ecr.aws/eks-anywhere/rufio:latest
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 smee:
   deploy: true
   http:
@@ -29,6 +35,9 @@ smee:
     staticIPAMEnabled: true
     url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
   publicIP: 1.2.3.4
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
   tinkWorkerImage: 1.2.3.4:443/custom/eks-anywhere/tink-worker:latest
   trustedProxies:
   - 192.168.0.0/16
@@ -52,8 +61,17 @@ stack:
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
   service:
     enabled: false
+  singleNodeClusterConfig:
+    controlPlaneTolerationsEnabled: true
+    nodeAffinityWeight: 1
 tink:
   controller:
     image: public.ecr.aws/eks-anywhere/tink-controller:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1
   server:
     image: public.ecr.aws/eks-anywhere/tink-server:latest
+    singleNodeClusterConfig:
+      controlPlaneTolerationsEnabled: true
+      nodeAffinityWeight: 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change enables the controlPlaneTolerationsEnabled flag for all Tinkerbell stack components in the values override for the Tinkerbell Helm chart.

When enabled, this flag adds tolerations for the control plane taint while maintaining a preference for worker nodes through node affinity rules. This allows the Tinkerbell stack to be scheduled on control plane nodes when necessary (e.g., when worker nodes are unavailable), while still preferring worker nodes under normal circumstances.

This change restores the behavior that was present in EKS-A 0.19, where the Tinkerbell stack could be installed on both control plane and worker nodes, ensuring better availability during cluster lifecycle operations.

*Testing (if applicable):*
Built cli and controller and ran a upgrade to new stack while making the worker node unavailable. Observed Tink stack getting scheduled on the worker nodes. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

