### PR TITLE
Skip package controller install for non-package tests

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -439,3 +439,13 @@ func WithSkipAdmissionForSystemResources(skip bool) ClusterFiller {
 		c.Spec.ControlPlaneConfiguration.SkipAdmissionForSystemResources = &skip
 	}
 }
+
+// WithPackagesDisabled disables the package controller installation on the cluster.
+func WithPackagesDisabled() ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.Packages == nil {
+			c.Spec.Packages = &anywherev1.PackageConfiguration{}
+		}
+		c.Spec.Packages.Disable = true
+	}
+}

--- a/test/e2e/labels.go
+++ b/test/e2e/labels.go
@@ -4,10 +4,7 @@
 package e2e
 
 import (
-	"time"
-
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -16,13 +13,6 @@ func runLabelsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.CreateCluster()
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneLabels)
-	// Add 1-minute wait for vSphere upgrade tests
-	// where it fails during upgrade preflight validation
-	// when packages controller installs credentials provider package on the node
-	if test.Provider.Name() == constants.VSphereProviderName {
-		test.T.Log("Waiting 2 minute before starting vSphere upgrade...")
-		time.Sleep(2 * time.Minute)
-	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)

--- a/test/e2e/taints.go
+++ b/test/e2e/taints.go
@@ -4,10 +4,7 @@
 package e2e
 
 import (
-	"time"
-
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -16,13 +13,6 @@ func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 	test.CreateCluster()
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints)
-	// Add 1-minute wait for vSphere upgrade tests
-	// where it fails during upgrade preflight validation
-	// when packages controller installs credentials provider package on the node
-	if test.Provider.Name() == constants.VSphereProviderName {
-		test.T.Log("Waiting 2 minute before starting vSphere upgrade...")
-		time.Sleep(1 * time.Minute)
-	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)

--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -4,24 +4,14 @@
 package e2e
 
 import (
-	"time"
-
 	"github.com/aws/eks-anywhere/internal/pkg/api"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
-	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
 func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
 	test.CreateCluster()
-	// Add 1-minute wait for vSphere upgrade tests
-	// where it fails during upgrade preflight validation
-	// when packages controller installs credentials provider package on the node
-	if test.Provider.Name() == constants.VSphereProviderName {
-		test.T.Log("Waiting 2 minute before starting vSphere upgrade...")
-		time.Sleep(1 * time.Minute)
-	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.StopIfFailed()
@@ -33,13 +23,6 @@ func runSimpleUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1
 // and avoids regenerating a cluster config with defaults.
 func runSimpleUpgradeFlowWithoutClusterConfigGeneration(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.CreateCluster()
-	// Add 1-minute wait for vSphere upgrade tests
-	// where it fails during upgrade preflight validation
-	// when packages controller installs credentials provider package on the node
-	if test.Provider.Name() == constants.VSphereProviderName {
-		test.T.Log("Waiting 2 minute before starting vSphere upgrade...")
-		time.Sleep(1 * time.Minute)
-	}
 	test.UpgradeClusterWithNewConfig(clusterOpts)
 	test.ValidateCluster(updateVersion)
 	test.StopIfFailed()

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -556,12 +556,19 @@ func (e *ClusterE2ETest) UpdateClusterConfig(fillers ...api.ClusterConfigFiller)
 }
 
 func (e *ClusterE2ETest) baseClusterConfigUpdates() []api.ClusterConfigFiller {
-	clusterFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+3)
+	clusterFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+4)
 	// This defaults all tests to a 1:1:1 configuration. Since all the fillers defined on each test are run
-	// after these 3, if the tests is explicit about any of these, the defaults will be overwritten
+	// after these defaults, if the tests is explicit about any of these, the defaults will be overwritten
 	clusterFillers = append(clusterFillers,
 		api.WithControlPlaneCount(1), api.WithWorkerNodeCount(1), api.WithEtcdCountIfExternal(1),
 	)
+
+	// Disable packages by default for non-package e2e tests
+	// Package tests have "CuratedPackages" in their test name
+	if !strings.Contains(e.T.Name(), "CuratedPackages") {
+		clusterFillers = append(clusterFillers, api.WithPackagesDisabled())
+	}
+
 	clusterFillers = append(clusterFillers, e.clusterFillers...)
 	configFillers := make([]api.ClusterConfigFiller, 0, len(e.clusterConfigFillers)+1)
 	configFillers = append(configFillers, api.ClusterToConfigFiller(clusterFillers...))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Skip package controller install for non-package test, this speeds up non-package tests, and also avoids an issue where package controller installs credential provider and then disrupts kubelet.

Also remove the wait time that we added in https://github.com/aws/eks-anywhere/pull/10260

*Testing (if applicable):*
ran a non package test, and can see that package controller install is skipped
```
2025-10-31T16:44:34.930-0700	V5	Retry execution successful	{"retries": 1, "duration": "488.462666ms"}
2025-10-31T16:44:34.931-0700	V0	🎉 Cluster created!
2025-10-31T16:44:34.931-0700	V4	Task finished	{"task_name": "delete-kind-cluster", "duration": "804.135667ms"}
2025-10-31T16:44:34.931-0700	V4	----------------------------------
2025-10-31T16:44:34.931-0700	V4	Task start	{"task_name": "install-curated-packages"}
2025-10-31T16:44:34.931-0700	V0	  Package controller disabled
2025-10-31T16:44:34.931-0700	V4	Task finished	{"task_name": "install-curated-packages", "duration": "112.209µs"}
2025-10-31T16:44:34.931-0700	V4	----------------------------------
2025-10-31T16:44:34.931-0700	V4	Tasks completed	{"duration": "11m19.769358417s"}
```

Also ran a package test:
```
    cluster.go:929: Skipping provider resource cleanup
--- PASS: TestVSphereKubernetes133BottleRocketCuratedPackagesPrometheusSimpleFlow (1212.80s)
PASS
```
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

