### PR TITLE
Cleanup pkg controller private registry field

### DIFF
--- a/docs/content/en/docs/packages/packages.md
+++ b/docs/content/en/docs/packages/packages.md
@@ -18,7 +18,6 @@ spec:
   activeBundle: v1-21-83
   defaultImageRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
   defaultRegistry: public.ecr.aws/eks-anywhere
-  privateRegistry: ""
   upgradeCheckInterval: 24h0m0s
 
 ---
@@ -196,13 +195,6 @@ PackageBundleControllerSpec defines the desired state of PackageBundleController
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>privateRegistry</b></td>
-        <td>string</td>
-        <td>
-          PrivateRegistry is the registry being used for all images, charts and bundles<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>upgradeCheckInterval</b></td>
         <td>string</td>
         <td>
@@ -335,13 +327,6 @@ Spec previous settings
           LogLevel controls the verbosity of logging in the controller.<br/>
           <br/>
             <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>privateRegistry</b></td>
-        <td>string</td>
-        <td>
-          PrivateRegistry is the registry being used for all images, charts and bundles<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3573

*Description of changes:*
PrivateRegistry field in package bundle controller was initially designed to be used for registry mirrors. But we always used defaultRegistry and defaultImageRegistry fields for registry mirrors as well. Removing the document references to PrivateRegistry field as it's not used. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

