### PR TITLE
Specify ipv4NativeRoutingCidr for native routing e2e test case

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -4367,6 +4367,8 @@ func TestVSphereKubernetes128CiliumHelmValuesComplexConfigUbuntuFlow(t *testing.
 			},
 			"policyEnforcementMode": "always",
 			"routingMode":           "native",
+			"ipv4NativeRoutingCIDR": "192.168.0.0/16",
+			"autoDirectNodeRoutes":  "true",
 		})),
 	)
 	runSimpleFlow(test)
@@ -4389,6 +4391,8 @@ func TestVSphereKubernetes133CiliumHelmValuesComplexConfigUbuntuFlow(t *testing.
 			},
 			"policyEnforcementMode": "always",
 			"routingMode":           "native",
+			"ipv4NativeRoutingCIDR": "192.168.0.0/16",
+			"autoDirectNodeRoutes":  "true",
 		})),
 	)
 	runSimpleFlow(test)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ipv4NativeRouting cidr is missing in e2e test cases using native routing mode, and because of that cilium pod will not come up, Native routing also needs autoDirectNodeRoute set to true.

This PR fixes these issues

*Testing (if applicable):*

```
2025-10-28T19:45:23.683-0700	V3	Cleaning up long running container	{"name": "eksa_1761705668824403000"}
    cluster.go:923: Skipping provider resource cleanup
--- PASS: TestVSphereKubernetes128CiliumHelmValuesComplexConfigUbuntuFlow (993.69s)
PASS
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

