### PR TITLE
Collect management cluster support bundle when target is a workload cluster

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,3 +20,4 @@ ignore:
   - "**/mock_*.go"
   - pkg/curatedpackages/curatedpackages.go
   - cmd/eksctl-anywhere/cmd/internal/commands/artifacts/import.go
+  - cmd/eksctl-anywhere/cmd/supportbundle.go


### PR DESCRIPTION
*Issue #, if available:*
[#1740](https://github.com/aws/eks-anywhere-internal/issues/1740)

*Description of changes:*
When collecting support bundles for workload clusters using the `-f` flag with a workload cluster config file, the CLI only collected diagnostics from the workload cluster itself. This prevented access to CAPI resources and controller logs from the management cluster, which are vital for debugging workload cluster issues. It also delayed the customer issues resolution as this required requesting customer to provide the mgmt support bundle too.

This PR adds automatic collection of the management cluster support bundle when the target is a workload cluster, ensuring all necessary diagnostic information is available for troubleshooting.

- When the target is a **workload cluster**, the CLI now:
   - Collects the workload cluster support bundle (as before)
   - Additionally collects the management cluster support bundle
- When the target is a **management cluster**, only the mgmt bundle is collected
- Graceful error handling: If the management cluster is inaccessible, the workload cluster bundle is still collected with warning logs

*Testing (if applicable):*

Created vSphere mgmt and workload test clusters locally and verified the following scenarios:
```
make eks-a
make lint
make unit-test
./bin/eksctl-anywhere generate clusterconfig test-spb -p vsphere > test-spb.yaml
./bin/eksctl-anywhere create cluster -f test-spb.yaml -v 9
./bin/eksctl-anywhere generate clusterconfig test-spb-wkld -p vsphere > test-spb-wkld.yaml
./bin/eksctl-anywhere create cluster -f test-spb-wkld.yaml -v 9 --kubeconfig test-spb/test-spb-eks-a-cluster.kubeconfig
```

**Test Case 1: Workload Cluster**

```bash
./bin/eksctl-anywhere generate support-bundle -f test-spb-wkld.yaml -v 3

Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.23.4-eks-a-v0.24.0-dev-build.241"}
Initializing long running container     {"name": "eksa_1761975363356030000", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.23.4-eks-a-v0.24.0-dev-build.241"}
bundle config written   {"path": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T22:36:04-07:00-bundle.yaml"}
creating temporary namespace for diagnostic collector   {"namespace": "eksa-diagnostics"}
creating temporary ClusterRole and RoleBinding for diagnostic collector
⏳ Collecting support bundle from cluster, this can take a while        {"cluster": "test-spb-wkld", "bundle": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T22:36:04-07:00-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "test-spb-wkld/test-spb-wkld-eks-a-cluster.kubeconfig"}
Support bundle archive created  {"path": "support-bundle-2025-11-01T05_36_07.tar.gz"}
Analyzing support bundle        {"bundle": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T22:36:04-07:00-bundle.yaml", "archive": "support-bundle-2025-11-01T05_36_07.tar.gz"}
Analysis output generated       {"path": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T22:37:00-07:00-analysis.yaml"}
cleaning up temporary roles for diagnostic collectors
cleaning up temporary namespace  for diagnostic collectors      {"namespace": "eksa-diagnostics"}

2025/10/31 22:37:06 Collecting management cluster support bundle for additional debugging information
bundle config written   {"path": "test-spb-wkld/generated/bootstrap-cluster-2025-10-31T22:37:06-07:00-bundle.yaml"}
creating temporary namespace for diagnostic collector   {"namespace": "eksa-diagnostics"}
WARNING: failed to create eksa-diagnostics namespace. Some collectors may fail to run.  {"err": "creating namespace eksa-diagnostics: Error from server (AlreadyExists): namespaces \"eksa-diagnostics\" already exists\n"}
creating temporary ClusterRole and RoleBinding for diagnostic collector
⏳ Collecting support bundle from cluster, this can take a while        {"cluster": "bootstrap-cluster", "bundle": "test-spb-wkld/generated/bootstrap-cluster-2025-10-31T22:37:06-07:00-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "test-spb/test-spb-eks-a-cluster.kubeconfig"}
Support bundle archive created  {"path": "support-bundle-2025-11-01T05_37_28.tar.gz"}
Analyzing support bundle        {"bundle": "test-spb-wkld/generated/bootstrap-cluster-2025-10-31T22:37:06-07:00-bundle.yaml", "archive": "support-bundle-2025-11-01T05_37_28.tar.gz"}
Analysis output generated       {"path": "test-spb-wkld/generated/bootstrap-cluster-2025-10-31T22:38:34-07:00-analysis.yaml"}
cleaning up temporary roles for diagnostic collectors
cleaning up temporary namespace  for diagnostic collectors      {"namespace": "eksa-diagnostics"}
```

- ✅ Creates workload cluster bundle
- ✅ Creates management cluster bundle

**Test Case 2: Management Cluster**

```bash
./bin/eksctl-anywhere generate support-bundle -f test-spb.yaml -v 3

Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.23.4-eks-a-v0.24.0-dev-build.241"}
Initializing long running container     {"name": "eksa_1761976887810493000", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.23.4-eks-a-v0.24.0-dev-build.241"}
bundle config written   {"path": "test-spb/generated/test-spb-2025-10-31T23:01:29-07:00-bundle.yaml"}
creating temporary namespace for diagnostic collector   {"namespace": "eksa-diagnostics"}
creating temporary ClusterRole and RoleBinding for diagnostic collector
⏳ Collecting support bundle from cluster, this can take a while        {"cluster": "test-spb", "bundle": "test-spb/generated/test-spb-2025-10-31T23:01:29-07:00-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "test-spb/test-spb-eks-a-cluster.kubeconfig"}
Support bundle archive created  {"path": "support-bundle-2025-11-01T06_01_32.tar.gz"}
Analyzing support bundle        {"bundle": "test-spb/generated/test-spb-2025-10-31T23:01:29-07:00-bundle.yaml", "archive": "support-bundle-2025-11-01T06_01_32.tar.gz"}
Analysis output generated       {"path": "test-spb/generated/test-spb-2025-10-31T23:03:04-07:00-analysis.yaml"}
cleaning up temporary roles for diagnostic collectors
cleaning up temporary namespace  for diagnostic collectors      {"namespace": "eksa-diagnostics"}
```

- ✅ Creates only the management cluster bundle

**Test Case 3: Management Cluster Inaccessible**

```bash
rm -rf test-spb
./bin/eksctl-anywhere generate support-bundle -f test-spb-wkld.yaml -v 3

Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.23.4-eks-a-v0.24.0-dev-build.241"}
Initializing long running container     {"name": "eksa_1761977258674013000", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.23.4-eks-a-v0.24.0-dev-build.241"}
bundle config written   {"path": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T23:07:39-07:00-bundle.yaml"}
creating temporary namespace for diagnostic collector   {"namespace": "eksa-diagnostics"}
creating temporary ClusterRole and RoleBinding for diagnostic collector
⏳ Collecting support bundle from cluster, this can take a while        {"cluster": "test-spb-wkld", "bundle": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T23:07:39-07:00-bundle.yaml", "since": -6795364578871345152, "kubeconfig": "test-spb-wkld/test-spb-wkld-eks-a-cluster.kubeconfig"}
Support bundle archive created  {"path": "support-bundle-2025-11-01T06_07_42.tar.gz"}
Analyzing support bundle        {"bundle": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T23:07:39-07:00-bundle.yaml", "archive": "support-bundle-2025-11-01T06_07_42.tar.gz"}
Analysis output generated       {"path": "test-spb-wkld/generated/test-spb-wkld-2025-10-31T23:08:36-07:00-analysis.yaml"}
cleaning up temporary roles for diagnostic collectors
cleaning up temporary namespace  for diagnostic collectors      {"namespace": "eksa-diagnostics"}

2025/10/31 23:08:42 Collecting management cluster support bundle for additional debugging information
2025/10/31 23:08:42 Warning: Management cluster kubeconfig not accessible, skipping management cluster bundle collection: validating kubeconfig "test-spb/test-spb-eks-a-cluster.kubeconfig": file does not exist (managementCluster: test-spb)
```

- ✅ Creates workload cluster bundle
- ✅ Warning logged, command succeeds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

