### PR TITLE
Set unique token for workload cluster in IAM auth workload cluster test

### DIFF
--- a/test/e2e/awsiamauth.go
+++ b/test/e2e/awsiamauth.go
@@ -42,7 +42,8 @@ func runTinkerbellAWSIamAuthFlow(test *framework.ClusterE2ETest) {
 func runAWSIamAuthFlowWorkload(test *framework.MulticlusterE2ETest) {
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
-		w.GenerateClusterConfig()
+		licenseToken := framework.GetLicenseToken2()
+		w.GenerateClusterConfigWithLicenseToken(licenseToken)
 		w.CreateCluster()
 		w.ValidateAWSIamAuth()
 		w.StopIfFailed()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Workload cluster's license token needs to be different from management cluster, fix this issue for IAMAuth workflow.
*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

