### PR TITLE
Add retry logic to helm chart push operations to handle rate limiting errors

### DIFF
--- a/release/cli/pkg/images/images.go
+++ b/release/cli/pkg/images/images.go
@@ -345,11 +345,11 @@ func GetPreviousReleaseImageSemver(r *releasetypes.ReleaseConfig, releaseImageUr
 		if keyExists {
 			contents, err := filereader.ReadHttpFile(bundleManifestUrl)
 			if err != nil {
-				return "", fmt.Errorf("Error reading bundle manifest from S3: %v", err)
+				return "", fmt.Errorf("reading bundle manifest from S3: %v", err)
 			}
 
 			if err = yaml.Unmarshal(contents, bundles); err != nil {
-				return "", fmt.Errorf("Error unmarshaling bundles manifest from [%s]: %v", bundleManifestUrl, err)
+				return "", fmt.Errorf("unmarshaling bundles manifest from [%s]: %v", bundleManifestUrl, err)
 			}
 
 			for _, versionedBundle := range bundles.Spec.VersionsBundles {
@@ -412,14 +412,14 @@ func CheckRepositoryImagesAndTagsCountLimit(sourceImageUri, releaseImageUri, sou
 
 	var sourceImageDigest string
 	var err error
-	switch ecrClient.(type) {
+	switch client := ecrClient.(type) {
 	case *ecrsdk.ECR:
-		sourceImageDigest, err = ecr.GetImageDigest(sourceImageUri, sourceContainerRegistry, ecrClient.(*ecrsdk.ECR))
+		sourceImageDigest, err = ecr.GetImageDigest(sourceImageUri, sourceContainerRegistry, client)
 		if err != nil {
 			return errors.Cause(err)
 		}
 	case *ecrpublicsdk.ECRPublic:
-		sourceImageDigest, err = ecrpublic.GetImageDigest(sourceImageUri, sourceContainerRegistry, ecrClient.(*ecrpublicsdk.ECRPublic))
+		sourceImageDigest, err = ecrpublic.GetImageDigest(sourceImageUri, sourceContainerRegistry, client)
 		if err != nil {
 			return errors.Cause(err)
 		}


### PR DESCRIPTION
*Issue #, if available:*
[#3622](https://github.com/aws/eks-anywhere-internal/issues/3622)

*Description of changes:*
This PR fixes the rate limiting issue for pushing helm charts to the public ECR registry during dev-release job triggered by all the e2e tests pipelines.

*Testing (if applicable):*
```
make -C release build
make -C release lint
make -C release unit-test
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

