### PR TITLE
[release-0.22] Fix e2e test failures after bumping eks distro release

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,3 +18,5 @@ ignore:
   - "test/framework" 
   - "internal/aws-sdk-go-v2"
   - "**/mock_*.go"
+  - pkg/curatedpackages/curatedpackages.go
+  - cmd/eksctl-anywhere/cmd/internal/commands/artifacts/import.go

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1542,7 +1542,6 @@ func createEKSDReleaseStatus() eksdv1alpha1.ReleaseStatus {
 		Components: []eksdv1alpha1.Component{
 			createKubernetesComponent(),
 			createEtcdComponent(),
-			createCSIComponent(),
 		},
 	}
 }
@@ -1557,28 +1556,6 @@ func createKubernetesComponent() eksdv1alpha1.Component {
 					URI: "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.32.0-eks-1-32-1",
 				},
 			},
-		},
-	}
-}
-
-func createEtcdComponent() eksdv1alpha1.Component {
-	return eksdv1alpha1.Component{
-		Name:   "etcd",
-		GitTag: "v3.5.0",
-		Assets: []eksdv1alpha1.Asset{
-			{
-				Name: "etcd-image",
-				Image: &eksdv1alpha1.AssetImage{
-					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.0-eks-1-32-1",
-				},
-			},
-		},
-	}
-}
-
-func createCSIComponent() eksdv1alpha1.Component {
-	return eksdv1alpha1.Component{
-		Assets: []eksdv1alpha1.Asset{
 			{
 				Name: "pause-image",
 				Image: &eksdv1alpha1.AssetImage{
@@ -1601,6 +1578,21 @@ func createCSIComponent() eksdv1alpha1.Component {
 				Name: "kube-proxy-image",
 				Image: &eksdv1alpha1.AssetImage{
 					URI: "public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.32.0-eks-1-32-1",
+				},
+			},
+		},
+	}
+}
+
+func createEtcdComponent() eksdv1alpha1.Component {
+	return eksdv1alpha1.Component{
+		Name:   "etcd",
+		GitTag: "v3.5.0",
+		Assets: []eksdv1alpha1.Asset{
+			{
+				Name: "etcd-image",
+				Image: &eksdv1alpha1.AssetImage{
+					URI: "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.0-eks-1-32-1",
 				},
 			},
 		},

--- a/controllers/controlplaneupgrade_controller_test.go
+++ b/controllers/controlplaneupgrade_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -700,7 +700,7 @@ func generateKcpSpec() *controlplanev1.KubeadmControlPlaneSpec {
 		RolloutStrategy: &controlplanev1.RolloutStrategy{
 			Type: "InPlace",
 		},
-		Replicas: pointer.Int32(3),
+		Replicas: ptr.To(int32(3)),
 		MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
 			InfrastructureRef: corev1.ObjectReference{
 				Name: "new-ref",

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -328,7 +328,7 @@ func generateKCP(name string) *controlplanev1.KubeadmControlPlane {
 					},
 				},
 			},
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To(int32(3)),
 			Version:  k8s129,
 		},
 	}

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -1059,7 +1059,7 @@ func (k *Kubectl) getPodLogs(ctx context.Context, namespace, podName, containerN
 	}
 	logs := stdOut.String()
 	if strings.Contains(logs, "Internal Error") {
-		return "", fmt.Errorf("Fetched log contains \"Internal Error\": %q", logs)
+		return "", fmt.Errorf("fetched log contains \"Internal Error\": %q", logs)
 	}
 	return logs, err
 }

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -736,16 +736,6 @@ func (e *ClusterE2ETest) ValidateCluster(kubeVersion v1alpha1.KubernetesVersion)
 	if err != nil {
 		e.T.Fatal(err)
 	}
-	e.T.Log("Validating cluster node version")
-	err = retrier.Retry(180, 1*time.Second, func() error {
-		if err = e.KubectlClient.ValidateNodesVersion(ctx, e.Cluster().KubeconfigFile, kubeVersion); err != nil {
-			return fmt.Errorf("validating nodes version: %v", err)
-		}
-		return nil
-	})
-	if err != nil {
-		e.T.Fatal(err)
-	}
 }
 
 func (e *ClusterE2ETest) WaitForMachineDeploymentReady(machineDeploymentName string) {


### PR DESCRIPTION
*Description of changes:*
This is a manual cherry-pick of [#10044](https://github.com/aws/eks-anywhere/pull/10044) to release-0.22 branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

