### PR TITLE
Apply hardware CSV entries during workload cluster upgrades

### DIFF
--- a/pkg/providers/tinkerbell/tinkerbell_test.go
+++ b/pkg/providers/tinkerbell/tinkerbell_test.go
@@ -1603,6 +1603,7 @@ func TestSetupAndValidateUpgradeWorkloadClusterErrorBMC(t *testing.T) {
 	kubectl.EXPECT().GetProvisionedTinkerbellHardware(ctx, clusterSpec.ManagementCluster.KubeconfigFile, constants.EksaSystemNamespace).Return([]tinkv1alpha1.Hardware{}, nil)
 
 	kubectl.EXPECT().WaitForRufioMachines(ctx, cluster, defaultBMCTimeout, "Contactable", gomock.Any()).Return(fmt.Errorf("error"))
+	kubectl.EXPECT().ApplyKubeSpecFromBytesForce(gomock.Any(), cluster, gomock.Any())
 
 	err := provider.SetupAndValidateUpgradeCluster(ctx, cluster, clusterSpec, clusterSpec)
 	assertError(t, "waiting for baseboard management to be contactable: error", err)


### PR DESCRIPTION
*Issue #, if available:*
Scale up for workload cluster fails with hardware validation errors as the hardware csv is not honored during upgrades of workload cluster. 

*Description of changes:*
The hardware CSV entries provided during workload cluster upgrades were not being applied due to an early return in the PreCoreComponentsUpgrade function for managed clusters that was introduced in commit eafc9b0315f890968526821f8261176980362aa9.

This change modifies the PreCoreComponentsUpgrade function to ensure hardware entries are applied for workload clusters while still skipping the stack upgrade which is only needed for management clusters.

*Testing (if applicable):*
Tested by manually building the cli and controller, providing additional hardware during workload cluster upgrades. 
 
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

