### PR TITLE
Update admin conf file path for Ubuntu and RHEL

### DIFF
--- a/docs/content/en/docs/clustermgmt/certificate-management/manual-steps-renew-certs.md
+++ b/docs/content/en/docs/clustermgmt/certificate-management/manual-steps-renew-certs.md
@@ -206,9 +206,9 @@ If this occurs, update `kubelet-client-current.pem` by running the following com
 
 {{< tabpane >}}
 {{< tab header="Ubuntu or RHEL" lang="bash" >}}
-cat /var/lib/kubeadm/admin.conf | grep client-certificate-data: | sed 's/^.*: //' | base64 -d > /var/lib/kubelet/pki/kubelet-client-current.pem
+cat /etc/kubernetes/admin.conf | grep client-certificate-data: | sed 's/^.*: //' | base64 -d > /var/lib/kubelet/pki/kubelet-client-current.pem
 
-cat /var/lib/kubeadm/admin.conf | grep client-key-data: | sed 's/^.*: //' | base64 -d >> /var/lib/kubelet/pki/kubelet-client-current.pem
+cat /etc/kubernetes/admin.conf | grep client-key-data: | sed 's/^.*: //' | base64 -d >> /var/lib/kubelet/pki/kubelet-client-current.pem
 
 systemctl restart kubelet
 

--- a/docs/content/en/docs/clustermgmt/certificate-management/manual-steps-renew-certs.md
+++ b/docs/content/en/docs/clustermgmt/certificate-management/manual-steps-renew-certs.md
@@ -310,8 +310,8 @@ ssh -i <YOUR_PRIVATE_KEY> <USER_NAME>@<YOUR_CONTROLPLANE_IP> # USER_NAME should 
 
 export CLUSTER_NAME="<YOUR_CLUSTER_NAME_HERE>"
 
-cat /var/lib/kubeadm/admin.conf
-export KUBECONFIG="/var/lib/kubeadm/admin.conf"
+cat /etc/kubernetes/admin.conf
+export KUBECONFIG="/etc/kubernetes/admin.conf"
 
 kubectl get secret ${CLUSTER_NAME}-kubeconfig -n eksa-system -o yaml -o=jsonpath="{.data.value}" | base64 --decode > /tmp/user-admin.kubeconfig
 


### PR DESCRIPTION
*Description of changes:*
For Ubuntu and RHEL OS, the admin kubeconfig volume path is `/etc/kubernetes/admin.conf`. Updating our docs to the correct path.

*Testing (if applicable):*
Ex: [Tinkerbell template](https://github.com/aws/eks-anywhere/blob/main/pkg/providers/tinkerbell/config/template-cp.yaml#L329-L333)

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

