### PR TITLE
Update Cilium unit test bundles to v1.17.6-0 and fix e2e test

### DIFF
--- a/internal/test/testdata/bundles.yaml
+++ b/internal/test/testdata/bundles.yaml
@@ -661,20 +661,20 @@ spec:
         arch:
           - amd64
         description: Container image for cilium image
-        imageDigest: sha256:fe31ed6950c4fcfa5eb2a93dc389e72b1b6563a58dc2665d1085afd0bb5fee8f
+        imageDigest: sha256:07607f99e841df9d7087003ac3618ba6c3476b87163ddfb631ab6d3368a71ad2
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium-eksa:v1.9.9-beta2
+        uri: public.ecr.aws/eks/cilium/cilium:v1.17.6-0
       manifest:
         uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.0.0-dev-build.158/cilium/manifests/cilium/v1.9.9-beta2/cilium.yaml
       operator:
         arch:
           - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:3726a965cd960295ca3c5e7f2b543c02096c0912c6652eb8bbb9ce54bcaa99d8
+        imageDigest: sha256:5172f58fef324075e9e927090e17a6b7d3d3a630e35c16c700d0377fc2305127
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic-eksa:v1.9.9-beta1
+        uri: public.ecr.aws/eks/cilium/operator-generic:v1.17.6-0
     cloudStack:
       clusterAPIController:
         uri: public.ecr.aws/j9l9l0k3/cluster-api-provider-capc:latest
@@ -1112,26 +1112,26 @@ spec:
         arch:
         - amd64
         description: Container image for cilium image
-        imageDigest: sha256:3999832c1d339148ea367a587b88e3c29cd745c5d659237ca3ab85f42a9dd845
+        imageDigest: sha256:07607f99e841df9d7087003ac3618ba6c3476b87163ddfb631ab6d3368a71ad2
         name: cilium
         os: linux
-        uri: public.ecr.aws/isovalent/cilium:v1.13.9-eksa.1
+        uri: public.ecr.aws/eks/cilium/cilium:v1.17.6-0
       helmChart:
         description: Helm chart for cilium-chart
-        imageDigest: sha256:3efe51316cca07ee9344870bda8a5564a23c238603737a1c3ce89f2721648fc8
+        imageDigest: sha256:e0a8e9cdd9d04a15c4a46fcbfbfc7a6d899adc7fd7072f2bc5a09fa9d3cbd31f
         name: cilium-chart
-        uri: public.ecr.aws/isovalent/cilium:1.13.9-eksa.1
+        uri: public.ecr.aws/eks/cilium/cilium:1.17.6-0
       manifest:
         uri: https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/artifacts/v0.19.0-dev-build.158/cilium/manifests/cilium/v1.13.9-eksa.1/cilium.yaml
       operator:
         arch:
         - amd64
         description: Container image for operator-generic image
-        imageDigest: sha256:777299bcf6829048d5a5f4db8ca71c472a8adf8bb21d79d272a264f4857d8c60
+        imageDigest: sha256:5172f58fef324075e9e927090e17a6b7d3d3a630e35c16c700d0377fc2305127
         name: operator-generic
         os: linux
-        uri: public.ecr.aws/isovalent/operator-generic:v1.13.9-eksa.1
-      version: v1.13.9-eksa.1
+        uri: public.ecr.aws/eks/cilium/operator-generic:v1.17.6-0
+      version: v1.17.6-0
     cloudStack:
       clusterAPIController:
         arch:

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -2440,7 +2440,7 @@ func TestKubectlGetDaemonSetSuccess(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Command: []string{"cilium-agent"},
-								Image:   "public.ecr.aws/isovalent/cilium:v1.9.11-eksa.1",
+								Image:   "public.ecr.aws/eks/cilium/cilium:v1.17.6-0",
 								Name:    "cilium-agent",
 							},
 						},

--- a/pkg/executables/testdata/kubectl_daemonset.json
+++ b/pkg/executables/testdata/kubectl_daemonset.json
@@ -13,7 +13,7 @@
                         "command": [
                             "cilium-agent"
                         ],
-                        "image": "public.ecr.aws/isovalent/cilium:v1.9.11-eksa.1",
+                        "image": "public.ecr.aws/eks/cilium/cilium:v1.17.6-0",
                         "name": "cilium-agent"
                     }
                 ]

--- a/pkg/networking/cilium/installation.go
+++ b/pkg/networking/cilium/installation.go
@@ -47,7 +47,7 @@ func (i Installation) Installed() bool {
 	var isEKSACilium bool
 	if i.DaemonSet != nil {
 		for _, c := range i.DaemonSet.Spec.Template.Spec.Containers {
-			isEKSACilium = isEKSACilium || strings.Contains(c.Image, "eksa")
+			isEKSACilium = isEKSACilium || strings.Contains(c.Image, "eks")
 		}
 	}
 	return i.DaemonSet != nil && i.Operator != nil && isEKSACilium

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -43,26 +43,26 @@ func newtemplaterTest(t *testing.T) *templaterTest {
 		h:         h,
 		t:         cilium.NewTemplater(hf),
 		manifest:  []byte("manifestContent"),
-		uri:       "oci://public.ecr.aws/isovalent/cilium",
-		version:   "1.9.11-eksa.1",
+		uri:       "oci://public.ecr.aws/eks/cilium/cilium",
+		version:   "1.17.6-0",
 		namespace: "kube-system",
 		currentSpec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.Cluster.Spec.KubernetesVersion = "1.22"
 			s.VersionsBundles["1.22"] = test.VersionBundle()
-			s.VersionsBundles["1.22"].Cilium.Version = "v1.9.10-eksa.1"
-			s.VersionsBundles["1.22"].Cilium.Cilium.URI = "public.ecr.aws/isovalent/cilium:v1.9.10-eksa.1"
-			s.VersionsBundles["1.22"].Cilium.Operator.URI = "public.ecr.aws/isovalent/operator-generic:v1.9.10-eksa.1"
-			s.VersionsBundles["1.22"].Cilium.HelmChart.URI = "public.ecr.aws/isovalent/cilium:1.9.10-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.Version = "v1.17.6-0"
+			s.VersionsBundles["1.22"].Cilium.Cilium.URI = "public.ecr.aws/eks/cilium/cilium:v1.17.6-0"
+			s.VersionsBundles["1.22"].Cilium.Operator.URI = "public.ecr.aws/eks/cilium/operator-generic:v1.17.6-0"
+			s.VersionsBundles["1.22"].Cilium.HelmChart.URI = "public.ecr.aws/eks/cilium/cilium:1.17.6-0"
 			s.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
 		spec: test.NewClusterSpec(func(s *cluster.Spec) {
 			s.Cluster.Spec.KubernetesVersion = "1.22"
 			s.VersionsBundles["1.22"] = test.VersionBundle()
-			s.VersionsBundles["1.22"].Cilium.Version = "v1.9.11-eksa.1"
-			s.VersionsBundles["1.22"].Cilium.Cilium.URI = "public.ecr.aws/isovalent/cilium:v1.9.11-eksa.1"
-			s.VersionsBundles["1.22"].Cilium.Operator.URI = "public.ecr.aws/isovalent/operator-generic:v1.9.11-eksa.1"
-			s.VersionsBundles["1.22"].Cilium.HelmChart.URI = "public.ecr.aws/isovalent/cilium:1.9.11-eksa.1"
+			s.VersionsBundles["1.22"].Cilium.Version = "v1.17.6-0"
+			s.VersionsBundles["1.22"].Cilium.Cilium.URI = "public.ecr.aws/eks/cilium/cilium:v1.17.6-0"
+			s.VersionsBundles["1.22"].Cilium.Operator.URI = "public.ecr.aws/eks/cilium/operator-generic:v1.17.6-0"
+			s.VersionsBundles["1.22"].Cilium.HelmChart.URI = "public.ecr.aws/eks/cilium/cilium:1.17.6-0"
 			s.VersionsBundles["1.22"].KubeDistro.Kubernetes.Tag = "v1.22.5-eks-1-22-9"
 			s.Cluster.Spec.ClusterNetwork.CNIConfig = &v1alpha1.CNIConfig{Cilium: &v1alpha1.CiliumConfig{}}
 		}),
@@ -127,13 +127,13 @@ func baseTemplateValues() map[string]interface{} {
 		"routingMode":       "tunnel",
 		"tunnelProtocol":    "geneve",
 		"image": map[string]interface{}{
-			"repository": "public.ecr.aws/isovalent/cilium",
-			"tag":        "v1.9.11-eksa.1",
+			"repository": "public.ecr.aws/eks/cilium/cilium",
+			"tag":        "v1.17.6-0",
 		},
 		"operator": map[string]interface{}{
 			"image": map[string]interface{}{
-				"repository": "public.ecr.aws/isovalent/operator",
-				"tag":        "v1.9.11-eksa.1",
+				"repository": "public.ecr.aws/eks/cilium/operator",
+				"tag":        "v1.17.6-0",
 			},
 			"prometheus": map[string]interface{}{
 				"enabled": true,
@@ -170,8 +170,8 @@ func withPreflightConfig(values map[string]interface{}) {
 	values["preflight"] = map[string]interface{}{
 		"enabled": true,
 		"image": map[string]interface{}{
-			"repository": "public.ecr.aws/isovalent/cilium",
-			"tag":        "v1.9.11-eksa.1",
+			"repository": "public.ecr.aws/eks/cilium/cilium",
+			"tag":        "v1.17.6-0",
 		},
 		"tolerations": []map[string]string{
 			{
@@ -416,7 +416,7 @@ func TestTemplaterGenerateManifestInvalidKubeVersion(t *testing.T) {
 
 func TestTemplaterGenerateManifestUpgradeSameKubernetesVersionSuccess(t *testing.T) {
 	wantValues := baseTemplateValues()
-	withUpgradeCompatibility(wantValues, "1.9")
+	withUpgradeCompatibility(wantValues, "1.17")
 
 	tt := newtemplaterTest(t)
 
@@ -437,7 +437,7 @@ func TestTemplaterGenerateManifestUpgradeSameKubernetesVersionSuccess(t *testing
 
 func TestTemplaterGenerateManifestUpgradeNewKubernetesVersionSuccess(t *testing.T) {
 	wantValues := baseTemplateValues()
-	withUpgradeCompatibility(wantValues, "1.9")
+	withUpgradeCompatibility(wantValues, "1.17")
 
 	tt := newtemplaterTest(t)
 

--- a/pkg/networking/cilium/testdata/cilium_manifest.yaml
+++ b/pkg/networking/cilium/testdata/cilium_manifest.yaml
@@ -483,7 +483,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: "public.ecr.aws/isovalent/cilium:v1.9.10-eksa.1"
+        image: "public.ecr.aws/eks/cilium/cilium:v1.17.6-0"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -545,7 +545,7 @@ spec:
           # same directory where we install cilium cni plugin so that exec permissions
           # are available.
           - 'cp /usr/bin/cilium-mount /hostbin/cilium-mount && nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT; rm /hostbin/cilium-mount'
-        image: "public.ecr.aws/isovalent/cilium:v1.9.10-eksa.1"
+        image: "public.ecr.aws/eks/cilium/cilium:v1.17.6-0"
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /hostproc
@@ -575,7 +575,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: "public.ecr.aws/isovalent/cilium:v1.9.10-eksa.1"
+        image: "public.ecr.aws/eks/cilium/cilium:v1.17.6-0"
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:
@@ -737,7 +737,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        image: "public.ecr.aws/isovalent/operator-generic:v1.9.10-eksa.1"
+        image: "public.ecr.aws/eks/cilium/operator-generic:v1.17.6-0"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         livenessProbe:


### PR DESCRIPTION
*Issue #, if available:*
[#3578](https://github.com/aws/eks-anywhere-internal/issues/3578)

The `TestDockerCiliumSkipUpgrade_CLICreate` test started failing with the following error after [#10157](https://github.com/aws/eks-anywhere/pull/10157) was merged:
```
cluster.go:2171: Validating cluster main-i-0d3ba-2240aa3
cilium.go:92: Checking for EKSA Cilium installation with main-i-0d3ba-2240aa3/main-i-0d3ba-2240aa3-eks-a-cluster.kubeconfig
cilium.go:104: Expected EKSA Cilium to be installed but found nothing
```
This is because the test validates the EKS-A embedded Cilium by checking whether the image name contains `eksa` string. After moving to the first-party supported Cilium images, we should check the image name for the `eks` string instead since we no longer use `-eksa` suffix in the image tags.

*Description of changes:*
This PR fixes the failing `TestDockerCiliumSkipUpgrade_CLICreate` e2e test and also updates all the unit tests to use the first-party supported Cilium images.

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

