### PR TITLE
fix authenticated registry for kind using containerdv2

### DIFF
--- a/pkg/executables/config/hosts.toml
+++ b/pkg/executables/config/hosts.toml
@@ -7,7 +7,7 @@ server = "https://{{.Server}}"
 {{- else }}
   skip_verify = true
 {{- end }}
-{{- if .Username }}
-  username = "{{.Username}}"
-  password = "{{.Password}}"
+{{- if .AuthHeader }}
+  [host."https://{{.Host}}".header]
+    authorization = "{{.AuthHeader}}"
 {{- end }}

--- a/pkg/executables/testdata/hosts_toml_with_auth_783794618700_dkr_ecr.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_783794618700_dkr_ecr.toml
@@ -3,5 +3,5 @@ server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
 [host."https://registry-mirror.test:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
   skip_verify = true
-  username = "username"
-  password = "password"
+  [host."https://registry-mirror.test:443/v2/curated-packages".header]
+    authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_auth_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_public_ecr_aws.toml
@@ -3,5 +3,5 @@ server = "https://public.ecr.aws"
 [host."https://registry-mirror.test:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
   skip_verify = true
-  username = "username"
-  password = "password"
+  [host."https://registry-mirror.test:443/v2/eks-anywhere".header]
+    authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_auth_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_registry_mirror.toml
@@ -3,5 +3,5 @@ server = "https://registry-mirror.test:443"
 [host."https://registry-mirror.test:443"]
   capabilities = ["pull", "resolve"]
   skip_verify = true
-  username = "username"
-  password = "password"
+  [host."https://registry-mirror.test:443".header]
+    authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="


### PR DESCRIPTION
*Description of changes:*
Changes in [PR](https://github.com/aws/eks-anywhere/pull/10101) to migrate kind containerd configuration to v2 format uses wrong configuration for username, password authentication to local registries. 

*Testing (if applicable):*
```
./bin/e2e.test -test.run 'TestVSphereKubernetes128UbuntuAuthenticatedRegistryMirror' -test.v 9
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

