### PR TITLE
Add diagnostic bundle during setup and validate upgrade test

### DIFF
--- a/controllers/kubeadmcontrolplane_controller.go
+++ b/controllers/kubeadmcontrolplane_controller.go
@@ -32,7 +32,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/cluster-api/util/annotations"
-	"sigs.k8s.io/cluster-api/util/patch"
+	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -84,7 +84,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	patchHelper, err := patch.NewHelper(kcp, r.client)
+	patchHelper, err := v1beta1patch.NewHelper(kcp, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -127,7 +127,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, log logr.
 		}
 		return ctrl.Result{}, fmt.Errorf("getting MachineHealthCheck %s: %v", cpMachineHealthCheckName(kcp.ObjectMeta.Name), err)
 	}
-	mhcPatchHelper, err := patch.NewHelper(mhc, r.client)
+	mhcPatchHelper, err := v1beta1patch.NewHelper(mhc, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -214,12 +214,12 @@ func (r *KubeadmControlPlaneReconciler) validateStackedEtcd(kcp *controlplanev1.
 	return nil
 }
 
-func pauseMachineHealthCheck(ctx context.Context, mhc *clusterv1.MachineHealthCheck, mhcPatchHelper *patch.Helper) error {
+func pauseMachineHealthCheck(ctx context.Context, mhc *clusterv1.MachineHealthCheck, mhcPatchHelper *v1beta1patch.Helper) error {
 	annotations.AddAnnotations(mhc, map[string]string{clusterv1.PausedAnnotation: "true"})
 	return mhcPatchHelper.Patch(ctx, mhc)
 }
 
-func resumeMachineHealthCheck(ctx context.Context, mhc *clusterv1.MachineHealthCheck, mhcPatchHelper *patch.Helper) error {
+func resumeMachineHealthCheck(ctx context.Context, mhc *clusterv1.MachineHealthCheck, mhcPatchHelper *v1beta1patch.Helper) error {
 	delete(mhc.Annotations, clusterv1.PausedAnnotation)
 	return mhcPatchHelper.Patch(ctx, mhc)
 }

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	"sigs.k8s.io/cluster-api/util/patch"
+	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -83,7 +83,7 @@ func (r *MachineDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	patchHelper, err := patch.NewHelper(md, r.client)
+	patchHelper, err := v1beta1patch.NewHelper(md, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -126,7 +126,7 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, log logr.Lo
 		}
 		return ctrl.Result{}, fmt.Errorf("getting MachineHealthCheck %s: %v", mdMachineHealthCheckName(md.ObjectMeta.Name), err)
 	}
-	mhcPatchHelper, err := patch.NewHelper(mhc, r.client)
+	mhcPatchHelper, err := v1beta1patch.NewHelper(mhc, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/workflows/management/validate.go
+++ b/pkg/workflows/management/validate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/task"
 	"github.com/aws/eks-anywhere/pkg/validations"
+	"github.com/aws/eks-anywhere/pkg/workflows"
 )
 
 type setupAndValidateCreate struct{}
@@ -70,7 +71,7 @@ func (s *setupAndValidateUpgrade) Run(ctx context.Context, commandContext *task.
 	err = runner.Run()
 	if err != nil {
 		commandContext.SetError(err)
-		return nil
+		return &workflows.CollectMgmtClusterDiagnosticsTask{}
 	}
 
 	return &updateSecrets{}


### PR DESCRIPTION
*Description of changes:*
- Use CAPI v1beta1 patch api for patching kcp machinehealthchecks and md machinehealthchecks.
 - Add diagnostic bundle during setup and validation step for upgrade cluster failures to figure out random upgrade failures.
 - Increase create and upgrade test verbosity to get more logs.
 
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

