### PR TITLE
Migrate registry mirror config to containerd v2 format

### DIFF
--- a/internal/test/registrymirror.go
+++ b/internal/test/registrymirror.go
@@ -42,14 +42,31 @@ xTAY4N4C2s/wIybZxaJ8iQ39OzDpyN2Ym40Q58GVOHt16XCjFVVorVcZsI3y2B9Q
 func RegistryMirrorConfigFilesInsecureSkipVerify() []bootstrapv1.File {
 	return []bootstrapv1.File{
 		{
-			Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://0.0.0.0:5000"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."0.0.0.0:5000".tls]
-    insecure_skip_verify = true
+			Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
 `,
 			Owner: "root:root",
 			Path:  "/etc/containerd/config_append.toml",
+		},
+		{
+			Content: `server = "https://0.0.0.0:5000"
+
+[host."https://0.0.0.0:5000"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+`,
+			Owner: "root:root",
+			Path:  "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml",
+		},
+		{
+			Content: `server = "https://public.ecr.aws"
+
+[host."https://0.0.0.0:5000"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+`,
+			Owner: "root:root",
+			Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
 		},
 	}
 }
@@ -64,15 +81,33 @@ func RegistryMirrorConfigFilesInsecureSkipVerifyAndCACert() []bootstrapv1.File {
 			Path:    "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt",
 		},
 		{
-			Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://0.0.0.0:5000"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."0.0.0.0:5000".tls]
-    ca_file = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
-    insecure_skip_verify = true
+			Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
 `,
 			Owner: "root:root",
 			Path:  "/etc/containerd/config_append.toml",
+		},
+		{
+			Content: `server = "https://0.0.0.0:5000"
+
+[host."https://0.0.0.0:5000"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
+  skip_verify = true
+`,
+			Owner: "root:root",
+			Path:  "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml",
+		},
+		{
+			Content: `server = "https://public.ecr.aws"
+
+[host."https://0.0.0.0:5000"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
+  skip_verify = true
+`,
+			Owner: "root:root",
+			Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
 		},
 	}
 }

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -268,22 +268,42 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          {{- range $orig, $mirror := .registryMirrorMap }}
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-            endpoint = ["https://{{ $mirror }}"]
-          {{- end }}
-          {{- if or .registryCACert .insecureSkip }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-          {{- if .registryCACert }}
-            ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-          {{- end }}
-          {{- if .insecureSkip }}
-            insecure_skip_verify = {{.insecureSkip}}
-          {{- end }}
-          {{- end }}
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://{{ .mirrorBase }}"
+        
+        [host."https://{{ .mirrorBase }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or .registryCACert .insecureSkip }}
+        {{- if .registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if .insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+    {{- range $orig, $mirror := .registryMirrorMap }}
+    - content: |
+        server = "https://{{ $orig }}"
+        
+        [host."https://{{ $mirror }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or $.registryCACert $.insecureSkip }}
+        {{- if $.registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if $.insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+    {{- end }}
 {{- end }}
 {{- if .awsIamAuth}}
     - content: |

--- a/pkg/providers/cloudstack/config/template-md.yaml
+++ b/pkg/providers/cloudstack/config/template-md.yaml
@@ -65,22 +65,42 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            {{- range $orig, $mirror := .registryMirrorMap }}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-              endpoint = ["https://{{ $mirror }}"]
-            {{- end }}
-            {{- if or .registryCACert .insecureSkip }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-            {{- if .registryCACert }}
-              ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-            {{- end }}
-            {{- if .insecureSkip }}
-              insecure_skip_verify = {{.insecureSkip}}
-            {{- end }}
-            {{- end }}
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://{{ .mirrorBase }}"
+          
+          [host."https://{{ .mirrorBase }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or .registryCACert .insecureSkip }}
+          {{- if .registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if .insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+      {{- range $orig, $mirror := .registryMirrorMap }}
+      - content: |
+          server = "https://{{ $orig }}"
+          
+          [host."https://{{ $mirror }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or $.registryCACert $.insecureSkip }}
+          {{- if $.registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if $.insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+      {{- end }}
 {{- end }}
       preKubeadmCommands:
       - swapoff -a

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -319,11 +319,24 @@ spec:
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:443/v2/eks-anywhere"]
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:443"
+        
+        [host."https://1.2.3.4:443"]
+          capabilities = ["pull", "resolve"]
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:443/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_md.yaml
@@ -18,11 +18,24 @@ spec:
           name: "{{ ds.meta_data.hostname }}"
       files:
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:443/v2/eks-anywhere"]
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:443"
+          
+          [host."https://1.2.3.4:443"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:443/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - swapoff -a
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -339,13 +339,26 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:443"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:443"
+        
+        [host."https://1.2.3.4:443"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:443"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -38,13 +38,26 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:443"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:443"
+          
+          [host."https://1.2.3.4:443"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:443"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - swapoff -a
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
@@ -330,14 +330,28 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://0.0.0.0:5000"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."0.0.0.0:5000".tls]
-            ca_file = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
-            insecure_skip_verify = true
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://0.0.0.0:5000"
+        
+        [host."https://0.0.0.0:5000"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
+          skip_verify = true
+      owner: root:root
+      path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://0.0.0.0:5000"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
+          skip_verify = true
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_md.yaml
@@ -29,14 +29,28 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://0.0.0.0:5000"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."0.0.0.0:5000".tls]
-              ca_file = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
-              insecure_skip_verify = true
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://0.0.0.0:5000"
+          
+          [host."https://0.0.0.0:5000"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
+            skip_verify = true
+        owner: root:root
+        path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://0.0.0.0:5000"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
+            skip_verify = true
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - swapoff -a
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
@@ -319,13 +319,26 @@ spec:
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://0.0.0.0:5000"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."0.0.0.0:5000".tls]
-            insecure_skip_verify = true
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://0.0.0.0:5000"
+        
+        [host."https://0.0.0.0:5000"]
+          capabilities = ["pull", "resolve"]
+          skip_verify = true
+      owner: root:root
+      path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://0.0.0.0:5000"]
+          capabilities = ["pull", "resolve"]
+          skip_verify = true
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_md.yaml
@@ -18,13 +18,26 @@ spec:
           name: "{{ ds.meta_data.hostname }}"
       files:
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://0.0.0.0:5000"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."0.0.0.0:5000".tls]
-              insecure_skip_verify = true
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://0.0.0.0:5000"
+          
+          [host."https://0.0.0.0:5000"]
+            capabilities = ["pull", "resolve"]
+            skip_verify = true
+        owner: root:root
+        path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://0.0.0.0:5000"]
+            capabilities = ["pull", "resolve"]
+            skip_verify = true
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - swapoff -a
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -174,27 +174,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          {{- range $orig, $mirror := .registryMirrorMap }}
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-            endpoint = ["https://{{ $mirror }}"]
-          {{- end }}
-          {{- if or .registryCACert .insecureSkip }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-          {{- if .registryCACert }}
-            ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-          {{- end }}
-          {{- if .insecureSkip }}
-            insecure_skip_verify = {{.insecureSkip}}
-          {{- end }}
-          {{- end }}
-          {{- if .registryAuth }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-            username = "{{.registryUsername}}"
-            password = "{{.registryPassword}}"
-          {{- end }}
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://{{ .mirrorBase }}"
+        
+        [host."https://{{ .mirrorBase }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or .registryCACert .insecureSkip }}
+        {{- if .registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if .insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+        {{- if .registryAuth }}
+          [host."https://{{ .mirrorBase }}".header]
+            authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+    {{- range $orig, $mirror := .registryMirrorMap }}
+    - content: |
+        server = "https://{{ $orig }}"
+        
+        [host."https://{{ $mirror }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or $.registryCACert $.insecureSkip }}
+        {{- if $.registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if $.insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+        {{- if $.registryAuth }}
+          [host."https://{{ $mirror }}".header]
+            authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+    {{- end }}
 {{- end }}
 {{- if .awsIamAuth}}
     - content: |

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -53,27 +53,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            {{- range $orig, $mirror := .registryMirrorMap }}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-              endpoint = ["https://{{ $mirror }}"]
-            {{- end }}
-            {{- if or .registryCACert .insecureSkip }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-            {{- if .registryCACert }}
-              ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-            {{- end }}
-            {{- if .insecureSkip }}
-              insecure_skip_verify = {{.insecureSkip}}
-            {{- end }}
-            {{- end }}
-            {{- if .registryAuth }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-              username = "{{.registryUsername}}"
-              password = "{{.registryPassword}}"
-            {{- end }}
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://{{ .mirrorBase }}"
+          
+          [host."https://{{ .mirrorBase }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or .registryCACert .insecureSkip }}
+          {{- if .registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if .insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if .registryAuth }}
+            [host."https://{{ .mirrorBase }}".header]
+              authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+      {{- range $orig, $mirror := .registryMirrorMap }}
+      - content: |
+          server = "https://{{ $orig }}"
+          
+          [host."https://{{ $mirror }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or $.registryCACert $.insecureSkip }}
+          {{- if $.registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if $.insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if $.registryAuth }}
+            [host."https://{{ $mirror }}".header]
+              authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+      {{- end }}
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - systemctl daemon-reload

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
@@ -265,11 +265,24 @@ spec:
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_md.yaml
@@ -16,11 +16,24 @@ spec:
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       files:
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - systemctl daemon-reload

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -286,16 +286,30 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-            username = "username"
-            password = "password"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [host."https://1.2.3.4:1234".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [host."https://1.2.3.4:1234/v2/eks-anywhere".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_md.yaml
@@ -37,16 +37,30 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-              username = "username"
-              password = "password"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [host."https://1.2.3.4:1234".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [host."https://1.2.3.4:1234/v2/eks-anywhere".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - systemctl daemon-reload

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
@@ -286,13 +286,26 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_md.yaml
@@ -37,13 +37,26 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - systemctl daemon-reload

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -288,27 +288,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          {{- range $orig, $mirror := .registryMirrorMap }}
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-            endpoint = ["https://{{ $mirror }}"]
-          {{- end }}
-{{- if or .registryCACert .insecureSkip }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-{{- if .registryCACert }}
-            ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .insecureSkip }}
-            insecure_skip_verify = {{ .insecureSkip }}
-{{- end }}
-{{- end }}
-{{- if .registryAuth }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-            username = "{{.registryUsername}}"
-            password = "{{.registryPassword}}"
-{{- end }}
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://{{ .mirrorBase }}"
+        
+        [host."https://{{ .mirrorBase }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or .registryCACert .insecureSkip }}
+        {{- if .registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if .insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+        {{- if .registryAuth }}
+          [host."https://{{ .mirrorBase }}".header]
+            authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+    {{- range $orig, $mirror := .registryMirrorMap }}
+    - content: |
+        server = "https://{{ $orig }}"
+        
+        [host."https://{{ $mirror }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or $.registryCACert $.insecureSkip }}
+        {{- if $.registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if $.insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+        {{- if $.registryAuth }}
+          [host."https://{{ $mirror }}".header]
+            authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+    {{- end }}
 {{- end }}
 {{- if .awsIamAuth}}
     - content: |

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -299,25 +299,48 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            {{- range $orig, $mirror := .registryMirrorMap }}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-              endpoint = ["https://{{ $mirror }}"]
-{{- end }}
-{{- if or .registryCACert .insecureSkip }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-{{- if .registryCACert }}
-              ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .insecureSkip }}
-              insecure_skip_verify = {{ .insecureSkip }}
-{{- end }}
-{{- end }}
-{{- if .registryAuth }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-              username = "{{.registryUsername}}"
-              password = "{{.registryPassword}}"
-{{- end }}
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://{{ .mirrorBase }}"
+          
+          [host."https://{{ .mirrorBase }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or .registryCACert .insecureSkip }}
+          {{- if .registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if .insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if .registryAuth }}
+            [host."https://{{ .mirrorBase }}".header]
+              authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+      {{- range $orig, $mirror := .registryMirrorMap }}
+      - content: |
+          server = "https://{{ $orig }}"
+          
+          [host."https://{{ $mirror }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or $.registryCACert $.insecureSkip }}
+          {{- if $.registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if $.insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if $.registryAuth }}
+            [host."https://{{ $mirror }}".header]
+              authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+      {{- end }}
 {{- end }}

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -175,17 +175,32 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            insecure_skip_verify = true
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-            username = "username"
-            password = "password"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          skip_verify = true
+          [host."https://1.2.3.4:1234".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          skip_verify = true
+          [host."https://1.2.3.4:1234/v2/eks-anywhere".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     - content: |
         apiVersion: audit.k8s.io/v1beta1
         kind: Policy

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror_md.yaml
@@ -106,16 +106,31 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-              insecure_skip_verify = true
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-              username = "username"
-              password = "password"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            skip_verify = true
+            [host."https://1.2.3.4:1234".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            skip_verify = true
+            [host."https://1.2.3.4:1234/v2/eks-anywhere".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
 
 ---

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -413,27 +413,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            {{- range $orig, $mirror := .registryMirrorMap }}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-              endpoint = ["https://{{ $mirror }}"]
-            {{- end }}
-            {{- if or .registryCACert .insecureSkip }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-            {{- if .registryCACert }}
-              ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-            {{- end }}
-            {{- if .insecureSkip }}
-              insecure_skip_verify = {{.insecureSkip}}
-            {{- end }}
-            {{- end }}
-            {{- if .registryAuth }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-              username = "{{.registryUsername}}"
-              password = "{{.registryPassword}}"
-            {{- end }}
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://{{ .mirrorBase }}"
+          
+          [host."https://{{ .mirrorBase }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or .registryCACert .insecureSkip }}
+          {{- if .registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if .insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if .registryAuth }}
+            [host."https://{{ .mirrorBase }}".header]
+              authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+      {{- range $orig, $mirror := .registryMirrorMap }}
+      - content: |
+          server = "https://{{ $orig }}"
+          
+          [host."https://{{ $mirror }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or $.registryCACert $.insecureSkip }}
+          {{- if $.registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if $.insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if $.registryAuth }}
+            [host."https://{{ $mirror }}".header]
+              authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- if .cpNtpServers }}

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -172,27 +172,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
         - content: |
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-              {{- range $orig, $mirror := .registryMirrorMap }}
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-                endpoint = ["https://{{ $mirror }}"]
-              {{- end }}
-              {{- if or .registryCACert .insecureSkip }}
-              [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-              {{- if .registryCACert }}
-                ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-              {{- end }}
-              {{- if .insecureSkip }}
-                insecure_skip_verify = {{.insecureSkip}}
-              {{- end }}
-              {{- end }}
-              {{- if .registryAuth }}
-              [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-                username = "{{.registryUsername}}"
-                password = "{{.registryPassword}}"
-              {{- end }}
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
           owner: root:root
           path: "/etc/containerd/config_append.toml"
+        - content: |
+            server = "https://{{ .mirrorBase }}"
+            
+            [host."https://{{ .mirrorBase }}"]
+              capabilities = ["pull", "resolve"]
+            {{- if or .registryCACert .insecureSkip }}
+            {{- if .registryCACert }}
+              ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+            {{- end }}
+            {{- if .insecureSkip }}
+              skip_verify = true
+            {{- end }}
+            {{- end }}
+            {{- if .registryAuth }}
+              [host."https://{{ .mirrorBase }}".header]
+                authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+            {{- end }}
+          owner: root:root
+          path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+        {{- range $orig, $mirror := .registryMirrorMap }}
+        - content: |
+            server = "https://{{ $orig }}"
+            
+            [host."https://{{ $mirror }}"]
+              capabilities = ["pull", "resolve"]
+            {{- if or $.registryCACert $.insecureSkip }}
+            {{- if $.registryCACert }}
+              ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+            {{- end }}
+            {{- if $.insecureSkip }}
+              skip_verify = true
+            {{- end }}
+            {{- end }}
+            {{- if $.registryAuth }}
+              [host."https://{{ $mirror }}".header]
+                authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+            {{- end }}
+          owner: root:root
+          path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+        {{- end }}
 {{- end }}
 {{- end }}
 {{- if .ntpServers }}

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -857,14 +857,28 @@ spec:
       path: /var/lib/kubeadm/aws-iam-authenticator/pki/key.pem
       permissions: "0640"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://:"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs.":".auth]
-            username = "username"
-            password = "password"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: /etc/containerd/config_append.toml
+    - content: |
+        server = "https://:"
+        
+        [host."https://:"]
+          capabilities = ["pull", "resolve"]
+          [host."https://:".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: /etc/containerd/certs.d/:/hosts.toml
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://:"]
+          capabilities = ["pull", "resolve"]
+          [host."https://:".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: /etc/containerd/certs.d/public.ecr.aws/hosts.toml
     format: cloud-config
     initConfiguration:
       localAPIEndpoint: {}

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
@@ -287,11 +287,24 @@ spec:
         owner: root:root
         path: /etc/kubernetes/audit-policy.yaml
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     preKubeadmCommands:
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
     - sudo systemctl daemon-reload

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
@@ -307,16 +307,30 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-              username = "username"
-              password = "password"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [host."https://1.2.3.4:1234".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [host."https://1.2.3.4:1234".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     preKubeadmCommands:
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
     - sudo systemctl daemon-reload

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -307,15 +307,34 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
-              endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
+          
+          [host."https://1.2.3.4:1234/v2/curated-packages"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     preKubeadmCommands:
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
     - sudo systemctl daemon-reload

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
@@ -164,11 +164,24 @@ spec:
             tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       files:
         - content: |
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-                endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
           owner: root:root
           path: "/etc/containerd/config_append.toml"
+        - content: |
+            server = "https://1.2.3.4:1234"
+            
+            [host."https://1.2.3.4:1234"]
+              capabilities = ["pull", "resolve"]
+          owner: root:root
+          path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+        - content: |
+            server = "https://public.ecr.aws"
+            
+            [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+              capabilities = ["pull", "resolve"]
+          owner: root:root
+          path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
@@ -180,16 +180,30 @@ spec:
           owner: root:root
           path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         - content: |
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-                endpoint = ["https://1.2.3.4:1234"]
-              [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-                ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-              [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-                username = "username"
-                password = "password"
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
           owner: root:root
           path: "/etc/containerd/config_append.toml"
+        - content: |
+            server = "https://1.2.3.4:1234"
+            
+            [host."https://1.2.3.4:1234"]
+              capabilities = ["pull", "resolve"]
+              ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+              [host."https://1.2.3.4:1234".header]
+                authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+          owner: root:root
+          path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+        - content: |
+            server = "https://public.ecr.aws"
+            
+            [host."https://1.2.3.4:1234"]
+              capabilities = ["pull", "resolve"]
+              ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+              [host."https://1.2.3.4:1234".header]
+                authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+          owner: root:root
+          path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
@@ -184,15 +184,34 @@ spec:
           owner: root:root
           path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         - content: |
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
-                endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-                endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-              [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-                ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
           owner: root:root
           path: "/etc/containerd/config_append.toml"
+        - content: |
+            server = "https://1.2.3.4:1234"
+            
+            [host."https://1.2.3.4:1234"]
+              capabilities = ["pull", "resolve"]
+              ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          owner: root:root
+          path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+        - content: |
+            server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
+            
+            [host."https://1.2.3.4:1234/v2/curated-packages"]
+              capabilities = ["pull", "resolve"]
+              ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          owner: root:root
+          path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
+        - content: |
+            server = "https://public.ecr.aws"
+            
+            [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+              capabilities = ["pull", "resolve"]
+              ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          owner: root:root
+          path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
@@ -307,13 +307,26 @@ spec:
       owner: root:root
       path: /etc/containerd/certs.d/10.10.10.10:443/ca.crt
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://10.10.10.10:443"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."10.10.10.10:443".tls]
-            ca_file = "/etc/containerd/certs.d/10.10.10.10:443/ca.crt"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: /etc/containerd/config_append.toml
+    - content: |
+        server = "https://10.10.10.10:443"
+
+        [host."https://10.10.10.10:443"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/10.10.10.10:443/ca.crt"
+      owner: root:root
+      path: /etc/containerd/certs.d/10.10.10.10:443/hosts.toml
+    - content: |
+        server = "https://public.ecr.aws"
+
+        [host."https://10.10.10.10:443"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/10.10.10.10:443/ca.crt"
+      owner: root:root
+      path: /etc/containerd/certs.d/public.ecr.aws/hosts.toml
     format: cloud-config
     initConfiguration:
       nodeRegistration:

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -367,27 +367,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          {{- range $orig, $mirror := .registryMirrorMap }}
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-            endpoint = ["https://{{ $mirror }}"]
-          {{- end }}
-          {{- if or .registryCACert .insecureSkip }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-          {{- if .registryCACert }}
-            ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-          {{- end }}
-          {{- if .insecureSkip }}
-            insecure_skip_verify = {{.insecureSkip}}
-          {{- end }}
-          {{- end }}
-          {{- if .registryAuth }}
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-            username = "{{.registryUsername}}"
-            password = "{{.registryPassword}}"
-          {{- end }}
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://{{ .mirrorBase }}"
+        
+        [host."https://{{ .mirrorBase }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or .registryCACert .insecureSkip }}
+        {{- if .registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if .insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+        {{- if .registryAuth }}
+          [host."https://{{ .mirrorBase }}".header]
+            authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+    {{- range $orig, $mirror := .registryMirrorMap }}
+    - content: |
+        server = "https://{{ $orig }}"
+        
+        [host."https://{{ $mirror }}"]
+          capabilities = ["pull", "resolve"]
+        {{- if or $.registryCACert $.insecureSkip }}
+        {{- if $.registryCACert }}
+          ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+        {{- end }}
+        {{- if $.insecureSkip }}
+          skip_verify = true
+        {{- end }}
+        {{- end }}
+        {{- if $.registryAuth }}
+          [host."https://{{ $mirror }}".header]
+            authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+        {{- end }}
+      owner: root:root
+      path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- if .awsIamAuth}}

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -113,27 +113,50 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            {{- range $orig, $mirror := .registryMirrorMap }}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-              endpoint = ["https://{{ $mirror }}"]
-            {{- end }}
-            {{- if or .registryCACert .insecureSkip }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-            {{- if .registryCACert }}
-              ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-            {{- end }}
-            {{- if .insecureSkip }}
-              insecure_skip_verify = {{.insecureSkip}}
-            {{- end }}
-            {{- end }}
-            {{- if .registryAuth }}
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".auth]
-              username = "{{.registryUsername}}"
-              password = "{{.registryPassword}}"
-            {{- end }}
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://{{ .mirrorBase }}"
+          
+          [host."https://{{ .mirrorBase }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or .registryCACert .insecureSkip }}
+          {{- if .registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if .insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if .registryAuth }}
+            [host."https://{{ .mirrorBase }}".header]
+              authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ .mirrorBase }}/hosts.toml"
+      {{- range $orig, $mirror := .registryMirrorMap }}
+      - content: |
+          server = "https://{{ $orig }}"
+          
+          [host."https://{{ $mirror }}"]
+            capabilities = ["pull", "resolve"]
+          {{- if or $.registryCACert $.insecureSkip }}
+          {{- if $.registryCACert }}
+            ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"
+          {{- end }}
+          {{- if $.insecureSkip }}
+            skip_verify = true
+          {{- end }}
+          {{- end }}
+          {{- if $.registryAuth }}
+            [host."https://{{ $mirror }}".header]
+              authorization = "Basic {{ printf "%s:%s" $.registryUsername $.registryPassword | b64enc }}"
+          {{- end }}
+        owner: root:root
+        path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- if .ntpServers }}

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -333,11 +333,24 @@ spec:
       owner: root:root
       path: /etc/kubernetes/audit-policy.yaml
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -19,11 +19,24 @@ spec:
           name: '{{ ds.meta_data.hostname }}'
       files:
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -353,15 +353,34 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
-            endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
+        
+        [host."https://1.2.3.4:1234/v2/curated-packages"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -39,15 +39,34 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
-              endpoint = ["https://1.2.3.4:1234/v2/curated-packages"]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234/v2/eks-anywhere"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
+          
+          [host."https://1.2.3.4:1234/v2/curated-packages"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234/v2/eks-anywhere"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -353,16 +353,30 @@ spec:
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
     - content: |
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-            endpoint = ["https://1.2.3.4:1234"]
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-            ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-          [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-            username = "username"
-            password = "password"
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
       owner: root:root
       path: "/etc/containerd/config_append.toml"
+    - content: |
+        server = "https://1.2.3.4:1234"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [host."https://1.2.3.4:1234".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+    - content: |
+        server = "https://public.ecr.aws"
+        
+        [host."https://1.2.3.4:1234"]
+          capabilities = ["pull", "resolve"]
+          ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+          [host."https://1.2.3.4:1234".header]
+            authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+      owner: root:root
+      path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_md.yaml
@@ -39,16 +39,30 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       - content: |
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-              endpoint = ["https://1.2.3.4:1234"]
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".tls]
-              ca_file = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:1234".auth]
-              username = "username"
-              password = "password"
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
         owner: root:root
         path: "/etc/containerd/config_append.toml"
+      - content: |
+          server = "https://1.2.3.4:1234"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [host."https://1.2.3.4:1234".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
+      - content: |
+          server = "https://public.ecr.aws"
+          
+          [host."https://1.2.3.4:1234"]
+            capabilities = ["pull", "resolve"]
+            ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
+            [host."https://1.2.3.4:1234".header]
+              authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        owner: root:root
+        path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - sudo systemctl daemon-reload


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3649

*Description of changes:*
This migrates containerd registry mirror configuration from v1 to v2 configuration format for all providers. This is required to support containerd v2 that's shipped with k8s 1.34 onwards.

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

