### PR TITLE
feat: Allow toggling Cilium skipUpgrade from true to false

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook.go
+++ b/pkg/api/v1alpha1/cluster_webhook.go
@@ -330,21 +330,6 @@ func validateImmutableFieldsCluster(new, old *Cluster) field.ErrorList {
 			field.Forbidden(specPath.Child("clusterNetwork", "dns"), "field is immutable"))
 	}
 
-	// We don't want users to be able to toggle off SkipUpgrade until we've understood the
-	// implications so we are temporarily disallowing it.
-
-	oCNI := old.Spec.ClusterNetwork.CNIConfig
-	nCNI := new.Spec.ClusterNetwork.CNIConfig
-	if oCNI != nil && oCNI.Cilium != nil && !oCNI.Cilium.IsManaged() && nCNI.Cilium.IsManaged() {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(
-				specPath.Child("clusterNetwork", "cniConfig", "cilium", "skipUpgrade"),
-				"cannot toggle off skipUpgrade once enabled",
-			),
-		)
-	}
-
 	if !new.Spec.ClusterNetwork.Nodes.Equal(old.Spec.ClusterNetwork.Nodes) {
 		allErrs = append(
 			allErrs,

--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -1921,10 +1921,9 @@ func TestClusterValidateUpdateLabelTaintsMultiWNTinkerbellRequest(t *testing.T) 
 
 func TestClusterValidateUpdateSkipUpgradeImmutability(t *testing.T) {
 	tests := []struct {
-		Name  string
-		Old   *v1alpha1.Cluster
-		New   *v1alpha1.Cluster
-		Error bool
+		Name string
+		Old  *v1alpha1.Cluster
+		New  *v1alpha1.Cluster
 	}{
 		{
 			Name: "NilToFalse",
@@ -1970,7 +1969,6 @@ func TestClusterValidateUpdateSkipUpgradeImmutability(t *testing.T) {
 			New: baseCluster(func(c *v1alpha1.Cluster) {
 				c.Spec.ClusterNetwork.CNIConfig.Cilium.SkipUpgrade = nil
 			}),
-			Error: true,
 		},
 		{
 			Name: "TrueToFalse",
@@ -1980,7 +1978,6 @@ func TestClusterValidateUpdateSkipUpgradeImmutability(t *testing.T) {
 			New: baseCluster(func(c *v1alpha1.Cluster) {
 				c.Spec.ClusterNetwork.CNIConfig.Cilium.SkipUpgrade = ptr.Bool(false)
 			}),
-			Error: true,
 		},
 	}
 
@@ -1990,14 +1987,7 @@ func TestClusterValidateUpdateSkipUpgradeImmutability(t *testing.T) {
 
 			warnings, err := tc.New.ValidateUpdate(context.TODO(), tc.Old, tc.New)
 			g.Expect(warnings).To(BeEmpty())
-			if !tc.Error {
-				g.Expect(err).To(Succeed())
-			} else {
-				g.Expect(err).To(MatchError(ContainSubstring(
-					"spec.clusterNetwork.cniConfig.cilium.skipUpgrade: Forbidden: cannot toggle " +
-						"off skipUpgrade once enabled",
-				)))
-			}
+			g.Expect(err).To(Succeed())
 		})
 	}
 }

--- a/pkg/validations/upgradevalidations/immutable_fields.go
+++ b/pkg/validations/upgradevalidations/immutable_fields.go
@@ -57,15 +57,6 @@ func ValidateImmutableFields(ctx context.Context, k validations.KubectlClient, c
 		return fmt.Errorf("spec.clusterNetwork.CNI/CNIConfig is immutable")
 	}
 
-	// We don't want users to be able to toggle  off SkipUpgrade until we've understood the
-	// implications so we are temporarily disallowing it.
-
-	oCNI := prevSpec.Spec.ClusterNetwork.CNIConfig
-	nCNI := spec.Cluster.Spec.ClusterNetwork.CNIConfig
-	if oCNI != nil && oCNI.Cilium != nil && !oCNI.Cilium.IsManaged() && nCNI.Cilium.IsManaged() {
-		return fmt.Errorf("spec.clusterNetwork.cniConfig.cilium.skipUpgrade cannot be toggled off")
-	}
-
 	if !nSpec.ProxyConfiguration.Equal(oSpec.ProxyConfiguration) {
 		return fmt.Errorf("spec.proxyConfiguration is immutable")
 	}

--- a/pkg/validations/upgradevalidations/immutable_fields_test.go
+++ b/pkg/validations/upgradevalidations/immutable_fields_test.go
@@ -299,7 +299,6 @@ func TestValidateImmutableFields(t *testing.T) {
 					},
 				}
 			},
-			ExpectedError: "spec.clusterNetwork.cniConfig.cilium.skipUpgrade cannot be toggled off",
 		},
 		{
 			Name: "Add AWS IAM identity provider when none existed",


### PR DESCRIPTION
Remove the temporary restriction that prevented users from changing cilium.skipUpgrade from true to false. This enables transitioning from self-managed Cilium back to EKS-A managed Cilium.

- Remove validation from cluster webhook (controller)
- Remove validation from upgrade validations (CLI)
- Update tests to allow skipUpgrade toggle in both directions


