### PR TITLE
Fix CloudStack test panic for Kubernetes 1.32/1.33 versions

### DIFF
--- a/test/framework/cloudstack.go
+++ b/test/framework/cloudstack.go
@@ -491,6 +491,10 @@ func (c *CloudStack) WithRedhatVersion(version anywherev1.KubernetesVersion) api
 		return c.WithRedhat130()
 	case anywherev1.Kube131:
 		return c.WithRedhat131()
+	case anywherev1.Kube132:
+		return c.WithRedhat9Kubernetes132()
+	case anywherev1.Kube133:
+		return c.WithRedhat9Kubernetes133()
 	default:
 		return nil
 	}


### PR DESCRIPTION
*Description of changes:*
The `TestCloudStackKubernetes133MulticlusterWorkloadClusterAPI` test was failing with a nil pointer dereference panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1f569d2]

github.com/aws/eks-anywhere/test/e2e.cloudStackAPIUpdateTestBaseStep.JoinClusterConfigFillers.func6(0xc0009af180)
	/codebuild/output/src839300286/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere/internal/pkg/api/cluster.go:32 +0x32
```

The CloudStack.WithRedhatVersion() method was missing support for Kubernetes versions 1.32 and 1.33. When these versions were passed to the method, it would return nil from the default case in the switch statement. This nil value was then passed to JoinClusterConfigFillers(), which attempted to call the nil function pointer, causing the panic.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

