### PR TITLE
fix containerd artifact upload path for release branch builds

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -125,6 +125,32 @@ func TarballArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettyp
 	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil
 }
 
+func ReleaseBranchedTarballArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.Archive, projectPath, gitTag, eksDReleaseChannel, eksDReleaseNumber, kubeVersion, latestPath, arch string) (string, string, string, string, error) {
+	os := "linux"
+	var sourceS3Key string
+	var sourceS3Prefix string
+	var releaseS3Path string
+	var releaseName string
+
+	if rc.DevRelease || rc.ReleaseEnvironment == "development" {
+		sourceS3Key = fmt.Sprintf("%s-%s-%s-%s.tar.gz", archive.Name, os, arch, gitTag)
+		sourceS3Prefix = fmt.Sprintf("%s/%s", projectPath, latestPath)
+	} else {
+		sourceS3Key = fmt.Sprintf("%s-%s-%s.tar.gz", archive.Name, os, arch)
+		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/%s/%s", rc.BundleNumber, archive.Name, gitTag)
+	}
+
+	if rc.DevRelease {
+		releaseName = fmt.Sprintf("%s-%s-%s-%s.tar.gz", archive.Name, rc.DevReleaseUriVersion, os, arch)
+		releaseS3Path = fmt.Sprintf("artifacts/%s/%s/%s/%s", rc.DevReleaseUriVersion, eksDReleaseChannel, archive.Name, gitTag)
+	} else {
+		releaseName = fmt.Sprintf("%s-%s-%s.tar.gz", archive.Name, os, arch)
+		releaseS3Path = fmt.Sprintf("releases/bundles/%d/artifacts/%s/%s/%s", rc.BundleNumber, eksDReleaseChannel, archive.Name, gitTag)
+	}
+
+	return sourceS3Key, sourceS3Prefix, releaseName, releaseS3Path, nil
+}
+
 func KernelArtifactPathGetter(rc *releasetypes.ReleaseConfig, archive *assettypes.Archive, projectPath, gitTag, eksDReleaseChannel, eksDReleaseNumber, kubeVersion, latestPath, arch string) (string, string, string, string, error) {
 	var sourceS3Prefix string
 	var releaseS3Path string

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -314,8 +314,9 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		HasSeparateTagPerReleaseBranch: true,
 		Archives: []*assettypes.Archive{
 			{
-				Name:   "containerd",
-				Format: "tarball",
+				Name:                "containerd",
+				Format:              "tarball",
+				ArchiveS3PathGetter: archives.ReleaseBranchedTarballArtifactPathGetter,
 			},
 		},
 	},

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -250,7 +250,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-28/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
@@ -1075,7 +1075,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-29/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
@@ -1900,7 +1900,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-30/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
@@ -2725,7 +2725,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-31/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
@@ -3550,7 +3550,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-32/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
@@ -4375,7 +4375,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-33/containerd/v1.7.28/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64
@@ -5200,7 +5200,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/containerd/v2.1.4/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/1-34/containerd/v2.1.4/containerd-v0.0.0-dev-build.0-linux-amd64.tar.gz
       crictl:
         arch:
         - amd64


### PR DESCRIPTION
*Issue:*
After the change of containerd to release branch specific builds, the built artifacts and their checkusms are different. But the artifacts are getting uploaded to same release bucket location during the release process. So, whatever k8s version artifact gets uploaded last will remain with other version artifacts getting overwritten. But the checksum entries in the bundle are still the ones computed from overwritten artifacts.

*Description of changes:*
Change s3 folder path for containerd archive assets to be release channel specific. It will change from `artifacts/v0.24.0-dev-build.140/containerd/v1.7.28/containerd-v0.24.0-dev-build.140-linux-amd64.tar.gz` to `artifacts/v0.24.0-dev-build.140/1-28/containerd/v1.7.28/containerd-v0.24.0-dev-build.140-linux-amd64.tar.gz`

*Testing (if applicable):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

