### PR TITLE
Adds upgrade e2e tests for AWS IAM addition and removal

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -346,6 +346,19 @@ func WithAWSIamIdentityProviderRef(name string) ClusterFiller {
 	}
 }
 
+func RemoveAWSIamIdentityProviderRef() ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		// Filter out AWS IAM identity provider refs
+		filtered := make([]anywherev1.Ref, 0, len(c.Spec.IdentityProviderRefs))
+		for _, ref := range c.Spec.IdentityProviderRefs {
+			if ref.Kind != anywherev1.AWSIamConfigKind {
+				filtered = append(filtered, ref)
+			}
+		}
+		c.Spec.IdentityProviderRefs = filtered
+	}
+}
+
 func RemoveAllWorkerNodeGroups() ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Spec.WorkerNodeGroupConfigurations = make([]anywherev1.WorkerNodeGroupConfiguration, 0)

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -276,6 +276,47 @@ func TestVSphereKubernetes133To134AWSIamAuthUpgrade(t *testing.T) {
 	)
 }
 
+// AWS IAM Auth Add/Remove Tests
+func TestVSphereKubernetes128UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu128()),
+		framework.WithAwsIamEnvVarCheck(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+	)
+	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube128)
+}
+
+func TestVSphereKubernetes134UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu134()),
+		framework.WithAwsIamEnvVarCheck(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+	)
+	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube134)
+}
+
+func TestVSphereKubernetes128UbuntuRemoveAWSIamAuthUpgrade(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu128()),
+		framework.WithAWSIam(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+	)
+	runUpgradeFlowRemoveAWSIamAuth(test, v1alpha1.Kube128)
+}
+
+func TestVSphereKubernetes134UbuntuRemoveAWSIamAuthUpgrade(t *testing.T) {
+	test := framework.NewClusterE2ETest(
+		t,
+		framework.NewVSphere(t, framework.WithUbuntu134()),
+		framework.WithAWSIam(),
+		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+	)
+	runUpgradeFlowRemoveAWSIamAuth(test, v1alpha1.Kube134)
+}
+
 // Curated Packages
 func TestVSphereKubernetes128CuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)

--- a/test/framework/awsiam.go
+++ b/test/framework/awsiam.go
@@ -151,3 +151,10 @@ func WithAwsIamConfig() api.ClusterConfigFiller {
 		)
 	}, api.ClusterToConfigFiller(api.WithAWSIamIdentityProviderRef(defaultClusterName)))
 }
+
+// RemoveAWSIamConfig removes AWS IAM config from cluster config.
+func RemoveAWSIamConfig() api.ClusterConfigFiller {
+	return func(config *cluster.Config) {
+		delete(config.AWSIAMConfigs, defaultClusterName)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3608

*Description of changes:*
Adds e2e tests for code changes in https://github.com/aws/eks-anywhere/pull/9897

*Testing (if applicable):*
Requires running the test in code build as the test configuration tries to validate aws authentication using codebuild role. Ran manual test to verify some part of the functionality. Will check in e2e run for the rest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

