### PR TITLE
Cleanup crd collectors as cluster resources collector has them

### DIFF
--- a/pkg/diagnostics/collectors.go
+++ b/pkg/diagnostics/collectors.go
@@ -153,7 +153,7 @@ func (c *EKSACollectorFactory) DataCenterConfigCollectors(datacenter v1alpha1.Re
 }
 
 func (c *EKSACollectorFactory) eksaNutanixCollectors() []*Collect {
-	nutanixLogs := []*Collect{
+	return []*Collect{
 		{
 			Logs: &logs{
 				Namespace: constants.CapxSystemNamespace,
@@ -161,11 +161,10 @@ func (c *EKSACollectorFactory) eksaNutanixCollectors() []*Collect {
 			},
 		},
 	}
-	return append(nutanixLogs, c.nutanixCrdCollectors()...)
 }
 
 func (c *EKSACollectorFactory) eksaSnowCollectors() []*Collect {
-	snowLogs := []*Collect{
+	return []*Collect{
 		{
 			Logs: &logs{
 				Namespace: constants.CapasSystemNamespace,
@@ -173,11 +172,10 @@ func (c *EKSACollectorFactory) eksaSnowCollectors() []*Collect {
 			},
 		},
 	}
-	return append(snowLogs, c.snowCrdCollectors()...)
 }
 
 func (c *EKSACollectorFactory) eksaTinkerbellCollectors() []*Collect {
-	tinkerbellLogs := []*Collect{
+	return []*Collect{
 		{
 			Logs: &logs{
 				Namespace: constants.CaptSystemNamespace,
@@ -185,7 +183,6 @@ func (c *EKSACollectorFactory) eksaTinkerbellCollectors() []*Collect {
 			},
 		},
 	}
-	return append(tinkerbellLogs, c.tinkerbellCrdCollectors()...)
 }
 
 func (c *EKSACollectorFactory) eksaVsphereCollectors(spec *cluster.Spec) []*Collect {
@@ -199,14 +196,13 @@ func (c *EKSACollectorFactory) eksaVsphereCollectors(spec *cluster.Spec) []*Coll
 		},
 	}
 	collectors = append(collectors, vsphereLogs...)
-	collectors = append(collectors, c.vsphereCrdCollectors()...)
 	collectors = append(collectors, c.apiServerCollectors(spec.Cluster.Spec.ControlPlaneConfiguration.Endpoint.Host)...)
 	collectors = append(collectors, c.vmsAccessCollector(spec.Cluster.Spec.ControlPlaneConfiguration))
 	return collectors
 }
 
 func (c *EKSACollectorFactory) eksaCloudstackCollectors() []*Collect {
-	cloudstackLogs := []*Collect{
+	return []*Collect{
 		{
 			Logs: &logs{
 				Namespace: constants.CapcSystemNamespace,
@@ -214,7 +210,6 @@ func (c *EKSACollectorFactory) eksaCloudstackCollectors() []*Collect {
 			},
 		},
 	}
-	return append(cloudstackLogs, c.cloudstackCrdCollectors()...)
 }
 
 func (c *EKSACollectorFactory) eksaDockerCollectors() []*Collect {
@@ -245,18 +240,12 @@ func (c *EKSACollectorFactory) hostTinkerbellCollectors() []*Collect {
 
 // ManagementClusterCollectors returns the collectors that only apply to management clusters.
 func (c *EKSACollectorFactory) ManagementClusterCollectors() []*Collect {
-	var collectors []*Collect
-	collectors = append(collectors, c.managementClusterCrdCollectors()...)
-	collectors = append(collectors, c.managementClusterLogCollectors()...)
-	return collectors
+	return c.managementClusterLogCollectors()
 }
 
 // PackagesCollectors returns the collectors that read information for curated packages.
 func (c *EKSACollectorFactory) PackagesCollectors() []*Collect {
-	var collectors []*Collect
-	collectors = append(collectors, c.packagesCrdCollectors()...)
-	collectors = append(collectors, c.packagesLogCollectors()...)
-	return collectors
+	return c.packagesLogCollectors()
 }
 
 // FileCollectors returns the collectors that interact with files.
@@ -444,141 +433,6 @@ func (c *EKSACollectorFactory) managementClusterLogCollectors() []*Collect {
 	}
 }
 
-func (c *EKSACollectorFactory) managementClusterCrdCollectors() []*Collect {
-	mgmtCrds := []string{
-		"clusters.anywhere.eks.amazonaws.com",
-		"controlplaneupgrades.anywhere.eks.amazonaws.com",
-		"machinedeploymentupgrades.anywhere.eks.amazonaws.com",
-		"nodeupgrades.anywhere.eks.amazonaws.com",
-		"bundles.anywhere.eks.amazonaws.com",
-		"clusters.cluster.x-k8s.io",
-		"machinedeployments.cluster.x-k8s.io",
-		"machines.cluster.x-k8s.io",
-		"machinehealthchecks.cluster.x-k8s.io",
-		"kubeadmcontrolplane.controlplane.cluster.x-k8s.io",
-	}
-	return c.generateCrdCollectors(mgmtCrds)
-}
-
-func (c *EKSACollectorFactory) snowCrdCollectors() []*Collect {
-	capasCrds := []string{
-		"awssnowclusters.infrastructure.cluster.x-k8s.io",
-		"awssnowmachines.infrastructure.cluster.x-k8s.io",
-		"awssnowmachinetemplates.infrastructure.cluster.x-k8s.io",
-		"snowdatacenterconfigs.anywhere.eks.amazonaws.com",
-		"snowmachineconfigs.anywhere.eks.amazonaws.com",
-	}
-	return c.generateCrdCollectors(capasCrds)
-}
-
-func (c *EKSACollectorFactory) tinkerbellCrdCollectors() []*Collect {
-	captCrds := []string{
-		"machines.bmc.tinkerbell.org",
-		"jobs.bmc.tinkerbell.org",
-		"tasks.bmc.tinkerbell.org",
-		"hardware.tinkerbell.org",
-		"templates.tinkerbell.org",
-		"tinkerbellclusters.infrastructure.cluster.x-k8s.io",
-		"tinkerbelldatacenterconfigs.anywhere.eks.amazonaws.com",
-		"tinkerbellmachineconfigs.anywhere.eks.amazonaws.com",
-		"tinkerbellmachines.infrastructure.cluster.x-k8s.io",
-		"tinkerbellmachinetemplates.infrastructure.cluster.x-k8s.io",
-		"tinkerbelltemplateconfigs.anywhere.eks.amazonaws.com",
-		"workflows.tinkerbell.org",
-	}
-	return c.generateCrdCollectors(captCrds)
-}
-
-func (c *EKSACollectorFactory) vsphereCrdCollectors() []*Collect {
-	capvCrds := []string{
-		"vsphereclusteridentities.infrastructure.cluster.x-k8s.io",
-		"vsphereclusters.infrastructure.cluster.x-k8s.io",
-		"vspheredatacenterconfigs.anywhere.eks.amazonaws.com",
-		"vspheremachineconfigs.anywhere.eks.amazonaws.com",
-		"vspheremachines.infrastructure.cluster.x-k8s.io",
-		"vspheremachinetemplates.infrastructure.cluster.x-k8s.io",
-		"vspherevms.infrastructure.cluster.x-k8s.io",
-	}
-	return c.generateCrdCollectors(capvCrds)
-}
-
-func (c *EKSACollectorFactory) cloudstackCrdCollectors() []*Collect {
-	crds := []string{
-		"cloudstackaffinitygroups.infrastructure.cluster.x-k8s.io",
-		"cloudstackclusters.infrastructure.cluster.x-k8s.io",
-		"cloudstackdatacenterconfigs.anywhere.eks.amazonaws.com",
-		"cloudstackisolatednetworks.infrastructure.cluster.x-k8s.io",
-		"cloudstackmachineconfigs.anywhere.eks.amazonaws.com",
-		"cloudstackmachines.infrastructure.cluster.x-k8s.io",
-		"cloudstackmachinestatecheckers.infrastructure.cluster.x-k8s.io",
-		"cloudstackmachinetemplates.infrastructure.cluster.x-k8s.io",
-		"cloudstackzones.infrastructure.cluster.x-k8s.io",
-	}
-	return c.generateCrdCollectors(crds)
-}
-
-func (c *EKSACollectorFactory) packagesCrdCollectors() []*Collect {
-	packageCrds := []string{
-		"packagebundlecontrollers.packages.eks.amazonaws.com",
-		"packagebundles.packages.eks.amazonaws.com",
-		"packagecontrollers.packages.eks.amazonaws.com",
-		"packages.packages.eks.amazonaws.com",
-	}
-	return c.generateCrdCollectors(packageCrds)
-}
-
-func (c *EKSACollectorFactory) nutanixCrdCollectors() []*Collect {
-	capxCrds := []string{
-		"nutanixclusters.infrastructure.cluster.x-k8s.io",
-		"nutanixdatacenterconfigs.anywhere.eks.amazonaws.com",
-		"nutanixmachineconfigs.anywhere.eks.amazonaws.com",
-		"nutanixmachines.infrastructure.cluster.x-k8s.io",
-		"nutanixmachinetemplates.infrastructure.cluster.x-k8s.io",
-	}
-	return c.generateCrdCollectors(capxCrds)
-}
-
-func (c *EKSACollectorFactory) generateCrdCollectors(crds []string) []*Collect {
-	var crdCollectors []*Collect
-	for _, d := range crds {
-		crdCollectors = append(crdCollectors, c.crdCollector(d))
-	}
-	return crdCollectors
-}
-
-func (c *EKSACollectorFactory) crdCollector(crdType string) *Collect {
-	command := []string{"kubectl"}
-	args := []string{"get", crdType, "-o", "json", "--all-namespaces"}
-	collectorPath := crdPath(crdType)
-	return &Collect{
-		RunPod: &runPod{
-			collectorMeta: collectorMeta{
-				CollectorName: crdType,
-			},
-			Name:      collectorPath,
-			Namespace: constants.EksaDiagnosticsNamespace,
-			PodSpec: &v1.PodSpec{
-				Containers: []v1.Container{{
-					Name:    collectorPath,
-					Image:   c.DiagnosticCollectorImage,
-					Command: command,
-					Args:    args,
-				}},
-				// It's possible for networking to not be working on the cluster or the nodes
-				// not being ready, so adding tolerations and running the pod on host networking
-				// to be able to pull the resources from the cluster
-				HostNetwork: true,
-				Tolerations: []v1.Toleration{{
-					Key:    "node.kubernetes.io",
-					Value:  "not-ready",
-					Effect: "NoSchedule",
-				}},
-			},
-			Timeout: "30s",
-		},
-	}
-}
-
 // apiServerCollectors collect connection info when running a pod on an existing cluster.
 func (c *EKSACollectorFactory) apiServerCollectors(controlPlaneIP string) []*Collect {
 	var collectors []*Collect
@@ -731,10 +585,6 @@ func logpath(namespace string) string {
 
 func hostlogPath(logType string) string {
 	return fmt.Sprintf("hostLogs/%s", logType)
-}
-
-func crdPath(crdType string) string {
-	return fmt.Sprintf("crds/%s", crdType)
 }
 
 // webhookConfigCollectors returns collectors for admission webhook configurations.

--- a/pkg/diagnostics/collectors_test.go
+++ b/pkg/diagnostics/collectors_test.go
@@ -75,16 +75,12 @@ func TestVsphereDataCenterConfigCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.VSphereDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(11), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(4), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapvSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapvSystemNamespace)))
-	for _, collector := range collectors[1:7] {
-		g.Expect(collector.RunPod.PodSpec.Containers[0].Command).To(Equal([]string{"kubectl"}))
-		g.Expect(collector.RunPod.Namespace).To(Equal("eksa-diagnostics"))
-	}
-	g.Expect(collectors[8].RunPod.PodSpec.Containers[0].Name).To(Equal("check-host-port"))
-	g.Expect(collectors[9].RunPod.PodSpec.Containers[0].Name).To(Equal("ping-host-ip"))
-	g.Expect(collectors[10].RunPod.PodSpec.Containers[0].Name).To(Equal("check-cloud-controller"))
+	g.Expect(collectors[1].RunPod.PodSpec.Containers[0].Name).To(Equal("check-host-port"))
+	g.Expect(collectors[2].RunPod.PodSpec.Containers[0].Name).To(Equal("ping-host-ip"))
+	g.Expect(collectors[3].RunPod.PodSpec.Containers[0].Name).To(Equal("check-cloud-controller"))
 }
 
 func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
@@ -93,13 +89,9 @@ func TestCloudStackDataCenterConfigCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.CloudStackDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(10), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(1), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapcSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapcSystemNamespace)))
-	for _, collector := range collectors[1:] {
-		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
-		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
-	}
 }
 
 func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
@@ -108,13 +100,9 @@ func TestTinkerbellDataCenterConfigCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.TinkerbellDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(13), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(1), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CaptSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CaptSystemNamespace)))
-	for _, collector := range collectors[1:] {
-		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
-		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
-	}
 }
 
 func TestSnowCollectors(t *testing.T) {
@@ -123,13 +111,9 @@ func TestSnowCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.SnowDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(6), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(1), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapasSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapasSystemNamespace)))
-	for _, collector := range collectors[1:] {
-		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
-		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
-	}
 }
 
 func TestNutanixCollectors(t *testing.T) {
@@ -138,13 +122,9 @@ func TestNutanixCollectors(t *testing.T) {
 	datacenter := eksav1alpha1.Ref{Kind: eksav1alpha1.NutanixDatacenterKind}
 	factory := diagnostics.NewDefaultCollectorFactory(test.NewFileReader())
 	collectors := factory.DataCenterConfigCollectors(datacenter, spec)
-	g.Expect(collectors).To(HaveLen(6), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
+	g.Expect(collectors).To(HaveLen(1), "DataCenterConfigCollectors() mismatch between number of desired collectors and actual")
 	g.Expect(collectors[0].Logs.Namespace).To(Equal(constants.CapxSystemNamespace))
 	g.Expect(collectors[0].Logs.Name).To(Equal(fmt.Sprintf("logs/%s", constants.CapxSystemNamespace)))
-	for _, collector := range collectors[1:] {
-		g.Expect([]string{"kubectl"}).To(Equal(collector.RunPod.PodSpec.Containers[0].Command))
-		g.Expect("eksa-diagnostics").To(Equal(collector.RunPod.Namespace))
-	}
 }
 
 func TestHostCollectors(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
custom runPod collectors present in the code for custom crds of ours, is neither needed nor being used. We rely on the custom-resources collected as part of cluster resources collector. And the crd collectors added in the code always fail currently due to usage of `/` containing file path as pod&container name. 

Refer the crd collector failure entries in the following excerpt from a product cluster support bundle, execution-data/summary.txt file 
```
============ Collectors summary =============
Succeeded (S), eXcluded (X), Failed (F)
=============================================
cluster-resources (S)                                               : 349,275ms
copy-from-host (S)                                                  : 40,881ms
run-pod/nutanixmachines.infrastructure.cluster.x-k8s.io (F)         : 31,205ms
run-pod/packagecontrollers.packages.eks.amazonaws.com (F)           : 31,204ms
run-pod/nutanixclusters.infrastructure.cluster.x-k8s.io (F)         : 31,201ms
run-pod/nutanixmachineconfigs.anywhere.eks.amazonaws.com (F)        : 31,200ms
run-pod/packagebundles.packages.eks.amazonaws.com (F)               : 31,200ms
run-pod/packagebundlecontrollers.packages.eks.amazonaws.com (F)     : 31,199ms
run-pod/nutanixdatacenterconfigs.anywhere.eks.amazonaws.com (F)     : 31,195ms
run-pod/nutanixmachinetemplates.infrastructure.cluster.x-k8s.io (F) : 31,195ms
run-pod/packages.packages.eks.amazonaws.com (F)                     : 31,195ms
secret (S)                                                          : 174ms
cluster-info (S)                                                    : 174ms
logs (S)                                                            : 173ms
data (S)                                                            : 0ms
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

