### PR TITLE
Allow RedHat for in-place upgrades validation

### DIFF
--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -71,8 +71,8 @@ func validateUpgradeRolloutStrategy(spec *ClusterSpec) error {
 		controlPlaneRef := spec.ControlPlaneConfiguration().MachineGroupRef
 		controlPlaneOsFamily := spec.MachineConfigs[controlPlaneRef.Name].OSFamily()
 
-		if controlPlaneOsFamily != v1alpha1.Ubuntu && cpUpgradeRolloutStrategyType == v1alpha1.InPlaceStrategyType {
-			return errors.New("InPlace upgrades are only supported on the Ubuntu OS family")
+		if controlPlaneOsFamily == v1alpha1.Bottlerocket && cpUpgradeRolloutStrategyType == v1alpha1.InPlaceStrategyType {
+			return fmt.Errorf("InPlace upgrades are not supported for OS family %s", controlPlaneOsFamily)
 		}
 	}
 
@@ -82,8 +82,9 @@ func validateUpgradeRolloutStrategy(spec *ClusterSpec) error {
 
 		if group.UpgradeRolloutStrategy != nil {
 			wnUpgradeRolloutStrategyType = group.UpgradeRolloutStrategy.Type
-			if spec.MachineConfigs[groupRef.Name].OSFamily() != v1alpha1.Ubuntu && wnUpgradeRolloutStrategyType == v1alpha1.InPlaceStrategyType {
-				return errors.New("InPlace upgrades are only supported on the Ubuntu OS family")
+			workerOsFamily := spec.MachineConfigs[groupRef.Name].OSFamily()
+			if workerOsFamily == v1alpha1.Bottlerocket && wnUpgradeRolloutStrategyType == v1alpha1.InPlaceStrategyType {
+				return fmt.Errorf("InPlace upgrades are not supported for OS family %s", workerOsFamily)
 			}
 		}
 		if wnUpgradeRolloutStrategyType != cpUpgradeRolloutStrategyType {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change validation from Ubuntu-only whitelist to Bottlerocket-only blocklist, allowing RedHat and future OS families to use in-place upgrades.

- Refactor validateUpgradeRolloutStrategy() to check for unsupported OS
- Add test coverage for RedHat in-place upgrade validation

*Testing (if applicable):*
Tested by creating redhat baremetal cluster with InPlace upgrade rollout strategy and upgraded it. 

<img width="1241" height="572" alt="Screenshot 2025-11-05 at 12 21 35 AM" src="https://github.com/user-attachments/assets/2d76555f-0980-46d0-bef3-30cc43b0491e" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

