### PR TITLE
Use the correct dev public registry for registry mirror packages tests

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	EksaPackageControllerHelmChartName = "eks-anywhere-packages"
-	EksaDevRegistryAlias               = "l0g8r8j6"
+	EksaDevRegistryAlias               = "x3k6m8v0"
 	EksaPackagesSourceRegistry         = "public.ecr.aws/" + EksaDevRegistryAlias
 	EksaPackageControllerHelmURI       = "oci://" + EksaPackagesSourceRegistry + "/eks-anywhere-packages"
 	EksaPackageControllerHelmVersion   = "0.2.20-eks-a-v0.0.0-dev-build.4894"


### PR DESCRIPTION
*Issue #, if available:*
[#3276](https://github.com/aws/eks-anywhere-internal/issues/3276)

*Description of changes:*
The `TestVSphereKubernetes132UbuntuAuthenticatedRegistryMirrorCuratedPackagesSimpleFlow` test is failing with the following error:
```
Error: cannot fetch package bundle: public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles:v1-32-latest: not found
    cluster.go:995: Command failed, scanning output for error
    cluster.go:1015: Command eksctl anywhere [copy packages 196.18.89.98:443/l0g8r8j6 --kube-version 1.32 --src-chart-registry public.ecr.aws/l0g8r8j6 --src-image-registry 067575901363.dkr.ecr.us-west-2.amazonaws.com --dst-insecure] failed with error: exit status 255: Error: cannot fetch package bundle: public.ecr.aws/l0g8r8j6/eks-anywhere-packages-bundles:v1-32-latest: not found
```
This is because the EKS-A CLI installs the helm chart from the packages beta account public ECR and the packages images are being released to that registry as well when we updated it in [#9550](https://github.com/aws/eks-anywhere/pull/9550).

This PR updates the e2e tests to use the correct dev public registry for registry mirror tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

