### PR TITLE
Fix e2e test failures after bumping eks distro release

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,3 +19,4 @@ ignore:
   - "internal/aws-sdk-go-v2"
   - "**/mock_*.go"
   - pkg/curatedpackages/curatedpackages.go
+  - cmd/eksctl-anywhere/cmd/internal/commands/artifacts/import.go

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1547,7 +1547,6 @@ func createEKSDReleaseStatus() eksdv1alpha1.ReleaseStatus {
 		Components: []eksdv1alpha1.Component{
 			createKubernetesComponent(),
 			createEtcdComponent(),
-			createCSIComponent(),
 		},
 	}
 }
@@ -1562,28 +1561,6 @@ func createKubernetesComponent() eksdv1alpha1.Component {
 					URI: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.32.0-eks-1-32-1",
 				},
 			},
-		},
-	}
-}
-
-func createEtcdComponent() eksdv1alpha1.Component {
-	return eksdv1alpha1.Component{
-		Name:   "etcd",
-		GitTag: "v3.5.0",
-		Assets: []eksdv1alpha1.Asset{
-			{
-				Name: "etcd-image",
-				Image: &eksdv1alpha1.AssetImage{
-					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.0-eks-1-32-1",
-				},
-			},
-		},
-	}
-}
-
-func createCSIComponent() eksdv1alpha1.Component {
-	return eksdv1alpha1.Component{
-		Assets: []eksdv1alpha1.Asset{
 			{
 				Name: "pause-image",
 				Image: &eksdv1alpha1.AssetImage{
@@ -1606,6 +1583,21 @@ func createCSIComponent() eksdv1alpha1.Component {
 				Name: "kube-proxy-image",
 				Image: &eksdv1alpha1.AssetImage{
 					URI: "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.32.0-eks-1-32-1",
+				},
+			},
+		},
+	}
+}
+
+func createEtcdComponent() eksdv1alpha1.Component {
+	return eksdv1alpha1.Component{
+		Name:   "etcd",
+		GitTag: "v3.5.0",
+		Assets: []eksdv1alpha1.Asset{
+			{
+				Name: "etcd-image",
+				Image: &eksdv1alpha1.AssetImage{
+					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.0-eks-1-32-1",
 				},
 			},
 		},

--- a/controllers/controlplaneupgrade_controller_test.go
+++ b/controllers/controlplaneupgrade_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -700,7 +700,7 @@ func generateKcpSpec() *controlplanev1.KubeadmControlPlaneSpec {
 		RolloutStrategy: &controlplanev1.RolloutStrategy{
 			Type: "InPlace",
 		},
-		Replicas: pointer.Int32(3),
+		Replicas: ptr.To(int32(3)),
 		MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
 			InfrastructureRef: corev1.ObjectReference{
 				Name: "new-ref",

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -328,7 +328,7 @@ func generateKCP(name string) *controlplanev1.KubeadmControlPlane {
 					},
 				},
 			},
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To(int32(3)),
 			Version:  k8s129,
 		},
 	}

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1059,7 +1059,7 @@ func (k *Kubectl) getPodLogs(ctx context.Context, namespace, podName, containerN
 	}
 	logs := stdOut.String()
 	if strings.Contains(logs, "Internal Error") {
-		return "", fmt.Errorf("Fetched log contains \"Internal Error\": %q", logs)
+		return "", fmt.Errorf("fetched log contains \"Internal Error\": %q", logs)
 	}
 	return logs, err
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -759,16 +759,6 @@ func (e *ClusterE2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion)
 	if err != nil {
 		e.T.Fatal(err)
 	}
-	e.T.Log("Validating cluster node version")
-	err = retrier.Retry(180, 1*time.Second, func() error {
-		if err = e.KubectlClient.ValidateNodesVersion(ctx, e.Cluster().KubeconfigFile, kubeVersion); err != nil {
-			return fmt.Errorf("validating nodes version: %v", err)
-		}
-		return nil
-	})
-	if err != nil {
-		e.T.Fatal(err)
-	}
 }
 
 func (e *ClusterE2ETest) WaitForMachineDeploymentReady(machineDeploymentName string) {


### PR DESCRIPTION
#### Issue
All the registry mirror tests are failing with the following error after the eks distro release version bump:
```
Error: writing images to destination with image mover: image processor worker failed, rest of jobs were aborted: unauthorized: project csi-components not found: project csi-components not found
```
This is because the latest EKS-D release removed all the CSI sidecar projects in [#3931](https://github.com/aws/eks-distro/pull/3931) but the csi-component images are still referenced in the manifest pointing to the [csi-components](https://gallery.ecr.aws/csi-components) registry instead of the original [eks-distro](https://gallery.ecr.aws/eks-distro) registry.

All the upgrade tests are failing with the following error after the eks distro release version bump:
```
cluster.go:770: validating nodes version: validating node version: kubernetes version v1.32.7-eks-5f95b3c does not match expected version 1.33
```
This is because there is a moment after upgrading the cluster where all nodes are ready but there is still an old worker node. This one is ready as well since there is a bit of delay between the latest new worker node coming up and the old one being deleted (it's a rolling update with max surge=1, so old nodes are not deleted until new ones are ready). If the `ValidateNodes` validation is run at that moment, it will pass. However, `ValidateNodesVersion` will fail since there is still one node with the old kube version.

Ref:- https://github.com/aws/eks-anywhere/pull/36/files#r700708117

This should also fix the Nutanix upgrade tests which failed with the above validation in a flaky manner
(Ref:- https://tiny.amazon.com/139zz9a7b/quipv0U1Mode)

#### Description of changes
This PR does the following changes to fix the above issues:
- Filter out CSI component images during import images command as they're not used by EKS Anywhere
- Removes the `ValidateNodesVersion` validation after upgrade as the nodes are indeed ready and upgrade is successful
- Removes that CSI component method and move its contents to the Kubernetes component method as there's nothing CSI-specific in that method anymore

#### Testing
```
# Build the EKS Anywhere CLI binary and test binaries
make eks-a
make build-all-test-binaries

# Run the linter to catch any code style issues or potential bugs
make lint

# Run unit tests to verify that the changes don't break existing functionality
make unit-test

# Download EKS-A artifacts
./bin/eksctl-anywhere download artifacts -v 9

# Extract the downloaded artifacts from the tarball
tar -xvf eks-anywhere-downloads.tar.gz

# Clean up the tarball after extraction
rm eks-anywhere-downloads.tar.gz

# Authenticate with AWS ECR Public to be able to pull container images
aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws

# Download container images and packages into a single tarball
./bin/eksctl-anywhere download images -o images.tar -v 9

# Import the downloaded images to the private registry
./bin/eksctl-anywhere import images --input images.tar --bundles ./eks-anywhere-downloads/bundle-release.yaml --registry 10.80.148.51:443 --insecure -v 9
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

