### PR TITLE
Remove AWSIamAuth removal e2e tests due to framework limitations

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -346,19 +346,6 @@ func WithAWSIamIdentityProviderRef(name string) ClusterFiller {
 	}
 }
 
-func RemoveAWSIamIdentityProviderRef() ClusterFiller {
-	return func(c *anywherev1.Cluster) {
-		// Filter out AWS IAM identity provider refs
-		filtered := make([]anywherev1.Ref, 0, len(c.Spec.IdentityProviderRefs))
-		for _, ref := range c.Spec.IdentityProviderRefs {
-			if ref.Kind != anywherev1.AWSIamConfigKind {
-				filtered = append(filtered, ref)
-			}
-		}
-		c.Spec.IdentityProviderRefs = filtered
-	}
-}
-
 func RemoveAllWorkerNodeGroups() ClusterFiller {
 	return func(c *anywherev1.Cluster) {
 		c.Spec.WorkerNodeGroupConfigurations = make([]anywherev1.WorkerNodeGroupConfiguration, 0)

--- a/test/e2e/awsiamauth.go
+++ b/test/e2e/awsiamauth.go
@@ -67,16 +67,3 @@ func runUpgradeFlowAddAWSIamAuth(test *framework.ClusterE2ETest, updateVersion v
 	test.StopIfFailed()
 	test.DeleteCluster()
 }
-
-func runUpgradeFlowRemoveAWSIamAuth(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion) {
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateAWSIamAuth()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{
-		framework.WithUpgradeClusterConfig(framework.RemoveAWSIamConfig()),
-		framework.WithClusterUpgrade(api.RemoveAWSIamIdentityProviderRef()),
-	})
-	test.ValidateCluster(updateVersion)
-	test.StopIfFailed()
-	test.DeleteCluster()
-}

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -298,26 +298,6 @@ func TestVSphereKubernetes134UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
 	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube134)
 }
 
-func TestVSphereKubernetes128UbuntuRemoveAWSIamAuthUpgrade(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runUpgradeFlowRemoveAWSIamAuth(test, v1alpha1.Kube128)
-}
-
-func TestVSphereKubernetes134UbuntuRemoveAWSIamAuthUpgrade(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runUpgradeFlowRemoveAWSIamAuth(test, v1alpha1.Kube134)
-}
-
 // Curated Packages
 func TestVSphereKubernetes128CuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)

--- a/test/framework/awsiam.go
+++ b/test/framework/awsiam.go
@@ -151,10 +151,3 @@ func WithAwsIamConfig() api.ClusterConfigFiller {
 		)
 	}, api.ClusterToConfigFiller(api.WithAWSIamIdentityProviderRef(defaultClusterName)))
 }
-
-// RemoveAWSIamConfig removes AWS IAM config from cluster config.
-func RemoveAWSIamConfig() api.ClusterConfigFiller {
-	return func(config *cluster.Config) {
-		delete(config.AWSIAMConfigs, defaultClusterName)
-	}
-}


### PR DESCRIPTION
*Description of changes:*
These tests are currently failing as during the upgrade cluster step, cluster.spec.identityProviderRefs field is completely removed in the generated cluster spec yaml file (omitempty field). And during eks-a cli upgrade cluster operation, it applies new cluster object server side, it doesn't remove the identityProviderRefs field in the remote resource. 
```
2025-10-31T04:03:11.663Z→   V6→   Executing command→   {"cmd": "/usr/bin/docker exec -i eksa_1761883350795938511 kubectl apply -f - --kubeconfig release-i-0672a-f3378eb/release-i-0672a-f3378eb-eks-a-cluster.kubeconfig --field-manager eks-a-cli --server-side --force-conflicts"}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

