### PR TITLE
[release-0.23] Skip package controller install for non-package tests

### DIFF
--- a/internal/pkg/api/cluster.go
+++ b/internal/pkg/api/cluster.go
@@ -412,3 +412,13 @@ func WithInPlaceUpgradeStrategy() ClusterFiller {
 		}
 	}
 }
+
+// WithPackagesDisabled disables the package controller installation on the cluster.
+func WithPackagesDisabled() ClusterFiller {
+	return func(c *anywherev1.Cluster) {
+		if c.Spec.Packages == nil {
+			c.Spec.Packages = &anywherev1.PackageConfiguration{}
+		}
+		c.Spec.Packages.Disable = true
+	}
+}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -556,12 +556,19 @@ func (e *ClusterE2ETest) UpdateClusterConfig(fillers ...api.ClusterConfigFiller)
 }
 
 func (e *ClusterE2ETest) baseClusterConfigUpdates() []api.ClusterConfigFiller {
-	clusterFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+3)
+	clusterFillers := make([]api.ClusterFiller, 0, len(e.clusterFillers)+4)
 	// This defaults all tests to a 1:1:1 configuration. Since all the fillers defined on each test are run
-	// after these 3, if the tests is explicit about any of these, the defaults will be overwritten
+	// after these defaults, if the tests is explicit about any of these, the defaults will be overwritten
 	clusterFillers = append(clusterFillers,
 		api.WithControlPlaneCount(1), api.WithWorkerNodeCount(1), api.WithEtcdCountIfExternal(1),
 	)
+
+	// Disable packages by default for non-package e2e tests
+	// Package tests have "CuratedPackages" in their test name
+	if !strings.Contains(e.T.Name(), "CuratedPackages") {
+		clusterFillers = append(clusterFillers, api.WithPackagesDisabled())
+	}
+
 	clusterFillers = append(clusterFillers, e.clusterFillers...)
 	configFillers := make([]api.ClusterConfigFiller, 0, len(e.clusterConfigFillers)+1)
 	configFillers = append(configFillers, api.ClusterToConfigFiller(clusterFillers...))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Manual cherry-pick of https://github.com/aws/eks-anywhere/pull/10275

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

