### PR TITLE
Pass placeholder for external etcd endpoints

### DIFF
--- a/pkg/clusterapi/etcd.go
+++ b/pkg/clusterapi/etcd.go
@@ -44,7 +44,7 @@ func SetUnstackedEtcdConfigInKubeadmControlPlaneForBottlerocket(kcp *controlplan
 	}
 
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{
-		Endpoints: []string{},
+		Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 		CAFile:    "/var/lib/kubeadm/pki/etcd/ca.crt",
 		CertFile:  "/var/lib/kubeadm/pki/server-etcd-client.crt",
 		KeyFile:   "/var/lib/kubeadm/pki/apiserver-etcd-client.key",
@@ -58,7 +58,7 @@ func SetUnstackedEtcdConfigInKubeadmControlPlaneForUbuntu(kcp *controlplanev1.Ku
 	}
 
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{
-		Endpoints: []string{},
+		Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 		CAFile:    "/etc/kubernetes/pki/etcd/ca.crt",
 		CertFile:  "/etc/kubernetes/pki/apiserver-etcd-client.crt",
 		KeyFile:   "/etc/kubernetes/pki/apiserver-etcd-client.key",

--- a/pkg/clusterapi/etcd_test.go
+++ b/pkg/clusterapi/etcd_test.go
@@ -10,6 +10,7 @@ import (
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
+	"github.com/aws/eks-anywhere/pkg/constants"
 )
 
 func TestSetUbuntuConfigInEtcdCluster(t *testing.T) {
@@ -68,7 +69,7 @@ func TestSetUnstackedEtcdConfigInKubeadmControlPlaneForBottlerocket(t *testing.T
 	}
 	got := wantKubeadmControlPlane()
 	got.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{
-		Endpoints: []string{},
+		Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 		CAFile:    "/var/lib/kubeadm/pki/etcd/ca.crt",
 		CertFile:  "/var/lib/kubeadm/pki/server-etcd-client.crt",
 		KeyFile:   "/var/lib/kubeadm/pki/apiserver-etcd-client.key",
@@ -85,7 +86,7 @@ func TestSetUnstackedEtcdConfigInKubeadmControlPlaneForUbuntu(t *testing.T) {
 	}
 	got := wantKubeadmControlPlane()
 	got.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{
-		Endpoints: []string{},
+		Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 		CAFile:    "/etc/kubernetes/pki/etcd/ca.crt",
 		CertFile:  "/etc/kubernetes/pki/apiserver-etcd-client.crt",
 		KeyFile:   "/etc/kubernetes/pki/apiserver-etcd-client.key",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -114,6 +114,9 @@ const (
 	// DefaultWorkerMaxUnhealthy is the default maxUnhealthy value for worker node machine health checks.
 	DefaultWorkerMaxUnhealthy = "40%"
 
+	// PlaceholderExternalEtcdEndpoint is the default placeholder endpoint for external etcd configuration.
+	PlaceholderExternalEtcdEndpoint = "https://placeholder:2379"
+
 	// SignatureAnnotation applied to the bundle during bundle manifest signing.
 	SignatureAnnotation = "anywhere.eks.amazonaws.com/signature"
 	// ExcludesAnnotation applied to the bundle during bundle manifest signing.

--- a/pkg/controller/clusters/controlplane.go
+++ b/pkg/controller/clusters/controlplane.go
@@ -211,7 +211,7 @@ func reconcileControlPlaneNodeChanges(ctx context.Context, log logr.Logger, c cl
 	// We do not want to update the field with an empty slice again, so here we check if the endpoints for the
 	// external etcd have already been populated on the KubeadmControlPlane object and override ours before applying it.
 	externalEndpoints := currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints
-	if len(externalEndpoints) != 0 {
+	if len(externalEndpoints) != 0 && !isPlaceholderEndpoint(externalEndpoints) {
 		desiredCP.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = externalEndpoints
 	}
 
@@ -235,6 +235,14 @@ func reconcileControlPlaneNodeChanges(ctx context.Context, log logr.Logger, c cl
 	}
 
 	return controller.Result{}, nil
+}
+
+// isPlaceholderEndpoint checks if endpoints are placeholder values that we set by default.
+func isPlaceholderEndpoint(endpoints []string) bool {
+	if len(endpoints) == 1 && endpoints[0] == "https://placeholder:2379" {
+		return true
+	}
+	return false
 }
 
 func getEtcdadmCluster(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (*etcdv1.EtcdadmCluster, error) {

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -77,7 +77,7 @@ spec:
       etcd:
 {{- if .externalEtcd }}
         external:
-          endpoints: []
+          endpoints: ["{{.placeholderExternalEtcdEndpoint}}"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -313,7 +313,7 @@ func kubeadmControlPlane(opts ...func(*controlplanev1.KubeadmControlPlane)) *con
 					ImageRepository: "public.ecr.aws/eks-distro/kubernetes",
 					Etcd: bootstrapv1.Etcd{
 						External: &bootstrapv1.ExternalEtcd{
-							Endpoints: []string{},
+							Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 							CAFile:    "/etc/kubernetes/pki/etcd/ca.crt",
 							CertFile:  "/etc/kubernetes/pki/apiserver-etcd-client.crt",
 							KeyFile:   "/etc/kubernetes/pki/apiserver-etcd-client.key",

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -238,6 +238,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
+		values["placeholderExternalEtcdEndpoint"] = constants.PlaceholderExternalEtcdEndpoint
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 		etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 		if etcdURL != "" {

--- a/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_affinity_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_availability_zones_cp.yaml
@@ -88,7 +88,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_cp_kubernetes_version.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_cp_kubernetes_version.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_node_labels_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_main_with_taints_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_resourceids_cp.yaml
@@ -68,7 +68,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -69,7 +69,7 @@ spec:
       etcd:
 {{- if .externalEtcd }}
         external:
-          endpoints: []
+          endpoints: ["{{.placeholderExternalEtcdEndpoint}}"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -476,7 +476,7 @@ func kubeadmControlPlane(opts ...func(*controlplanev1.KubeadmControlPlane)) *con
 					ImageRepository: "public.ecr.aws/eks-distro/kubernetes",
 					Etcd: bootstrapv1.Etcd{
 						External: &bootstrapv1.ExternalEtcd{
-							Endpoints: []string{},
+							Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 							CAFile:    "/etc/kubernetes/pki/etcd/ca.crt",
 							CertFile:  "/etc/kubernetes/pki/apiserver-etcd-client.crt",
 							KeyFile:   "/etc/kubernetes/pki/apiserver-etcd-client.key",

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -308,6 +308,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
+		values["placeholderExternalEtcdEndpoint"] = constants.PlaceholderExternalEtcdEndpoint
 		etcdURL, _ := common.GetExternalEtcdReleaseURL(clusterSpec.Cluster.Spec.EksaVersion, versionsBundle)
 		if etcdURL != "" {
 			values["externalEtcdReleaseUrl"] = etcdURL

--- a/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_full_oidc_cp_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/capd_valid_minimal_oidc_cp_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_expected_124onwards.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_pod_iam_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_cp_taints_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_custom_cidrs_cp_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
+++ b/pkg/providers/docker/testdata/valid_deployment_node_labels_cp_expected.yaml
@@ -66,7 +66,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -194,7 +194,7 @@ spec:
       etcd:
 {{- if .externalEtcd }}
         external:
-          endpoints: []
+          endpoints: ["{{.placeholderExternalEtcdEndpoint}}"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -282,6 +282,7 @@ func buildTemplateMapCP(
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
+		values["placeholderExternalEtcdEndpoint"] = constants.PlaceholderExternalEtcdEndpoint
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 		values["etcdSshAuthorizedKey"] = etcdMachineSpec.Users[0].SshAuthorizedKeys[0]
 		values["etcdVCPUsPerSocket"] = etcdMachineSpec.VCPUsPerSocket

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -97,7 +97,7 @@ spec:
         imageTag: v1.8.0-eks-1-19-4
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
@@ -97,7 +97,7 @@ spec:
         imageTag: v1.8.0-eks-1-19-4
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -214,7 +214,7 @@ func wantKubeadmControlPlaneUnstackedEtcd() *controlplanev1.KubeadmControlPlane 
 	kcp := wantKubeadmControlPlane("1.21")
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd = bootstrapv1.Etcd{
 		External: &bootstrapv1.ExternalEtcd{
-			Endpoints: []string{},
+			Endpoints: []string{constants.PlaceholderExternalEtcdEndpoint},
 			CAFile:    "/etc/kubernetes/pki/etcd/ca.crt",
 			CertFile:  "/etc/kubernetes/pki/apiserver-etcd-client.crt",
 			KeyFile:   "/etc/kubernetes/pki/apiserver-etcd-client.key",

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -46,7 +46,7 @@ spec:
       etcd:
 {{- if .externalEtcd }}
         external:
-          endpoints: []
+          endpoints: ["{{.placeholderExternalEtcdEndpoint}}"]
 {{- if (eq .format "bottlerocket") }}
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -472,6 +472,7 @@ func buildTemplateMapCP(
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
+		values["placeholderExternalEtcdEndpoint"] = constants.PlaceholderExternalEtcdEndpoint
 		values["etcdSshUsername"] = etcdMachineSpec.Users[0].Name
 		values["etcdTemplateOverride"] = etcdTemplateOverride
 		values["etcdHardwareSelector"] = etcdMachineSpec.HardwareSelector

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -98,7 +98,7 @@ spec:
       etcd:
 {{- if .externalEtcd }}
         external:
-          endpoints: []
+          endpoints: ["{{.placeholderExternalEtcdEndpoint}}"]
 {{- if (eq .format "bottlerocket") }}
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -497,7 +497,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -314,6 +314,7 @@ func buildTemplateMapCP(
 
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
+		values["placeholderExternalEtcdEndpoint"] = constants.PlaceholderExternalEtcdEndpoint
 		values["etcdVsphereDatastore"] = etcdMachineSpec.Datastore
 		values["etcdVsphereFolder"] = etcdMachineSpec.Folder
 		values["etcdDiskGiB"] = etcdMachineSpec.DiskGiB

--- a/pkg/providers/vsphere/testdata/expected_kcp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
@@ -85,7 +85,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_boot_settings_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_boot_settings_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_external_etcd_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_multiple_ocinamespaces_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_multiple_ocinamespaces_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_settings_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_settings_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/var/lib/kubeadm/pki/etcd/ca.crt"
           certFile: "/var/lib/kubeadm/pki/server-etcd-client.crt"
           keyFile: "/var/lib/kubeadm/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_custom_resolv_conf.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_diff_template_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_121_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provder_and_csi_driver_credentials.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_cloud_provider_credentials.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_cp_csi_driver_credentials.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_no_machinetemplate_update_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_node_labels_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_main_with_taints_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_pod_iam_config.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_etcd_encryption_cp_1_29.yaml
@@ -84,7 +84,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"

--- a/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -82,7 +82,7 @@ spec:
       imageRepository: public.ecr.aws/eks-distro/kubernetes
       etcd:
         external:
-          endpoints: []
+          endpoints: ["https://placeholder:2379"]
           caFile: "/etc/kubernetes/pki/etcd/ca.crt"
           certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
           keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"


### PR DESCRIPTION
*Description of changes:*

Problem: After upgrading from CAPI v1.10 to v1.11, EKS Anywhere clusters with external etcd fail to create for Kubernetes 1.28/1.29 with validation error: `spec.kubeadmConfigSpec.clusterConfiguration.etcd.external.endpoints: Required value`. The CAPI controller cannot patch KubeadmControlPlane resources due to the new `MinItems=1` validation rule in v1beta2 API, creating an infinite reconciliation loop.

Root Cause: CAPI v1.11 introduced stricter validation for `ExternalEtcd.Endpoints` field - v1beta1 allowed empty arrays (`endpoints: []`) but v1beta2 requires at least one endpoint (`+kubebuilder:validation:MinItems=1`). EKS Anywhere templates create KubeadmControlPlane with empty endpoints, expecting CAPI to populate them from EtcdadmCluster status, but the validation prevents the patch from succeeding.

Solution: • Use placeholder endpoints (`endpoints: ["https://placeholder:2379"]`) in templates to satisfy v1beta2 validation • Modify controller logic to preserve real endpoints and avoid overwriting with placeholders • Add helper function to detect and filter placeholder endpoints during reconciliation

Reference: [CAPI v1.10 to v1.11 Migration Guide](https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.10-to-v1.11#kubeadmcontrolplane)

*Testing (if applicable):*
Tested by creating 1.28 and 1.32 docker cluster. 

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

