### PR TITLE
Docker changes to accomodate CAPI 1.11.1 changes

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -30,6 +30,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -66,6 +67,7 @@ func init() {
 	utilruntime.Must(bootstrapv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vspherev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(dockerv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(dockerv1beta2.AddToScheme(scheme.Scheme))
 	utilruntime.Must(cloudstackv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(admissionv1beta1.AddToScheme(scheme.Scheme))

--- a/manager/main.go
+++ b/manager/main.go
@@ -27,6 +27,7 @@ import (
 	clusterv2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -58,6 +59,7 @@ func init() {
 	utilruntime.Must(vspherev1.AddToScheme(scheme))
 	utilruntime.Must(cloudstackv1.AddToScheme(scheme))
 	utilruntime.Must(dockerv1.AddToScheme(scheme))
+	utilruntime.Must(dockerv1beta2.AddToScheme(scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme))
 	utilruntime.Must(kubeadmv1.AddToScheme(scheme))
 	utilruntime.Must(eksdv1alpha1.AddToScheme(scheme))

--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -15,6 +15,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	tinkerbellv1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1/thirdparty/tinkerbell/capt/v1beta1"
@@ -37,6 +38,7 @@ var schemeAdders = []schemeAdder{
 	snowv1.AddToScheme,
 	cloudstackv1.AddToScheme,
 	dockerv1.AddToScheme,
+	dockerv1beta2.AddToScheme,
 	releasev1.AddToScheme,
 	eksdv1alpha1.AddToScheme,
 	vspherev1.AddToScheme,

--- a/pkg/controller/clusters/controlplane_test.go
+++ b/pkg/controller/clusters/controlplane_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -293,6 +293,12 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 					Name:      clusterName,
 					Namespace: namespace,
 				},
+				InfrastructureRef: &corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
+					Kind:       "DockerCluster",
+					Name:       clusterName,
+					Namespace:  namespace,
+				},
 			},
 		},
 		KubeadmControlPlane: &controlplanev1.KubeadmControlPlane{
@@ -311,19 +317,32 @@ func controlPlaneStackedEtcd(namespace string) *clusters.ControlPlane {
 				},
 			},
 		},
-		ProviderCluster: &dockerv1.DockerCluster{
+		ProviderCluster: &dockerv1beta2.DockerCluster{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 				Kind:       "DockerCluster",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
 				Namespace: namespace,
 			},
+			Spec: dockerv1beta2.DockerClusterSpec{
+				LoadBalancer: dockerv1beta2.DockerLoadBalancer{
+					ImageMeta: dockerv1beta2.ImageMeta{
+						ImageRepository: "public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind",
+						ImageTag:        "v0.11.1-eks-a-v0.0.0-dev-build.1464",
+					},
+				},
+			},
+			Status: dockerv1beta2.DockerClusterStatus{
+				Initialization: dockerv1beta2.DockerClusterInitializationStatus{
+					Provisioned: &[]bool{true}[0],
+				},
+			},
 		},
-		ControlPlaneMachineTemplate: &dockerv1.DockerMachineTemplate{
+		ControlPlaneMachineTemplate: &dockerv1beta2.DockerMachineTemplate{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 				Kind:       "DockerMachineTemplate",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -359,9 +378,9 @@ func controlPlaneExternalEtcd(namespace string) *clusters.ControlPlane {
 		Namespace: cp.EtcdCluster.Namespace,
 	}
 
-	cp.EtcdMachineTemplate = &dockerv1.DockerMachineTemplate{
+	cp.EtcdMachineTemplate = &dockerv1beta2.DockerMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 			Kind:       "DockerMachineTemplate",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/clusters/workers_test.go
+++ b/pkg/controller/clusters/workers_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -181,7 +181,7 @@ func kubeadmConfigTemplate(name, namespace string) *bootstrapv1.KubeadmConfigTem
 func dockerMachineTemplate(name, namespace string) *dockerv1.DockerMachineTemplate {
 	return &dockerv1.DockerMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 			Kind:       "DockerMachineTemplate",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -16,7 +16,7 @@ spec:
     name: {{.clusterName}}
     namespace: {{.eksaSystemNamespace}}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: {{.clusterName}}
     namespace: {{.eksaSystemNamespace}}
@@ -28,7 +28,7 @@ spec:
     namespace: {{.eksaSystemNamespace}}
 {{- end }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: {{.clusterName}}
@@ -38,7 +38,7 @@ spec:
     imageRepository: {{.haproxyImageRepository}}
     imageTag: {{.haproxyImageTag}}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: {{.controlPlaneTemplateName}}
@@ -59,7 +59,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: {{.controlPlaneTemplateName}}
       namespace: {{.eksaSystemNamespace}}
@@ -339,12 +339,12 @@ spec:
       {{- end }}
 {{- end }}
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: {{.etcdTemplateName}}
     namespace: {{.eksaSystemNamespace}}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: {{.etcdTemplateName}}

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -107,7 +107,7 @@ spec:
           namespace: {{.eksaSystemNamespace}}
       clusterName: {{.clusterName}}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: {{.workloadTemplateName}}
         namespace: {{.eksaSystemNamespace}}
@@ -119,7 +119,7 @@ spec:
       maxUnavailable: {{.maxUnavailable}}
 {{- end }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: {{.workloadTemplateName}}

--- a/pkg/providers/docker/controlplane.go
+++ b/pkg/providers/docker/controlplane.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"
@@ -16,9 +16,9 @@ import (
 )
 
 // ControlPlane represents a CAPI Docker control plane.
-type ControlPlane = clusterapi.ControlPlane[*dockerv1.DockerCluster, *dockerv1.DockerMachineTemplate]
+type ControlPlane = clusterapi.ControlPlane[*dockerv1beta2.DockerCluster, *dockerv1beta2.DockerMachineTemplate]
 
-type controlPlaneBuilder = yamlcapi.ControlPlaneBuilder[*dockerv1.DockerCluster, *dockerv1.DockerMachineTemplate]
+type controlPlaneBuilder = yamlcapi.ControlPlaneBuilder[*dockerv1beta2.DockerCluster, *dockerv1beta2.DockerMachineTemplate]
 
 // ControlPlaneSpec builds a docker ControlPlane definition based on an eks-a cluster spec.
 func ControlPlaneSpec(ctx context.Context, logger logr.Logger, client kubernetes.Client, spec *cluster.Spec) (*ControlPlane, error) {
@@ -58,14 +58,14 @@ func newControlPlaneParser(logger logr.Logger) (*yamlutil.Parser, *controlPlaneB
 		logger,
 		yamlutil.NewMapping(
 			"DockerCluster",
-			func() *dockerv1.DockerCluster {
-				return &dockerv1.DockerCluster{}
+			func() *dockerv1beta2.DockerCluster {
+				return &dockerv1beta2.DockerCluster{}
 			},
 		),
 		yamlutil.NewMapping(
 			"DockerMachineTemplate",
-			func() *dockerv1.DockerMachineTemplate {
-				return &dockerv1.DockerMachineTemplate{}
+			func() *dockerv1beta2.DockerMachineTemplate {
+				return &dockerv1beta2.DockerMachineTemplate{}
 			},
 		),
 	)

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -14,7 +14,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -176,8 +176,8 @@ func TestControlPlaneSpecNoChangesMachineTemplates(t *testing.T) {
 
 	// This is testing defaults. It's possible that some default logic will set items that are not set in our machine templates.
 	// We need to take this into consideration when checking for equality.
-	originalCPMachineTemplate.Spec.Template.Spec.ProviderID = ptr.String("default-id")
-	originalEtcdMachineTemplate.Spec.Template.Spec.ProviderID = ptr.String("default-id")
+	originalCPMachineTemplate.Spec.Template.Spec.ProviderID = "default-id"
+	originalEtcdMachineTemplate.Spec.Template.Spec.ProviderID = "default-id"
 
 	client := test.NewFakeKubeClient(
 		originalKubeadmControlPlane,
@@ -404,17 +404,17 @@ func capiCluster() *clusterv1.Cluster {
 				Kind:       "DockerCluster",
 				Name:       "test",
 				Namespace:  constants.EksaSystemNamespace,
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 			},
 		},
 	}
 }
 
-func dockerCluster() *dockerv1.DockerCluster {
-	return &dockerv1.DockerCluster{
+func dockerCluster() *dockerv1beta2.DockerCluster {
+	return &dockerv1beta2.DockerCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DockerCluster",
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -423,21 +423,21 @@ func dockerCluster() *dockerv1.DockerCluster {
 	}
 }
 
-func dockerMachineTemplate(name string) *dockerv1.DockerMachineTemplate {
-	return &dockerv1.DockerMachineTemplate{
+func dockerMachineTemplate(name string) *dockerv1beta2.DockerMachineTemplate {
+	return &dockerv1beta2.DockerMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DockerMachineTemplate",
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: constants.EksaSystemNamespace,
 		},
-		Spec: dockerv1.DockerMachineTemplateSpec{
-			Template: dockerv1.DockerMachineTemplateResource{
-				Spec: dockerv1.DockerMachineSpec{
+		Spec: dockerv1beta2.DockerMachineTemplateSpec{
+			Template: dockerv1beta2.DockerMachineTemplateResource{
+				Spec: dockerv1beta2.DockerMachineSpec{
 					CustomImage: "public.ecr.aws/eks-anywhere/kubernetes-sigs/kind/node:v1.23.12-eks-d-1-23-6-eks-a-19",
-					ExtraMounts: []dockerv1.Mount{
+					ExtraMounts: []dockerv1beta2.Mount{
 						{
 							ContainerPath: "/var/run/docker.sock",
 							HostPath:      "/var/run/docker.sock",
@@ -465,7 +465,7 @@ func kubeadmControlPlane(opts ...func(*controlplanev1.KubeadmControlPlane)) *con
 		Spec: controlplanev1.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
 				InfrastructureRef: corev1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 					Kind:       "DockerMachineTemplate",
 					Name:       "test-control-plane-1",
 					Namespace:  constants.EksaSystemNamespace,
@@ -750,7 +750,7 @@ func etcdCluster(opts ...func(*etcdv1.EtcdadmCluster)) *etcdv1.EtcdadmCluster {
 				CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 			},
 			InfrastructureTemplate: corev1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 				Kind:       "DockerMachineTemplate",
 				Name:       "test-etcd-1",
 				Namespace:  constants.EksaSystemNamespace,

--- a/pkg/providers/docker/machinetemplate.go
+++ b/pkg/providers/docker/machinetemplate.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 )

--- a/pkg/providers/docker/reconciler/reconciler_test.go
+++ b/pkg/providers/docker/reconciler/reconciler_test.go
@@ -17,7 +17,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -67,7 +67,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-control-plane-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -75,7 +75,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerCluster{
+		&dockerv1beta2.DockerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name,
 				Namespace: constants.EksaSystemNamespace,
@@ -83,7 +83,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyNotExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-etcd-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -118,7 +118,7 @@ func TestReconcilerReconcileSuccess(t *testing.T) {
 	)
 
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-md-0-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -201,7 +201,7 @@ func TestReconcilerReconcileWorkersSuccess(t *testing.T) {
 	)
 
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-md-0-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -247,7 +247,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-control-plane-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -255,7 +255,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerCluster{
+		&dockerv1beta2.DockerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name,
 				Namespace: constants.EksaSystemNamespace,
@@ -263,7 +263,7 @@ func TestReconcileControlPlaneStackedEtcdSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyNotExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-etcd-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -303,7 +303,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-control-plane-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -311,7 +311,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerCluster{
+		&dockerv1beta2.DockerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name,
 				Namespace: constants.EksaSystemNamespace,
@@ -319,7 +319,7 @@ func TestReconcileControlPlaneUnstackedEtcdSuccess(t *testing.T) {
 		},
 	)
 	tt.ShouldEventuallyExist(tt.ctx,
-		&dockerv1.DockerMachineTemplate{
+		&dockerv1beta2.DockerMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tt.cluster.Name + "-etcd-1",
 				Namespace: constants.EksaSystemNamespace,
@@ -453,7 +453,7 @@ func (tt *reconcilerTest) cleanup() {
 	tt.DeleteAndWait(tt.ctx, tt.allObjs()...)
 
 	tt.DeleteAllOfAndWait(tt.ctx, &clusterv1.Cluster{})
-	tt.DeleteAllOfAndWait(tt.ctx, &dockerv1.DockerMachineTemplate{})
+	tt.DeleteAllOfAndWait(tt.ctx, &dockerv1beta2.DockerMachineTemplate{})
 	tt.DeleteAllOfAndWait(tt.ctx, &etcdv1.EtcdadmCluster{})
 }
 

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -306,12 +306,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_md_expected.yaml
@@ -35,13 +35,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -301,12 +301,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_md_expected.yaml
@@ -35,13 +35,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -16,12 +16,12 @@ spec:
     name: test
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test
@@ -31,7 +31,7 @@ spec:
     imageRepository: 
     imageTag: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: <no value>
@@ -52,7 +52,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: <no value>
       namespace: eksa-system

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -16,12 +16,12 @@ spec:
     name: test
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test
@@ -31,7 +31,7 @@ spec:
     imageRepository: 
     imageTag: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: <no value>
@@ -52,7 +52,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: <no value>
       namespace: eksa-system

--- a/pkg/providers/docker/testdata/expected_results_cluster_docker_cp_single_node.yaml
+++ b/pkg/providers/docker/testdata/expected_results_cluster_docker_cp_single_node.yaml
@@ -16,12 +16,12 @@ spec:
     name: single-node
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: single-node
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: single-node
@@ -31,7 +31,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: single-node-control-plane-template-1234567890000
@@ -52,7 +52,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: single-node-control-plane-template-1234567890000
       namespace: eksa-system

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
@@ -16,7 +16,7 @@ spec:
     name: test
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test
@@ -36,7 +36,7 @@ spec:
     imageRepository: 
     imageTag: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
@@ -311,12 +311,12 @@ spec:
     registryMirror:
       endpoint: 1.2.3.4:1234/v2/eks-anywhere
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_md.yaml
@@ -46,13 +46,13 @@ spec:
           namespace: eksa-system
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-md-0-1234567890000
         namespace: eksa-system
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-md-0-1234567890000

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -16,7 +16,7 @@ spec:
     name: test
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test
@@ -36,7 +36,7 @@ spec:
     imageRepository: 
     imageTag: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
@@ -356,12 +356,12 @@ spec:
         -----END CERTIFICATE-----
         
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_md.yaml
@@ -72,13 +72,13 @@ spec:
           namespace: eksa-system
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-md-0-1234567890000
         namespace: eksa-system
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-md-0-1234567890000

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
@@ -16,7 +16,7 @@ spec:
     name: test
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test
@@ -36,7 +36,7 @@ spec:
     imageRepository: 
     imageTag: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
@@ -353,12 +353,12 @@ spec:
         -----END CERTIFICATE-----
         
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_md.yaml
@@ -69,13 +69,13 @@ spec:
           namespace: eksa-system
       clusterName: test
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-md-0-1234567890000
         namespace: eksa-system
       version: v1.21.2-eks-1-21-4
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-md-0-1234567890000

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_cp_expected.yaml
@@ -16,12 +16,12 @@ spec:
     name: fluxTestCluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: fluxTestCluster
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: fluxTestCluster
@@ -31,7 +31,7 @@ spec:
     imageRepository: 
     imageTag: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-control-plane-template-original
@@ -52,7 +52,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-control-plane-template-original
       namespace: eksa-system

--- a/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
+++ b/pkg/providers/docker/testdata/no_machinetemplate_update_md_expected.yaml
@@ -35,13 +35,13 @@ spec:
           namespace: eksa-system
       clusterName: fluxTestCluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-md-0-original
         namespace: eksa-system
       version: 
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-md-0-original

--- a/pkg/providers/docker/testdata/valid_autoscaler_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_autoscaler_deployment_md_expected.yaml
@@ -37,13 +37,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -299,12 +299,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -327,12 +327,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -300,12 +300,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_stacked_etcd_expected.yaml
@@ -16,12 +16,12 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -31,7 +31,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -52,7 +52,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -319,12 +319,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -301,12 +301,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_md_expected.yaml
@@ -36,13 +36,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected.yaml
@@ -35,13 +35,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected_124onwards.yaml
@@ -35,13 +35,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_md_expected_worker_version.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_expected_worker_version.yaml
@@ -35,13 +35,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.18.4-eks-1-18-3
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000
@@ -92,13 +92,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-1-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-1-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_md_taints_expected.yaml
@@ -38,13 +38,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_multiple_md_taints_expected.yaml
@@ -38,13 +38,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000
@@ -98,13 +98,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-1-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-1-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -16,7 +16,7 @@ spec:
     name: test-cluster
     namespace: eksa-system
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerCluster
     name: test-cluster
     namespace: eksa-system
@@ -26,7 +26,7 @@ spec:
     name: test-cluster-etcd
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerCluster
 metadata:
   name: test-cluster
@@ -36,7 +36,7 @@ spec:
     imageRepository: public.ecr.aws/l0g8r8j6/kubernetes-sigs/kind
     imageTag: v0.11.1-eks-a-v0.0.0-dev-build.1464
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-control-plane-template-1234567890000
@@ -57,7 +57,7 @@ metadata:
 spec:
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerMachineTemplate
       name: test-cluster-control-plane-template-1234567890000
       namespace: eksa-system
@@ -301,12 +301,12 @@ spec:
       etcdReleaseURL: https://distro.eks.amazonaws.com/kubernetes-1-21/releases/4/artifacts/etcd/v3.4.16/etcd-linux-amd64-v3.4.16.tar.gz
     cipherSuites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: DockerMachineTemplate
     name: test-cluster-etcd-template-1234567890000
     namespace: eksa-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-etcd-template-1234567890000

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_md_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_md_expected.yaml
@@ -36,13 +36,13 @@ spec:
           namespace: eksa-system
       clusterName: test-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: test-cluster-md-0-1234567890000
         namespace: eksa-system
       version: v1.19.6-eks-1-19-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: test-cluster-md-0-1234567890000

--- a/pkg/providers/docker/workers.go
+++ b/pkg/providers/docker/workers.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"

--- a/pkg/providers/docker/workers_test.go
+++ b/pkg/providers/docker/workers_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -238,8 +238,8 @@ func TestWorkersSpecNoMachineTemplateChanges(t *testing.T) {
 
 	// This is testing defaults. It's possible that some default logic will set items that are not set in our machine templates.
 	// We need to take this into consideration when checking for equality.
-	currentGroup1.ProviderMachineTemplate.Spec.Template.Spec.ProviderID = ptr.String("default-id")
-	currentGroup2.ProviderMachineTemplate.Spec.Template.Spec.ProviderID = ptr.String("default-id")
+	currentGroup1.ProviderMachineTemplate.Spec.Template.Spec.ProviderID = "default-id"
+	currentGroup2.ProviderMachineTemplate.Spec.Template.Spec.ProviderID = "default-id"
 
 	objs := make([]kubernetes.Object, 0, 6)
 	objs = append(objs, currentGroup1.Objects()...)
@@ -443,7 +443,7 @@ func machineDeployment(opts ...func(*clusterv1.MachineDeployment)) *clusterv1.Ma
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "DockerMachineTemplate",
 						Name:       "test-md-0-1",
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 						Namespace:  "eksa-system",
 					},
 					Version: ptr.String("v1.23.12-eks-1-23-6"),


### PR DESCRIPTION
*Description of changes:*
New capd v1.11.1 creates DockerMachineTemplate and DockerCluster object into v1beta2 schema and EKS-A keeps applying kcp object into v1beta1 schema which cause KCP to keep reconciling. Moving DockerMachineTemplate and DockerCluster to using v1beta2 APIs with this PR.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

