### PR TITLE
Add management cluster name for renew certificates command

### DIFF
--- a/cmd/eksctl-anywhere/cmd/renewcertificates.go
+++ b/cmd/eksctl-anywhere/cmd/renewcertificates.go
@@ -58,12 +58,17 @@ func (rc *renewCertificatesOptions) renewCertificates(cmd *cobra.Command, _ []st
 	}
 
 	kubeCfgPath := kubeconfig.FromClusterName(cfg.ClusterName)
+	if cfg.ManagementClusterName != "" {
+		kubeCfgPath, err = getManagementClusterKubeconfig(cfg.ManagementClusterName)
+		if err != nil {
+			return err
+		}
+	}
 
 	kubeClient := deps.UnAuthKubeClient.KubeconfigClient(kubeCfgPath)
 
 	cluster := &types.Cluster{
-		Name:           cfg.ClusterName,
-		KubeconfigFile: kubeCfgPath,
+		Name: cfg.ClusterName,
 	}
 
 	if err := certificates.PopulateConfig(ctx, cfg, kubeClient, cluster); err != nil {

--- a/cmd/eksctl-anywhere/cmd/renewcertificates_test.go
+++ b/cmd/eksctl-anywhere/cmd/renewcertificates_test.go
@@ -15,6 +15,7 @@ import (
 var (
 	validConfigYaml = `
 clusterName: test-cluster
+managementCluster: mgmt-cluster
 os: ubuntu
 controlPlane:
   nodes:

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -33,10 +33,11 @@ type NodeConfig struct {
 
 // RenewalConfig defines the configuration for certificate renewal operations.
 type RenewalConfig struct {
-	ClusterName  string     `yaml:"clusterName"`
-	OS           string     `yaml:"os"`
-	ControlPlane NodeConfig `yaml:"controlPlane"`
-	Etcd         NodeConfig `yaml:"etcd"`
+	ClusterName           string     `yaml:"clusterName"`
+	ManagementClusterName string     `yaml:"managementCluster"`
+	OS                    string     `yaml:"os"`
+	ControlPlane          NodeConfig `yaml:"controlPlane"`
+	Etcd                  NodeConfig `yaml:"etcd"`
 }
 
 // ParseConfig reads and parses a certificate renewal configuration file.


### PR DESCRIPTION
*Description of changes:*
For workload cluster, for certificate renewal, the command used to fail with error 
```
error: the server doesn't have a resource type \"Machine\"\n"}
Error: cluster is not reachable, please provide control plane and/or external etcd IP addresses: listing machines: getting Machine.v1beta1.cluster.x-k8s.io
```

This PR adds a new field named `managementCluster` if the cluster for which we are renewing certs is a workload cluster to avoid running into this error.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*
I will create a separate PR for the doc change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

