### PR TITLE
Update registry mirror repo for the first-party supported Cilium images

### DIFF
--- a/docs/content/en/docs/getting-started/optional/registrymirror.md
+++ b/docs/content/en/docs/getting-started/optional/registrymirror.md
@@ -120,7 +120,7 @@ The following projects must be created in your registry before importing the EKS
 bottlerocket
 eks-anywhere
 eks-distro
-isovalent
+eks
 cilium-chart
 curated-packages
 ```
@@ -131,7 +131,7 @@ For example, if a registry is available at `private-registry.local`, then the fo
 https://private-registry.local/bottlerocket
 https://private-registry.local/eks-anywhere
 https://private-registry.local/eks-distro
-https://private-registry.local/isovalent
+https://private-registry.local/eks
 https://private-registry.local/cilium-chart
 https://private-registry.local/curated-packages
 ```


### PR DESCRIPTION
*Issue #, if available:*
[#3578](https://github.com/aws/eks-anywhere-internal/issues/3578)

*Description of changes:*
This CR updates the registry mirror repo for the first-party supported Cilium images in our docs. We now use our first-party supported Cilium images from eks repo in our bundles instead of the isovalent images.

EKS Public ECR registry: https://gallery.ecr.aws/eks/cilium/cilium

*Testing (if applicable):*
```
make -C build docs
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

