### PR TITLE
Update nodedeletiontimeout for tinkerbell to 30s

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -491,6 +491,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: {{.controlPlaneTemplateName}}
       namespace: {{.eksaSystemNamespace}}
+    nodeDeletionTimeout: 30s
   replicas: {{.controlPlaneReplicas}}
 {{- if .upgradeRolloutStrategy }}
   rolloutStrategy:

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -30,6 +30,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: {{.workloadkubeadmconfigTemplateName}}
       clusterName: {{.clusterName}}
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -544,6 +544,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-1
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   version: v1.21.2-eks-1-21-4`)
 	if err := yaml.UnmarshalStrict(b, &kcp); err != nil {
@@ -920,6 +921,7 @@ spec:
       name: test-control-plane-1
       namespace: eksa-system
     metadata: {}
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -1321,6 +1321,7 @@ func tinkerbellCP(clusterName string, opts ...cpOpt) *tinkerbell.ControlPlane {
 					},
 					Version: "v1.19.8",
 					MachineTemplate: controlplanev1.KubeadmControlPlaneMachineTemplate{
+						NodeDeletionTimeout: &metav1.Duration{Duration: 30 * time.Second},
 						InfrastructureRef: corev1.ObjectReference{
 							Kind:       "TinkerbellMachineTemplate",
 							Name:       "workload-cluster-control-plane-1",
@@ -1749,6 +1750,7 @@ func tinkWorker(clusterName string, opts ...workerOpt) *tinkerbell.Workers {
 										APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
 									},
 								},
+								NodeDeletionTimeout: &metav1.Duration{Duration: 30 * time.Second},
 								InfrastructureRef: corev1.ObjectReference{
 									Kind:       "TinkerbellMachineTemplate",
 									Name:       clusterName + "-md-0-1",

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
@@ -308,6 +308,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: <no value>
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
@@ -308,6 +308,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: <no value>
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
@@ -317,6 +317,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: <no value>
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
@@ -298,6 +298,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: <no value>
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
@@ -298,6 +298,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: <no value>
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_kct.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kct.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-test-1
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-1
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-1
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_cp.yaml
@@ -385,6 +385,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_cert_bundles_config_md.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_cp.yaml
@@ -351,6 +351,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_kernel_config_md.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_cp.yaml
@@ -331,6 +331,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_ntp_config_md.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_cp.yaml
@@ -343,6 +343,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_settings_config_md.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_upgrade_cert_bundles_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_upgrade_cert_bundles_config_cp.yaml
@@ -385,6 +385,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_upgrade_cert_bundles_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_bottlerocket_upgrade_cert_bundles_config_md.yaml
@@ -31,6 +31,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate
         name: test-md-0-1234567890000
+      nodeDeletionTimeout: 30s
       version: v1.21.2-eks-1-21-4
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_autoscaler_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_autoscaler_md.yaml
@@ -25,6 +25,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_minimal_registry_mirror.yaml
@@ -329,6 +329,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -365,6 +365,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -365,6 +365,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_minimal_registry_mirror.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_awsiam.yaml
@@ -342,6 +342,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_external_etcd.yaml
@@ -298,6 +298,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_full_oidc.yaml
@@ -305,6 +305,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_oidc.yaml
@@ -300,6 +300,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
@@ -321,6 +321,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_labels.yaml
@@ -300,6 +300,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_node_taints.yaml
@@ -318,6 +318,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_proxy.yaml
@@ -308,6 +308,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
@@ -347,6 +347,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -351,6 +351,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node.yaml
@@ -306,6 +306,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: single-node-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_in_place.yaml
@@ -306,6 +306,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: single-node-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     type: InPlace

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_single_node_skip_lb.yaml
@@ -300,6 +300,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: single-node-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_stacked_etcd.yaml
@@ -298,6 +298,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_disable_kube_vip.yaml
@@ -246,6 +246,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: single-node-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_labels.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_taints.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_taints.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_node_worker_version.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate
@@ -196,6 +197,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-1-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_proxy.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_missing_ssh_keys.yaml
@@ -298,6 +298,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
@@ -359,6 +359,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cp_template.yaml
@@ -298,6 +298,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_md_template.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_md_template.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_md_multiple_node_groups.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate
@@ -195,6 +196,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-1-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_pod_iam_config.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_tinkerbell_pod_iam_config.yaml
@@ -343,6 +343,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_cp.yaml
@@ -304,6 +304,7 @@ spec:
       kind: TinkerbellMachineTemplate
       name: test-control-plane-template-1234567890000
       namespace: eksa-system
+    nodeDeletionTimeout: 30s
   replicas: 1
   rolloutStrategy:
     rollingUpdate:

--- a/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_md.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_ubuntu_ntp_config_md.yaml
@@ -23,6 +23,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: test-md-0-template-1234567890000
       clusterName: test
+      nodeDeletionTimeout: 30s
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: TinkerbellMachineTemplate

--- a/pkg/providers/tinkerbell/workers_test.go
+++ b/pkg/providers/tinkerbell/workers_test.go
@@ -317,6 +317,7 @@ func machineDeployment(opts ...func(*clusterv1.MachineDeployment)) *clusterv1.Ma
 							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
 						},
 					},
+					NodeDeletionTimeout: &metav1.Duration{Duration: 30 * time.Second},
 					InfrastructureRef: corev1.ObjectReference{
 						Kind:       "TinkerbellMachineTemplate",
 						Name:       "test-md-0-1",


### PR DESCRIPTION
*Description of changes:*
For tinkerbell, we are seeing e2e tests failures with the error message like below,

```
cluster condition ControlPlaneReady is False: Control plane Node eksa-cp07 does not have a corresponding Machine
```
this happens when capt takes more than 10s (default node deletion timeout) to delete the machine corresponding to node.

Increasing `nodedeletiontimeout` to 30s for tinkerbell provider to overcome this issue.


*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

