### PR TITLE
Skip 134 RTOS upgrade test

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -182,6 +182,7 @@ skipped_tests:
 - TestTinkerbellKubernetes134Ubuntu2204To2404GenericUpgrade
 - TestTinkerbellKubernetes134Ubuntu2404RTOSSimpleFlow
 - TestTinkerbellKubernetes134Ubuntu2404GenericSimpleFlow
+- TestTinkerbellKubernetes134Ubuntu2204To2404RTOSUpgrade
 
 # Vsphere 
 # Auto import tests fail from time to time if the underlying template doesn't go well with the content library.


### PR DESCRIPTION
*Issue #, if available:*
134 rtos tests are failing because Ubuntu RTOS 134 image is not available.

*Description of changes:*
Skip 134 RTOS upgrade test - TestTinkerbellKubernetes134Ubuntu2204To2404RTOSUpgrade



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


