### PR TITLE
fix registry mirror alias for curated package e2e

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -8,7 +8,8 @@ import (
 
 const (
 	EksaPackageControllerHelmChartName = "eks-anywhere-packages"
-	EksaPackagesSourceRegistry         = "public.ecr.aws/l0g8r8j6"
+	EksaDevRegistryAlias               = "l0g8r8j6"
+	EksaPackagesSourceRegistry         = "public.ecr.aws/" + EksaDevRegistryAlias
 	EksaPackageControllerHelmURI       = "oci://" + EksaPackagesSourceRegistry + "/eks-anywhere-packages"
 	EksaPackageControllerHelmVersion   = "0.2.20-eks-a-v0.0.0-dev-build.4894"
 	EksaPackageBundleURI               = "oci://" + EksaPackagesSourceRegistry + "/eks-anywhere-packages-bundles"

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -52,7 +52,7 @@ func runDisabledCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) 
 }
 
 func runCuratedPackageInstallSimpleFlowRegistryMirror(test *framework.ClusterE2ETest) {
-	test.WithClusterRegistryMirror(EksaPackagesSourceRegistry, EksaPackagesRegistry, runCuratedPackageInstall)
+	test.WithClusterRegistryMirror(EksaDevRegistryAlias, EksaPackagesSourceRegistry, EksaPackagesRegistry, runCuratedPackageInstall)
 }
 
 func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2845,7 +2845,7 @@ func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: "",
+				Namespace: EksaDevRegistryAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube129),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2866,7 +2866,7 @@ func TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: "",
+				Namespace: EksaDevRegistryAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube130),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2887,7 +2887,7 @@ func TestVSphereKubernetes131UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: "",
+				Namespace: EksaDevRegistryAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube131),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2908,7 +2908,7 @@ func TestVSphereKubernetes132UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: "",
+				Namespace: EksaDevRegistryAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube132),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2929,7 +2929,7 @@ func TestVSphereKubernetes133UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: "",
+				Namespace: EksaDevRegistryAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube133),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -682,7 +682,7 @@ func (e *ClusterE2ETest) ImportImages(opts ...CommandOpt) {
 }
 
 // CopyPackages runs the EKS-A `copy packages` command to copy curated packages to the registry mirror.
-func (e *ClusterE2ETest) CopyPackages(packageChartRegistry string, packageRegistry string, opts ...CommandOpt) {
+func (e *ClusterE2ETest) CopyPackages(packageMirrorAlias string, packageChartRegistry string, packageRegistry string, opts ...CommandOpt) {
 	clusterConfig := e.ClusterConfig.Cluster
 	registyMirrorEndpoint, registryMirrorPort := clusterConfig.Spec.RegistryMirrorConfiguration.Endpoint, clusterConfig.Spec.RegistryMirrorConfiguration.Port
 	registryMirrorHost := net.JoinHostPort(registyMirrorEndpoint, registryMirrorPort)
@@ -691,7 +691,7 @@ func (e *ClusterE2ETest) CopyPackages(packageChartRegistry string, packageRegist
 
 	copyPackagesArgs := []string{
 		"copy", "packages",
-		registryMirrorHost,
+		registryMirrorHost + "/" + packageMirrorAlias,
 		"--kube-version", kubeVersion,
 		"--src-chart-registry", packageChartRegistry,
 		"--src-image-registry", packageRegistry,
@@ -1345,13 +1345,13 @@ func (e *ClusterE2ETest) WithCluster(f func(e *ClusterE2ETest)) {
 }
 
 // WithClusterRegistryMirror helps with bringing up and tearing down E2E test clusters when using registry mirror.
-func (e *ClusterE2ETest) WithClusterRegistryMirror(packageChartRegistry string, packageRegistry string, f func(e *ClusterE2ETest)) {
+func (e *ClusterE2ETest) WithClusterRegistryMirror(packageMirrorAlias string, packageChartRegistry string, packageRegistry string, f func(e *ClusterE2ETest)) {
 	e.GenerateClusterConfig()
 	e.DownloadArtifacts()
 	e.ExtractDownloadedArtifacts()
 	e.DownloadImages()
 	e.ImportImages()
-	e.CopyPackages(packageChartRegistry, packageRegistry)
+	e.CopyPackages(packageMirrorAlias, packageChartRegistry, packageRegistry)
 	e.CreateCluster(WithBundlesOverride(bundleReleasePathFromArtifacts))
 	defer func() {
 		e.GenerateSupportBundleIfTestFailed()


### PR DESCRIPTION
*Description of changes:*
AuthenticatedRegistryMirrorCuratedPackagesSimpleFlow test currently fails with error as it's trying to copy images into root of the mirror registry. This PR changes the destination project for package images. 

```
Error: cannot copy chart to repo: HEAD "https://196.18.89.98:443/v2/eks-anywhere-packages/manifests/sha256:14a559d530534fbc8af7ecfb520ad24f04be0e01ea319a3d9f569d3fd47709f9": response status code 400: Bad Request
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

