### PR TITLE
Fix metallb BGPConfiguration e2e test

### DIFF
--- a/test/e2e/metallb.go
+++ b/test/e2e/metallb.go
@@ -258,7 +258,6 @@ spec:
       - myASN: 123
         peerASN: 55001
         peerAddress: 12.2.4.2
-        keepaliveTime: 30s
 `, test.ClusterName, ipTwoSub, ipSub))
 			err := WaitForPackageToBeInstalled(test, ctx, packagePrefix, 120*time.Second)
 			if err != nil {
@@ -319,7 +318,7 @@ spec:
 				t.Fatal(err)
 			}
 
-			expectedBGPPeer := `{"disableMP":false,"keepaliveTime":"30s","myASN":123,"peerASN":55001,"peerAddress":"12.2.4.2","peerPort":179}`
+			expectedBGPPeer := `{"disableMP":false,"dualStackAddressFamily":false,"myASN":123,"peerASN":55001,"peerAddress":"12.2.4.2","peerPort":179}`
 			err = WaitForResource(
 				test,
 				ctx,


### PR DESCRIPTION
*Description of changes:*
- Remove `keepaliveTime` from the configuration
  - configuration of `keepaliveTime` is not supported in BGP native mode
    -  The speaker log is complaining about the `keepaliveTime` configuration
          ```
          {"caller":"config_controller.go:140","controller":"ConfigReconciler","error":"peer 12.2.4.2 has keepalive-time set on native bgp mode","level":"error","ts":"2025-09-02T23:29:04Z"}
          ```
    - [Upstream Source](https://github.com/metallb/metallb/blob/aa2fa5744e4bcd7ce5c44c8d3ba60c4fa360d303/internal/config/validation.go#L39)
- Change the expected output for the configuration
  - In metallb v0.15.2, they added support for flag dualStackFamily defaults to false. This results in `bgppeers.metallb.io` to have an extra expected value `"dualStackAddressFamily":false` in its spec, which differs from the statically defined "expected" in [here](https://github.com/aws/eks-anywhere/blob/main/test/e2e/metallb.go#L322). 
 
    - Previous expected output:
        ```
        {"disableMP":false,"keepaliveTime":"30s","myASN":123,"peerASN":55001,"peerAddress":"12.2.4.2","peerPort":179}
        ```
     - Current expected output:
        ```
        {"disableMP":false,"dualStackAddressFamily":false,"myASN":123,"peerASN":55001,"peerAddress":"12.2.4.2","peerPort":179}
        ```

*Testing (if applicable):*
- Run e2e test and it pass
  -   [Link](https://857151390494-utheasob.us-west-2.console.aws.amazon.com/codesuite/codebuild/857151390494/projects/aws-eks-anywhere-test-docker/build/aws-eks-anywhere-test-docker%3A67f764e2-7978-46d3-b17f-85dcec56b81c/config?region=us-west-2) for e2e test on CodeBuild

*Documentation added/planned (if applicable):*
- If we include metallb v0.15.2 in our next package release, will update the package doc on the configuration change in the new version v0.15.2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

