### PR TITLE
Add secure diagnostics endpoint with authentication to EKS-A manager

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_vspheremachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_vspheremachineconfigs.yaml
@@ -275,8 +275,9 @@ spec:
               memoryMiB:
                 type: integer
               networks:
-                description: The field Networks is for enabling multiple network interfaces
-                  for workernode
+                description: The field Networks is for configuring custom networks
+                  for worker nodes. This can be used to configure upto 2 networks
+                  for a worker node group.
                 items:
                   type: string
                 maxItems: 2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,12 +19,17 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --diagnostics-address=:8443
+        - --insecure-diagnostics=false
         image: controller:latest
         imagePullPolicy: Always
         name: manager
         ports:
         - containerPort: 8081
           name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4028,16 +4028,25 @@ spec:
                         properties:
                           cniExclusive:
                             description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
                               CNIExclusive controls whether Cilium should remove other CNI configuration files.
                               When true (default), Cilium removes other CNI configs; when false, it leaves them alone.
                             type: boolean
                           egressMasqueradeInterfaces:
-                            description: EgressMasquaradeInterfaces determines which
-                              network interfaces are used for masquerading. Accepted
-                              values are a valid interface name or interface prefix.
+                            description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
+                              EgressMasquaradeInterfaces determines which network interfaces are used for masquerading. Accepted values are a valid interface name or interface prefix.
                             type: string
+                          helmValues:
+                            description: |-
+                              HelmValues specifies the complete Helm values configuration for Cilium in YAML format.
+                              When set, this parameter takes precedence over all other Cilium-specific fields in this configuration.
+                              All other Cilium properties (CNIExclusive, EgressMasqueradeInterfaces, IPv4NativeRoutingCIDR, etc.)
+                              will be ignored when HelmValues is specified.
+                            x-kubernetes-preserve-unknown-fields: true
                           ipv4NativeRoutingCIDR:
                             description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
                               IPv4NativeRoutingCIDR specifies the CIDR to use when RoutingMode is set to direct.
                               When specified, Cilium assumes networking for this CIDR is preconfigured and
                               hands traffic destined for that range to the Linux network stack without
@@ -4046,6 +4055,7 @@ spec:
                             type: string
                           ipv6NativeRoutingCIDR:
                             description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
                               IPv6NativeRoutingCIDR specifies the IPv6 CIDR to use when RoutingMode is set to direct.
                               When specified, Cilium assumes networking for this CIDR is preconfigured and
                               hands traffic destined for that range to the Linux network stack without
@@ -4053,18 +4063,20 @@ spec:
                               If this is not set autoDirectNodeRoutes will be set to true
                             type: string
                           policyEnforcementMode:
-                            description: PolicyEnforcementMode determines communication
-                              allowed between pods. Accepted values are default, always,
-                              never.
+                            description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
+                              PolicyEnforcementMode determines communication allowed between pods. Accepted values are default, always, never.
                             type: string
                           routingMode:
                             description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
                               RoutingMode indicates the routing tunnel mode to use for Cilium. Accepted values are overlay (geneve tunnel with overlay)
                               or direct (tunneling disabled with direct routing)
                               Defaults to overlay.
                             type: string
                           skipUpgrade:
                             description: |-
+                              DEPRECATED: Use HelmValues instead. This field will be ignored when HelmValues is set.
                               SkipUpgrade indicicates that Cilium maintenance should be skipped during upgrades. This can
                               be used when operators wish to self manage the Cilium installation.
                             type: boolean
@@ -7860,8 +7872,9 @@ spec:
               memoryMiB:
                 type: integer
               networks:
-                description: The field Networks is for enabling multiple network interfaces
-                  for workernode
+                description: The field Networks is for configuring custom networks
+                  for worker nodes. This can be used to configure upto 2 networks
+                  for a worker node group.
                 items:
                   type: string
                 maxItems: 2
@@ -8418,6 +8431,8 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --diagnostics-address=:8443
+        - --insecure-diagnostics=false
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -8444,6 +8459,9 @@ spec:
           protocol: TCP
         - containerPort: 8081
           name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,6 +13,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create  
+- apiGroups:
   - ""
   resources:
   - events

--- a/go.mod
+++ b/go.mod
@@ -68,16 +68,35 @@ require (
 )
 
 require (
+	cel.dev/expr v0.19.1 // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/cel-go v0.23.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.15 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 // indirect
+	go.opentelemetry.io/otel/metric v1.34.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 )
 
@@ -101,7 +120,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.2 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.28.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.28.4
 	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/internal/configsources v0.0.0-00010101000000-000000000000 // indirect
 	github.com/aws/eks-anywhere/internal/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-00010101000000-000000000000 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -184,7 +203,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	k8s.io/apiextensions-apiserver v0.33.3 // indirect
+	k8s.io/apiextensions-apiserver v0.33.3
 	k8s.io/cluster-bootstrap v0.33.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/kubelet v0.29.5

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
@@ -543,7 +545,6 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 h1:TmHmbvxPmaegwhDubVz0lICL0J5Ka2vwTzhoePEXsGE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0/go.mod h1:qztMSjm835F2bXf+5HKAPIS5qsmQDqZna/PgVt4rWtI=
@@ -1389,7 +1390,6 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
-google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 h1:ToEetK57OidYuqD4Q5w+vfEnPvPpuTwedCNVohYJfNk=
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 h1:GVIKPyP/kLIyVOgOnTwFOrvQaQUzOzGMCxgFUOEmm24=
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422/go.mod h1:b6h1vNKhxaSoEI+5jc3PJUCustfli/mRab7295pY7rw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f h1:OxYkA3wjPsZyBylwymxSHa7ViiW1Sml4ToBrncvFehI=


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3429
*Description of changes:*
Integrates CAPI's diagnostics flags to enable secure metrics serving with authentication and authorization. The diagnostics endpoint serves metrics, pprof, and log level controls over HTTPS with proper RBAC protection.

Changes:
- Add changes to manager to use capi diagnostic fields
- Add RBAC permissions for TokenReviews and SubjectAccessReviews
- Add comprehensive unit tests for manager options integration
- Update go.mod dependencies
- Ran make release-manifests

The manager now supports:
- --diagnostics-address flag (default :8443)
- --insecure-diagnostics flag for development
- Authenticated access to /metrics, /debug/pprof/*, and /debug/flags/v endpoints

*Testing (if applicable):*
Created docker cluster and followed https://cluster-api.sigs.k8s.io/tasks/diagnostics#via-kubectl to test
<img width="980" height="226" alt="Screenshot 2025-11-03 at 3 02 51 PM" src="https://github.com/user-attachments/assets/1e748086-aeb1-474c-8b0e-3ed2a0397d16" />


*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

