### PR TITLE
Fix cert-manager tests by ensuring certificate cleanup on failure

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -26,8 +26,13 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		packageName := "cert-manager"
 		packagePrefix := "test"
 		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace, e.ClusterName)
+		// Ensure cleanup happens even if the test fails
+		defer func() {
+			if err := e.CleanupCerts(withCluster(test.ManagementCluster)); err != nil {
+				e.T.Logf("Warning: Failed to cleanup certificates: %v", err)
+			}
+		}()
 		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withCluster(test.ManagementCluster))
-		e.CleanupCerts(withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()
 		e.ValidateClusterDelete()
 	})


### PR DESCRIPTION
*Issue #, if available:*
[#3627](https://github.com/aws/eks-anywhere-internal/issues/3627)

*Description of changes:*
[#7163](https://github.com/aws/eks-anywhere/pull/7163) added a cleanup function in our cert-manager tests to cleanup the Let's encrypt certificates and the Route53 DNS TXT records that were created. But the cleanup happens only if the test succeeds and doesn't run on any test failures. This PR updates the cert manager test flow to ensure certificate cleanup happens even on failures to fix the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

