### PR TITLE
Fix error message format in RegistryMirror CuratedPackages e2e

### DIFF
--- a/test/framework/ecr.go
+++ b/test/framework/ecr.go
@@ -36,12 +36,12 @@ func loginToECRWithCredentials(e *ClusterE2ETest, registry, accessKey, secretKey
 	ecrClient := ecr.NewFromConfig(cfg)
 	authTokenOutput, err := ecrClient.GetAuthorizationToken(context.Background(), &ecr.GetAuthorizationTokenInput{})
 	if err != nil {
-		e.T.Fatalf("failed to fetch authorization token from ECR for registry %s : %w", registry, err)
+		e.T.Fatalf("failed to fetch authorization token from ECR for registry %s : %v", registry, err)
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(*authTokenOutput.AuthorizationData[0].AuthorizationToken)
 	if err != nil {
-		e.T.Fatalf("failed to decode authorization token from ECR for registry %s: %w", registry, err)
+		e.T.Fatalf("failed to decode authorization token from ECR for registry %s: %v", registry, err)
 	}
 
 	parts := strings.SplitN(string(decoded), ":", 2)


### PR DESCRIPTION
*Description of changes:*
Fixes the incorrect error message in the current e2e failure
```    
ecr.go:39: failed to fetch authorization token from ECR for registry 067575901363.dkr.ecr.us-west-2.amazonaws.com : %!w(*smithy.OperationError=&{ECR GetAuthorizationToken 0xc000e2e198})
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

