### PR TITLE
Implement on-demand per test AWS credential for pkg tests

### DIFF
--- a/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/cloudstack-test-eks-a-cli.yml
@@ -84,16 +84,6 @@ phases:
         -n ${CLUSTER_NAME_PREFIX}
         --delete-duplicate-networks
         -v 6
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export CERT_MANAGER_ROLE
-      - export ROUTE53_ACCESS_KEY_ID=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export ROUTE53_SECRET_ACCESS_KEY=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export ROUTE53_SESSION_TOKEN=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/conformance-eks-a-cli.yml
@@ -146,11 +146,6 @@ phases:
       - source ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/create_infra_config.sh
       - ${CODEBUILD_SRC_DIR}/cmd/integration_test/build/script/start_docker.sh
       - make conformance-tests
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken') 
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/docker-test-eks-a-cli.yml
@@ -34,16 +34,6 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e docker" E2E_OUTPUT_FILE=bin/docker/e2e.test
         fi
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional --duration-seconds 3600)
-      - export NON_REGIONAL_PACKAGES_ROLE
-      - export NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export NON_REGIONAL_EKSA_AWS_SESSION_TOKEN=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/nutanix-test-eks-a-cli.yml
@@ -71,11 +71,6 @@ phases:
         --insecure
         --ignoreErrors
         -v 4
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken') 
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/quick-test-eks-a-cli.yml
@@ -268,16 +268,6 @@ phases:
         --insecure
         --ignoreErrors
         -v 4
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - NON_REGIONAL_PACKAGES_ROLE=$(aws sts assume-role --role-arn $NON_REGIONAL_PACKAGES_ROLE_ARN --role-session-name test-non-regional --duration-seconds 3600)
-      - export NON_REGIONAL_PACKAGES_ROLE
-      - export NON_REGIONAL_EKSA_AWS_ACCESS_KEY_ID=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export NON_REGIONAL_EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export NON_REGIONAL_EKSA_AWS_SESSION_TOKEN=$(echo "${NON_REGIONAL_PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/snow-test-eks-a-cli.yml
@@ -32,11 +32,6 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e snow" E2E_OUTPUT_FILE=bin/snow/e2e.test
         fi
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken') 
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/tinkerbell-test-eks-a-cli.yml
@@ -111,11 +111,6 @@ phases:
         if ! [[ ${CODEBUILD_INITIATOR} =~ "codepipeline" ]]; then
           make build-eks-a-for-e2e build-integration-test-binary e2e-tests-binary E2E_TAGS="e2e tinkerbell" E2E_OUTPUT_FILE=bin/tinkerbell/e2e.test
         fi
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')        
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
+++ b/cmd/integration_test/build/buildspecs/vsphere-test-eks-a-cli.yml
@@ -119,16 +119,6 @@ phases:
         ./bin/test e2e cleanup vsphere
         -n ${CLUSTER_NAME_PREFIX}
         -v 4
-      - PACKAGES_ROLE=$(aws sts assume-role --role-arn $PACKAGES_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export PACKAGES_ROLE
-      - export EKSA_AWS_ACCESS_KEY_ID=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export EKSA_AWS_SECRET_ACCESS_KEY=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export EKSA_AWS_SESSION_TOKEN=$(echo "${PACKAGES_ROLE}" | jq -r '.Credentials.SessionToken')
-      - CERT_MANAGER_ROLE=$(aws sts assume-role --role-arn $CERT_MANAGER_ROLE_ARN --role-session-name test --duration-seconds 3600)
-      - export CERT_MANAGER_ROLE
-      - export ROUTE53_ACCESS_KEY_ID=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.AccessKeyId')
-      - export ROUTE53_SECRET_ACCESS_KEY=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SecretAccessKey')
-      - export ROUTE53_SESSION_TOKEN=$(echo "${CERT_MANAGER_ROLE}" | jq -r '.Credentials.SessionToken')
   build:
     commands:
       - export JOB_ID=$CODEBUILD_BUILD_ID

--- a/internal/test/e2e/packages.go
+++ b/internal/test/e2e/packages.go
@@ -1,10 +1,14 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"regexp"
+	"time"
 
-	e2etests "github.com/aws/eks-anywhere/test/framework"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 const (
@@ -13,27 +17,67 @@ const (
 	certManagerRegex         = "^.*CuratedPackagesCertManager.*$"
 )
 
+// assumeRoleAndGetCredentials assumes an IAM role using the role ARN from env and
+// returns the temporary credentials (access key, secret key, session token) or an error.
+func assumeRoleAndGetCredentials(roleArnEnvVar, sessionName string) (accessKey, secretKey, sessionToken string, err error) {
+	roleArn := os.Getenv(roleArnEnvVar)
+	if roleArn == "" {
+		return "", "", "", fmt.Errorf("%s environment variable not set", roleArnEnvVar)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	duration := int32(3600) // (max for role chaining)
+
+	result, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         &roleArn,
+		RoleSessionName: &sessionName,
+		DurationSeconds: &duration,
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to assume role %s: %w", roleArn, err)
+	}
+
+	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, nil
+}
+
 func (e *E2ESession) setupPackagesEnv(testRegex string) error {
 	re := regexp.MustCompile(packagesRegex)
 	if !re.MatchString(testRegex) {
 		return nil
 	}
 
-	requiredEnvVars := e2etests.RequiredPackagesEnvVars()
-	for _, eVar := range requiredEnvVars {
-		if val, ok := os.LookupEnv(eVar); ok {
-			e.testEnvVars[eVar] = val
-		}
+	isNonRegional := regexp.MustCompile(nonRegionalPackagesRegex).MatchString(testRegex)
+
+	var roleArnEnvVar, sessionName string
+	if isNonRegional {
+		roleArnEnvVar = "NON_REGIONAL_PACKAGES_ROLE_ARN"
+		sessionName = "test-packages-nonregional"
+	} else {
+		roleArnEnvVar = "PACKAGES_ROLE_ARN"
+		sessionName = "test-packages"
 	}
 
-	// overwrite envs for regional curated packages test
-	if regexp.MustCompile(nonRegionalPackagesRegex).MatchString(testRegex) {
-		for _, eVar := range requiredEnvVars {
-			if val, ok := os.LookupEnv("NON_REGIONAL_" + eVar); ok {
-				e.testEnvVars[eVar] = val
-			}
-		}
+	accessKey, secretKey, sessionToken, err := assumeRoleAndGetCredentials(roleArnEnvVar, sessionName)
+	if err != nil {
+		return fmt.Errorf("failed to get packages credentials: %w", err)
 	}
+
+	e.testEnvVars["EKSA_AWS_ACCESS_KEY_ID"] = accessKey
+	e.testEnvVars["EKSA_AWS_SECRET_ACCESS_KEY"] = secretKey
+	e.testEnvVars["EKSA_AWS_SESSION_TOKEN"] = sessionToken
+
+	if region, ok := os.LookupEnv("EKSA_AWS_REGION"); ok {
+		e.testEnvVars["EKSA_AWS_REGION"] = region
+	}
+
 	return nil
 }
 
@@ -43,11 +87,21 @@ func (e *E2ESession) setupCertManagerEnv(testRegex string) error {
 		return nil
 	}
 
-	requiredEnvVars := e2etests.RequiredCertManagerEnvVars()
-	for _, eVar := range requiredEnvVars {
-		if val, ok := os.LookupEnv(eVar); ok {
-			e.testEnvVars[eVar] = val
-		}
+	accessKey, secretKey, sessionToken, err := assumeRoleAndGetCredentials("CERT_MANAGER_ROLE_ARN", "test-certmanager")
+	if err != nil {
+		return fmt.Errorf("failed to get cert manager credentials: %w", err)
 	}
+
+	e.testEnvVars["ROUTE53_ACCESS_KEY_ID"] = accessKey
+	e.testEnvVars["ROUTE53_SECRET_ACCESS_KEY"] = secretKey
+	e.testEnvVars["ROUTE53_SESSION_TOKEN"] = sessionToken
+
+	if region, ok := os.LookupEnv("ROUTE53_REGION"); ok {
+		e.testEnvVars["ROUTE53_REGION"] = region
+	}
+	if zoneId, ok := os.LookupEnv("ROUTE53_ZONEID"); ok {
+		e.testEnvVars["ROUTE53_ZONEID"] = zoneId
+	}
+
 	return nil
 }


### PR DESCRIPTION
Assumes roles on-demand before each test that needs credentials as aws role chaning only allows maximum of 1 hour and e2e test suites take longer than that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

