### PR TITLE
Configure audit policy for control plane via cluster spec

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -165,6 +165,11 @@ spec:
                     description: APIServerExtraArgs defines the flags to configure
                       for the API server.
                     type: object
+                  auditPolicyContent:
+                    description: |-
+                      AuditPolicyContent defines the audit policy configuration as a string.
+                      If not specified, the default audit policy will be used.
+                    type: string
                   certSans:
                     description: |-
                       CertSANs is a slice of domain names or IPs to be added as Subject Name Alternatives of the

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4119,6 +4119,11 @@ spec:
                     description: APIServerExtraArgs defines the flags to configure
                       for the API server.
                     type: object
+                  auditPolicyContent:
+                    description: |-
+                      AuditPolicyContent defines the audit policy configuration as a string.
+                      If not specified, the default audit policy will be used.
+                    type: string
                   certSans:
                     description: |-
                       CertSANs is a slice of domain names or IPs to be added as Subject Name Alternatives of the

--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -196,6 +196,7 @@ var clusterConfigValidations = []func(*Cluster) error{
 	validateControlPlaneAPIServerOIDCExtraArgs,
 	validateControlPlaneKubeletConfiguration,
 	validateWorkerNodeKubeletConfiguration,
+	validateAuditPolicyContent,
 }
 
 // GetClusterConfig parses a Cluster object from a multiobject yaml file in disk
@@ -564,6 +565,17 @@ func validateWorkerNodeKubeletConfiguration(clusterConfig *Cluster) error {
 		}
 	}
 
+	return nil
+}
+
+func validateAuditPolicyContent(c *Cluster) error {
+	if c.Spec.ControlPlaneConfiguration.AuditPolicyContent != "" {
+		var yamlObj interface{}
+		err := yaml.Unmarshal([]byte(c.Spec.ControlPlaneConfiguration.AuditPolicyContent), &yamlObj)
+		if err != nil {
+			return fmt.Errorf("invalid YAML in auditPolicyContent: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -321,6 +321,10 @@ type ControlPlaneConfiguration struct {
 	// KubeletConfiguration is a struct that exposes the Kubelet settings for the user to set on control plane nodes.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	KubeletConfiguration *unstructured.Unstructured `json:"kubeletConfiguration,omitempty"`
+	// AuditPolicyContent defines the audit policy configuration as a string.
+	// If not specified, the default audit policy will be used.
+	// +optional
+	AuditPolicyContent string `json:"auditPolicyContent,omitempty"`
 }
 
 // MachineHealthCheck allows to configure timeouts for machine health checks. Machine Health Checks are responsible for remediating unhealthy Machines.
@@ -377,7 +381,8 @@ func (n *ControlPlaneConfiguration) Equal(o *ControlPlaneConfiguration) bool {
 	}
 	return n.Count == o.Count && n.MachineGroupRef.Equal(o.MachineGroupRef) &&
 		TaintsSliceEqual(n.Taints, o.Taints) && MapEqual(n.Labels, o.Labels) &&
-		SliceEqual(n.CertSANs, o.CertSANs) && MapEqual(n.APIServerExtraArgs, o.APIServerExtraArgs)
+		SliceEqual(n.CertSANs, o.CertSANs) && MapEqual(n.APIServerExtraArgs, o.APIServerExtraArgs) &&
+		n.AuditPolicyContent == o.AuditPolicyContent
 }
 
 type Endpoint struct {

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -198,11 +198,15 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"eksaSystemNamespace":                        constants.EksaSystemNamespace,
 	}
 
-	auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
-	if err != nil {
-		return nil, err
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent != "" {
+		values["auditPolicy"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent
+	} else {
+		auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+		if err != nil {
+			return nil, err
+		}
+		values["auditPolicy"] = auditPolicy
 	}
-	values["auditPolicy"] = auditPolicy
 
 	fillDiskOffering(values, controlPlaneMachineSpec.DiskOffering, "ControlPlane")
 	fillDiskOffering(values, etcdMachineSpec.DiskOffering, "Etcd")

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -170,9 +170,15 @@ func buildTemplateMapCP(
 		Append(clusterapi.EtcdEncryptionExtraArgs(clusterSpec.Cluster.Spec.EtcdEncryption))
 	clusterapi.SetPodIAMAuthExtraArgs(clusterSpec.Cluster.Spec.PodIAMConfig, apiServerExtraArgs)
 
-	auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
-	if err != nil {
-		return nil, err
+	var auditPolicy string
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent != "" {
+		auditPolicy = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent
+	} else {
+		var err error
+		auditPolicy, err = common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	failureDomains := generateNutanixFailureDomains(datacenterSpec.FailureDomains)

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -386,9 +386,15 @@ func buildTemplateMapCP(
 	etcdTemplateOverride string,
 	datacenterSpec v1alpha1.TinkerbellDatacenterConfigSpec,
 ) (map[string]interface{}, error) {
-	auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
-	if err != nil {
-		return nil, err
+	var auditPolicy string
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent != "" {
+		auditPolicy = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent
+	} else {
+		var err error
+		auditPolicy, err = common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	versionsBundle := clusterSpec.RootVersionsBundle()

--- a/pkg/providers/tinkerbell/template_test.go
+++ b/pkg/providers/tinkerbell/template_test.go
@@ -1,6 +1,7 @@
 package tinkerbell
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/providers/common"
 	"github.com/aws/eks-anywhere/pkg/utils/ptr"
 )
 
@@ -361,4 +363,66 @@ func TestTemplateBuilderMDHookIso(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		test.AssertContentToFile(t, string(data), tc.Output)
 	}
+}
+
+func TestTinkerbellTemplateBuilderGenerateCAPISpecControlPlaneWithCustomAuditPolicy(t *testing.T) {
+	g := NewWithT(t)
+	clusterSpec := test.NewFullClusterSpec(t, testClusterConfigFilename)
+
+	customAuditPolicy := `apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata
+  omitStages:
+  - RequestReceived`
+
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent = customAuditPolicy
+
+	cpMachineCfg, err := getControlPlaneMachineSpec(clusterSpec)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	wngMachineCfgs, err := getWorkerNodeGroupMachineSpec(clusterSpec)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	tinkIPBefore := "0.0.0.0"
+	bldr := NewTemplateBuilder(&clusterSpec.TinkerbellDatacenter.Spec, cpMachineCfg, nil, wngMachineCfgs, tinkIPBefore, time.Now)
+
+	data, err := bldr.GenerateCAPISpecControlPlane(clusterSpec)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	str := collapseWhitespace(string(data))
+	g.Expect(str).To(ContainSubstring(collapseWhitespace(customAuditPolicy)))
+
+	defaultAuditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(str).ToNot(ContainSubstring(collapseWhitespace(defaultAuditPolicy)))
+}
+
+func TestTinkerbellTemplateBuilderGenerateCAPISpecControlPlaneWithDefaultAuditPolicy(t *testing.T) {
+	g := NewWithT(t)
+	clusterSpec := test.NewFullClusterSpec(t, testClusterConfigFilename)
+
+	clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent = ""
+
+	cpMachineCfg, err := getControlPlaneMachineSpec(clusterSpec)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	wngMachineCfgs, err := getWorkerNodeGroupMachineSpec(clusterSpec)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	tinkIPBefore := "0.0.0.0"
+	bldr := NewTemplateBuilder(&clusterSpec.TinkerbellDatacenter.Spec, cpMachineCfg, nil, wngMachineCfgs, tinkIPBefore, time.Now)
+
+	data, err := bldr.GenerateCAPISpecControlPlane(clusterSpec)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	str := collapseWhitespace(string(data))
+
+	defaultAuditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(str).To(ContainSubstring(collapseWhitespace(defaultAuditPolicy)))
+}
+
+func collapseWhitespace(s string) string {
+	return regexp.MustCompile(`\s+`).ReplaceAllString(s, " ")
 }

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -240,11 +240,15 @@ func buildTemplateMapCP(
 		"etcdCloneMode":                        etcdMachineSpec.CloneMode,
 	}
 
-	auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
-	if err != nil {
-		return nil, err
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent != "" {
+		values["auditPolicy"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.AuditPolicyContent
+	} else {
+		auditPolicy, err := common.GetAuditPolicy(clusterSpec.Cluster.Spec.KubernetesVersion)
+		if err != nil {
+			return nil, err
+		}
+		values["auditPolicy"] = auditPolicy
 	}
-	values["auditPolicy"] = auditPolicy
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)


### PR DESCRIPTION
*Description of changes:*
Allow creating audit policy for control plane nodes.

Currently the audit policy used by EKS Anywhere cluster is defined by in https://github.com/aws/eks-anywhere/blob/main/pkg/providers/common/auditpolicy.go

The only way to modify audit-policy is to ssh to the control plane node, update /etc/kuberenets/audit-policy.yaml file and restart API Server pod. This changes get lost upon upgrading the cluster.

This PR allows defining custom audit policy through cluster spec while creating/upgrading cluster.

```
spec:
  controlPlaneConfiguration:
    auditPolicyContent: |
      apiVersion: audit.k8s.io/v1
      kind: Policy
      rules:
      # Audit policy rules...
```

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

