### PR TITLE
Fix failing pkg registry docker login for pkg reg mirror e2e

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	EksaPackageControllerHelmChartName = "eks-anywhere-packages"
-	EksaDevRegistryAlias               = "x3k6m8v0"
-	EksaPackagesSourceRegistry         = "public.ecr.aws/" + EksaDevRegistryAlias
+	EksaPackagesRegistryMirrorAlias    = "curated-packages"
+	EksaPackagesSourceRegistry         = "public.ecr.aws/x3k6m8v0"
 	EksaPackageControllerHelmURI       = "oci://" + EksaPackagesSourceRegistry + "/eks-anywhere-packages"
 	EksaPackageControllerHelmVersion   = "0.2.20-eks-a-v0.0.0-dev-build.4894"
 	EksaPackageBundleURI               = "oci://" + EksaPackagesSourceRegistry + "/eks-anywhere-packages-bundles"

--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -52,7 +52,7 @@ func runDisabledCuratedPackageInstallSimpleFlow(test *framework.ClusterE2ETest) 
 }
 
 func runCuratedPackageInstallSimpleFlowRegistryMirror(test *framework.ClusterE2ETest) {
-	test.WithClusterRegistryMirror(EksaDevRegistryAlias, EksaPackagesSourceRegistry, EksaPackagesRegistry, runCuratedPackageInstall)
+	test.WithClusterRegistryMirror(EksaPackagesRegistryMirrorAlias, EksaPackagesSourceRegistry, EksaPackagesRegistry, runCuratedPackageInstall)
 }
 
 func runCuratedPackageRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2ETest) {

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -2845,7 +2845,7 @@ func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: EksaDevRegistryAlias,
+				Namespace: EksaPackagesRegistryMirrorAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube129),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2866,7 +2866,7 @@ func TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: EksaDevRegistryAlias,
+				Namespace: EksaPackagesRegistryMirrorAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube130),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2887,7 +2887,7 @@ func TestVSphereKubernetes131UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: EksaDevRegistryAlias,
+				Namespace: EksaPackagesRegistryMirrorAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube131),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2908,7 +2908,7 @@ func TestVSphereKubernetes132UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: EksaDevRegistryAlias,
+				Namespace: EksaPackagesRegistryMirrorAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube132),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,
@@ -2929,7 +2929,7 @@ func TestVSphereKubernetes133UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName,
 			v1alpha1.OCINamespace{
 				Registry:  EksaPackagesRegistry,
-				Namespace: EksaDevRegistryAlias,
+				Namespace: EksaPackagesRegistryMirrorAlias,
 			}),
 		framework.WithPackageConfig(t, packageBundleURI(v1alpha1.Kube133),
 			EksaPackageControllerHelmChartName, EksaPackageControllerHelmURI,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3276

*Description of changes:*
Fixes failing docker login as fetching ecr login-password was failing 
```
failed to fetch authorization token from ECR for registry 067575901363.dkr.ecr.us-west-2.amazonaws.com : %!w(*smithy.OperationError=&{ECR GetAuthorizationToken 0xc000c020f0})
```

*Testing (if applicable):*
```
./bin/e2e.test -test.run 'TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirrorCuratedPackagesSimpleFlow' -test.v 9
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

