### PR TITLE
Update custom TinkerbellTemplateConfig to use new static IPAM logic

### DIFF
--- a/test/framework/testdata/tinkerbell/custom_config.yaml
+++ b/test/framework/testdata/tinkerbell/custom_config.yaml
@@ -17,13 +17,50 @@ spec:
         name: stream image to disk
         timeout: 600
       - environment:
+          CONTENTS: |
+            {{ if (index .Hardware.Interfaces 0).DHCP.VLANID }}network:
+                version: 2
+                renderer: networkd
+                ethernets:
+                    mainif:
+                        match:
+                            macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
+                        set-name: mainif
+
+                vlans:
+                    vlan{{ (index .Hardware.Interfaces 0).DHCP.VLANID }}:
+                        id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
+                        link: mainif
+                        addresses:
+                        - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                        nameservers:
+                            addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
+                        {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
+                        routes:
+                            - to: default
+                              via: {{ (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
+                        {{- end }}
+            {{ else }}network:
+                version: 2
+                renderer: networkd
+                ethernets:
+                    id0:
+                        match:
+                            macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
+                        addresses:
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                        nameservers:
+                            addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
+                        routes:
+                            - to: default
+                              via: {{ (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
+            {{ end }}
           DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
           DEST_PATH: /etc/netplan/config.yaml
           DIRMODE: "0755"
           FS_TYPE: ext4
           GID: "0"
           MODE: "0644"
-          STATIC_NETPLAN: "true"
           UID: "0"
         image: 127.0.0.1/embedded/writefile
         name: write netplan config
@@ -54,11 +91,11 @@ spec:
           CONTENTS: |
             datasource:
               Ec2:
-                metadata_urls: [http://__TINKERBELL_LOCAL_IP__:50061,http://__TINKERBELL_LB_IP__:50061]
+                metadata_urls: [http://__TINKERBELL_LOCAL_IP__:50061, http://__TINKERBELL_LB_IP__:50061]
                 strict_id: false
             manage_etc_hosts: localhost
             warnings:
-              dsid_missing_source: off            
+              dsid_missing_source: off
           DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
           DEST_PATH: /etc/cloud/cloud.cfg.d/10_tinkerbell.cfg
           DIRMODE: "0700"
@@ -70,8 +107,7 @@ spec:
         name: add cloud-init config
         timeout: 90
       - environment:
-          CONTENTS: |
-                        datasource: Ec2
+          CONTENTS: "datasource: Ec2\n"
           DEST_DISK: '{{ formatPartition ( index .Hardware.Disks 0 ) 2 }}'
           DEST_PATH: /etc/cloud/ds-identify.cfg
           DIRMODE: "0700"


### PR DESCRIPTION
The custom template in TestTinkerbellCustomTemplateRefSimpleFlow was using the deprecated STATIC_NETPLAN environment variable approach which was removed in PR #10163. That PR changed the templating logic to directly configure IPAM using netplan or NetworkManager by referencing the Hardware object's network metadata.

This commit updates the custom template to:
- Remove STATIC_NETPLAN environment variable
- Add CONTENTS with Go template expressions that access network details directly from .Hardware.Interfaces[0].DHCP fields
- Support both VLAN and non-VLAN configurations using conditional logic
- Use netmaskToCIDR template function for proper CIDR notation

Ref: https://github.com/aws/eks-anywhere/pull/10163

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

