### PR TITLE
Add license token for 1.30 workload cluster

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -160,6 +160,7 @@ func TestTinkerbellKubernetes131UbuntuTo132Upgrade(t *testing.T) {
 }
 
 func TestTinkerbellKubernetes130UbuntuTo131UpgradeCPOnly(t *testing.T) {
+	licenseToken := framework.GetLicenseToken()
 	provider := framework.NewTinkerbell(t)
 	kube130 := v1alpha1.Kube130
 	test := framework.NewClusterE2ETest(
@@ -174,6 +175,9 @@ func TestTinkerbellKubernetes130UbuntuTo131UpgradeCPOnly(t *testing.T) {
 	).WithClusterConfig(
 		provider.WithCPKubeVersionAndOS(kube130, framework.Ubuntu2004),
 		provider.WithWorkerKubeVersionAndOS(kube130, framework.Ubuntu2004),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
 		test,

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -7411,18 +7411,6 @@ func TestVSphereKubernetes134MulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithStackedEtcdTopology(),
 				api.WithLicenseToken(licenseToken),
 			),
-			vsphere.WithUbuntu128(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
 			vsphere.WithUbuntu129(),
 		),
 		framework.NewClusterE2ETest(
@@ -7433,6 +7421,7 @@ func TestVSphereKubernetes134MulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
+				api.WithLicenseToken(licenseToken2),
 			),
 			vsphere.WithUbuntu130(),
 		),
@@ -8273,18 +8262,6 @@ func TestVSphereKubernetes133MulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithStackedEtcdTopology(),
 				api.WithLicenseToken(licenseToken),
 			),
-			vsphere.WithUbuntu128(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
 			vsphere.WithUbuntu129(),
 		),
 		framework.NewClusterE2ETest(
@@ -8295,6 +8272,7 @@ func TestVSphereKubernetes133MulticlusterWorkloadClusterAPI(t *testing.T) {
 				api.WithControlPlaneCount(1),
 				api.WithWorkerNodeCount(1),
 				api.WithStackedEtcdTopology(),
+				api.WithLicenseToken(licenseToken2),
 			),
 			vsphere.WithUbuntu130(),
 		),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1.30 cluster needs license Token, removed 1.28 cluster and add license token for 1.30 cluster in the MultiWorkloadCluster test cases.

*Testing (if applicable):*

```
--- PASS: TestVSphereKubernetes134MulticlusterWorkloadClusterAPI (1295.07s)
PASS
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

