### PR TITLE
docs: add AWS-supported Cilium management guide

### DIFF
--- a/docs/content/en/docs/clustermgmt/networking/cilium-aws-supported.md
+++ b/docs/content/en/docs/clustermgmt/networking/cilium-aws-supported.md
@@ -3,7 +3,7 @@ title: "Cilium supported by AWS"
 linkTitle: "Cilium supported by AWS"
 weight: 40
 description: >
-  How to implement and manage versions of the Cilium CNI build maintained by AWS for EKS Anywhere clusters
+  How to install and manage versions of the Cilium CNI build maintained by AWS for EKS Anywhere clusters
 ---
 
 ## Overview


### PR DESCRIPTION
Add comprehensive documentation for managing AWS-supported Cilium in EKS Anywhere clusters. This guide covers:

- Overview of EKS-A managed vs self-managed Cilium approaches
- Installing AWS-supported Cilium with Helm for self-management
- Pros and cons of self-managing Cilium deployment
- Migration path from open source to AWS-supported version
- Transitioning from self-managed to EKS-A managed Cilium
- Verification steps and expected outputs

The documentation helps users understand their options for managing Cilium CNI and provides clear instructions for each approach.

*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3664
