### PR TITLE
Fix 1.33 stacked etcd test case

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3731,10 +3731,9 @@ func TestVSphereKubernetes133StackedEtcdUbuntu(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,
 		framework.NewVSphere(t, framework.WithUbuntu133()),
 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.DeleteCluster()
+		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+	runStackedEtcdFlow(test)
 }
 
 // Taints


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing TestVSphereKubernetes133StackedEtcdUbuntu as it's currently using unstacked etcd topology

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

