### PR TITLE
Add 1 minute wait for vSphere upgrade test

### DIFF
--- a/test/e2e/labels.go
+++ b/test/e2e/labels.go
@@ -4,7 +4,10 @@
 package e2e
 
 import (
+	"time"
+
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -13,6 +16,13 @@ func runLabelsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.CreateCluster()
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneLabels)
+	// Add 1-minute wait for vSphere upgrade tests
+	// where it fails during upgrade preflight validation
+	// when packages controller installs credentials provider package on the node
+	if test.Provider.Name() == constants.VSphereProviderName {
+		test.T.Log("Waiting 1 minute before starting vSphere upgrade...")
+		time.Sleep(1 * time.Minute)
+	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)

--- a/test/e2e/taints.go
+++ b/test/e2e/taints.go
@@ -4,7 +4,10 @@
 package e2e
 
 import (
+	"time"
+
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -13,6 +16,13 @@ func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.CreateCluster()
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints)
+	// Add 1-minute wait for vSphere upgrade tests
+	// where it fails during upgrade preflight validation
+	// when packages controller installs credentials provider package on the node
+	if test.Provider.Name() == constants.VSphereProviderName {
+		test.T.Log("Waiting 1 minute before starting vSphere upgrade...")
+		time.Sleep(1 * time.Minute)
+	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -4,14 +4,24 @@
 package e2e
 
 import (
+	"time"
+
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
+	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
 func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
+	// Add 1-minute wait for vSphere upgrade tests
+	// where it fails during upgrade preflight validation
+	// when packages controller installs credentials provider package on the node
+	if test.Provider.Name() == constants.VSphereProviderName {
+		test.T.Log("Waiting 1 minute before starting vSphere upgrade...")
+		time.Sleep(1 * time.Minute)
+	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.StopIfFailed()
@@ -23,6 +33,13 @@ func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 // and avoids regenerating a cluster config with defaults.
 func runSimpleUpgradeFlowWithoutClusterConfigGeneration(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.CreateCluster()
+	// Add 1-minute wait for vSphere upgrade tests
+	// where it fails during upgrade preflight validation
+	// when packages controller installs credentials provider package on the node
+	if test.Provider.Name() == constants.VSphereProviderName {
+		test.T.Log("Waiting 1 minute before starting vSphere upgrade...")
+		time.Sleep(1 * time.Minute)
+	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.StopIfFailed()

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -6801,9 +6801,9 @@ func TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) 
 	)
 }
 
-func TestVSphereKubernetes134WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+func TestVSphereKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
 	provider := framework.NewVSphere(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.Ubuntu2004, v1alpha1.Kube134)
+	runTestManagementClusterUpgradeSideEffects(t, provider, framework.Ubuntu2004, v1alpha1.Kube133)
 }
 
 func TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {


### PR DESCRIPTION
*Description of changes:*
vSphere upgrade tests are failing randomly during upgrade preflight validation when package controller installs credentials provider package on nodes, causing kubelet restarts. Running upgrades immediately during these restarts leads to intermittent e2e test failures.

Added 1-minute wait for vSphere upgrade tests to wait 1 minute before starting upgrades, but only for vSphere provider tests.

*Testing (if applicable):*


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

