### PR TITLE
Skip 134 Ubuntu RTOS tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -177,6 +177,12 @@ skipped_tests:
 - TestTinkerbellKubernetes131ThreeReplicasTwoWorkersConformanceFlow
 - TestTinkerbellKubernetes132ThreeReplicasTwoWorkersConformanceFlow
 
+# Tinkerbell 134 RTOS tests
+# These tests need to be skipped until the 1.34 RTOS image from cannonical is available
+- TestTinkerbellKubernetes134Ubuntu2204To2404GenericUpgrade
+- TestTinkerbellKubernetes134Ubuntu2404RTOSSimpleFlow
+- TestTinkerbellKubernetes134Ubuntu2404GenericSimpleFlow
+
 # Vsphere 
 # Auto import tests fail from time to time if the underlying template doesn't go well with the content library.
 # Currently there's no fix for this and issue has been brought up with the BR team multiple times.


### PR DESCRIPTION
*Issue #, if available:*
134 rtos tests are failing because Ubuntu RTOS 134 image is not available. 
*Description of changes:*
Skip 134 Ubuntu RTOS tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

