### PR TITLE
Fix tinkerbell airgapped proxy tests

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -46,6 +46,8 @@ const (
 	vsphereInvalidResourcePoolUpdateVar = "*/Resources/INVALID-ResourcePool"
 	vsphereResourcePoolVar              = "T_VSPHERE_RESOURCE_POOL"
 	TinkerbellHardwareCountFile         = "TINKERBELL_HARDWARE_COUNT.yaml"
+	TinkerbellHookOSImagesURLPath       = "http://10.80.18.43:8080/hook"
+	TinkerbellNoProxyCIDR               = "10.80.0.0/16"
 )
 
 var (

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -2684,7 +2684,7 @@ func TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
 		t,
 		framework.NewTinkerbell(t,
 			framework.WithUbuntu132Tinkerbell(),
-			framework.WithHookImagesURLPath("http://"+localIp.String()+":8080"),
+			framework.WithHookImagesURLPath(TinkerbellHookOSImagesURLPath),
 		),
 		framework.WithClusterFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube132),
@@ -2694,7 +2694,7 @@ func TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
 		framework.WithProxy(framework.TinkerbellProxyRequiredEnvVars),
 	)
 
-	runTinkerbellAirgapConfigProxyFlow(test, "10.80.0.0/16", kubeVersion)
+	runTinkerbellAirgapConfigProxyFlow(test, TinkerbellNoProxyCIDR, kubeVersion)
 }
 
 func TestTinkerbellAirgappedKubernetes133UbuntuProxyConfigFlow(t *testing.T) {
@@ -2710,7 +2710,7 @@ func TestTinkerbellAirgappedKubernetes133UbuntuProxyConfigFlow(t *testing.T) {
 		t,
 		framework.NewTinkerbell(t,
 			framework.WithUbuntu133Tinkerbell(),
-			framework.WithHookImagesURLPath("http://"+localIp.String()+":8080"),
+			framework.WithHookImagesURLPath(TinkerbellHookOSImagesURLPath),
 		),
 		framework.WithClusterFiller(
 			api.WithKubernetesVersion(v1alpha1.Kube133),
@@ -2720,7 +2720,7 @@ func TestTinkerbellAirgappedKubernetes133UbuntuProxyConfigFlow(t *testing.T) {
 		framework.WithProxy(framework.TinkerbellProxyRequiredEnvVars),
 	)
 
-	runTinkerbellAirgapConfigProxyFlow(test, "10.80.0.0/16", kubeVersion)
+	runTinkerbellAirgapConfigProxyFlow(test, TinkerbellNoProxyCIDR, kubeVersion)
 }
 
 // OOB tests


### PR DESCRIPTION
*Issue #, if available:*
[#3277](https://github.com/aws/eks-anywhere-internal/issues/3277)

*Description of changes:*
This PR fixes the tinkerbell airgapped proxy tests by using the correct image URL path for the hook OS. The test was using a non-existent IP address which was the admin machine assigned to Jacob before but it doesn't exist anymore. That's why the test has been failing to bring up the control plane nodes since it is not able to install hookOS.

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
make e2e-tests-binary
```
Manually ran `TestTinkerbellAirgappedKubernetes133UbuntuProxyConfigFlow` test through Codebuild job and it passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

