### PR TITLE
Collect admission webhook configurations in support bundle

### DIFF
--- a/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
+++ b/pkg/diagnostics/config/diagnostic-collector-rbac.yaml
@@ -10,6 +10,7 @@ rules:
     - anywhere.eks.amazonaws.com
     - packages.eks.amazonaws.com
     - tinkerbell.org
+    - admissionregistration.k8s.io
     resources:
     - '*'
     verbs:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3606

*Description of changes:*
This adds the collection of mutating and validation admission webhook configurations deployed in a cluster as part of diagnostic (aka support) bundle. This helps us debug potential cluster downtime issues faster, as webhooks can disrupt critical system resources.

*Testing (if applicable):*
Collected support bundle of an eks-anywhere cluster on vsphere provider manually, And verified that all the mutating and validating webhooks in the cluster are collected in support bundle. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

