### PR TITLE
fix: install pkg ctlr not using helm chart from bundles override

### DIFF
--- a/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
+++ b/cmd/eksctl-anywhere/cmd/installpackagecontroller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/pkg/validations"
@@ -54,7 +55,11 @@ func runInstallPackageController(cmd *cobra.Command, args []string) error {
 func installPackageController(ctx context.Context) error {
 	kubeConfig := kubeconfig.FromEnvironment()
 
-	clusterSpec, err := readAndValidateClusterSpec(ico.fileName, version.Get())
+	var opts []cluster.FileSpecBuilderOpt
+	if ico.bundlesOverride != "" {
+		opts = append(opts, cluster.WithOverrideBundlesManifest(ico.bundlesOverride))
+	}
+	clusterSpec, err := readAndValidateClusterSpec(ico.fileName, version.Get(), opts...)
 	if err != nil {
 		return fmt.Errorf("the cluster config file provided is invalid: %v", err)
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3528

*Description of changes:*
Install package controller is not using the packages helm chart from bundles-override. This PR fixes that. 

*Testing (if applicable):*
Created a test cluster in vsphere and reinstalled package controller with custom helm chart. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

