### PR TITLE
Pull locally embedded tink-worker image

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -47,6 +47,9 @@ const (
 	service                      = "service"
 	relay                        = "relay"
 	smeeHTTPPort                 = "7171"
+
+	// localTinkWorkerImage is the path to the tink-worker image in the hook-OS.
+	localTinkWorkerImage = "127.0.0.1/embedded/tink-worker"
 )
 
 type Docker interface {
@@ -297,7 +300,7 @@ func (s *Installer) installBootsOnDocker(ctx context.Context, bundle releasev1al
 func (s *Installer) getSmeeKernelArgs(bundle releasev1alpha1.TinkerbellStackBundle) []string {
 	extraKernelArgs := []string{}
 	if s.bootsOnDocker {
-		extraKernelArgs = append(extraKernelArgs, fmt.Sprintf("tink_worker_image=%s", s.localRegistryURL(bundle.Tink.TinkWorker.URI)))
+		extraKernelArgs = append(extraKernelArgs, fmt.Sprintf("tink_worker_image=%s", localTinkWorkerImage))
 	}
 
 	if s.registryMirror != nil {
@@ -597,7 +600,7 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 				},
 				"additionalKernelArgs": bootEnv,
 			},
-			"tinkWorkerImage": s.localRegistryURL(bundle.TinkerbellStack.Tink.TinkWorker.URI),
+			"tinkWorkerImage": localTinkWorkerImage,
 			"iso": map[string]interface{}{
 				// it's safe to populate the URL and default to true as rufio jobs for mounting and booting
 				// from iso happens only when bootmode is set to iso on tinkerbellmachinetemplate

--- a/pkg/providers/tinkerbell/stack/testdata/expected_tinkerbell_chart_overrides_with_all_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_tinkerbell_chart_overrides_with_all_options.yaml
@@ -11,7 +11,7 @@ boots:
     - name: TINKERBELL_GRPC_AUTHORITY
       value: 1.2.3.4:42113
     - name: BOOTS_EXTRA_KERNEL_ARGS
-      value: tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
+      value: tink_worker_image=127.0.0.1/embedded/tink-worker
   image: public.ecr.aws/eks-anywhere/boots:latest
 createNamespace: true
 envoy:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -38,7 +38,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -17,7 +17,7 @@ smee:
   deploy: false
   http:
     additionalKernelArgs:
-    - tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
+    - tink_worker_image=127.0.0.1/embedded/tink-worker
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook
@@ -36,7 +36,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -17,7 +17,7 @@ smee:
   deploy: false
   http:
     additionalKernelArgs:
-    - tink_worker_image=public.ecr.aws/eks-anywhere/tink-worker:latest
+    - tink_worker_image=127.0.0.1/embedded/tink-worker
     osieUrl:
       host: anywhere-assests.eks.amazonaws.com
       path: /tinkerbell/hook
@@ -36,7 +36,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -35,7 +35,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -38,7 +38,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: public.ecr.aws/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -38,7 +38,7 @@ smee:
   singleNodeClusterConfig:
     controlPlaneTolerationsEnabled: true
     nodeAffinityWeight: 1
-  tinkWorkerImage: 1.2.3.4:443/custom/eks-anywhere/tink-worker:latest
+  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
   trustedProxies:
   - 192.168.0.0/16
 stack:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tink-worker image gets embedded into Hook-OS at build time. Pull the locally embedded image to circumvent against airgapped scenarios.

*Testing (if applicable):*
Tested with locally building cli and controller. 
 
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

