### PR TITLE
Disable cilium envoy by default in the helm template

### DIFF
--- a/pkg/networking/cilium/templater.go
+++ b/pkg/networking/cilium/templater.go
@@ -236,6 +236,9 @@ func templateValues(spec *cluster.Spec, versionsBundle *cluster.VersionsBundle) 
 				},
 			},
 		},
+		"envoy": values{
+			"enabled": false,
+		},
 	}
 
 	if len(spec.Cluster.Spec.WorkerNodeGroupConfigurations) == 0 && spec.Cluster.Spec.ControlPlaneConfiguration.Count == 1 {

--- a/pkg/networking/cilium/templater_test.go
+++ b/pkg/networking/cilium/templater_test.go
@@ -153,6 +153,9 @@ func baseTemplateValues() map[string]interface{} {
 				},
 			},
 		},
+		"envoy": map[string]interface{}{
+			"enabled": false,
+		},
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
[#3639](https://github.com/aws/eks-anywhere-internal/issues/3639)

*Description of changes:*
This PR updates the helm template values in the first-party supported cilium helm chart to disable envoy by default.

*Testing (if applicable):*
```
make eks-a
make lint
make unit-test
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

