### PR TITLE
Fix production bundle CLI generation

### DIFF
--- a/release/cli/pkg/assets/archives/archives.go
+++ b/release/cli/pkg/assets/archives/archives.go
@@ -137,7 +137,7 @@ func ReleaseBranchedTarballArtifactPathGetter(rc *releasetypes.ReleaseConfig, ar
 		sourceS3Prefix = fmt.Sprintf("%s/%s", projectPath, latestPath)
 	} else {
 		sourceS3Key = fmt.Sprintf("%s-%s-%s.tar.gz", archive.Name, os, arch)
-		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/%s/%s", rc.BundleNumber, archive.Name, gitTag)
+		sourceS3Prefix = fmt.Sprintf("releases/bundles/%d/artifacts/%s/%s/%s", rc.BundleNumber, eksDReleaseChannel, archive.Name, gitTag)
 	}
 
 	if rc.DevRelease {


### PR DESCRIPTION
*Description of changes:*
ReleaseBranchedTarballArtifactPathGetter was generating incorrect S3 paths for containerd artifacts in production builds - looking for `releases/bundles/108/artifacts/containerd/v1.7.28/` instead of the actual storage location `releases/bundles/108/artifacts/1-28/containerd/v1.7.28/`.

Fix: Updated the sourceS3Prefix generation to include eksDReleaseChannel in the correct path position: `releases/bundles/{bundleNumber}/artifacts/{eksDReleaseChannel}/{archive.Name}/{gitTag}`.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

