### PR TITLE
Add missing copy packages cmd to fix e2e test

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -13,6 +13,7 @@ const (
 	EksaPackageControllerHelmVersion   = "0.2.20-eks-a-v0.0.0-dev-build.4894"
 	EksaPackageBundleURI               = "oci://" + EksaPackagesSourceRegistry + "/eks-anywhere-packages-bundles"
 	EksaPackagesNamespace              = "eksa-packages"
+	EksaPackagesRegistry               = "067575901363.dkr.ecr.us-west-2.amazonaws.com"
 
 	clusterNamespace = "test-namespace"
 

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -52,7 +52,7 @@ func runDisabledCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) 
 }
 
 func runCuratedPackageInstallSimpleFlowRegistryMirror(test *framework.ClusterE2ETest) {
-	test.WithClusterRegistryMirror(runCuratedPackageInstall)
+	test.WithClusterRegistryMirror(EksaPackagesSourceRegistry, EksaPackagesRegistry, runCuratedPackageInstall)
 }
 
 func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2846,6 +2846,11 @@ func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube129),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  EksaPackagesRegistry,
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }
@@ -2863,6 +2868,11 @@ func TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube130),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  EksaPackagesRegistry,
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }
@@ -2880,6 +2890,11 @@ func TestVSphereKubernetes131UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube131),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  EksaPackagesRegistry,
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }
@@ -2897,6 +2912,11 @@ func TestVSphereKubernetes132UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube132),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  EksaPackagesRegistry,
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }
@@ -2914,6 +2934,11 @@ func TestVSphereKubernetes133UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube133),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
 			EksaPackageControllerHelmVersion, EksaPackageControllerHelmValues, nil),
+		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName,
+			v1alpha1.OCINamespace{
+				Registry:  EksaPackagesRegistry,
+				Namespace: "",
+			}),
 	)
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }

--- a/test/framework/registry_mirror.go
+++ b/test/framework/registry_mirror.go
@@ -65,7 +65,7 @@ func WithRegistryMirrorEndpointAndCert(providerName string) ClusterE2ETestOpt {
 }
 
 // WithRegistryMirrorOciNamespaces sets up e2e for registry mirrors with ocinamespaces.
-func WithRegistryMirrorOciNamespaces(providerName string) ClusterE2ETestOpt {
+func WithRegistryMirrorOciNamespaces(providerName string, optNamespaces ...v1alpha1.OCINamespace) ClusterE2ETestOpt {
 	return func(e *ClusterE2ETest) {
 		var ociNamespaces []v1alpha1.OCINamespace
 
@@ -83,6 +83,7 @@ func WithRegistryMirrorOciNamespaces(providerName string) ClusterE2ETestOpt {
 				Namespace: ns2val,
 			})
 		}
+		ociNamespaces = append(ociNamespaces, optNamespaces...)
 
 		setupRegistryMirrorEndpointAndCert(e, providerName, false, ociNamespaces...)
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3276

*Description of changes:*
Packages registry mirror e2e tests have been failing forever as we were not setting up the environment correctly. We missed copy packages to the registry mirror and adding an entry in ociNamespaces for the packages registry. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

