### PR TITLE
Use test framework cleanup to cleanup the certs

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -27,11 +27,11 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		packagePrefix := "test"
 		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace, e.ClusterName)
 		// Ensure cleanup happens even if the test fails
-		defer func() {
+		e.T.Cleanup(func() {
 			if err := e.CleanupCerts(withCluster(test.ManagementCluster)); err != nil {
 				e.T.Logf("Warning: Failed to cleanup certificates: %v", err)
 			}
-		}()
+		})
 		e.VerifyCertManagerPackageInstalled(packagePrefix, EksaPackagesNamespace, cmPackageName, withCluster(test.ManagementCluster))
 		e.DeleteClusterWithKubectl()
 		e.ValidateClusterDelete()


### PR DESCRIPTION
*Issue #, if available:*
We are still seeing left over test certs in route53. Current clean up is in defer func but if the other methods fatals it calls runtime Goexit which immediately terminates the current goroutine and this skips calling defer func.

*Description of changes:*
Using t.Cleanup() to register certs cleanup with test framework.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

