### PR TITLE
Fix regional package registries with registry mirror

### DIFF
--- a/pkg/clusterapi/registry_mirror_test.go
+++ b/pkg/clusterapi/registry_mirror_test.go
@@ -45,7 +45,7 @@ var registryMirrorTests = []struct {
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
 				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
     endpoint = ["https://1.2.3.4:443/v2/curated-packages"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
     endpoint = ["https://1.2.3.4:443/v2/eks-anywhere"]

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -77,8 +77,8 @@ const (
 	// DefaultCuratedPackagesRegistry matches the default registry for curated packages in all regions.
 	DefaultCuratedPackagesRegistryRegex = `783794618700\.dkr\.ecr\..*\.amazonaws\.com`
 
-	// DefaultcuratedPackagesRegistry is a containerd compatible registry format that matches all AWS regions.
-	DefaultCuratedPackagesRegistry = "783794618700.dkr.ecr.*.amazonaws.com"
+	// DefaultcuratedPackagesRegistry is the default registry used by earlier customers using non-regional registry.
+	DefaultCuratedPackagesRegistry = "783794618700.dkr.ecr.us-west-2.amazonaws.com"
 
 	// Provider specific env vars.
 	VSphereUsernameKey     = "VSPHERE_USERNAME"

--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -244,26 +245,40 @@ func (pc *PackageControllerClient) Enable(ctx context.Context) error {
 func (pc *PackageControllerClient) GetCuratedPackagesRegistries(ctx context.Context) (sourceRegistry, defaultRegistry, defaultImageRegistry string) {
 	sourceRegistry = prodPublicRegistryURI
 	defaultImageRegistry = prodNonRegionalPrivateRegistryURI
-	registry := prodPublicRegistryAlias
+	eksaPackagesPublicAlias := prodPublicRegistryAlias
 	if strings.Contains(pc.chart.Image(), devRegionalPublicRegistryAlias) {
-		registry = devRegionalPublicRegistryAlias
+		eksaPackagesPublicAlias = devRegionalPublicRegistryAlias
 		defaultImageRegistry = devRegionalPrivateRegistryURI
 		sourceRegistry = devRegionalPublicRegistryURI
 	}
 	if strings.Contains(pc.chart.Image(), stagingPublicRegistryAlias) {
-		registry = stagingPublicRegistryAlias
+		eksaPackagesPublicAlias = stagingPublicRegistryAlias
 		defaultImageRegistry = devRegionalPrivateRegistryURI
 		sourceRegistry = stagingPublicRegistryURI
 	}
 	defaultRegistry = sourceRegistry
 
+	// If registry mirror is configured, admin machine may be airgapped.
+	// We will use registry mirror configuration as source of truth to decide package registries
 	if pc.registryMirror != nil {
-		// registry name is added as part of sourceRegistry field in package controller helm chart
-		// https://github.com/aws/eks-anywhere-packages/blob/main/charts/eks-anywhere-packages/values.yaml#L15-L18
-		sourceRegistry = fmt.Sprintf("%s/%s", pc.registryMirror.CoreEKSAMirror(), registry)
-		defaultRegistry = fmt.Sprintf("%s/%s", pc.registryMirror.CoreEKSAMirror(), registry)
-		if gatedOCINamespace := pc.registryMirror.CuratedPackagesMirror(); gatedOCINamespace != "" {
-			defaultImageRegistry = gatedOCINamespace
+		sourceRegistry = fmt.Sprintf("%s/%s", pc.registryMirror.CoreEKSAMirror(), eksaPackagesPublicAlias)
+
+		nonRegionalRegistryMatcher := regexp.MustCompile(constants.DefaultCuratedPackagesRegistryRegex)
+		for registry, mirrorURI := range pc.registryMirror.NamespacedRegistryMap {
+			if nonRegionalRegistryMatcher.MatchString(registry) {
+				// registry name is added as part of sourceRegistry field in package controller helm chart
+				// https://github.com/aws/eks-anywhere-packages/blob/main/charts/eks-anywhere-packages/values.yaml#L15-L18
+				defaultRegistry = fmt.Sprintf("%s/%s", pc.registryMirror.CoreEKSAMirror(), eksaPackagesPublicAlias)
+				defaultImageRegistry = mirrorURI
+				break
+			}
+		}
+		for _, regionalRegistry := range getAllEnvRegionalPrivateRegistryURIs() {
+			if mirrorURI := pc.registryMirror.NamespacedRegistryMap[regionalRegistry]; mirrorURI != "" {
+				defaultRegistry = mirrorURI
+				defaultImageRegistry = mirrorURI
+				break
+			}
 		}
 	} else {
 		if pc.eksaRegion != eksaDefaultRegion {

--- a/pkg/curatedpackages/registry_constants.go
+++ b/pkg/curatedpackages/registry_constants.go
@@ -48,3 +48,12 @@ var prodRegionalPrivateRegistryURIByRegion = map[string]string{
 	"us-west-1":      "440460740297.dkr.ecr.us-west-1.amazonaws.com",
 	"us-west-2":      "346438352937.dkr.ecr.us-west-2.amazonaws.com",
 }
+
+func getAllEnvRegionalPrivateRegistryURIs() []string {
+	var regionalPrivateRegistryURIs []string
+	for _, uri := range prodRegionalPrivateRegistryURIByRegion {
+		regionalPrivateRegistryURIs = append(regionalPrivateRegistryURIs, uri)
+	}
+	regionalPrivateRegistryURIs = append(regionalPrivateRegistryURIs, devRegionalPrivateRegistryURI, stagingRegionalPrivateRegistryURI)
+	return regionalPrivateRegistryURIs
+}

--- a/pkg/executables/testdata/kind_config_registry_mirror_with_auth.yaml
+++ b/pkg/executables/testdata/kind_config_registry_mirror_with_auth.yaml
@@ -38,7 +38,7 @@ kubeadmConfigPatches:
 containerdConfigPatches:
   - |
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
         endpoint = ["https://registry-mirror.test:443/v2/curated-packages"]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
         endpoint = ["https://registry-mirror.test:443/v2/eks-anywhere"]

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -304,7 +304,7 @@ var registryMirrorTests = []struct {
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
 				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
     endpoint = ["https://1.2.3.4:443/v2/curated-packages"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
     endpoint = ["https://1.2.3.4:443/v2/eks-anywhere"]

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -308,7 +308,7 @@ spec:
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
               endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
               endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
@@ -185,7 +185,7 @@ spec:
           path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         - content: |
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
                 endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
               [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
                 endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -353,7 +353,7 @@ spec:
       path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
     - content: |
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
             endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
             endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -40,7 +40,7 @@ spec:
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.*.amazonaws.com"]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
               endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
               endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]

--- a/pkg/registrymirror/registrymirror.go
+++ b/pkg/registrymirror/registrymirror.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	urllib "net/url"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -26,8 +25,6 @@ type RegistryMirror struct {
 	InsecureSkipVerify bool
 }
 
-var re = regexp.MustCompile(constants.DefaultCuratedPackagesRegistryRegex)
-
 // FromCluster is a constructor for RegistryMirror from a cluster schema.
 func FromCluster(cluster *v1alpha1.Cluster) *RegistryMirror {
 	return FromClusterRegistryMirrorConfiguration(cluster.Spec.RegistryMirrorConfiguration)
@@ -44,13 +41,7 @@ func FromClusterRegistryMirrorConfiguration(config *v1alpha1.RegistryMirrorConfi
 	// for each namespace, add corresponding endpoint
 	for _, ociNamespace := range config.OCINamespaces {
 		mirror := filepath.Join(base, ociNamespace.Namespace)
-		if re.MatchString(ociNamespace.Registry) {
-			// handle curated packages in all regions
-			// static key makes it easier for mirror lookup
-			registryMap[constants.DefaultCuratedPackagesRegistry] = mirror
-		} else {
-			registryMap[ociNamespace.Registry] = mirror
-		}
+		registryMap[ociNamespace.Registry] = mirror
 	}
 	if len(registryMap) == 0 {
 		// for backward compatibility, default mapping for public.ecr.aws is added
@@ -71,11 +62,6 @@ func (r *RegistryMirror) CoreEKSAMirror() string {
 	return r.NamespacedRegistryMap[constants.DefaultCoreEKSARegistry]
 }
 
-// CuratedPackagesMirror returns the mirror for curated packages.
-func (r *RegistryMirror) CuratedPackagesMirror() string {
-	return r.NamespacedRegistryMap[constants.DefaultCuratedPackagesRegistry]
-}
-
 // ReplaceRegistry replaces the host in a url with corresponding registry mirror
 // It supports full URLs and container image URLs
 // If the provided original url is malformed, there are no guarantees
@@ -92,9 +78,6 @@ func (r *RegistryMirror) ReplaceRegistry(url string) string {
 		u.Scheme = ""
 	}
 	key := u.Host
-	if re.MatchString(key) {
-		key = constants.DefaultCuratedPackagesRegistry
-	}
 	if v, ok := r.NamespacedRegistryMap[key]; ok {
 		return strings.Replace(url, u.Host, v, 1)
 	}

--- a/pkg/registrymirror/registrymirror_test.go
+++ b/pkg/registrymirror/registrymirror_test.go
@@ -254,41 +254,6 @@ func TestCoreEKSAMirror(t *testing.T) {
 	}
 }
 
-func TestCuratedPackagesMirror(t *testing.T) {
-	testCases := []struct {
-		testName       string
-		registryMirror *registrymirror.RegistryMirror
-		want           string
-	}{
-		{
-			testName: "with namespace",
-			registryMirror: &registrymirror.RegistryMirror{
-				BaseRegistry: "1.2.3.4:443",
-				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/curated-packages",
-				},
-			},
-			want: "1.2.3.4:443/curated-packages",
-		},
-		{
-			testName: "no required namespace",
-			registryMirror: &registrymirror.RegistryMirror{
-				BaseRegistry: "1.2.3.4:443",
-				NamespacedRegistryMap: map[string]string{
-					constants.DefaultCoreEKSARegistry: "1.2.3.4:443/eks-anywhere",
-				},
-			},
-			want: "",
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.testName, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(tt.registryMirror.CuratedPackagesMirror()).To(Equal(tt.want))
-		})
-	}
-}
-
 func TestReplaceRegistry(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3572

*Description of changes:*
Registry mirror lookup for curated packages is broken after adding support for regional registries. We lookup only for the old non-regional registry uri in the ociNamespaces list. Added support to handle regional registries. 

This PR also removes the problematic wildcard registry usage in registry mirror namespaces map. This breaks containerd v2 as it doesn't support adding mirror for registry url with wildcard. Wildcard key was added in NamespacedRegistryMap as a way to lookup curated packages mirror easily.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

