### PR TITLE
Add eksa namespace and rollout strategy config for nutanix cp template

### DIFF
--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -103,10 +103,16 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "{{.controlPlaneTemplateName}}"
+      namespace: {{.eksaSystemNamespace}}
 {{- if .upgradeRolloutStrategy }}
   rolloutStrategy:
     rollingUpdate:
       maxSurge: {{.maxSurge}} 
+  {{- else }}
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
 {{- end }}
   kubeadmConfigSpec:
     clusterConfiguration:

--- a/pkg/providers/nutanix/testdata/admission_exclusion_enabled.yaml
+++ b/pkg/providers/nutanix/testdata/admission_exclusion_enabled.yaml
@@ -3,6 +3,10 @@ kind: KubeadmControlPlane
 metadata:
   name: eksa-unit-test
 spec:
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -85,6 +85,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_cluster_ccm_exclude_node_ips.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_ccm_exclude_node_ips.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_cp.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cp.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_bootType.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_bootType.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -57,6 +57,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
@@ -57,6 +57,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_failure_domains.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_failure_domains.yaml
@@ -72,6 +72,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_gpus.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_gpus.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_multi_worker_fds.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_multi_worker_fds.yaml
@@ -68,6 +68,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -52,6 +52,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"

--- a/pkg/providers/nutanix/testdata/expected_results_worker_fds.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_worker_fds.yaml
@@ -68,6 +68,11 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixMachineTemplate
       name: "<no value>"
+      namespace: eksa-system
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: "public.ecr.aws/eks-distro/kubernetes"


### PR DESCRIPTION
*Issue #, if available:*
Latest capi v1.11.1 adds namespace and rolloutstrategy when converting v1beta2 to v1beta1. Since this fields are missing in nutanix cp template, when eksa controller applies cp, server side sees diff and updates it. This puts reconciliation in loop

*Description of changes:*
- Add eksa namespace and rollout strategy config for nutanix cp template
- Update unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

