### PR TITLE
[release-0.24] Skip non packages tests temporarily

### DIFF
--- a/test/e2e/cloudstack_test.go
+++ b/test/e2e/cloudstack_test.go
@@ -17,218 +17,218 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-// APIServerExtraArgs
-func TestCloudStackKubernetes134RedHat9APIServerExtraArgsSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneAPIServerExtraArgs(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
+// // APIServerExtraArgs
+// func TestCloudStackKubernetes134RedHat9APIServerExtraArgsSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneAPIServerExtraArgs(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
 
-// TODO: Investigate why this test takes long time to pass with service-account-issuer flag
-func TestCloudStackKubernetes134Redhat9APIServerExtraArgsUpgradeFlow(t *testing.T) {
-	var addAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
-	var removeAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
-	)
-	addAPIServerExtraArgsclusterOpts = append(
-		addAPIServerExtraArgsclusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithControlPlaneAPIServerExtraArgs(),
-		),
-	)
-	removeAPIServerExtraArgsclusterOpts = append(
-		removeAPIServerExtraArgsclusterOpts,
-		framework.WithClusterUpgrade(
-			api.RemoveAllAPIServerExtraArgs(),
-		),
-	)
-	runAPIServerExtraArgsUpgradeFlow(
-		test,
-		addAPIServerExtraArgsclusterOpts,
-		removeAPIServerExtraArgsclusterOpts,
-	)
-}
+// // TODO: Investigate why this test takes long time to pass with service-account-issuer flag
+// func TestCloudStackKubernetes134Redhat9APIServerExtraArgsUpgradeFlow(t *testing.T) {
+// 	var addAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
+// 	var removeAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
+// 	)
+// 	addAPIServerExtraArgsclusterOpts = append(
+// 		addAPIServerExtraArgsclusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithControlPlaneAPIServerExtraArgs(),
+// 		),
+// 	)
+// 	removeAPIServerExtraArgsclusterOpts = append(
+// 		removeAPIServerExtraArgsclusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveAllAPIServerExtraArgs(),
+// 		),
+// 	)
+// 	runAPIServerExtraArgsUpgradeFlow(
+// 		test,
+// 		addAPIServerExtraArgsclusterOpts,
+// 		removeAPIServerExtraArgsclusterOpts,
+// 	)
+// }
 
-// AWS IAM Auth
-func TestCloudStackKubernetes128AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// // AWS IAM Auth
+// func TestCloudStackKubernetes128AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes129AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestCloudStackKubernetes129AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes130AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestCloudStackKubernetes130AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes131AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestCloudStackKubernetes131AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes132AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestCloudStackKubernetes132AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes133AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestCloudStackKubernetes133AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes134AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestCloudStackKubernetes134AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestCloudStackKubernetes128to129AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
-	)
-}
+// func TestCloudStackKubernetes128to129AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
+// 	)
+// }
 
-func TestCloudStackKubernetes129to130AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
-	)
-}
+// func TestCloudStackKubernetes129to130AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
+// 	)
+// }
 
-func TestCloudStackKubernetes130to131AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
-	)
-}
+// func TestCloudStackKubernetes130to131AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
+// 	)
+// }
 
-func TestCloudStackKubernetes131to132AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
-	)
-}
+// func TestCloudStackKubernetes131to132AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
+// 	)
+// }
 
-func TestCloudStackKubernetes132to133AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
-	)
-}
+// func TestCloudStackKubernetes132to133AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
+// 	)
+// }
 
-func TestCloudStackKubernetes133to134AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
-	)
-}
+// func TestCloudStackKubernetes133to134AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
+// 	)
+// }
 
 // Curated Packages
 func TestCloudStackKubernetes128RedhatCuratedPackagesSimpleFlow(t *testing.T) {
@@ -1022,5407 +1022,5407 @@ func TestCloudStackKubernetes134RedhatCuratedPackagesPrometheusSimpleFlow(t *tes
 	runCuratedPackagesPrometheusInstallSimpleFlow(test)
 }
 
-// Download Artifacts
-func TestCloudStackDownloadArtifacts(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat131()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runDownloadArtifactsFlow(test)
-}
-
-func TestCloudStackRedhat9DownloadArtifacts(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runDownloadArtifactsFlow(test)
-}
-
-// Flux
-func TestCloudStackKubernetes128GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes129GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes130GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes131GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes132GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes128GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes129GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes130GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes131GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes132GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes133GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes133GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes134GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes134GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestCloudStackKubernetes129To130GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
-	)
-}
-
-func TestCloudStackKubernetes130To131GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
-	)
-}
-
-func TestCloudStackKubernetes131To132GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
-	)
-}
-
-func TestCloudStackKubernetes132To133GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
-	)
-}
-
-func TestCloudStackKubernetes133To134GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
-	)
-}
-
-func TestCloudStackKubernetes128InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube128,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes129InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube129,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes130InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube130,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes131InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube131,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes132InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube132,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes133InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube133,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes134InstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube134,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-func TestCloudStackKubernetes134UpgradeManagementComponents(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
-	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube134, framework.RedHat9)
-}
-
-// Labels
-func TestCloudStackKubernetes128LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes128(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes129LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes129(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes130LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes130(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes131LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes131(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes132LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes132(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes133LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes133(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes134LabelsAndNodeNameRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes134(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
-				api.WithCount(1),
-				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
-			),
-		),
-	)
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes128RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat128ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes129RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat129ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes130RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat130ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes131RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat131ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes132RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat132ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat133ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes134RedhatLabelsUpgradeFlow(t *testing.T) {
-	provider := redhat134ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func redhat128ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes128(),
-	)
-}
-
-func redhat129ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes129(),
-	)
-}
-
-func redhat130ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes130(),
-	)
-}
-
-func redhat131ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes131(),
-	)
-}
-
-func redhat132ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes132(),
-	)
-}
-
-func redhat133ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes133(),
-	)
-}
-
-func redhat134ProviderWithLabels(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes134(),
-	)
-}
-
-func redhat133ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes133(),
-	)
-}
-
-func redhat134ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes134(),
-	)
-}
-
-// Multicluster
-func TestCloudStackKubernetes128MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackKubernetes129MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube129),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube129),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackKubernetes130MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackKubernetes131MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackKubernetes132MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackKubernetes133MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackKubernetes134MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestCloudStackUpgradeKubernetes129MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			provider.Redhat9Kubernetes129Template(),
-		),
-	)
-}
-
-func TestCloudStackUpgradeKubernetes130MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube129),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube129),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			provider.Redhat9Kubernetes130Template(),
-		),
-	)
-}
-
-func TestCloudStackUpgradeKubernetes131MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			provider.Redhat9Kubernetes131Template(),
-		),
-	)
-}
-
-func TestCloudStackUpgradeKubernetes132MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			provider.Redhat9Kubernetes132Template(),
-		),
-	)
-}
-
-func TestCloudStackUpgradeKubernetes133MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			provider.Redhat9Kubernetes133Template(),
-		),
-	)
-}
-
-func TestCloudStackUpgradeKubernetes134MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(3),
-		),
-		provider.WithProviderUpgradeGit(
-			provider.Redhat9Kubernetes134Template(),
-		),
-	)
-}
-
-// OIDC
-func TestCloudStackKubernetes128WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube128)
-}
-
-func TestCloudStackKubernetes129WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube129)
-}
-
-func TestCloudStackKubernetes130WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube130)
-}
-
-func TestCloudStackKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube131)
-}
-
-func TestCloudStackKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube132)
-}
-
-func TestCloudStackKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube133)
-}
-
-func TestCloudStackKubernetes134WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube134)
-}
-
-func TestCloudStackKubernetes128OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes129OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes130OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes131OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes132OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes133OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes134OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestCloudStackKubernetes130To131OIDCUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithOIDC(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
-	)
-}
-
-func TestCloudStackKubernetes131To132OIDCUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithOIDC(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
-	)
-}
-
-func TestCloudStackKubernetes132To133OIDCUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithOIDC(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
-	)
-}
-
-func TestCloudStackKubernetes133To134OIDCUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithOIDC(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
-	)
-}
-
-// Proxy Config
-func TestCloudStackKubernetes128RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestCloudStackKubernetes129RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestCloudStackKubernetes130RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestCloudStackKubernetes131RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestCloudStackKubernetes132RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestCloudStackKubernetes133RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestCloudStackKubernetes134RedhatProxyConfig(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-// Proxy Config Multicluster
-func TestCloudStackKubernetes128RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes128(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes128(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes129RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes129(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes129(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes130RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes130(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes130(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes131RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes131(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes131(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes132RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes132(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes132(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134RedhatProxyConfigAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-// Registry Mirror
-func TestCloudStackKubernetes128RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes129RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes130RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes131RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes132RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes128RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes129RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes130RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes131RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes132RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes132RedhatAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithAuthenticatedRegistryMirror(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes133RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes133RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes133RedhatAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithAuthenticatedRegistryMirror(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes134RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes134RedhatRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestCloudStackKubernetes134RedhatAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithAuthenticatedRegistryMirror(constants.CloudStackProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-// Simple Flow
-func TestCloudStackKubernetes128RedHat8SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes129RedHat8SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes130RedHat8SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes131RedHat8SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes128RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes129RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes130RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes131RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes132RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes133RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes134RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes134ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes134MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes134DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes133ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes133MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes133DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes128ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes129ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes130ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes131ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes132ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes128MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes129MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes130MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes131MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes132MultiEndpointSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132(),
-			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes128DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes129DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes130DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes131DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes132DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132(),
-			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
-				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-// Cilium Policy
-func TestCloudStackKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes129CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes130CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes131CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes132CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes133CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes134CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-// Stacked Etcd
-func TestCloudStackKubernetes128StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes129StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes130StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes131StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes132StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes133StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestCloudStackKubernetes134StackedEtcdRedhat(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-// Taints
-func TestCloudStackKubernetes128RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat128ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestCloudStackKubernetes129RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat129ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestCloudStackKubernetes130RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat130ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestCloudStackKubernetes131RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat131ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestCloudStackKubernetes132RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat132ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat133ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestCloudStackKubernetes134RedhatTaintsUpgradeFlow(t *testing.T) {
-	provider := redhat134ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func redhat128ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes128(),
-	)
-}
-
-func redhat129ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes129(),
-	)
-}
-
-func redhat130ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes130(),
-	)
-}
-
-func redhat131ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes131(),
-	)
-}
-
-func redhat132ProviderWithTaints(t *testing.T) *framework.CloudStack {
-	return framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithCloudStackRedhat9Kubernetes132(),
-	)
-}
-
-// Upgrade
-func TestCloudStackKubernetes128RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes128(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes129RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes129(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes130RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes130(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes131RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes131(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes132RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes132(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes133(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes134RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewCloudStack(t,
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithCloudStackWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithCloudStackRedhat9Kubernetes134(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewCloudStackWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestCloudStackKubernetes134RedhatControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestCloudStackKubernetes134RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestCloudStackKubernetes132To133Redhat9UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
-	)
-}
-
-func TestCloudStackKubernetes133To134Redhat9UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
-	)
-}
-
-func TestCloudStackKubernetes132To133Redhat9StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
-	)
-}
-
-func TestCloudStackKubernetes133To134Redhat9StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
-	)
-}
-
-func TestCloudStackKubernetes128To129Redhat8UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat129Template()),
-	)
-}
-
-func TestCloudStackKubernetes129To130Redhat8UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat130Template()),
-	)
-}
-
-func TestCloudStackKubernetes130To131Redhat8UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat131Template()),
-	)
-}
-
-func TestCloudStackKubernetes128To129Redhat8StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat129Template()),
-	)
-}
-
-func TestCloudStackKubernetes129To130Redhat8StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat130Template()),
-	)
-}
-
-func TestCloudStackKubernetes130To131Redhat8StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat131Template()),
-	)
-}
-
-func TestCloudStackKubernetes128To129Redhat9UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
-	)
-}
-
-func TestCloudStackKubernetes129To130Redhat9UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
-	)
-}
-
-func TestCloudStackKubernetes130To131Redhat9UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
-	)
-}
-
-func TestCloudStackKubernetes131To132Redhat9UnstackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
-	)
-}
-
-func TestCloudStackKubernetes128To129Redhat9StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
-	)
-}
-
-func TestCloudStackKubernetes129To130Redhat9StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
-	)
-}
-
-func TestCloudStackKubernetes130To131Redhat9StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
-	)
-}
-
-func TestCloudStackKubernetes131To132Redhat9StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
-	)
-}
-
-func TestCloudStackKubernetes128Redhat8ToRedhat9Upgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes128Template()),
-	)
-}
-
-func TestCloudStackKubernetes129Redhat8ToRedhat9Upgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
-	)
-}
-
-func TestCloudStackKubernetes130Redhat8ToRedhat9Upgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
-	)
-}
-
-func TestCloudStackKubernetes131Redhat8ToRedhat9Upgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
-	)
-}
-
-// TODO: investigate these tests further as they pass even without the expected behavior(upgrade should fail the first time and continue from the checkpoint on second upgrade)
-func TestCloudStackKubernetes128RedhatTo129UpgradeWithCheckpoint(t *testing.T) {
-	var clusterOpts []framework.ClusterE2ETestOpt
-	var clusterOpts2 []framework.ClusterE2ETestOpt
-
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes128Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
-
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
-
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
-
-	runUpgradeFlowWithCheckpoint(
-		test,
-		v1alpha1.Kube129,
-		clusterOpts,
-		clusterOpts2,
-		commandOpts,
-	)
-}
-
-func TestCloudStackKubernetes129RedhatTo130UpgradeWithCheckpoint(t *testing.T) {
-	var clusterOpts []framework.ClusterE2ETestOpt
-	var clusterOpts2 []framework.ClusterE2ETestOpt
-
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
-
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
-
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
-
-	runUpgradeFlowWithCheckpoint(
-		test,
-		v1alpha1.Kube130,
-		clusterOpts,
-		clusterOpts2,
-		commandOpts,
-	)
-}
-
-func TestCloudStackKubernetes130RedhatTo131UpgradeWithCheckpoint(t *testing.T) {
-	var clusterOpts []framework.ClusterE2ETestOpt
-	var clusterOpts2 []framework.ClusterE2ETestOpt
-
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
-
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
-
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
-
-	runUpgradeFlowWithCheckpoint(
-		test,
-		v1alpha1.Kube131,
-		clusterOpts,
-		clusterOpts2,
-		commandOpts,
-	)
-}
-
-func TestCloudStackKubernetes131RedhatTo132UpgradeWithCheckpoint(t *testing.T) {
-	var clusterOpts []framework.ClusterE2ETestOpt
-	var clusterOpts2 []framework.ClusterE2ETestOpt
-
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
-
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
-
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
-
-	runUpgradeFlowWithCheckpoint(
-		test,
-		v1alpha1.Kube132,
-		clusterOpts,
-		clusterOpts2,
-		commandOpts,
-	)
-}
-
-func TestCloudStackKubernetes132RedhatTo133UpgradeWithCheckpoint(t *testing.T) {
-	var clusterOpts []framework.ClusterE2ETestOpt
-	var clusterOpts2 []framework.ClusterE2ETestOpt
-
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
-
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
-
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
-
-	runUpgradeFlowWithCheckpoint(
-		test,
-		v1alpha1.Kube133,
-		clusterOpts,
-		clusterOpts2,
-		commandOpts,
-	)
-}
-
-func TestCloudStackKubernetes128RedhatControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestCloudStackKubernetes129RedhatControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestCloudStackKubernetes130RedhatControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestCloudStackKubernetes131RedhatControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestCloudStackKubernetes132RedhatControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestCloudStackKubernetes128RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestCloudStackKubernetes129RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestCloudStackKubernetes130RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestCloudStackKubernetes131RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestCloudStackKubernetes132RedhatWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestCloudStackKubernetes128To129RedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes129Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes129To130RedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes130Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes130To131RedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes131Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes131To132RedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes132Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes130To131StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes131Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes131To132StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes132Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes132To133RedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes133Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes132To133StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes133Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133To134RedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes134Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133To134StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		provider.WithProviderUpgrade(
-			provider.Redhat9Kubernetes134Template(),
-			framework.UpdateLargerCloudStackComputeOffering(),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133RedhatTo134UpgradeWithCheckpoint(t *testing.T) {
-	var clusterOpts []framework.ClusterE2ETestOpt
-	var clusterOpts2 []framework.ClusterE2ETestOpt
-
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-
-	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)), framework.ExpectFailure(true),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
-
-	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
-
-	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)), framework.ExpectFailure(false),
-		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
-
-	runUpgradeFlowWithCheckpoint(
-		test,
-		v1alpha1.Kube134,
-		clusterOpts,
-		clusterOpts2,
-		commandOpts,
-	)
-}
-
-// This test is skipped as registry mirror was not configured for CloudStack
-func TestCloudStackKubernetes134RedhatAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t,
-			framework.WithCloudStackRedhat9Kubernetes134(),
-			framework.WithCloudStackFillers(
-				framework.RemoveAllCloudStackAzs(),
-				framework.UpdateAddCloudStackAz3(),
-			),
-		),
-		framework.WithClusterFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "10.0.0.1/8")
-}
-
-// Workload API
-func TestCloudStackKubernetes134MulticlusterWorkloadClusterAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				runCloudStackAPIWorkloadUpgradeTest(t, wc, tt)
-			})
-		}
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134MulticlusterWorkloadClusterNewCredentialsSecretsAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	))
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	))
-
-	test.CreateManagementCluster()
-	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133MulticlusterWorkloadClusterAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes132(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				runCloudStackAPIWorkloadUpgradeTest(t, wc, tt)
-			})
-		}
-
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133MulticlusterWorkloadClusterNewCredentialsSecretsAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	))
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	))
-
-	test.CreateManagementCluster()
-	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-// Workload GitOps API
-func TestCloudStackKubernetes134MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				runCloudStackAPIWorkloadUpgradeTestWithFlux(t, test, wc, tt)
-			})
-		}
-
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134MulticlusterWorkloadClusterNewCredentialsSecretGitHubFluxAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	))
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	))
-
-	test.CreateManagementCluster()
-	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134WorkloadClusterAWSIamAuthAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-
-			framework.WithAwsIamEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithAwsIamConfig(),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateAWSIamAuth()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134WorkloadClusterAWSIamAuthGithubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithAwsIamEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithAwsIamConfig(),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateAWSIamAuth()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134WorkloadClusterOIDCAuthAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithOIDCEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithOIDCClusterConfig(t),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateOIDC()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134WorkloadClusterOIDCAuthGithubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithOIDCEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithOIDCClusterConfig(t),
-			cloudstack.WithRedhat9Kubernetes134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateOIDC()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes134EtcdEncryption(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-		),
-		framework.WithPodIamConfig(),
-	)
-	test.OSFamily = v1alpha1.RedHat
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.PostClusterCreateEtcdEncryptionSetup()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
-	test.StopIfFailed()
-	test.ValidateEtcdEncryption()
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes134ValidateDomainFourLevelsSimpleFlow(t *testing.T) {
-	provider := framework.NewCloudStack(
-		t,
-		framework.WithCloudStackRedhat9Kubernetes134(),
-		framework.WithCloudStackFillers(
-			framework.RemoveAllCloudStackAzs(),
-			framework.UpdateAddCloudStackAz4(),
-		),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-		),
-	)
-	runSimpleFlow(test)
-}
-
-func TestCloudStackKubernetes134EtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
-
-func TestCloudStackKubernetes134EtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
-
-func TestCloudStackKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestCloudStackKubernetes133MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithControlPlaneCount(1),
-			),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				runCloudStackAPIWorkloadUpgradeTestWithFlux(t, test, wc, tt)
-			})
-		}
-
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133MulticlusterWorkloadClusterNewCredentialsSecretGitHubFluxAPI(t *testing.T) {
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	))
-
-	test.WithWorkloadClusters(framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithClusterName(test.NewWorkloadClusterName()),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithManagementCluster(managementCluster.ClusterName),
-			api.WithStackedEtcdTopology(),
-			api.WithControlPlaneCount(1),
-		),
-		api.CloudStackToConfigFiller(
-			api.WithCloudStackCredentialsRef("test-creds"),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	))
-
-	test.CreateManagementCluster()
-	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133WorkloadClusterAWSIamAuthAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-
-			framework.WithAwsIamEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithAwsIamConfig(),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateAWSIamAuth()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133WorkloadClusterAWSIamAuthGithubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithAwsIamEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithAwsIamConfig(),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateAWSIamAuth()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133WorkloadClusterOIDCAuthAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, cloudstack,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithOIDCEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithOIDCClusterConfig(t),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateOIDC()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133WorkloadClusterOIDCAuthGithubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	cloudstack := framework.NewCloudStack(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		cloudstack,
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		cloudstack.WithRedhat9Kubernetes133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			cloudstack,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithOIDCEnvVarCheck(),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			framework.WithOIDCClusterConfig(t),
-			cloudstack.WithRedhat9Kubernetes133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-
-	// Create workload clusters
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.ValidateOIDC()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestCloudStackKubernetes133EtcdEncryption(t *testing.T) {
-	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-		),
-		framework.WithPodIamConfig(),
-	)
-	test.OSFamily = v1alpha1.RedHat
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.PostClusterCreateEtcdEncryptionSetup()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
-	test.StopIfFailed()
-	test.ValidateEtcdEncryption()
-	test.DeleteCluster()
-}
-
-func TestCloudStackKubernetes133ValidateDomainFourLevelsSimpleFlow(t *testing.T) {
-	provider := framework.NewCloudStack(
-		t,
-		framework.WithCloudStackRedhat9Kubernetes133(),
-		framework.WithCloudStackFillers(
-			framework.RemoveAllCloudStackAzs(),
-			framework.UpdateAddCloudStackAz4(),
-		),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-		),
-	)
-	runSimpleFlow(test)
-}
-
-// Etcd Scale tests
-func TestCloudStackKubernetes133EtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
-
-func TestCloudStackKubernetes133EtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
-
-// Kubelet Configuration tests
-func TestCloudStackKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestCloudStackKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestCloudStackKubernetes131KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestCloudStackKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestCloudStackKubernetes133KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// // Download Artifacts
+// func TestCloudStackDownloadArtifacts(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat131()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runDownloadArtifactsFlow(test)
+// }
+
+// func TestCloudStackRedhat9DownloadArtifacts(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runDownloadArtifactsFlow(test)
+// }
+
+// // Flux
+// func TestCloudStackKubernetes128GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes129GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes130GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes131GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes132GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes128GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes129GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes130GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes131GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes132GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes133GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes133GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes134GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes134GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestCloudStackKubernetes129To130GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131To132GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132To133GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133To134GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134InstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134UpgradeManagementComponents(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
+// 	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube134, framework.RedHat9)
+// }
+
+// // Labels
+// func TestCloudStackKubernetes128LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes128(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes129LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes129(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes130LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes130(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes131LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes131(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes132LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes132(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes133LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes133(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes134LabelsAndNodeNameRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes134(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			api.WithWorkerNodeGroup(constants.DefaultWorkerNodeGroupName,
+// 				api.WithCount(1),
+// 				api.WithLabel(constants.FailureDomainLabelName, constants.CloudstackFailureDomainPlaceholder),
+// 			),
+// 		),
+// 	)
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneFailureDomainLabels, framework.ValidateControlPlaneNodeNameMatchCAPIMachineName)
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeFailureDomainLabels, framework.ValidateWorkerNodeNameMatchCAPIMachineName)
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes128RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat128ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat129ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat130ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat131ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat132ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat133ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134RedhatLabelsUpgradeFlow(t *testing.T) {
+// 	provider := redhat134ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func redhat128ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes128(),
+// 	)
+// }
+
+// func redhat129ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes129(),
+// 	)
+// }
+
+// func redhat130ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes130(),
+// 	)
+// }
+
+// func redhat131ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes131(),
+// 	)
+// }
+
+// func redhat132ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes132(),
+// 	)
+// }
+
+// func redhat133ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes133(),
+// 	)
+// }
+
+// func redhat134ProviderWithLabels(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes134(),
+// 	)
+// }
+
+// func redhat133ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes133(),
+// 	)
+// }
+
+// func redhat134ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes134(),
+// 	)
+// }
+
+// // Multicluster
+// func TestCloudStackKubernetes128MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackKubernetes129MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube129),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube129),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackKubernetes130MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackKubernetes131MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackKubernetes132MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackKubernetes133MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackKubernetes134MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestCloudStackUpgradeKubernetes129MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(3),
+// 		),
+// 		provider.WithProviderUpgradeGit(
+// 			provider.Redhat9Kubernetes129Template(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackUpgradeKubernetes130MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube129),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube129),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(3),
+// 		),
+// 		provider.WithProviderUpgradeGit(
+// 			provider.Redhat9Kubernetes130Template(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackUpgradeKubernetes131MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(3),
+// 		),
+// 		provider.WithProviderUpgradeGit(
+// 			provider.Redhat9Kubernetes131Template(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackUpgradeKubernetes132MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(3),
+// 		),
+// 		provider.WithProviderUpgradeGit(
+// 			provider.Redhat9Kubernetes132Template(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackUpgradeKubernetes133MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(3),
+// 		),
+// 		provider.WithProviderUpgradeGit(
+// 			provider.Redhat9Kubernetes133Template(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackUpgradeKubernetes134MulticlusterWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(3),
+// 		),
+// 		provider.WithProviderUpgradeGit(
+// 			provider.Redhat9Kubernetes134Template(),
+// 		),
+// 	)
+// }
+
+// // OIDC
+// func TestCloudStackKubernetes128WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube128)
+// }
+
+// func TestCloudStackKubernetes129WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube129)
+// }
+
+// func TestCloudStackKubernetes130WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube130)
+// }
+
+// func TestCloudStackKubernetes131WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube131)
+// }
+
+// func TestCloudStackKubernetes132WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube132)
+// }
+
+// func TestCloudStackKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube133)
+// }
+
+// func TestCloudStackKubernetes134WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, cloudstack, framework.RedHat9, anywherev1.Kube134)
+// }
+
+// func TestCloudStackKubernetes128OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes129OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes130OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes131OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes132OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes133OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes134OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestCloudStackKubernetes130To131OIDCUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithOIDC(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131To132OIDCUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithOIDC(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132To133OIDCUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithOIDC(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133To134OIDCUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithOIDC(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
+// 	)
+// }
+
+// // Proxy Config
+// func TestCloudStackKubernetes128RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes129RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes130RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes131RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes132RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes133RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes134RedhatProxyConfig(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// // Proxy Config Multicluster
+// func TestCloudStackKubernetes128RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes128(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes128(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes129RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes129(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes129(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes130RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes130(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes130(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes131RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes131(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes131(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes132RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes132(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes132(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134RedhatProxyConfigAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// // Registry Mirror
+// func TestCloudStackKubernetes128RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes129RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes130RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes131RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes132RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes128RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes129RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes130RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes131RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes132RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes132RedhatAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes133RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes133RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes133RedhatAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes134RedhatRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes134RedhatRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestCloudStackKubernetes134RedhatAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.CloudStackProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// // Simple Flow
+// func TestCloudStackKubernetes128RedHat8SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes129RedHat8SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes130RedHat8SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes131RedHat8SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes128RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes129RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes130RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes131RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes132RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes133RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes134RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes134ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes134MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes134DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes133ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes133MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes133DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes128ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes129ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes130ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes131ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes132ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes128MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes129MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes130MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes131MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes132MultiEndpointSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132(),
+// 			framework.WithCloudStackFillers(framework.UpdateAddCloudStackAz2())),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes128DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes129DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes130DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes131DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes132DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132(),
+// 			framework.WithCloudStackFillers(api.WithCloudStackConfigNamespace(clusterNamespace),
+// 				api.WithCloudStackConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Cilium Policy
+// func TestCloudStackKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes129CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes130CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes131CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes132CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes133CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes134CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Stacked Etcd
+// func TestCloudStackKubernetes128StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestCloudStackKubernetes129StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestCloudStackKubernetes130StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestCloudStackKubernetes131StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestCloudStackKubernetes132StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestCloudStackKubernetes133StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestCloudStackKubernetes134StackedEtcdRedhat(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// // Taints
+// func TestCloudStackKubernetes128RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat128ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat129ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat130ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat131ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat132ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat133ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134RedhatTaintsUpgradeFlow(t *testing.T) {
+// 	provider := redhat134ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func redhat128ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes128(),
+// 	)
+// }
+
+// func redhat129ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes129(),
+// 	)
+// }
+
+// func redhat130ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes130(),
+// 	)
+// }
+
+// func redhat131ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes131(),
+// 	)
+// }
+
+// func redhat132ProviderWithTaints(t *testing.T) *framework.CloudStack {
+// 	return framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes132(),
+// 	)
+// }
+
+// // Upgrade
+// func TestCloudStackKubernetes128RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes128(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes129(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes130(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes131(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes132(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes133(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134RedhatAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewCloudStack(t,
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithCloudStackWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithCloudStackRedhat9Kubernetes134(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewCloudStackWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134RedhatControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134RedhatWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132To133Redhat9UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133To134Redhat9UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132To133Redhat9StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133To134Redhat9StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128To129Redhat8UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat129Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129To130Redhat8UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat130Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131Redhat8UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat131Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128To129Redhat8StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat129Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129To130Redhat8StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat130Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131Redhat8StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat131Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128To129Redhat9UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129To130Redhat9UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131Redhat9UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131To132Redhat9UnstackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128To129Redhat9StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129To130Redhat9StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131Redhat9StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131To132Redhat9StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128Redhat8ToRedhat9Upgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes128Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129Redhat8ToRedhat9Upgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130Redhat8ToRedhat9Upgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131Redhat8ToRedhat9Upgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()),
+// 	)
+// }
+
+// // TODO: investigate these tests further as they pass even without the expected behavior(upgrade should fail the first time and continue from the checkpoint on second upgrade)
+// func TestCloudStackKubernetes128RedhatTo129UpgradeWithCheckpoint(t *testing.T) {
+// 	var clusterOpts []framework.ClusterE2ETestOpt
+// 	var clusterOpts2 []framework.ClusterE2ETestOpt
+
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+
+// 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)), framework.ExpectFailure(true),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes128Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
+
+// 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+
+// 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)), framework.ExpectFailure(false),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
+
+// 	runUpgradeFlowWithCheckpoint(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		clusterOpts,
+// 		clusterOpts2,
+// 		commandOpts,
+// 	)
+// }
+
+// func TestCloudStackKubernetes129RedhatTo130UpgradeWithCheckpoint(t *testing.T) {
+// 	var clusterOpts []framework.ClusterE2ETestOpt
+// 	var clusterOpts2 []framework.ClusterE2ETestOpt
+
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+
+// 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)), framework.ExpectFailure(true),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes129Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
+
+// 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+
+// 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)), framework.ExpectFailure(false),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
+
+// 	runUpgradeFlowWithCheckpoint(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		clusterOpts,
+// 		clusterOpts2,
+// 		commandOpts,
+// 	)
+// }
+
+// func TestCloudStackKubernetes130RedhatTo131UpgradeWithCheckpoint(t *testing.T) {
+// 	var clusterOpts []framework.ClusterE2ETestOpt
+// 	var clusterOpts2 []framework.ClusterE2ETestOpt
+
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+
+// 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)), framework.ExpectFailure(true),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes130Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
+
+// 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+
+// 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)), framework.ExpectFailure(false),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
+
+// 	runUpgradeFlowWithCheckpoint(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		clusterOpts,
+// 		clusterOpts2,
+// 		commandOpts,
+// 	)
+// }
+
+// func TestCloudStackKubernetes131RedhatTo132UpgradeWithCheckpoint(t *testing.T) {
+// 	var clusterOpts []framework.ClusterE2ETestOpt
+// 	var clusterOpts2 []framework.ClusterE2ETestOpt
+
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+
+// 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)), framework.ExpectFailure(true),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes131Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
+
+// 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+
+// 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)), framework.ExpectFailure(false),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
+
+// 	runUpgradeFlowWithCheckpoint(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		clusterOpts,
+// 		clusterOpts2,
+// 		commandOpts,
+// 	)
+// }
+
+// func TestCloudStackKubernetes132RedhatTo133UpgradeWithCheckpoint(t *testing.T) {
+// 	var clusterOpts []framework.ClusterE2ETestOpt
+// 	var clusterOpts2 []framework.ClusterE2ETestOpt
+
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+
+// 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)), framework.ExpectFailure(true),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes132Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
+
+// 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+
+// 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)), framework.ExpectFailure(false),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
+
+// 	runUpgradeFlowWithCheckpoint(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		clusterOpts,
+// 		clusterOpts2,
+// 		commandOpts,
+// 	)
+// }
+
+// func TestCloudStackKubernetes128RedhatControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129RedhatControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130RedhatControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131RedhatControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132RedhatControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128RedhatWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129RedhatWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130RedhatWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131RedhatWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132RedhatWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestCloudStackKubernetes128To129RedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes129Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes129To130RedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes130Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131RedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes131Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131To132RedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes132Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes130To131StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes131Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes131To132StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes132Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132To133RedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes133Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes132To133StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes133Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133To134RedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes134Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133To134StackedEtcdRedhatMultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9Kubernetes134Template(),
+// 			framework.UpdateLargerCloudStackComputeOffering(),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133RedhatTo134UpgradeWithCheckpoint(t *testing.T) {
+// 	var clusterOpts []framework.ClusterE2ETestOpt
+// 	var clusterOpts2 []framework.ClusterE2ETestOpt
+
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+
+// 	clusterOpts = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)), framework.ExpectFailure(true),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes133Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "false"))
+
+// 	commandOpts := []framework.CommandOpt{framework.WithExternalEtcdWaitTimeout("10m")}
+
+// 	clusterOpts2 = append(clusterOpts, framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)), framework.ExpectFailure(false),
+// 		provider.WithProviderUpgrade(provider.Redhat9Kubernetes134Template()), framework.WithEnvVar(features.CheckpointEnabledEnvVar, "true"), framework.WithEnvVar(framework.CleanupResourcesVar, "true"))
+
+// 	runUpgradeFlowWithCheckpoint(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		clusterOpts,
+// 		clusterOpts2,
+// 		commandOpts,
+// 	)
+// }
+
+// // This test is skipped as registry mirror was not configured for CloudStack
+// func TestCloudStackKubernetes134RedhatAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t,
+// 			framework.WithCloudStackRedhat9Kubernetes134(),
+// 			framework.WithCloudStackFillers(
+// 				framework.RemoveAllCloudStackAzs(),
+// 				framework.UpdateAddCloudStackAz3(),
+// 			),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithProxy(framework.CloudstackProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "10.0.0.1/8")
+// }
+
+// // Workload API
+// func TestCloudStackKubernetes134MulticlusterWorkloadClusterAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
+
+// 		for _, tt := range tests {
+// 			t.Run(tt.name, func(t *testing.T) {
+// 				runCloudStackAPIWorkloadUpgradeTest(t, wc, tt)
+// 			})
+// 		}
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134MulticlusterWorkloadClusterNewCredentialsSecretsAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	))
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	))
+
+// 	test.CreateManagementCluster()
+// 	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133MulticlusterWorkloadClusterAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes132(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
+
+// 		for _, tt := range tests {
+// 			t.Run(tt.name, func(t *testing.T) {
+// 				runCloudStackAPIWorkloadUpgradeTest(t, wc, tt)
+// 			})
+// 		}
+
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133MulticlusterWorkloadClusterNewCredentialsSecretsAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	))
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	))
+
+// 	test.CreateManagementCluster()
+// 	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// // Workload GitOps API
+// func TestCloudStackKubernetes134MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
+
+// 		for _, tt := range tests {
+// 			t.Run(tt.name, func(t *testing.T) {
+// 				runCloudStackAPIWorkloadUpgradeTestWithFlux(t, test, wc, tt)
+// 			})
+// 		}
+
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134MulticlusterWorkloadClusterNewCredentialsSecretGitHubFluxAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	))
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	))
+
+// 	test.CreateManagementCluster()
+// 	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134WorkloadClusterAWSIamAuthAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+
+// 			framework.WithAwsIamEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithAwsIamConfig(),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateAWSIamAuth()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134WorkloadClusterAWSIamAuthGithubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithAwsIamEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithAwsIamConfig(),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateAWSIamAuth()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134WorkloadClusterOIDCAuthAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithOIDCEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithOIDCClusterConfig(t),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateOIDC()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134WorkloadClusterOIDCAuthGithubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithOIDCEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithOIDCClusterConfig(t),
+// 			cloudstack.WithRedhat9Kubernetes134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateOIDC()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes134EtcdEncryption(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		framework.WithPodIamConfig(),
+// 	)
+// 	test.OSFamily = v1alpha1.RedHat
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.PostClusterCreateEtcdEncryptionSetup()
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
+// 	test.StopIfFailed()
+// 	test.ValidateEtcdEncryption()
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes134ValidateDomainFourLevelsSimpleFlow(t *testing.T) {
+// 	provider := framework.NewCloudStack(
+// 		t,
+// 		framework.WithCloudStackRedhat9Kubernetes134(),
+// 		framework.WithCloudStackFillers(
+// 			framework.RemoveAllCloudStackAzs(),
+// 			framework.UpdateAddCloudStackAz4(),
+// 		),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 		),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestCloudStackKubernetes134EtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134EtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestCloudStackKubernetes133MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithControlPlaneCount(1),
+// 			),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		tests := cloudStackAPIWorkloadUpgradeTests(wc, cloudstack)
+
+// 		for _, tt := range tests {
+// 			t.Run(tt.name, func(t *testing.T) {
+// 				runCloudStackAPIWorkloadUpgradeTestWithFlux(t, test, wc, tt)
+// 			})
+// 		}
+
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133MulticlusterWorkloadClusterNewCredentialsSecretGitHubFluxAPI(t *testing.T) {
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	))
+
+// 	test.WithWorkloadClusters(framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		api.CloudStackToConfigFiller(
+// 			api.WithCloudStackCredentialsRef("test-creds"),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	))
+
+// 	test.CreateManagementCluster()
+// 	test.ManagementCluster.CreateCloudStackCredentialsSecretFromEnvVar("test-creds", framework.CloudStackCredentialsAz1())
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133WorkloadClusterAWSIamAuthAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+
+// 			framework.WithAwsIamEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithAwsIamConfig(),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateAWSIamAuth()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133WorkloadClusterAWSIamAuthGithubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithAwsIamEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithAwsIamConfig(),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateAWSIamAuth()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133WorkloadClusterOIDCAuthAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, cloudstack,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithOIDCEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithOIDCClusterConfig(t),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateOIDC()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133WorkloadClusterOIDCAuthGithubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	cloudstack := framework.NewCloudStack(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		cloudstack,
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		cloudstack.WithRedhat9Kubernetes133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			cloudstack,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithOIDCEnvVarCheck(),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			framework.WithOIDCClusterConfig(t),
+// 			cloudstack.WithRedhat9Kubernetes133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+
+// 	// Create workload clusters
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateOIDC()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestCloudStackKubernetes133EtcdEncryption(t *testing.T) {
+// 	provider := framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		framework.WithPodIamConfig(),
+// 	)
+// 	test.OSFamily = v1alpha1.RedHat
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.PostClusterCreateEtcdEncryptionSetup()
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
+// 	test.StopIfFailed()
+// 	test.ValidateEtcdEncryption()
+// 	test.DeleteCluster()
+// }
+
+// func TestCloudStackKubernetes133ValidateDomainFourLevelsSimpleFlow(t *testing.T) {
+// 	provider := framework.NewCloudStack(
+// 		t,
+// 		framework.WithCloudStackRedhat9Kubernetes133(),
+// 		framework.WithCloudStackFillers(
+// 			framework.RemoveAllCloudStackAzs(),
+// 			framework.UpdateAddCloudStackAz4(),
+// 		),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 		),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Etcd Scale tests
+// func TestCloudStackKubernetes133EtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
+
+// func TestCloudStackKubernetes133EtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
+
+// // Kubelet Configuration tests
+// func TestCloudStackKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestCloudStackKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestCloudStackKubernetes131KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestCloudStackKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestCloudStackKubernetes133KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewCloudStack(t, framework.WithCloudStackRedhat9Kubernetes133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -18,214 +18,214 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-// Labels
-func TestDockerKubernetesLabels(t *testing.T) {
-	provider := framework.NewDocker(t)
+// // Labels
+// func TestDockerKubernetesLabels(t *testing.T) {
+// 	provider := framework.NewDocker(t)
 
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-			api.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 			api.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 	)
 
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
 
-// Flux
-func TestDockerKubernetes133GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runFluxFlow(test)
-}
+// // Flux
+// func TestDockerKubernetes133GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runFluxFlow(test)
+// }
 
-func TestDockerKubernetes134GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runFluxFlow(test)
-}
+// func TestDockerKubernetes134GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runFluxFlow(test)
+// }
 
-func TestDockerKubernetes133GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runFluxFlow(test)
-}
+// func TestDockerKubernetes133GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runFluxFlow(test)
+// }
 
-func TestDockerKubernetes134GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runFluxFlow(test)
-}
+// func TestDockerKubernetes134GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runFluxFlow(test)
+// }
 
-func TestDockerInstallGitFluxDuringUpgrade(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube134,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
+// func TestDockerInstallGitFluxDuringUpgrade(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
 
-func TestDockerInstallGithubFluxDuringUpgrade(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube134,
-		framework.WithFluxGithub(api.WithFluxConfigName(framework.DefaultFluxConfigName)),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
+// func TestDockerInstallGithubFluxDuringUpgrade(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithFluxGithub(api.WithFluxConfigName(framework.DefaultFluxConfigName)),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
 
-func TestDockerKubernetes132UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(2),
-			api.WithWorkerNodeCount(2),
-		),
-		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
-		// compared to when it was initially created without it.
-		provider.WithProviderUpgradeGit(),
-	)
-}
+// func TestDockerKubernetes132UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(2),
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
+// 		// compared to when it was initially created without it.
+// 		provider.WithProviderUpgradeGit(),
+// 	)
+// }
 
-func TestDockerKubernetes133UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(2),
-			api.WithWorkerNodeCount(2),
-		),
-		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
-		// compared to when it was initially created without it.
-		provider.WithProviderUpgradeGit(),
-	)
-}
+// func TestDockerKubernetes133UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(2),
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
+// 		// compared to when it was initially created without it.
+// 		provider.WithProviderUpgradeGit(),
+// 	)
+// }
 
-func TestDockerKubernetes134UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithFluxGithub(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-			),
-		),
-	)
-	runWorkloadClusterFlowWithGitOps(
-		test,
-		framework.WithClusterUpgradeGit(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(2),
-			api.WithWorkerNodeCount(2),
-		),
-		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
-		// compared to when it was initially created without it.
-		provider.WithProviderUpgradeGit(),
-	)
-}
+// func TestDockerKubernetes134UpgradeWorkloadClusterWithGithubFlux(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithFluxGithub(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlowWithGitOps(
+// 		test,
+// 		framework.WithClusterUpgradeGit(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(2),
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 		// Needed in order to replace the DockerDatacenterConfig namespace field with the value specified
+// 		// compared to when it was initially created without it.
+// 		provider.WithProviderUpgradeGit(),
+// 	)
+// }
 
 // Curated Packages
 func TestDockerKubernetes128CuratedPackagesSimpleFlow(t *testing.T) {
@@ -752,1156 +752,1156 @@ func TestDockerKubernetes134CuratedPackagesMetalLB(t *testing.T) {
 	RunMetalLBDockerTestsForKubeVersion(t, v1alpha1.Kube134)
 }
 
-// AWS IAM Auth
-func TestDockerKubernetes128AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestDockerKubernetes129AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestDockerKubernetes130AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestDockerKubernetes131AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestDockerKubernetes132AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestDockerKubernetes133AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestDockerKubernetes134AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-// OIDC
-func TestDockerKubernetes128OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestDockerKubernetes129OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestDockerKubernetes130OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestDockerKubernetes131OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestDockerKubernetes132OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestDockerKubernetes133OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestDockerKubernetes134OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runOIDCFlow(test)
-}
-
-// Registry Mirror
-func TestDockerKubernetes131RegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestDockerKubernetes131AirgappedRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
-	)
-	runDockerAirgapConfigFlow(test)
-}
-
-func TestDockerKubernetes131AirgappedUpgradeFromLatestRegistryMirrorAndCert(t *testing.T) {
-	release := latestMinorRelease(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
-	)
-	runDockerAirgapUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube131,
-	)
-}
-
-func TestDockerKubernetes131RegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestDockerKubernetes132RegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestDockerKubernetes133RegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestDockerKubernetes134RegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-// Simple Flow
-func TestDockerKubernetes128SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestDockerKubernetes129SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestDockerKubernetes130SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestDockerKubernetes131SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestDockerKubernetes132SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestDockerKubernetes133SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestDockerKubernetes134SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-// Stacked Etcd
-func TestDockerKubernetesStackedEtcd(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-// Taints
-func TestDockerKubernetes132Taints(t *testing.T) {
-	provider := framework.NewDocker(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
-			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestDockerKubernetes133Taints(t *testing.T) {
-	provider := framework.NewDocker(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
-			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestDockerKubernetes134Taints(t *testing.T) {
-	provider := framework.NewDocker(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
-			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestDockerKubernetes132WorkloadClusterTaints(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint())),
-				api.WithWorkerNodeGroup("worker-1", api.WithCount(1), api.WithTaint(framework.NoExecuteTaint())),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-
-	runWorkloadClusterExistingConfigFlow(test)
-}
-
-// Upgrade
-func TestDockerKubernetes132UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithLicenseToken(licenseToken),
-		),
-		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
-		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-		provider.WithNewWorkerNodeGroup(
-			"", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend")),
-		),
-	)
-
-	runUpgradeFlowWithAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.RemoveWorkerNodeGroup("worker-2"),
-			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
-			api.RemoveWorkerNodeGroup("worker-3"),
-			api.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint())),
-		),
-		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
-	)
-}
-
-func TestDockerKubernetes131To132StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-}
-
-func TestDockerKubernetes131To132ExternalEtcdUpgrade(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-}
-
-// Upgrade From Latest Minor Release
-func TestDockerKubernetes128to129UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestDockerKubernetes129to130UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestDockerKubernetes130to131UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestDockerKubernetes131to132UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestDockerKubernetes131to132GithubFluxEnabledUpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeWithFluxFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-}
-
-func TestDockerKubernetes128WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	provider := framework.NewDocker(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube128)
-}
-
-// Workload Cluster API
-func TestDockerUpgradeKubernetes131to132WorkloadClusterScaleupAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-		),
-	)
-}
-
-func TestDockerUpgradeWorkloadClusterLabelsAndTaintsAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("tier", "frontend"), api.WithTaint(framework.NoScheduleTaint())),
-				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
-				api.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithTaint(framework.PreferNoScheduleTaint())),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-			api.RemoveWorkerNodeGroup("worker-0"),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
-		),
-	)
-}
-
-func TestDockerUpgradeWorkloadClusterScaleAddRemoveWorkerNodeGroupsAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
-				api.WithWorkerNodeGroup("worker-2", api.WithCount(1)),
-				api.WithExternalEtcdTopology(1),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
-			api.WithWorkerNodeGroup("worker-1", api.WithCount(2)),
-			api.RemoveWorkerNodeGroup("worker-2"),
-			api.WithWorkerNodeGroup("worker-3", api.WithCount(1)),
-		),
-	)
-}
-
-func TestDockerKubernetes131to132UpgradeFromLatestMinorReleaseAPI(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	)
-	managementCluster.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	managementCluster.UpdateClusterConfig(api.ClusterToConfigFiller(
-		api.WithKubernetesVersion(v1alpha1.Kube131),
-	))
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	wc := framework.NewClusterE2ETest(
-		t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-	)
-	wc.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	wc.UpdateClusterConfig(api.ClusterToConfigFiller(
-		api.WithKubernetesVersion(v1alpha1.Kube131),
-		api.WithManagementCluster(managementCluster.ClusterName),
-		api.WithControlPlaneCount(1),
-		api.WithWorkerNodeCount(1),
-		api.WithStackedEtcdTopology(),
-	))
-	test.WithWorkloadClusters(wc)
-
-	runMulticlusterUpgradeFromReleaseFlowAPI(
-		test,
-		release,
-		wc.ClusterConfig.Cluster.Spec.KubernetesVersion,
-		v1alpha1.Kube132,
-		"",
-	)
-}
-
-func TestDockerUpgradeKubernetes131to132WorkloadClusterScaleupGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		framework.WithFluxGithubConfig(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPIWithFlux(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-		),
-	)
-}
-
-func TestDockerUpgradeKubernetes132to133WorkloadClusterScaleupGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		framework.WithFluxGithubConfig(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPIWithFlux(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-		),
-	)
-}
-
-func TestDockerUpgradeKubernetes133to134WorkloadClusterScaleupGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		framework.WithFluxGithubConfig(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPIWithFlux(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-		),
-	)
-}
-
-func TestDockerKubernetes132UpgradeWorkloadClusterLabelsAndTaintsGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		framework.WithFluxGithubConfig(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("tier", "frontend"), api.WithTaint(framework.NoScheduleTaint())),
-				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
-				api.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithTaint(framework.PreferNoScheduleTaint())),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPIWithFlux(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-			api.RemoveWorkerNodeGroup("worker-0"),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
-		),
-	)
-}
-
-func TestDockerKubernetes132UpgradeWorkloadClusterScaleAddRemoveWorkerNodeGroupsGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-		framework.WithFluxGithubConfig(
-			api.WithClusterConfigPath("test"),
-			api.WithBranch("docker"),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
-				api.WithWorkerNodeGroup("worker-2", api.WithCount(1)),
-				api.WithExternalEtcdTopology(1),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterUpgradeFlowAPIWithFlux(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
-			api.WithWorkerNodeGroup("worker-1", api.WithCount(2)),
-			api.RemoveWorkerNodeGroup("worker-2"),
-			api.WithWorkerNodeGroup("worker-3", api.WithCount(1)),
-		),
-	)
-}
-
-// Cilium Skip Upgrade
-func TestDockerCiliumSkipUpgrade_CLICreate(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(t, provider,
-		framework.WithClusterFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithCiliumSkipUpgrade(),
-		),
-	)
-
-	test.ValidateCiliumCLIAvailable()
-
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.ValidateClusterState()
-	test.ValidateEKSACiliumInstalled()
-	test.DeleteCluster()
-}
-
-func TestDockerUpgradeFromLatestMinorReleaseCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
-	release := latestMinorRelease(t)
-
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(t, provider,
-		framework.WithClusterFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-	)
-
-	test.ValidateCiliumCLIAvailable()
-
-	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	test.CreateCluster(framework.ExecuteWithEksaRelease(release))
-	test.ReplaceCiliumWithOSSCilium()
-
-	t.Log("Waiting for cilium replacement to complete")
-	// Wait two minutes before validating cluster state and attempting the upgrade
-	// After replacing cilium, the nodes can temporarily go into a not ready state
-	// and we want to give them time to recover before validating the cluster state
-	time.Sleep(5 * time.Minute)
-
-	test.ValidateClusterState()
-	test.UpgradeClusterWithNewConfig(
-		[]framework.ClusterE2ETestOpt{
-			framework.WithClusterUpgrade(api.WithCiliumSkipUpgrade()),
-		},
-	)
-	test.ValidateClusterState()
-	test.ValidateEKSACiliumNotInstalled()
-	test.DeleteCluster()
-}
-
-func TestDockerCiliumSkipUpgrade_ControllerCreate(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	management := framework.NewClusterE2ETest(t, provider).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-
-	management.ValidateCiliumCLIAvailable()
-
-	test := framework.NewMulticlusterE2ETest(t, management)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(management.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithCiliumSkipUpgrade(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-
-		client, err := wc.BuildWorkloadClusterClient()
-		if err != nil {
-			wc.T.Fatalf("Error creating workload cluster client: %v", err)
-		}
-
-		framework.AwaitCiliumDaemonSetReady(context.Background(), client, 20, 5*time.Second)
-
-		wc.DeleteClusterWithKubectl()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestDockerCiliumSkipUpgrade_ControllerUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewDocker(t)
-	management := framework.NewClusterE2ETest(t, provider).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-
-	management.ValidateCiliumCLIAvailable()
-
-	test := framework.NewMulticlusterE2ETest(t, management)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(management.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-
-		client, err := wc.BuildWorkloadClusterClient()
-		if err != nil {
-			wc.T.Fatalf("Error creating workload cluster client: %v", err)
-		}
-
-		// Wait for Cilium to come up.
-		framework.AwaitCiliumDaemonSetReady(context.Background(), client, 20, 5*time.Second)
-
-		// Skip Cilium upgrades and reapply the kubeconfig.
-		wc.UpdateClusterConfig(api.ClusterToConfigFiller(api.WithCiliumSkipUpgrade()))
-		wc.ApplyClusterManifest()
-
-		// Give some time for reconciliation to happen.
-		time.Sleep(15 * time.Second)
-
-		// Validate EKSA Cilium is still installed because we haven't done anything to it yet
-		// and the controller shouldn't have removed it.
-		framework.AwaitCiliumDaemonSetReady(context.Background(), client, 20, 5*time.Second)
-
-		// Introduce a different OSS Cillium, wait for it to come up and validate the controller
-		// doesn't try to override the new Cilium.
-		wc.ReplaceCiliumWithOSSCilium()
-		wc.ValidateClusterState()
-		wc.ValidateEKSACiliumNotInstalled()
-
-		wc.DeleteClusterWithKubectl()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
+// // AWS IAM Auth
+// func TestDockerKubernetes128AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestDockerKubernetes129AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestDockerKubernetes130AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestDockerKubernetes131AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestDockerKubernetes132AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestDockerKubernetes133AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestDockerKubernetes134AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// // OIDC
+// func TestDockerKubernetes128OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestDockerKubernetes129OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestDockerKubernetes130OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestDockerKubernetes131OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestDockerKubernetes132OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestDockerKubernetes133OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestDockerKubernetes134OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// // Registry Mirror
+// func TestDockerKubernetes131RegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestDockerKubernetes131AirgappedRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
+// 	)
+// 	runDockerAirgapConfigFlow(test)
+// }
+
+// func TestDockerKubernetes131AirgappedUpgradeFromLatestRegistryMirrorAndCert(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.DockerProviderName),
+// 	)
+// 	runDockerAirgapUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube131,
+// 	)
+// }
+
+// func TestDockerKubernetes131RegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestDockerKubernetes132RegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestDockerKubernetes133RegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestDockerKubernetes134RegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.DockerProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// // Simple Flow
+// func TestDockerKubernetes128SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestDockerKubernetes129SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestDockerKubernetes130SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestDockerKubernetes131SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestDockerKubernetes132SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestDockerKubernetes133SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestDockerKubernetes134SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Stacked Etcd
+// func TestDockerKubernetesStackedEtcd(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// // Taints
+// func TestDockerKubernetes132Taints(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes133Taints(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes134Taints(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoScheduleTaint()), api.WithCount(2)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 			api.WithWorkerNodeGroup(worker2, api.WithTaint(framework.PreferNoScheduleTaint()), api.WithCount(1)),
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes132WorkloadClusterTaints(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint())),
+// 				api.WithWorkerNodeGroup("worker-1", api.WithCount(1), api.WithTaint(framework.NoExecuteTaint())),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+
+// 	runWorkloadClusterExistingConfigFlow(test)
+// }
+
+// // Upgrade
+// func TestDockerKubernetes132UpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
+// 		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+// 		provider.WithNewWorkerNodeGroup(
+// 			"", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend")),
+// 		),
+// 	)
+
+// 	runUpgradeFlowWithAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.RemoveWorkerNodeGroup("worker-2"),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+// 			api.RemoveWorkerNodeGroup("worker-3"),
+// 			api.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint())),
+// 		),
+// 		provider.WithNewWorkerNodeGroup("", framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
+// 	)
+// }
+
+// func TestDockerKubernetes131To132StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// }
+
+// func TestDockerKubernetes131To132ExternalEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// }
+
+// // Upgrade From Latest Minor Release
+// func TestDockerKubernetes128to129UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes129to130UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes130to131UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes131to132UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes131to132GithubFluxEnabledUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeWithFluxFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// }
+
+// func TestDockerKubernetes128WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube128)
+// }
+
+// // Workload Cluster API
+// func TestDockerUpgradeKubernetes131to132WorkloadClusterScaleupAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 		),
+// 	)
+// }
+
+// func TestDockerUpgradeWorkloadClusterLabelsAndTaintsAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("tier", "frontend"), api.WithTaint(framework.NoScheduleTaint())),
+// 				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+// 				api.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithTaint(framework.PreferNoScheduleTaint())),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 			api.RemoveWorkerNodeGroup("worker-0"),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+// 		),
+// 	)
+// }
+
+// func TestDockerUpgradeWorkloadClusterScaleAddRemoveWorkerNodeGroupsAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+// 				api.WithWorkerNodeGroup("worker-2", api.WithCount(1)),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithCount(2)),
+// 			api.RemoveWorkerNodeGroup("worker-2"),
+// 			api.WithWorkerNodeGroup("worker-3", api.WithCount(1)),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes131to132UpgradeFromLatestMinorReleaseAPI(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	)
+// 	managementCluster.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	managementCluster.UpdateClusterConfig(api.ClusterToConfigFiller(
+// 		api.WithKubernetesVersion(v1alpha1.Kube131),
+// 	))
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	wc := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	)
+// 	wc.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	wc.UpdateClusterConfig(api.ClusterToConfigFiller(
+// 		api.WithKubernetesVersion(v1alpha1.Kube131),
+// 		api.WithManagementCluster(managementCluster.ClusterName),
+// 		api.WithControlPlaneCount(1),
+// 		api.WithWorkerNodeCount(1),
+// 		api.WithStackedEtcdTopology(),
+// 	))
+// 	test.WithWorkloadClusters(wc)
+
+// 	runMulticlusterUpgradeFromReleaseFlowAPI(
+// 		test,
+// 		release,
+// 		wc.ClusterConfig.Cluster.Spec.KubernetesVersion,
+// 		v1alpha1.Kube132,
+// 		"",
+// 	)
+// }
+
+// func TestDockerUpgradeKubernetes131to132WorkloadClusterScaleupGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 		),
+// 	)
+// }
+
+// func TestDockerUpgradeKubernetes132to133WorkloadClusterScaleupGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 		),
+// 	)
+// }
+
+// func TestDockerUpgradeKubernetes133to134WorkloadClusterScaleupGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes132UpgradeWorkloadClusterLabelsAndTaintsGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("tier", "frontend"), api.WithTaint(framework.NoScheduleTaint())),
+// 				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+// 				api.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithTaint(framework.PreferNoScheduleTaint())),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 			api.RemoveWorkerNodeGroup("worker-0"),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+// 		),
+// 	)
+// }
+
+// func TestDockerKubernetes132UpgradeWorkloadClusterScaleAddRemoveWorkerNodeGroupsGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		framework.WithFluxGithubConfig(
+// 			api.WithClusterConfigPath("test"),
+// 			api.WithBranch("docker"),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 				api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+// 				api.WithWorkerNodeGroup("worker-2", api.WithCount(1)),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(1)),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithCount(2)),
+// 			api.RemoveWorkerNodeGroup("worker-2"),
+// 			api.WithWorkerNodeGroup("worker-3", api.WithCount(1)),
+// 		),
+// 	)
+// }
+
+// // Cilium Skip Upgrade
+// func TestDockerCiliumSkipUpgrade_CLICreate(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(t, provider,
+// 		framework.WithClusterFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithCiliumSkipUpgrade(),
+// 		),
+// 	)
+
+// 	test.ValidateCiliumCLIAvailable()
+
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.ValidateClusterState()
+// 	test.ValidateEKSACiliumInstalled()
+// 	test.DeleteCluster()
+// }
+
+// func TestDockerUpgradeFromLatestMinorReleaseCiliumSkipUpgrade_CLIUpgrade(t *testing.T) {
+// 	release := latestMinorRelease(t)
+
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(t, provider,
+// 		framework.WithClusterFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 	)
+
+// 	test.ValidateCiliumCLIAvailable()
+
+// 	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	test.CreateCluster(framework.ExecuteWithEksaRelease(release))
+// 	test.ReplaceCiliumWithOSSCilium()
+
+// 	t.Log("Waiting for cilium replacement to complete")
+// 	// Wait two minutes before validating cluster state and attempting the upgrade
+// 	// After replacing cilium, the nodes can temporarily go into a not ready state
+// 	// and we want to give them time to recover before validating the cluster state
+// 	time.Sleep(5 * time.Minute)
+
+// 	test.ValidateClusterState()
+// 	test.UpgradeClusterWithNewConfig(
+// 		[]framework.ClusterE2ETestOpt{
+// 			framework.WithClusterUpgrade(api.WithCiliumSkipUpgrade()),
+// 		},
+// 	)
+// 	test.ValidateClusterState()
+// 	test.ValidateEKSACiliumNotInstalled()
+// 	test.DeleteCluster()
+// }
+
+// func TestDockerCiliumSkipUpgrade_ControllerCreate(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	management := framework.NewClusterE2ETest(t, provider).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+
+// 	management.ValidateCiliumCLIAvailable()
+
+// 	test := framework.NewMulticlusterE2ETest(t, management)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(management.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithCiliumSkipUpgrade(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+
+// 		client, err := wc.BuildWorkloadClusterClient()
+// 		if err != nil {
+// 			wc.T.Fatalf("Error creating workload cluster client: %v", err)
+// 		}
+
+// 		framework.AwaitCiliumDaemonSetReady(context.Background(), client, 20, 5*time.Second)
+
+// 		wc.DeleteClusterWithKubectl()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestDockerCiliumSkipUpgrade_ControllerUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewDocker(t)
+// 	management := framework.NewClusterE2ETest(t, provider).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+
+// 	management.ValidateCiliumCLIAvailable()
+
+// 	test := framework.NewMulticlusterE2ETest(t, management)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(management.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+
+// 		client, err := wc.BuildWorkloadClusterClient()
+// 		if err != nil {
+// 			wc.T.Fatalf("Error creating workload cluster client: %v", err)
+// 		}
+
+// 		// Wait for Cilium to come up.
+// 		framework.AwaitCiliumDaemonSetReady(context.Background(), client, 20, 5*time.Second)
+
+// 		// Skip Cilium upgrades and reapply the kubeconfig.
+// 		wc.UpdateClusterConfig(api.ClusterToConfigFiller(api.WithCiliumSkipUpgrade()))
+// 		wc.ApplyClusterManifest()
+
+// 		// Give some time for reconciliation to happen.
+// 		time.Sleep(15 * time.Second)
+
+// 		// Validate EKSA Cilium is still installed because we haven't done anything to it yet
+// 		// and the controller shouldn't have removed it.
+// 		framework.AwaitCiliumDaemonSetReady(context.Background(), client, 20, 5*time.Second)
+
+// 		// Introduce a different OSS Cillium, wait for it to come up and validate the controller
+// 		// doesn't try to override the new Cilium.
+// 		wc.ReplaceCiliumWithOSSCilium()
+// 		wc.ValidateClusterState()
+// 		wc.ValidateEKSACiliumNotInstalled()
+
+// 		wc.DeleteClusterWithKubectl()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
 
 func TestDockerKubernetesNonRegionalCuratedPackages(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
@@ -1913,590 +1913,590 @@ func TestDockerKubernetesNonRegionalCuratedPackages(t *testing.T) {
 	runCuratedPackageInstallSimpleFlow(test)
 }
 
-func TestDockerKubernetesUpgradeManagementComponents(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube128, "")
-}
+// func TestDockerKubernetesUpgradeManagementComponents(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube128, "")
+// }
 
-// Etcd Scale tests
-func TestDockerKubernetes132EtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// // Etcd Scale tests
+// func TestDockerKubernetes132EtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes132EtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes132EtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes131to132EtcdScaleUp(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes131to132EtcdScaleUp(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes131to132EtcdScaleDown(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes131to132EtcdScaleDown(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes132To133StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-}
+// func TestDockerKubernetes132To133StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// }
 
-func TestDockerKubernetes132To133ExternalEtcdUpgrade(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-}
+// func TestDockerKubernetes132To133ExternalEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// }
 
-func TestDockerKubernetes133To134StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-}
+// func TestDockerKubernetes133To134StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// }
 
-func TestDockerKubernetes133To134ExternalEtcdUpgrade(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-}
+// func TestDockerKubernetes133To134ExternalEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// }
 
-func TestDockerKubernetes132to133UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
+// func TestDockerKubernetes132to133UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes132to133GithubFluxEnabledUpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeWithFluxFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-}
+// func TestDockerKubernetes132to133GithubFluxEnabledUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeWithFluxFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// }
 
-func TestDockerKubernetes133to134UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
+// func TestDockerKubernetes133to134UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes133to134GithubFluxEnabledUpgradeFromLatestMinorRelease(t *testing.T) {
-	release := latestMinorRelease(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeWithFluxFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-}
+// func TestDockerKubernetes133to134GithubFluxEnabledUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeWithFluxFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// }
 
-func TestDockerKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	provider := framework.NewDocker(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube133)
-}
+// func TestDockerKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube133)
+// }
 
-func TestDockerKubernetes134WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	provider := framework.NewDocker(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube134)
-}
+// func TestDockerKubernetes134WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, provider, framework.DockerOS, v1alpha1.Kube134)
+// }
 
-func TestDockerKubernetes132to133EtcdScaleUp(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes132to133EtcdScaleUp(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes132to133EtcdScaleDown(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes132to133EtcdScaleDown(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes133EtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes133EtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes133EtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes133EtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes133to134EtcdScaleUp(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes133to134EtcdScaleUp(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes133to134EtcdScaleDown(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes133to134EtcdScaleDown(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes134EtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes134EtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
 
-func TestDockerKubernetes134EtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// func TestDockerKubernetes134EtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
 
-// Kubelet Configuration tests
-func TestDockerKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// // Kubelet Configuration tests
+// func TestDockerKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
 
-func TestDockerKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// func TestDockerKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
 
-func TestDockerKubernetes131KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// func TestDockerKubernetes131KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
 
-func TestDockerKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// func TestDockerKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
 
-func TestDockerKubernetes133KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// func TestDockerKubernetes133KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
 
-func TestDockerKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewDocker(t),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// func TestDockerKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewDocker(t),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
 
-// Skip Admission for System Resources
-func TestDockerKubernetes133SkipAdmissionForSystemResources(t *testing.T) {
-	provider := framework.NewDocker(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
+// // Skip Admission for System Resources
+// func TestDockerKubernetes133SkipAdmissionForSystemResources(t *testing.T) {
+// 	provider := framework.NewDocker(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
 
-	// Create cluster without the feature enabled
-	test.GenerateClusterConfig()
-	test.CreateCluster()
+// 	// Create cluster without the feature enabled
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
 
-	ctx := context.Background()
+// 	ctx := context.Background()
 
-	// Define a broken validating webhook that targets cilium daemonset
-	// This webhook points to a non-existent service and will block updates to cilium
-	brokenWebhook := `apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: broken-cilium-webhook
-webhooks:
-- name: broken.webhook.test
-  clientConfig:
-    service:
-      name: non-existent-webhook-service
-      namespace: kube-system
-      path: "/validate"
-  rules:
-  - apiGroups: ["apps"]
-    apiVersions: ["v1"]
-    operations: ["UPDATE"]
-    resources: ["daemonsets"]
-    scope: "Namespaced"
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: kube-system
-  objectSelector:
-    matchLabels:
-      k8s-app: cilium
-  failurePolicy: Fail
-  sideEffects: None
-  admissionReviewVersions: ["v1"]`
+// 	// Define a broken validating webhook that targets cilium daemonset
+// 	// This webhook points to a non-existent service and will block updates to cilium
+// 	brokenWebhook := `apiVersion: admissionregistration.k8s.io/v1
+// kind: ValidatingWebhookConfiguration
+// metadata:
+//   name: broken-cilium-webhook
+// webhooks:
+// - name: broken.webhook.test
+//   clientConfig:
+//     service:
+//       name: non-existent-webhook-service
+//       namespace: kube-system
+//       path: "/validate"
+//   rules:
+//   - apiGroups: ["apps"]
+//     apiVersions: ["v1"]
+//     operations: ["UPDATE"]
+//     resources: ["daemonsets"]
+//     scope: "Namespaced"
+//   namespaceSelector:
+//     matchLabels:
+//       kubernetes.io/metadata.name: kube-system
+//   objectSelector:
+//     matchLabels:
+//       k8s-app: cilium
+//   failurePolicy: Fail
+//   sideEffects: None
+//   admissionReviewVersions: ["v1"]`
 
-	// Apply the broken webhook
-	t.Log("Deploying broken validating webhook targeting cilium daemonset")
-	err := test.KubectlClient.ApplyKubeSpecFromBytes(ctx, test.Cluster(), []byte(brokenWebhook))
-	if err != nil {
-		t.Fatalf("Failed to apply broken webhook: %v", err)
-	}
+// 	// Apply the broken webhook
+// 	t.Log("Deploying broken validating webhook targeting cilium daemonset")
+// 	err := test.KubectlClient.ApplyKubeSpecFromBytes(ctx, test.Cluster(), []byte(brokenWebhook))
+// 	if err != nil {
+// 		t.Fatalf("Failed to apply broken webhook: %v", err)
+// 	}
 
-	// Try to annotate cilium daemonset - this should FAIL due to the broken webhook
-	t.Log("Attempting to annotate cilium daemonset (expected to fail)")
-	err = test.KubectlClient.UpdateAnnotation(
-		ctx,
-		"daemonset",
-		"cilium",
-		map[string]string{"test.eks.amazonaws.com/admission-test": "before-upgrade"},
-		executables.WithKubeconfig(test.Cluster().KubeconfigFile),
-		executables.WithNamespace("kube-system"),
-	)
-	if err == nil {
-		t.Fatal("Expected annotation to fail due to broken webhook, but it succeeded")
-	}
-	t.Logf("Annotation correctly failed as expected: %v", err)
+// 	// Try to annotate cilium daemonset - this should FAIL due to the broken webhook
+// 	t.Log("Attempting to annotate cilium daemonset (expected to fail)")
+// 	err = test.KubectlClient.UpdateAnnotation(
+// 		ctx,
+// 		"daemonset",
+// 		"cilium",
+// 		map[string]string{"test.eks.amazonaws.com/admission-test": "before-upgrade"},
+// 		executables.WithKubeconfig(test.Cluster().KubeconfigFile),
+// 		executables.WithNamespace("kube-system"),
+// 	)
+// 	if err == nil {
+// 		t.Fatal("Expected annotation to fail due to broken webhook, but it succeeded")
+// 	}
+// 	t.Logf("Annotation correctly failed as expected: %v", err)
 
-	// Upgrade cluster with SkipAdmissionForSystemResources enabled
-	t.Log("Upgrading cluster with skipAdmissionForSystemResources enabled")
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{
-		framework.WithClusterUpgrade(
-			api.WithSkipAdmissionForSystemResources(true),
-		),
-	})
+// 	// Upgrade cluster with SkipAdmissionForSystemResources enabled
+// 	t.Log("Upgrading cluster with skipAdmissionForSystemResources enabled")
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{
+// 		framework.WithClusterUpgrade(
+// 			api.WithSkipAdmissionForSystemResources(true),
+// 		),
+// 	})
 
-	// Validate cluster is healthy after upgrade
-	test.ValidateCluster(v1alpha1.Kube133)
+// 	// Validate cluster is healthy after upgrade
+// 	test.ValidateCluster(v1alpha1.Kube133)
 
-	// Retry annotation on cilium daemonset - should SUCCEED now
-	t.Log("Retrying annotation on cilium daemonset (expected to succeed)")
-	err = test.KubectlClient.UpdateAnnotation(
-		ctx,
-		"daemonset",
-		"cilium",
-		map[string]string{"test.eks.amazonaws.com/admission-test": "after-upgrade"},
-		executables.WithKubeconfig(test.Cluster().KubeconfigFile),
-		executables.WithNamespace("kube-system"),
-		executables.WithOverwrite(),
-	)
-	if err != nil {
-		t.Fatalf("Expected annotation to succeed after enabling skipAdmissionForSystemResources, but got error: %v", err)
-	}
-	t.Log("Annotation succeeded - feature is working correctly!")
+// 	// Retry annotation on cilium daemonset - should SUCCEED now
+// 	t.Log("Retrying annotation on cilium daemonset (expected to succeed)")
+// 	err = test.KubectlClient.UpdateAnnotation(
+// 		ctx,
+// 		"daemonset",
+// 		"cilium",
+// 		map[string]string{"test.eks.amazonaws.com/admission-test": "after-upgrade"},
+// 		executables.WithKubeconfig(test.Cluster().KubeconfigFile),
+// 		executables.WithNamespace("kube-system"),
+// 		executables.WithOverwrite(),
+// 	)
+// 	if err != nil {
+// 		t.Fatalf("Expected annotation to succeed after enabling skipAdmissionForSystemResources, but got error: %v", err)
+// 	}
+// 	t.Log("Annotation succeeded - feature is working correctly!")
 
-	// Cleanup
-	test.StopIfFailed()
-	test.DeleteCluster()
-}
+// 	// Cleanup
+// 	test.StopIfFailed()
+// 	test.DeleteCluster()
+// }

--- a/test/e2e/nutanix_test.go
+++ b/test/e2e/nutanix_test.go
@@ -522,1439 +522,1439 @@ func TestNutanixKubernetes134UbuntuCuratedPackagesHarborSimpleFlow(t *testing.T)
 	runCuratedPackageHarborInstallSimpleFlowLocalStorageProvisioner(test)
 }
 
-// Simple Flow
-func TestNutanixKubernetes128UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu128Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes129UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes130UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes131UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes132UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes133UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu133Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes128RedHat8SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat128Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes129RedHat8SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat129Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes130RedHat8SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat130Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes131RedHat8SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat131Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes128RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes128Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes129RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes129Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes130RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes130Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes131RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes131Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes132RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes132Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes133RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes133Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes128UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu128NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes129UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu129NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes130UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu130NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes131UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu131NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes132UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu132NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes133UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu133NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes128RedHatSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat128NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes129RedHatSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat129NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes130RedHatSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat130NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes131RedHatSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat131NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes128RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes128NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes129RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes129NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes130RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes130NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes131RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes131NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes132RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes132NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes133RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes133NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes134UbuntuSimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes134RedHat9SimpleFlowWithName(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes134Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes134UbuntuSimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu134NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestNutanixKubernetes134RedHat9SimpleFlowWithUUID(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithRedHat9Kubernetes134NutanixUUID(),
-			framework.WithPrismElementClusterUUID(),
-			framework.WithNutanixSubnetUUID()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-// Upgrade
-func TestNutanixKubernetes128To129StackedEtcdUbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestNutanixKubernetes129To130StackedEtcdUbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
-	)
-}
-
-func TestNutanixKubernetes130To131StackedEtcdUbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
-	)
-}
-
-func TestNutanixKubernetes131To132StackedEtcdUbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
-	)
-}
-
-func TestNutanixKubernetes128To129UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestNutanixKubernetes129To130UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
-	)
-}
-
-func TestNutanixKubernetes130To131UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
-	)
-}
-
-func TestNutanixKubernetes131To132UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
-	)
-}
-
-func TestNutanixKubernetes128to129RedHatUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.RedHat129Template()),
-	)
-}
-
-func TestNutanixKubernetes129to130RedHatUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.RedHat130Template()),
-	)
-}
-
-func TestNutanixKubernetes130to131RedHatUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.RedHat131Template()),
-	)
-}
-
-func TestNutanixKubernetes128to129RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes129Template()),
-	)
-}
-
-func TestNutanixKubernetes129to130RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes130Template()),
-	)
-}
-
-func TestNutanixKubernetes130to131RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes131Template()),
-	)
-}
-
-func TestNutanixKubernetes131to132RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes132Template()),
-	)
-}
-
-func TestNutanixKubernetes131to132StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes132Template()),
-	)
-}
-
-func TestNutanixKubernetes132To133UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-func TestNutanixKubernetes132To133StackedEtcdUbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-func TestNutanixKubernetes132to133RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes133Template()),
-	)
-}
-
-func TestNutanixKubernetes132to133StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes133Template()),
-	)
-}
-
-func TestNutanixKubernetes133To134UbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu133Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestNutanixKubernetes133To134StackedEtcdUbuntuUpgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu133Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestNutanixKubernetes133to134RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes133Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes134Template()),
-	)
-}
-
-func TestNutanixKubernetes133to134StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes133Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.RedHat9Kubernetes134Template()),
-	)
-}
-
-func TestNutanixKubernetes128UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-func TestNutanixKubernetes129UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-func TestNutanixKubernetes130UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-func TestNutanixKubernetes131UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-func TestNutanixKubernetes132UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-func TestNutanixKubernetes134UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes128UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithEnvVar("features.NutanixProviderEnvVar", "true"),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes129UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes130UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes131UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes132UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 1 node control plane cluster scaled up to 3
-func TestNutanixKubernetes134UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes128UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes129UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes130UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes131UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes132UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 3 worker node cluster scaled down to 1
-func TestNutanixKubernetes134UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes128UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes129UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes130UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes131UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes132UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// 3 node control plane cluster scaled down to 1
-func TestNutanixKubernetes134UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
-	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-	)
-}
-
-// OIDC
-func TestNutanixKubernetes128OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu128Nutanix()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestNutanixKubernetes129OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestNutanixKubernetes130OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestNutanixKubernetes131OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestNutanixKubernetes132OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestNutanixKubernetes134OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-// AWS IAM Auth
-func TestNutanixKubernetes129AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestNutanixKubernetes130AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestNutanixKubernetes131AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestNutanixKubernetes132AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestNutanixKubernetes134AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runAWSIamAuthFlow(test)
-}
-
-func TestNutanixKubernetes132UbuntuManagementCPUpgradeAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
-	test := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runUpgradeFlowWithAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(3),
-		),
-	)
-}
-
-func TestNutanixKubernetes134UbuntuManagementCPUpgradeAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
-	test := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(1),
-			api.WithWorkerNodeCount(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runUpgradeFlowWithAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(3),
-		),
-	)
-}
-
-// Kubelet Configuration tests
-func TestNutanixKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestNutanixKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestNutanixKubernetes131KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestNutanixKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestNutanixKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// // Simple Flow
+// func TestNutanixKubernetes128UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu128Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes129UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes130UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes131UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes132UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes133UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu133Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes128RedHat8SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat128Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes129RedHat8SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat129Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes130RedHat8SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat130Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes131RedHat8SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat131Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes128RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes128Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes129RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes129Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes130RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes130Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes131RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes131Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes132RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes132Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes133RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes133Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes128UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu128NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes129UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu129NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes130UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu130NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes131UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu131NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes132UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu132NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes133UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu133NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes128RedHatSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat128NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes129RedHatSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat129NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes130RedHatSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat130NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes131RedHatSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat131NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes128RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes128NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes129RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes129NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes130RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes130NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes131RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes131NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes132RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes132NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes133RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes133NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes134UbuntuSimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes134RedHat9SimpleFlowWithName(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes134Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes134UbuntuSimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu134NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestNutanixKubernetes134RedHat9SimpleFlowWithUUID(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithRedHat9Kubernetes134NutanixUUID(),
+// 			framework.WithPrismElementClusterUUID(),
+// 			framework.WithNutanixSubnetUUID()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Upgrade
+// func TestNutanixKubernetes128To129StackedEtcdUbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes129To130StackedEtcdUbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes130To131StackedEtcdUbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes131To132StackedEtcdUbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes128To129UbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes129To130UbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes130To131UbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes131To132UbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes128to129RedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.RedHat129Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes129to130RedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.RedHat130Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes130to131RedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.RedHat131Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes128to129RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes129Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes129to130RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes130Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes130to131RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes131Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes131to132RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes132Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes131to132StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes132Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes132To133UbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes132To133StackedEtcdUbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes132to133RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes133Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes132to133StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes133Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes133To134UbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu133Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes133To134StackedEtcdUbuntuUpgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu133Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes133to134RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes133Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes134Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes133to134StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithRedHat9Kubernetes133Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.RedHat9Kubernetes134Template()),
+// 	)
+// }
+
+// func TestNutanixKubernetes128UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
+// 	)
+// }
+
+// func TestNutanixKubernetes129UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
+// 	)
+// }
+
+// func TestNutanixKubernetes130UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
+// 	)
+// }
+
+// func TestNutanixKubernetes131UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
+// 	)
+// }
+
+// func TestNutanixKubernetes132UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
+// 	)
+// }
+
+// func TestNutanixKubernetes134UbuntuWorkerNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(3)),
+// 	)
+// }
+
+// // 1 node control plane cluster scaled up to 3
+// func TestNutanixKubernetes128UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithEnvVar("features.NutanixProviderEnvVar", "true"),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// // 1 node control plane cluster scaled up to 3
+// func TestNutanixKubernetes129UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// // 1 node control plane cluster scaled up to 3
+// func TestNutanixKubernetes130UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// // 1 node control plane cluster scaled up to 3
+// func TestNutanixKubernetes131UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// // 1 node control plane cluster scaled up to 3
+// func TestNutanixKubernetes132UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// // 1 node control plane cluster scaled up to 3
+// func TestNutanixKubernetes134UbuntuControlPlaneNodeScaleUp1To3(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// // 3 worker node cluster scaled down to 1
+// func TestNutanixKubernetes128UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// // 3 worker node cluster scaled down to 1
+// func TestNutanixKubernetes129UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// // 3 worker node cluster scaled down to 1
+// func TestNutanixKubernetes130UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// // 3 worker node cluster scaled down to 1
+// func TestNutanixKubernetes131UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// // 3 worker node cluster scaled down to 1
+// func TestNutanixKubernetes132UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// // 3 worker node cluster scaled down to 1
+// func TestNutanixKubernetes134UbuntuWorkerNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// // 3 node control plane cluster scaled down to 1
+// func TestNutanixKubernetes128UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu128Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // 3 node control plane cluster scaled down to 1
+// func TestNutanixKubernetes129UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu129Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // 3 node control plane cluster scaled down to 1
+// func TestNutanixKubernetes130UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu130Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // 3 node control plane cluster scaled down to 1
+// func TestNutanixKubernetes131UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu131Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // 3 node control plane cluster scaled down to 1
+// func TestNutanixKubernetes132UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // 3 node control plane cluster scaled down to 1
+// func TestNutanixKubernetes134UbuntuControlPlaneNodeScaleDown3To1(t *testing.T) {
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // OIDC
+// func TestNutanixKubernetes128OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu128Nutanix()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestNutanixKubernetes129OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestNutanixKubernetes130OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestNutanixKubernetes131OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestNutanixKubernetes132OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestNutanixKubernetes134OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// // AWS IAM Auth
+// func TestNutanixKubernetes129AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestNutanixKubernetes130AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestNutanixKubernetes131AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestNutanixKubernetes132AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestNutanixKubernetes134AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
+
+// func TestNutanixKubernetes132UbuntuManagementCPUpgradeAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu132Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runUpgradeFlowWithAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 	)
+// }
+
+// func TestNutanixKubernetes134UbuntuManagementCPUpgradeAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewNutanix(t, framework.WithUbuntu134Nutanix())
+// 	test := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runUpgradeFlowWithAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 	)
+// }
+
+// // Kubelet Configuration tests
+// func TestNutanixKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu129Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestNutanixKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu130Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestNutanixKubernetes131KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu131Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestNutanixKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu132Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestNutanixKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewNutanix(t, framework.WithUbuntu134Nutanix()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }

--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -19,1370 +19,1370 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-// AWS IAM Auth
-func TestTinkerbellKubernetes134AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellAWSIamAuthFlow(test)
-}
+// // AWS IAM Auth
+// func TestTinkerbellKubernetes134AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellAWSIamAuthFlow(test)
+// }
 
-func TestTinkerbellKubernetes132AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellAWSIamAuthFlow(test)
-}
+// func TestTinkerbellKubernetes132AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellAWSIamAuthFlow(test)
+// }
 
-// Upgrade
-func TestTinkerbellKubernetes128UbuntuTo129Upgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
-	)
-}
+// // Upgrade
+// func TestTinkerbellKubernetes128UbuntuTo129Upgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes129UbuntuTo130Upgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu129Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
-	)
-}
+// func TestTinkerbellKubernetes129UbuntuTo130Upgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu129Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130UbuntuTo131Upgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
-	)
-}
+// func TestTinkerbellKubernetes130UbuntuTo131Upgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuTo134Upgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuTo134Upgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuTo133Upgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuTo133Upgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131UbuntuTo132Upgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
-	)
-}
+// func TestTinkerbellKubernetes131UbuntuTo132Upgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130UbuntuTo131UpgradeCPOnly(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	kube130 := v1alpha1.Kube130
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube130)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(kube130, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(kube130, framework.Ubuntu2004),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(framework.Ubuntu131ImageForCP()),
-	)
-}
+// func TestTinkerbellKubernetes130UbuntuTo131UpgradeCPOnly(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	kube130 := v1alpha1.Kube130
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube130)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(kube130, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(kube130, framework.Ubuntu2004),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu131ImageForCP()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuTo134UpgradeCPOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube133 := v1alpha1.Kube133
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(kube133, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(kube133, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu134ImageForCP()),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuTo134UpgradeCPOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube133 := v1alpha1.Kube133
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(kube133, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(kube133, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134ImageForCP()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube132 := v1alpha1.Kube132
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(kube132, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(kube132, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu133ImageForCP()),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube132 := v1alpha1.Kube132
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(kube132, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(kube132, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133ImageForCP()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131UbuntuTo132UpgradeCPOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube131 := v1alpha1.Kube131
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(kube131, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(kube131, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu132ImageForCP()),
-	)
-}
+// func TestTinkerbellKubernetes131UbuntuTo132UpgradeCPOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube131 := v1alpha1.Kube131
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(kube131, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(kube131, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132ImageForCP()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130UbuntuTo131UpgradeWorkerOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube130 := v1alpha1.Kube130
-	kube131 := v1alpha1.Kube131
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube130)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131)),
-		provider.WithProviderUpgrade(framework.Ubuntu131ImageForWorker()),
-	)
-}
+// func TestTinkerbellKubernetes130UbuntuTo131UpgradeWorkerOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube130 := v1alpha1.Kube130
+// 	kube131 := v1alpha1.Kube131
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube130)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu131ImageForWorker()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuTo134UpgradeWorkerOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube133 := v1alpha1.Kube133
-	kube134 := v1alpha1.Kube134
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu134ImageForWorker()),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuTo134UpgradeWorkerOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube133 := v1alpha1.Kube133
+// 	kube134 := v1alpha1.Kube134
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134ImageForWorker()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuTo133UpgradeWorkerOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube132 := v1alpha1.Kube132
-	kube133 := v1alpha1.Kube133
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu133ImageForWorker()),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuTo133UpgradeWorkerOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube132 := v1alpha1.Kube132
+// 	kube133 := v1alpha1.Kube133
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133ImageForWorker()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131UbuntuTo132UpgradeWorkerOnly(t *testing.T) {
-	provider := framework.NewTinkerbell(t)
-	kube131 := v1alpha1.Kube131
-	kube132 := v1alpha1.Kube132
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithCPKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004),
-		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004),
-	)
-	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu132ImageForWorker()),
-	)
-}
+// func TestTinkerbellKubernetes131UbuntuTo132UpgradeWorkerOnly(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t)
+// 	kube131 := v1alpha1.Kube131
+// 	kube132 := v1alpha1.Kube132
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube131)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithCPKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004),
+// 		provider.WithWorkerKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004),
+// 	)
+// 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132ImageForWorker()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes128To129Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes129Image()),
-	)
-}
+// func TestTinkerbellKubernetes128To129Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes129Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes129To130Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes130Image()),
-	)
-}
+// func TestTinkerbellKubernetes129To130Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes130Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130To131Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes131Image()),
-	)
-}
+// func TestTinkerbellKubernetes130To131Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes131Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131To132Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes132Image()),
-	)
-}
+// func TestTinkerbellKubernetes131To132Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes132Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133To134Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes134Image()),
-	)
-}
+// func TestTinkerbellKubernetes133To134Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132To133Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes133Image()),
-	)
-}
+// func TestTinkerbellKubernetes132To133Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes133Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133To134Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134Image()),
-	)
-}
+// func TestTinkerbellKubernetes133To134Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes128Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes128Image()),
-	)
-}
+// func TestTinkerbellKubernetes128Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes128Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes129Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes129Image()),
-	)
-}
+// func TestTinkerbellKubernetes129Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes129Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134Ubuntu2204To2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134Image()),
-	)
-}
+// func TestTinkerbellKubernetes134Ubuntu2204To2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134Ubuntu2204To2404RTOSUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134RTOSImage()),
-	)
-}
+// func TestTinkerbellKubernetes134Ubuntu2204To2404RTOSUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134RTOSImage()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134Ubuntu2204To2404GenericUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134GenericImage()),
-	)
-}
+// func TestTinkerbellKubernetes134Ubuntu2204To2404GenericUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes134GenericImage()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133Ubuntu2204To2404RTOSUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes133RTOSImage()),
-	)
-}
+// func TestTinkerbellKubernetes133Ubuntu2204To2404RTOSUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes133RTOSImage()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133Ubuntu2204To2404GenericUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes133GenericImage()),
-	)
-}
+// func TestTinkerbellKubernetes133Ubuntu2204To2404GenericUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2404Kubernetes133GenericImage()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes130Image()),
-	)
-}
+// func TestTinkerbellKubernetes130Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes130Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes131Image()),
-	)
-}
+// func TestTinkerbellKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes131Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes134Image()),
-	)
-}
+// func TestTinkerbellKubernetes134Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes133Image()),
-	)
-}
+// func TestTinkerbellKubernetes133Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes133Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes132Image()),
-	)
-}
+// func TestTinkerbellKubernetes132Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowForBaremetalWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu2204Kubernetes132Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
+// func TestTinkerbellKubernetes134UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuWorkerNodeScaleUpWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runUpgradeFlowForBareMetalWithAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeCount(2),
-		),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuWorkerNodeScaleUpWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runUpgradeFlowForBareMetalWithAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134UbuntuWorkerNodeScaleUpWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runUpgradeFlowForBareMetalWithAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeCount(2),
-		),
-	)
-}
+// func TestTinkerbellKubernetes134UbuntuWorkerNodeScaleUpWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runUpgradeFlowForBareMetalWithAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuWorkerNodeScaleUpWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runUpgradeFlowForBareMetalWithAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeCount(2),
-		),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuWorkerNodeScaleUpWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runUpgradeFlowForBareMetalWithAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithCustomLabelHardware(1, "worker-0"),
-	)
-	runUpgradeFlowForBareMetalWithAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0",
-				api.WithCount(1),
-				api.WithMachineGroupRef("worker-0", "TinkerbellMachineConfig"),
-			),
-		),
-		api.TinkerbellToConfigFiller(
-			api.WithCustomTinkerbellMachineConfig("worker-0",
-				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
-				api.WithOsFamilyForTinkerbellMachineConfig(v1alpha1.Ubuntu),
-			),
-		),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithCustomLabelHardware(1, "worker-0"),
+// 	)
+// 	runUpgradeFlowForBareMetalWithAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0",
+// 				api.WithCount(1),
+// 				api.WithMachineGroupRef("worker-0", "TinkerbellMachineConfig"),
+// 			),
+// 		),
+// 		api.TinkerbellToConfigFiller(
+// 			api.WithCustomTinkerbellMachineConfig("worker-0",
+// 				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
+// 				api.WithOsFamilyForTinkerbellMachineConfig(v1alpha1.Ubuntu),
+// 			),
+// 		),
+// 	)
+// }
 
-func TestTinkerbellKubernetes134UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithCustomLabelHardware(1, "worker-0"),
-	)
-	runUpgradeFlowForBareMetalWithAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0",
-				api.WithCount(1),
-				api.WithMachineGroupRef("worker-0", "TinkerbellMachineConfig"),
-			),
-		),
-		api.TinkerbellToConfigFiller(
-			api.WithCustomTinkerbellMachineConfig("worker-0",
-				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
-				api.WithOsFamilyForTinkerbellMachineConfig(v1alpha1.Ubuntu),
-			),
-		),
-	)
-}
+// func TestTinkerbellKubernetes134UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithCustomLabelHardware(1, "worker-0"),
+// 	)
+// 	runUpgradeFlowForBareMetalWithAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0",
+// 				api.WithCount(1),
+// 				api.WithMachineGroupRef("worker-0", "TinkerbellMachineConfig"),
+// 			),
+// 		),
+// 		api.TinkerbellToConfigFiller(
+// 			api.WithCustomTinkerbellMachineConfig("worker-0",
+// 				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
+// 				api.WithOsFamilyForTinkerbellMachineConfig(v1alpha1.Ubuntu),
+// 			),
+// 		),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithCustomLabelHardware(1, "worker-0"),
-	)
-	runUpgradeFlowForBareMetalWithAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0",
-				api.WithCount(1),
-				api.WithMachineGroupRef("worker-0", "TinkerbellMachineConfig"),
-			),
-		),
-		api.TinkerbellToConfigFiller(
-			api.WithCustomTinkerbellMachineConfig("worker-0",
-				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
-				api.WithOsFamilyForTinkerbellMachineConfig(v1alpha1.Ubuntu),
-			),
-		),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuAddWorkerNodeGroupWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithCustomLabelHardware(1, "worker-0"),
+// 	)
+// 	runUpgradeFlowForBareMetalWithAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0",
+// 				api.WithCount(1),
+// 				api.WithMachineGroupRef("worker-0", "TinkerbellMachineConfig"),
+// 			),
+// 		),
+// 		api.TinkerbellToConfigFiller(
+// 			api.WithCustomTinkerbellMachineConfig("worker-0",
+// 				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
+// 				api.WithOsFamilyForTinkerbellMachineConfig(v1alpha1.Ubuntu),
+// 			),
+// 		),
+// 	)
+// }
 
-func TestTinkerbellKubernetes128UbuntuTo129InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129), api.WithInPlaceUpgradeStrategy()),
-		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
-	)
-}
+// func TestTinkerbellKubernetes128UbuntuTo129InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129), api.WithInPlaceUpgradeStrategy()),
+// 		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes129UbuntuTo130InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130), api.WithInPlaceUpgradeStrategy()),
-		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
-	)
-}
+// func TestTinkerbellKubernetes129UbuntuTo130InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130), api.WithInPlaceUpgradeStrategy()),
+// 		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130UbuntuTo131InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131), api.WithInPlaceUpgradeStrategy()),
-		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
-	)
-}
+// func TestTinkerbellKubernetes130UbuntuTo131InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131), api.WithInPlaceUpgradeStrategy()),
+// 		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131UbuntuTo132InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132), api.WithInPlaceUpgradeStrategy()),
-		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
-	)
-}
+// func TestTinkerbellKubernetes131UbuntuTo132InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132), api.WithInPlaceUpgradeStrategy()),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuTo134InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134), api.WithInPlaceUpgradeStrategy()),
-		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuTo134InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134), api.WithInPlaceUpgradeStrategy()),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuTo133InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133), api.WithInPlaceUpgradeStrategy()),
-		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuTo133InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133), api.WithInPlaceUpgradeStrategy()),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes128UbuntuTo129SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube128),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube129),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
-	)
-}
+// func TestTinkerbellKubernetes128UbuntuTo129SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube128),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube129),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes129UbuntuTo130SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube129),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
-	)
-}
+// func TestTinkerbellKubernetes129UbuntuTo130SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube129),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes130UbuntuTo131SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube130),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube131),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
-	)
-}
+// func TestTinkerbellKubernetes130UbuntuTo131SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube130),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube131),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes131UbuntuTo132SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube131),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
-	)
-}
+// func TestTinkerbellKubernetes131UbuntuTo132SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube131),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133UbuntuTo134SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube133),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
-	)
-}
+// func TestTinkerbellKubernetes133UbuntuTo134SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube133),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes133RedHat9To134SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube133),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.RedHat9, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.RedHat9Kubernetes134Image()),
-	)
-}
+// func TestTinkerbellKubernetes133RedHat9To134SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube133),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.RedHat9, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.RedHat9Kubernetes134Image()),
+// 	)
+// }
 
-func TestTinkerbellKubernetes132UbuntuTo133SingleNodeInPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterSingleNode(v1alpha1.Kube132),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
-		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
-		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
-		framework.WithControlPlaneHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runInPlaceUpgradeFlowForBareMetal(
-		test,
-		framework.WithUpgradeClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithInPlaceUpgradeStrategy(),
-			),
-			api.TinkerbellToConfigFiller(
-				api.RemoveTinkerbellWorkerMachineConfig(),
-			),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
-	)
-}
+// func TestTinkerbellKubernetes132UbuntuTo133SingleNodeInPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterSingleNode(v1alpha1.Kube132),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithEtcdCountIfExternal(0)),
+// 		framework.WithClusterFiller(api.RemoveAllWorkerNodeGroups()),
+// 		framework.WithClusterFiller(api.WithInPlaceUpgradeStrategy()),
+// 		framework.WithControlPlaneHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFlowForBareMetal(
+// 		test,
+// 		framework.WithUpgradeClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 			),
+// 			api.TinkerbellToConfigFiller(
+// 				api.RemoveTinkerbellWorkerMachineConfig(),
+// 			),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
+// 	)
+// }
 
 // Curated Packages
 func TestTinkerbellKubernetes128UbuntuSingleNodeCuratedPackagesFlow(t *testing.T) {
@@ -1619,2131 +1619,2131 @@ func TestTinkerbellKubernetes134UbuntuCuratedPackagesClusterAutoscalerSimpleFlow
 	runAutoscalerWithMetricsServerTinkerbellSimpleFlow(test)
 }
 
-func TestTinkerbellKubernetes132UbuntuSingleNodeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-		framework.WithControlPlaneHardware(1),
-	)
-
-	runTinkerbellSingleNodeFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuSingleNodeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-		framework.WithControlPlaneHardware(1),
-	)
-
-	runTinkerbellSingleNodeFlow(test)
-}
-
-// ISO booting tests
-func TestTinkerbellKubernetes131UbuntuHookIsoSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t,
-			framework.WithUbuntu131Tinkerbell(),
-			framework.WithHookIsoBoot(),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-		framework.WithControlPlaneHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes131UbuntuHookIsoOverrideSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell(),
-			framework.WithHookIsoBoot(),
-			framework.WithHookIsoURLPath(framework.HookIsoURLOverride())),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-		framework.WithControlPlaneHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-// Multicluster
-func TestTinkerbellKubernetes132UbuntuWorkloadCluster(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuWorkloadCluster(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes133UbuntuWorkloadCluster(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuWorkloadClusterWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuWorkloadClusterWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes133UbuntuWorkloadClusterWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		framework.WithFluxGithubConfig(),
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterGitOpsAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		framework.WithFluxGithubConfig(),
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterGitOpsAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes133UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		framework.WithFluxGithubConfig(),
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterGitOpsAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes128BottlerocketWorkloadClusterSimpleFlow(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes128BottlerocketWorkloadClusterWithAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithLicenseToken(licenseToken2),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuSingleNodeWorkloadCluster(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(0),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuSingleNodeWorkloadCluster(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(0),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes133UbuntuSingleNodeWorkloadCluster(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-			framework.WithControlPlaneHardware(2),
-			framework.WithWorkerHardware(0),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-		),
-	)
-	runTinkerbellWorkloadClusterFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuSingleNodeWorkloadClusterWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(0),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuSingleNodeWorkloadClusterWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(0),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellKubernetes133UbuntuSingleNodeWorkloadClusterWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(0),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithEtcdCountIfExternal(0),
-				api.RemoveAllWorkerNodeGroups(),
-			),
-		),
-	)
-	runWorkloadClusterWithAPIFlowForBareMetal(test)
-}
-
-func TestTinkerbellUpgrade132MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		framework.WithFluxGithubConfig(),
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterGitOpsAPIUpgradeFlowForBareMetal(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeCount(2),
-		),
-	)
-}
-
-func TestTinkerbellUpgrade134MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		framework.WithFluxGithubConfig(),
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterGitOpsAPIUpgradeFlowForBareMetal(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeCount(2),
-		),
-	)
-}
-
-func TestTinkerbellUpgrade133MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-		framework.WithFluxGithubEnvVarCheck(),
-		framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		framework.WithFluxGithubConfig(),
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube133),
-				api.WithManagementCluster(managementCluster.ClusterName),
-			),
-		),
-	)
-	runWorkloadClusterGitOpsAPIUpgradeFlowForBareMetal(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeCount(2),
-		),
-	)
-}
-
-func TestTinkerbellUpgrade132MulticlusterWorkloadClusterCPScaleup(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-			framework.WithControlPlaneHardware(4),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		),
-	)
-	runSimpleWorkloadUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(3),
-		),
-	)
-}
-
-func TestTinkerbellUpgrade134MulticlusterWorkloadClusterCPScaleup(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-			framework.WithControlPlaneHardware(4),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		),
-	)
-	runSimpleWorkloadUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(3),
-		),
-	)
-}
-
-func TestTinkerbellUpgrade133MulticlusterWorkloadClusterCPScaleup(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-			framework.WithControlPlaneHardware(4),
-			framework.WithWorkerHardware(2),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		),
-	)
-	runSimpleWorkloadUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(3),
-		),
-	)
-}
-
-func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade131To132(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-			framework.WithControlPlaneHardware(3),
-			framework.WithWorkerHardware(3),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		),
-	)
-	runSimpleWorkloadUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
-	)
-}
-
-func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade133To134(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-			framework.WithControlPlaneHardware(3),
-			framework.WithWorkerHardware(3),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		),
-	)
-	runSimpleWorkloadUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
-	)
-}
-
-func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade132To133(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-			framework.WithControlPlaneHardware(3),
-			framework.WithWorkerHardware(3),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		),
-	)
-	runSimpleWorkloadUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
-	)
-}
-
-// OIDC
-func TestTinkerbellKubernetes132OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellOIDCFlow(test)
-}
-
-func TestTinkerbellKubernetes134OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellOIDCFlow(test)
-}
-
-// Registry Mirror
-func TestTinkerbellKubernetes132UbuntuRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithRegistryMirrorEndpointAndCert(constants.TinkerbellProviderName),
-	)
-	runTinkerbellRegistryMirrorFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithRegistryMirrorEndpointAndCert(constants.TinkerbellProviderName),
-	)
-	runTinkerbellRegistryMirrorFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuInsecureSkipVerifyRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.TinkerbellProviderName),
-	)
-	runTinkerbellRegistryMirrorFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuInsecureSkipVerifyRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.TinkerbellProviderName),
-	)
-	runTinkerbellRegistryMirrorFlow(test)
-}
-
-func TestTinkerbellKubernetes131UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithAuthenticatedRegistryMirror(constants.TinkerbellProviderName),
-	)
-	runTinkerbellRegistryMirrorFlow(test)
-}
-
-// Simple Flow
-func TestTinkerbellKubernetes128UbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes129UbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu129Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes130UbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes131UbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes128Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes129Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes130Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes131Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes132Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes134Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes134Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes130Ubuntu2204RTOSSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil, "rtos"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes131Ubuntu2204RTOSSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil, "rtos"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes132Ubuntu2204RTOSSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil, "rtos"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes134Ubuntu2404RTOSSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil, "rtos"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes129Ubuntu2204GenericSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil, "generic"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes130Ubuntu2204GenericSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil, "generic"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes131Ubuntu2204GenericSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil, "generic"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes132Ubuntu2204GenericSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil, "generic"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes134Ubuntu2404GenericSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil, "generic"),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestTinkerbellKubernetes128RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat128Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes129RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat129Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes130RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat130Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes131RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat131Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes128RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat9128Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes129RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat9129Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes130RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat9130Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes131RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat9131Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes132RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat9132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes134RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithRedHat9134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes128BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuThreeControlPlaneReplicasSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuThreeControlPlaneReplicasSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuThreeWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(3),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuThreeWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(3),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes132UbuntuControlPlaneScaleUp(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestTinkerbellKubernetes134UbuntuControlPlaneScaleUp(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestTinkerbellKubernetes133UbuntuControlPlaneScaleUp(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestTinkerbellKubernetes132UbuntuWorkerNodeScaleUp(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
-
-func TestTinkerbellKubernetes134UbuntuWorkerNodeScaleUp(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
-
-func TestTinkerbellKubernetes133UbuntuWorkerNodeScaleUp(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
-	)
-}
-
-func TestTinkerbellKubernetes132UbuntuWorkerNodeScaleDown(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-func TestTinkerbellKubernetes134UbuntuWorkerNodeScaleDown(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-func TestTinkerbellKubernetes133UbuntuWorkerNodeScaleDown(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
-	)
-}
-
-func TestTinkerbellKubernetes134UbuntuControlPlaneScaleDown(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(1)),
-	)
-}
-
-func TestTinkerbellKubernetes133UbuntuControlPlaneScaleDown(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(1)),
-	)
-}
-
-func TestTinkerbellKubernetes132UbuntuControlPlaneScaleDown(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(3),
-		framework.WithWorkerHardware(1),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(1)),
-	)
-}
-
-// Worker Nodegroup Taints and Labels
-func TestTinkerbellKubernetes132UbuntuWorkerNodeGroupsTaintsAndLabels(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(
-			t,
-			framework.WithUbuntu132Tinkerbell(),
-			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel1),
-			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel2),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.NoScheduleTaint()}),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithWorkerNodeGroup(worker0, api.WithMachineGroupRef(nodeGroupLabel1, "TinkerbellMachineConfig"), api.WithTaint(framework.PreferNoScheduleTaint()), api.WithLabel(key1, val1), api.WithCount(1)),
-			api.WithWorkerNodeGroup(worker1, api.WithMachineGroupRef(nodeGroupLabel2, "TinkerbellMachineConfig"), api.WithLabel(key2, val2), api.WithCount(1)),
-		),
-		framework.WithControlPlaneHardware(1),
-		framework.WithCustomLabelHardware(1, nodeGroupLabel1),
-		framework.WithCustomLabelHardware(1, nodeGroupLabel2),
-	)
-
-	test.GenerateClusterConfig()
-	test.GenerateHardwareConfig()
-	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints, framework.ValidateWorkerNodeLabels)
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints, framework.ValidateControlPlaneLabels)
-	test.DeleteCluster()
-	test.ValidateHardwareDecommissioned()
-}
-
-func TestTinkerbellKubernetes134UbuntuWorkerNodeGroupsTaintsAndLabels(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(
-			t,
-			framework.WithUbuntu134Tinkerbell(),
-			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel1),
-			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel2),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.NoScheduleTaint()}),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithWorkerNodeGroup(worker0, api.WithMachineGroupRef(nodeGroupLabel1, "TinkerbellMachineConfig"), api.WithTaint(framework.PreferNoScheduleTaint()), api.WithLabel(key1, val1), api.WithCount(1)),
-			api.WithWorkerNodeGroup(worker1, api.WithMachineGroupRef(nodeGroupLabel2, "TinkerbellMachineConfig"), api.WithLabel(key2, val2), api.WithCount(1)),
-		),
-		framework.WithControlPlaneHardware(1),
-		framework.WithCustomLabelHardware(1, nodeGroupLabel1),
-		framework.WithCustomLabelHardware(1, nodeGroupLabel2),
-	)
-
-	test.GenerateClusterConfig()
-	test.GenerateHardwareConfig()
-	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
-	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints, framework.ValidateWorkerNodeLabels)
-	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints, framework.ValidateControlPlaneLabels)
-	test.DeleteCluster()
-	test.ValidateHardwareDecommissioned()
-}
-
-// Proxy tests
-func TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
-	localIp, err := networkutils.GetLocalIP()
-	if err != nil {
-		t.Fatalf("Cannot get admin machine local IP: %v", err)
-	}
-	t.Logf("Admin machine's IP is: %s", localIp)
-
-	kubeVersion := strings.Replace(string(v1alpha1.Kube132), ".", "-", 1)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t,
-			framework.WithUbuntu132Tinkerbell(),
-			framework.WithHookImagesURLPath(TinkerbellHookOSImagesURLPath),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-		),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithProxy(framework.TinkerbellProxyRequiredEnvVars),
-	)
-
-	runTinkerbellAirgapConfigProxyFlow(test, TinkerbellNoProxyCIDR, kubeVersion)
-}
-
-func TestTinkerbellAirgappedKubernetes134UbuntuProxyConfigFlow(t *testing.T) {
-	localIp, err := networkutils.GetLocalIP()
-	if err != nil {
-		t.Fatalf("Cannot get admin machine local IP: %v", err)
-	}
-	t.Logf("Admin machine's IP is: %s", localIp)
-
-	kubeVersion := strings.Replace(string(v1alpha1.Kube134), ".", "-", 1)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t,
-			framework.WithUbuntu134Tinkerbell(),
-			framework.WithHookImagesURLPath(TinkerbellHookOSImagesURLPath),
-		),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-		),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithProxy(framework.TinkerbellProxyRequiredEnvVars),
-	)
-
-	runTinkerbellAirgapConfigProxyFlow(test, TinkerbellNoProxyCIDR, kubeVersion)
-}
-
-// OOB tests
-func TestTinkerbellKubernetes132UbuntuOOB(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithOOBConfiguration(),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellKubernetes134UbuntuOOB(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithOOBConfiguration(),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	runTinkerbellSimpleFlow(test)
-}
-
-func TestTinkerbellK8sUpgrade131to132WithUbuntuOOB(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithOOBConfiguration(),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
-	)
-}
-
-func TestTinkerbellK8sUpgrade133to134WithUbuntuOOB(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithOOBConfiguration(),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
-	)
-}
-
-func TestTinkerbellK8sUpgrade132to133WithUbuntuOOB(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithOOBConfiguration(),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	)
-	runSimpleUpgradeFlowForBareMetal(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
-	)
-}
-
-func TestTinkerbellSingleNode131To132UbuntuManagementCPUpgradeAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(3),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
-	)
-}
-
-func TestTinkerbellSingleNode133To134UbuntuManagementCPUpgradeAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneCount(3),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2004, nil),
-	)
-}
-
-func TestTinkerbellSingleNode132To133UbuntuManagementCPUpgradeAPI(t *testing.T) {
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithControlPlaneCount(1),
-			api.WithEtcdCountIfExternal(0),
-			api.RemoveAllWorkerNodeGroups(),
-		),
-	)
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		managementCluster,
-	)
-	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
-		test,
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(3),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-	)
-}
-
-func TestTinkerbellKubernetes128UpgradeManagementComponents(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	)
-	// create cluster with old eksa
-	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	test.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-	)
-
-	test.GenerateHardwareConfig(framework.ExecuteWithEksaRelease(release))
-	test.CreateCluster(framework.ExecuteWithEksaRelease(release), framework.WithControlPlaneWaitTimeout("20m"))
-	// upgrade management-components with new eksa
-	test.RunEKSA([]string{"upgrade", "management-components", "-f", test.ClusterConfigLocation, "-v", "99"})
-	test.DeleteCluster()
-}
-
-// TestTinkerbellKubernetes128UbuntuTo132MultipleUpgrade creates a single 1.28 cluster and upgrades it
-// all the way until 1.32. This tests each K8s version upgrade in a single test and saves up
-// hardware which would otherwise be needed for each test as part of both create and upgrade.
-func TestTinkerbellKubernetes128UbuntuTo132MultipleUpgrade(t *testing.T) {
-	var kube129clusterOpts []framework.ClusterE2ETestOpt
-	var kube130clusterOpts []framework.ClusterE2ETestOpt
-	var kube131clusterOpts []framework.ClusterE2ETestOpt
-	var kube132clusterOpts []framework.ClusterE2ETestOpt
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithControlPlaneHardware(2),
-		framework.WithWorkerHardware(2),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	kube129clusterOpts = append(
-		kube129clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
-	)
-	kube130clusterOpts = append(
-		kube130clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
-	)
-	kube131clusterOpts = append(
-		kube131clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
-	)
-	kube132clusterOpts = append(
-		kube132clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-		),
-		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
-	)
-	runMultipleUpgradesFlowForBareMetal(
-		test,
-		kube129clusterOpts,
-		kube130clusterOpts,
-		kube131clusterOpts,
-		kube132clusterOpts,
-	)
-}
-
-// Kubelet Configuration tests
-func TestTinkerbellKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu129Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationTinkerbellFlow(test)
-}
-
-func TestTinkerbellKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationTinkerbellFlow(test)
-}
-
-func TestTinkerbellKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationTinkerbellFlow(test)
-}
-
-func TestTinkerbellKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationTinkerbellFlow(test)
-}
-
-func TestTinkerbellCustomTemplateRefSimpleFlow(t *testing.T) {
-
-	// Get license token for Ubuntu 2204
-	licenseToken := framework.GetLicenseToken()
-
-	// Create a new test with 1 control plane and 1 worker node using Ubuntu 2204
-	provider := framework.NewTinkerbell(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithControlPlaneHardware(1),
-		framework.WithWorkerHardware(1),
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-
-	// Get the custom template config
-	customTemplateConfig, err := framework.GetCustomTinkerbellConfig(
-		test.ClusterConfig.TinkerbellDatacenter.Spec.TinkerbellIP,
-		test.ClusterConfig.TinkerbellDatacenter.Spec.OSImageURL)
-	if err != nil {
-		t.Fatalf("Failed to get custom template config: %v", err)
-	}
-
-	// Add the custom template config to the cluster
-	test.UpdateClusterConfig(
-		provider.WithTinkerbellTemplateConfig(customTemplateConfig),
-	)
-
-	// Get the control plane and worker node names
-	clusterName := test.ClusterName
-	cpName := providers.GetControlPlaneNodeName(clusterName)
-	workerName := clusterName
-
-	// Override the machine config for both control plane and worker nodes
-	test.UpdateClusterConfig(
-		api.TinkerbellToConfigFiller(
-			api.WithCustomTinkerbellMachineConfig(cpName,
-				framework.WithTemplateRef(customTemplateConfig.Name, anywherev1.TinkerbellTemplateConfigKind),
-				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
-				api.WithOsFamilyForTinkerbellMachineConfig(anywherev1.Ubuntu),
-			),
-			api.WithCustomTinkerbellMachineConfig(workerName,
-				framework.WithTemplateRef(customTemplateConfig.Name, anywherev1.TinkerbellTemplateConfigKind),
-				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
-				api.WithOsFamilyForTinkerbellMachineConfig(anywherev1.Ubuntu),
-			),
-		),
-	)
-	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
-}
+// func TestTinkerbellKubernetes132UbuntuSingleNodeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 	)
+
+// 	runTinkerbellSingleNodeFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuSingleNodeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 	)
+
+// 	runTinkerbellSingleNodeFlow(test)
+// }
+
+// // ISO booting tests
+// func TestTinkerbellKubernetes131UbuntuHookIsoSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t,
+// 			framework.WithUbuntu131Tinkerbell(),
+// 			framework.WithHookIsoBoot(),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes131UbuntuHookIsoOverrideSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell(),
+// 			framework.WithHookIsoBoot(),
+// 			framework.WithHookIsoURLPath(framework.HookIsoURLOverride())),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// // Multicluster
+// func TestTinkerbellKubernetes132UbuntuWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuWorkloadClusterWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuWorkloadClusterWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuWorkloadClusterWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		framework.WithFluxGithubConfig(),
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterGitOpsAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		framework.WithFluxGithubConfig(),
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterGitOpsAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuWorkloadClusterGitFluxWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		framework.WithFluxGithubConfig(),
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterGitOpsAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes128BottlerocketWorkloadClusterSimpleFlow(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes128BottlerocketWorkloadClusterWithAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuSingleNodeWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(0),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuSingleNodeWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(0),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuSingleNodeWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 			framework.WithControlPlaneHardware(2),
+// 			framework.WithWorkerHardware(0),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 		),
+// 	)
+// 	runTinkerbellWorkloadClusterFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuSingleNodeWorkloadClusterWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(0),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuSingleNodeWorkloadClusterWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(0),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuSingleNodeWorkloadClusterWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(0),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithEtcdCountIfExternal(0),
+// 				api.RemoveAllWorkerNodeGroups(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterWithAPIFlowForBareMetal(test)
+// }
+
+// func TestTinkerbellUpgrade132MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		framework.WithFluxGithubConfig(),
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterGitOpsAPIUpgradeFlowForBareMetal(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 	)
+// }
+
+// func TestTinkerbellUpgrade134MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		framework.WithFluxGithubConfig(),
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterGitOpsAPIUpgradeFlowForBareMetal(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 	)
+// }
+
+// func TestTinkerbellUpgrade133MulticlusterWorkloadClusterWorkerScaleupGitFluxWithAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 		framework.WithFluxGithubEnvVarCheck(),
+// 		framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		framework.WithFluxGithubConfig(),
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube133),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterGitOpsAPIUpgradeFlowForBareMetal(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeCount(2),
+// 		),
+// 	)
+// }
+
+// func TestTinkerbellUpgrade132MulticlusterWorkloadClusterCPScaleup(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 			framework.WithControlPlaneHardware(4),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		),
+// 	)
+// 	runSimpleWorkloadUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 	)
+// }
+
+// func TestTinkerbellUpgrade134MulticlusterWorkloadClusterCPScaleup(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 			framework.WithControlPlaneHardware(4),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		),
+// 	)
+// 	runSimpleWorkloadUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 	)
+// }
+
+// func TestTinkerbellUpgrade133MulticlusterWorkloadClusterCPScaleup(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 			framework.WithControlPlaneHardware(4),
+// 			framework.WithWorkerHardware(2),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		),
+// 	)
+// 	runSimpleWorkloadUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 	)
+// }
+
+// func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade131To132(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 			framework.WithControlPlaneHardware(3),
+// 			framework.WithWorkerHardware(3),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		),
+// 	)
+// 	runSimpleWorkloadUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
+// 	)
+// }
+
+// func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade133To134(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 			framework.WithControlPlaneHardware(3),
+// 			framework.WithWorkerHardware(3),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		),
+// 	)
+// 	runSimpleWorkloadUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
+// 	)
+// }
+
+// func TestTinkerbellUpgradeMulticlusterWorkloadClusterK8sUpgrade132To133(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 			framework.WithControlPlaneHardware(3),
+// 			framework.WithWorkerHardware(3),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		),
+// 	)
+// 	runSimpleWorkloadUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
+// 	)
+// }
+
+// // OIDC
+// func TestTinkerbellKubernetes132OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellOIDCFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellOIDCFlow(test)
+// }
+
+// // Registry Mirror
+// func TestTinkerbellKubernetes132UbuntuRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.TinkerbellProviderName),
+// 	)
+// 	runTinkerbellRegistryMirrorFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.TinkerbellProviderName),
+// 	)
+// 	runTinkerbellRegistryMirrorFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuInsecureSkipVerifyRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.TinkerbellProviderName),
+// 	)
+// 	runTinkerbellRegistryMirrorFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuInsecureSkipVerifyRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.TinkerbellProviderName),
+// 	)
+// 	runTinkerbellRegistryMirrorFlow(test)
+// }
+
+// func TestTinkerbellKubernetes131UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithAuthenticatedRegistryMirror(constants.TinkerbellProviderName),
+// 	)
+// 	runTinkerbellRegistryMirrorFlow(test)
+// }
+
+// // Simple Flow
+// func TestTinkerbellKubernetes128UbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes129UbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu129Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes130UbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes131UbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes128Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes129Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes130Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes131Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes132Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes134Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes134Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes130Ubuntu2204RTOSSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil, "rtos"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes131Ubuntu2204RTOSSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil, "rtos"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes132Ubuntu2204RTOSSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil, "rtos"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes134Ubuntu2404RTOSSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil, "rtos"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes129Ubuntu2204GenericSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil, "generic"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes130Ubuntu2204GenericSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil, "generic"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes131Ubuntu2204GenericSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil, "generic"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes132Ubuntu2204GenericSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil, "generic"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes134Ubuntu2404GenericSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil, "generic"),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestTinkerbellKubernetes128RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat128Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes129RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat129Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes130RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat130Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes131RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat131Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes128RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat9128Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes129RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat9129Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes130RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat9130Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes131RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat9131Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat9132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithRedHat9134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes128BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithBottleRocketTinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuThreeControlPlaneReplicasSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuThreeControlPlaneReplicasSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuThreeWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(3),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuThreeWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(3),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuControlPlaneScaleUp(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuControlPlaneScaleUp(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuControlPlaneScaleUp(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuWorkerNodeScaleUp(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuWorkerNodeScaleUp(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuWorkerNodeScaleUp(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(2)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuWorkerNodeScaleDown(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuWorkerNodeScaleDown(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuWorkerNodeScaleDown(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(2)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(1)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuControlPlaneScaleDown(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes133UbuntuControlPlaneScaleDown(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes132UbuntuControlPlaneScaleDown(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(3),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(1)),
+// 	)
+// }
+
+// // Worker Nodegroup Taints and Labels
+// func TestTinkerbellKubernetes132UbuntuWorkerNodeGroupsTaintsAndLabels(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(
+// 			t,
+// 			framework.WithUbuntu132Tinkerbell(),
+// 			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel1),
+// 			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel2),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.NoScheduleTaint()}),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithWorkerNodeGroup(worker0, api.WithMachineGroupRef(nodeGroupLabel1, "TinkerbellMachineConfig"), api.WithTaint(framework.PreferNoScheduleTaint()), api.WithLabel(key1, val1), api.WithCount(1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithMachineGroupRef(nodeGroupLabel2, "TinkerbellMachineConfig"), api.WithLabel(key2, val2), api.WithCount(1)),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithCustomLabelHardware(1, nodeGroupLabel1),
+// 		framework.WithCustomLabelHardware(1, nodeGroupLabel2),
+// 	)
+
+// 	test.GenerateClusterConfig()
+// 	test.GenerateHardwareConfig()
+// 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints, framework.ValidateWorkerNodeLabels)
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints, framework.ValidateControlPlaneLabels)
+// 	test.DeleteCluster()
+// 	test.ValidateHardwareDecommissioned()
+// }
+
+// func TestTinkerbellKubernetes134UbuntuWorkerNodeGroupsTaintsAndLabels(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(
+// 			t,
+// 			framework.WithUbuntu134Tinkerbell(),
+// 			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel1),
+// 			framework.WithCustomTinkerbellMachineConfig(nodeGroupLabel2),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.NoScheduleTaint()}),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithWorkerNodeGroup(worker0, api.WithMachineGroupRef(nodeGroupLabel1, "TinkerbellMachineConfig"), api.WithTaint(framework.PreferNoScheduleTaint()), api.WithLabel(key1, val1), api.WithCount(1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithMachineGroupRef(nodeGroupLabel2, "TinkerbellMachineConfig"), api.WithLabel(key2, val2), api.WithCount(1)),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithCustomLabelHardware(1, nodeGroupLabel1),
+// 		framework.WithCustomLabelHardware(1, nodeGroupLabel2),
+// 	)
+
+// 	test.GenerateClusterConfig()
+// 	test.GenerateHardwareConfig()
+// 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
+// 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints, framework.ValidateWorkerNodeLabels)
+// 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints, framework.ValidateControlPlaneLabels)
+// 	test.DeleteCluster()
+// 	test.ValidateHardwareDecommissioned()
+// }
+
+// // Proxy tests
+// func TestTinkerbellAirgappedKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
+// 	localIp, err := networkutils.GetLocalIP()
+// 	if err != nil {
+// 		t.Fatalf("Cannot get admin machine local IP: %v", err)
+// 	}
+// 	t.Logf("Admin machine's IP is: %s", localIp)
+
+// 	kubeVersion := strings.Replace(string(v1alpha1.Kube132), ".", "-", 1)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t,
+// 			framework.WithUbuntu132Tinkerbell(),
+// 			framework.WithHookImagesURLPath(TinkerbellHookOSImagesURLPath),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithProxy(framework.TinkerbellProxyRequiredEnvVars),
+// 	)
+
+// 	runTinkerbellAirgapConfigProxyFlow(test, TinkerbellNoProxyCIDR, kubeVersion)
+// }
+
+// func TestTinkerbellAirgappedKubernetes134UbuntuProxyConfigFlow(t *testing.T) {
+// 	localIp, err := networkutils.GetLocalIP()
+// 	if err != nil {
+// 		t.Fatalf("Cannot get admin machine local IP: %v", err)
+// 	}
+// 	t.Logf("Admin machine's IP is: %s", localIp)
+
+// 	kubeVersion := strings.Replace(string(v1alpha1.Kube134), ".", "-", 1)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t,
+// 			framework.WithUbuntu134Tinkerbell(),
+// 			framework.WithHookImagesURLPath(TinkerbellHookOSImagesURLPath),
+// 		),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 		),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithProxy(framework.TinkerbellProxyRequiredEnvVars),
+// 	)
+
+// 	runTinkerbellAirgapConfigProxyFlow(test, TinkerbellNoProxyCIDR, kubeVersion)
+// }
+
+// // OOB tests
+// func TestTinkerbellKubernetes132UbuntuOOB(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithOOBConfiguration(),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134UbuntuOOB(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithOOBConfiguration(),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	runTinkerbellSimpleFlow(test)
+// }
+
+// func TestTinkerbellK8sUpgrade131to132WithUbuntuOOB(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithOOBConfiguration(),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
+// 	)
+// }
+
+// func TestTinkerbellK8sUpgrade133to134WithUbuntuOOB(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithOOBConfiguration(),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu134Image()),
+// 	)
+// }
+
+// func TestTinkerbellK8sUpgrade132to133WithUbuntuOOB(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithOOBConfiguration(),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	)
+// 	runSimpleUpgradeFlowForBareMetal(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(framework.Ubuntu133Image()),
+// 	)
+// }
+
+// func TestTinkerbellSingleNode131To132UbuntuManagementCPUpgradeAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu131Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
+// 	)
+// }
+
+// func TestTinkerbellSingleNode133To134UbuntuManagementCPUpgradeAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu133Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2004, nil),
+// 	)
+// }
+
+// func TestTinkerbellSingleNode132To133UbuntuManagementCPUpgradeAPI(t *testing.T) {
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithEtcdCountIfExternal(0),
+// 			api.RemoveAllWorkerNodeGroups(),
+// 		),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		managementCluster,
+// 	)
+// 	runWorkloadClusterUpgradeFlowWithAPIForBareMetal(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(3),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 	)
+// }
+
+// func TestTinkerbellKubernetes128UpgradeManagementComponents(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	)
+// 	// create cluster with old eksa
+// 	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	test.UpdateClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 	)
+
+// 	test.GenerateHardwareConfig(framework.ExecuteWithEksaRelease(release))
+// 	test.CreateCluster(framework.ExecuteWithEksaRelease(release), framework.WithControlPlaneWaitTimeout("20m"))
+// 	// upgrade management-components with new eksa
+// 	test.RunEKSA([]string{"upgrade", "management-components", "-f", test.ClusterConfigLocation, "-v", "99"})
+// 	test.DeleteCluster()
+// }
+
+// // TestTinkerbellKubernetes128UbuntuTo132MultipleUpgrade creates a single 1.28 cluster and upgrades it
+// // all the way until 1.32. This tests each K8s version upgrade in a single test and saves up
+// // hardware which would otherwise be needed for each test as part of both create and upgrade.
+// func TestTinkerbellKubernetes128UbuntuTo132MultipleUpgrade(t *testing.T) {
+// 	var kube129clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube130clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube131clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube132clusterOpts []framework.ClusterE2ETestOpt
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewTinkerbell(t, framework.WithUbuntu128Tinkerbell())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithControlPlaneHardware(2),
+// 		framework.WithWorkerHardware(2),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	kube129clusterOpts = append(
+// 		kube129clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu129Image()),
+// 	)
+// 	kube130clusterOpts = append(
+// 		kube130clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu130Image()),
+// 	)
+// 	kube131clusterOpts = append(
+// 		kube131clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu131Image()),
+// 	)
+// 	kube132clusterOpts = append(
+// 		kube132clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 		),
+// 		provider.WithProviderUpgrade(framework.Ubuntu132Image()),
+// 	)
+// 	runMultipleUpgradesFlowForBareMetal(
+// 		test,
+// 		kube129clusterOpts,
+// 		kube130clusterOpts,
+// 		kube131clusterOpts,
+// 		kube132clusterOpts,
+// 	)
+// }
+
+// // Kubelet Configuration tests
+// func TestTinkerbellKubernetes129KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu129Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationTinkerbellFlow(test)
+// }
+
+// func TestTinkerbellKubernetes130KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu130Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationTinkerbellFlow(test)
+// }
+
+// func TestTinkerbellKubernetes132KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu132Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationTinkerbellFlow(test)
+// }
+
+// func TestTinkerbellKubernetes134KubeletConfigurationSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewTinkerbell(t, framework.WithUbuntu134Tinkerbell()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationTinkerbellFlow(test)
+// }
+
+// func TestTinkerbellCustomTemplateRefSimpleFlow(t *testing.T) {
+
+// 	// Get license token for Ubuntu 2204
+// 	licenseToken := framework.GetLicenseToken()
+
+// 	// Create a new test with 1 control plane and 1 worker node using Ubuntu 2204
+// 	provider := framework.NewTinkerbell(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithControlPlaneHardware(1),
+// 		framework.WithWorkerHardware(1),
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+
+// 	// Get the custom template config
+// 	customTemplateConfig, err := framework.GetCustomTinkerbellConfig(
+// 		test.ClusterConfig.TinkerbellDatacenter.Spec.TinkerbellIP,
+// 		test.ClusterConfig.TinkerbellDatacenter.Spec.OSImageURL)
+// 	if err != nil {
+// 		t.Fatalf("Failed to get custom template config: %v", err)
+// 	}
+
+// 	// Add the custom template config to the cluster
+// 	test.UpdateClusterConfig(
+// 		provider.WithTinkerbellTemplateConfig(customTemplateConfig),
+// 	)
+
+// 	// Get the control plane and worker node names
+// 	clusterName := test.ClusterName
+// 	cpName := providers.GetControlPlaneNodeName(clusterName)
+// 	workerName := clusterName
+
+// 	// Override the machine config for both control plane and worker nodes
+// 	test.UpdateClusterConfig(
+// 		api.TinkerbellToConfigFiller(
+// 			api.WithCustomTinkerbellMachineConfig(cpName,
+// 				framework.WithTemplateRef(customTemplateConfig.Name, anywherev1.TinkerbellTemplateConfigKind),
+// 				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
+// 				api.WithOsFamilyForTinkerbellMachineConfig(anywherev1.Ubuntu),
+// 			),
+// 			api.WithCustomTinkerbellMachineConfig(workerName,
+// 				framework.WithTemplateRef(customTemplateConfig.Name, anywherev1.TinkerbellTemplateConfigKind),
+// 				framework.UpdateTinkerbellMachineSSHAuthorizedKey(),
+// 				api.WithOsFamilyForTinkerbellMachineConfig(anywherev1.Ubuntu),
+// 			),
+// 		),
+// 	)
+// 	runTinkerbellSimpleFlowWithoutClusterConfigGeneration(test)
+// }

--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -17,285 +17,285 @@ import (
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
-// APIServerExtraArgs
-func TestVSphereKubernetes134BottlerocketAPIServerExtraArgsSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithControlPlaneAPIServerExtraArgs(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
+// // APIServerExtraArgs
+// func TestVSphereKubernetes134BottlerocketAPIServerExtraArgsSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithControlPlaneAPIServerExtraArgs(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
 
-// TODO: Investigate why this test takes long time to pass with service-account-issuer flag
-func TestVSphereKubernetes134BottlerocketAPIServerExtraArgsUpgradeFlow(t *testing.T) {
-	var addAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
-	var removeAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
-	)
-	addAPIServerExtraArgsclusterOpts = append(
-		addAPIServerExtraArgsclusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithControlPlaneAPIServerExtraArgs(),
-		),
-	)
-	removeAPIServerExtraArgsclusterOpts = append(
-		removeAPIServerExtraArgsclusterOpts,
-		framework.WithClusterUpgrade(
-			api.RemoveAllAPIServerExtraArgs(),
-		),
-	)
-	runAPIServerExtraArgsUpgradeFlow(
-		test,
-		addAPIServerExtraArgsclusterOpts,
-		removeAPIServerExtraArgsclusterOpts,
-	)
-}
+// // TODO: Investigate why this test takes long time to pass with service-account-issuer flag
+// func TestVSphereKubernetes134BottlerocketAPIServerExtraArgsUpgradeFlow(t *testing.T) {
+// 	var addAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
+// 	var removeAPIServerExtraArgsclusterOpts []framework.ClusterE2ETestOpt
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithEnvVar(features.APIServerExtraArgsEnabledEnvVar, "true"),
+// 	)
+// 	addAPIServerExtraArgsclusterOpts = append(
+// 		addAPIServerExtraArgsclusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithControlPlaneAPIServerExtraArgs(),
+// 		),
+// 	)
+// 	removeAPIServerExtraArgsclusterOpts = append(
+// 		removeAPIServerExtraArgsclusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveAllAPIServerExtraArgs(),
+// 		),
+// 	)
+// 	runAPIServerExtraArgsUpgradeFlow(
+// 		test,
+// 		addAPIServerExtraArgsclusterOpts,
+// 		removeAPIServerExtraArgsclusterOpts,
+// 	)
+// }
 
-// Autoimport
-func TestVSphereKubernetes128BottlerocketAutoimport(t *testing.T) {
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithTemplateForAllMachines(""),
-			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
-		),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runAutoImportFlow(test, provider)
-}
+// // Autoimport
+// func TestVSphereKubernetes128BottlerocketAutoimport(t *testing.T) {
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithTemplateForAllMachines(""),
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
+// 		),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runAutoImportFlow(test, provider)
+// }
 
-func TestVSphereKubernetes134BottlerocketAutoimport(t *testing.T) {
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithTemplateForAllMachines(""),
-			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
-		),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runAutoImportFlow(test, provider)
-}
+// func TestVSphereKubernetes134BottlerocketAutoimport(t *testing.T) {
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithTemplateForAllMachines(""),
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
+// 		),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runAutoImportFlow(test, provider)
+// }
 
-// AWS IAM Auth
-func TestVSphereKubernetes128AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// // AWS IAM Auth
+// func TestVSphereKubernetes128AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes129AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes129AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes130AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes130AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes131AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes131AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes130AWSIamAuthWorkloadCluster(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithAWSIam(),
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube130),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runAWSIamAuthFlowWorkload(test)
-}
+// func TestVSphereKubernetes130AWSIamAuthWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithAWSIam(),
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube130),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runAWSIamAuthFlowWorkload(test)
+// }
 
-func TestVSphereKubernetes128BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes128BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes129BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes129BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes130BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes130BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes131BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes131BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes132BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes132BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes133BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes133BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes134AWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes134AWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes134BottleRocketAWSIamAuth(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runAWSIamAuthFlow(test)
-}
+// func TestVSphereKubernetes134BottleRocketAWSIamAuth(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runAWSIamAuthFlow(test)
+// }
 
-func TestVSphereKubernetes132To133AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
+// func TestVSphereKubernetes132To133AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
 
-func TestVSphereKubernetes133To134AWSIamAuthUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithAWSIam(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runUpgradeFlowWithAWSIamAuth(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
+// func TestVSphereKubernetes133To134AWSIamAuthUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithAWSIam(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runUpgradeFlowWithAWSIamAuth(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
 
-// AWS IAM Auth Add/Remove Tests
-func TestVSphereKubernetes128UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithAwsIamEnvVarCheck(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube128)
-}
+// // AWS IAM Auth Add/Remove Tests
+// func TestVSphereKubernetes128UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithAwsIamEnvVarCheck(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube128)
+// }
 
-func TestVSphereKubernetes134UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithAwsIamEnvVarCheck(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube134)
-}
+// func TestVSphereKubernetes134UbuntuAddAWSIamAuthUpgrade(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithAwsIamEnvVarCheck(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runUpgradeFlowAddAWSIamAuth(test, v1alpha1.Kube134)
+// }
 
 // Curated Packages
 func TestVSphereKubernetes128CuratedPackagesSimpleFlow(t *testing.T) {
@@ -1767,1438 +1767,1438 @@ func TestVSphereKubernetes134BottleRocketWorkloadClusterCuratedPackagesCertManag
 	runCertManagerRemoteClusterInstallSimpleFlow(test)
 }
 
-// Download Artifacts
-func TestVSphereDownloadArtifacts(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runDownloadArtifactsFlow(test)
-}
-
-// Flux
-func TestVSphereKubernetes128GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes129GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes130GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes131GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes132GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu132()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes133GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes128GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes129GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes130GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes131GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes132GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu132()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes133GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes134GithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes134GitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes128BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes129BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket129()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes130BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket130()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes131BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket131()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes132BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket132()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes133BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket133()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes128BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes129BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket129()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes130BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket130()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes131BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket131()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes132BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket132()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes133BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket133()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes134BottleRocketGithubFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithFluxGithub(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes134BottleRocketGitFlux(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runFluxFlow(test)
-}
-
-func TestVSphereKubernetes128To129GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu131())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134GitFluxUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithFluxGit(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestVSphereInstallGitFluxDuringUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithFlux(
-		test,
-		v1alpha1.Kube132,
-		framework.WithFluxGit(),
-		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
-	)
-}
-
-// Labels
-func TestVSphereKubernetes128UbuntuLabelsUpgradeFlow(t *testing.T) {
-	provider := ubuntu128ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestVSphereKubernetes134UbuntuLabelsUpgradeFlow(t *testing.T) {
-	provider := ubuntu134ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketLabelsUpgradeFlow(t *testing.T) {
-	provider := bottlerocket128ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-func TestVSphereKubernetes134BottlerocketLabelsUpgradeFlow(t *testing.T) {
-	provider := bottlerocket134ProviderWithLabels(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runLabelsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
-			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
-			api.WithWorkerNodeGroup(worker2),
-			api.WithControlPlaneLabel(cpKey1, cpVal1),
-		),
-	)
-}
-
-// Multicluster
-func TestVSphereKubernetes128MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-func TestVSphereKubernetes134MulticlusterWorkloadCluster(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu134())
-	test := framework.NewMulticlusterE2ETest(
-		t,
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-		),
-	)
-	runWorkloadClusterFlow(test)
-}
-
-// OIDC
-func TestVSphereKubernetes128OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes129OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes130OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes131OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes132OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes133OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes134OIDC(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runOIDCFlow(test)
-}
-
-func TestVSphereKubernetes132To133OIDCUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithOIDC(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134OIDCUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithOIDC(),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFlowWithOIDC(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-// Proxy Config
-func TestVSphereKubernetes128UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes129UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes130UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes131UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes133UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes128BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes129BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes130BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes131BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes132BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes133BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes134UbuntuProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-func TestVSphereKubernetes134BottlerocketProxyConfigFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134(),
-			framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-	runProxyConfigFlow(test)
-}
-
-// Registry Mirror
-func TestVSphereKubernetes133UbuntuRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes134UbuntuRegistryMirrorInsecureSkipVerify(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorInsecureSkipVerify(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes128UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes129UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes130UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes131UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes132UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes133UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes134UbuntuRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes128BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes129BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes130BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes131BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes132BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes133BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes134BottlerocketRegistryMirrorAndCert(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes128UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes131UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes132UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes133UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes134UbuntuAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes128BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes134BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes129BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes130BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes131BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes132BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes133BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes129BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes134BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes130BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes131BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes132BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
-
-func TestVSphereKubernetes133BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
-	)
-	runRegistryMirrorConfigFlow(test)
-}
+// // Download Artifacts
+// func TestVSphereDownloadArtifacts(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runDownloadArtifactsFlow(test)
+// }
+
+// // Flux
+// func TestVSphereKubernetes128GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes129GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes130GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes131GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes132GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes133GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes128GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes129GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes130GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes131GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes132GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes133GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes134GithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes134GitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottleRocketGithubFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithFluxGithub(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottleRocketGitFlux(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runFluxFlow(test)
+// }
+
+// func TestVSphereKubernetes128To129GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134GitFluxUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestVSphereInstallGitFluxDuringUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithFlux(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithFluxGit(),
+// 		framework.WithClusterUpgrade(api.WithGitOpsRef(framework.DefaultFluxConfigName, v1alpha1.FluxConfigKind)),
+// 	)
+// }
+
+// // Labels
+// func TestVSphereKubernetes128UbuntuLabelsUpgradeFlow(t *testing.T) {
+// 	provider := ubuntu128ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UbuntuLabelsUpgradeFlow(t *testing.T) {
+// 	provider := ubuntu134ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketLabelsUpgradeFlow(t *testing.T) {
+// 	provider := bottlerocket128ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134BottlerocketLabelsUpgradeFlow(t *testing.T) {
+// 	provider := bottlerocket134ProviderWithLabels(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runLabelsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithLabel(key1, val1)),
+// 			api.WithWorkerNodeGroup(worker1, api.WithLabel(key2, val2)),
+// 			api.WithWorkerNodeGroup(worker2),
+// 			api.WithControlPlaneLabel(cpKey1, cpVal1),
+// 		),
+// 	)
+// }
+
+// // Multicluster
+// func TestVSphereKubernetes128MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// func TestVSphereKubernetes134MulticlusterWorkloadCluster(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu134())
+// 	test := framework.NewMulticlusterE2ETest(
+// 		t,
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube134),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 		),
+// 	)
+// 	runWorkloadClusterFlow(test)
+// }
+
+// // OIDC
+// func TestVSphereKubernetes128OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes129OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes130OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes131OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes132OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes133OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes134OIDC(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runOIDCFlow(test)
+// }
+
+// func TestVSphereKubernetes132To133OIDCUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithOIDC(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134OIDCUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithOIDC(),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFlowWithOIDC(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// // Proxy Config
+// func TestVSphereKubernetes128UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134UbuntuProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottlerocketProxyConfigFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134(),
+// 			framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+// 	runProxyConfigFlow(test)
+// }
+
+// // Registry Mirror
+// func TestVSphereKubernetes133UbuntuRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134UbuntuRegistryMirrorInsecureSkipVerify(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorInsecureSkipVerify(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes128UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134UbuntuRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottlerocketRegistryMirrorAndCert(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes128UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134UbuntuAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottlerocketAuthenticatedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithAuthenticatedRegistryMirror(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottlerocketRegistryMirrorOciNamespaces(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorOciNamespaces(constants.VSphereProviderName),
+// 	)
+// 	runRegistryMirrorConfigFlow(test)
+// }
 
 func TestVSphereKubernetes129UbuntuAuthenticatedRegistryMirrorCuratedPackagesSimpleFlow(t *testing.T) {
 	framework.CheckCuratedPackagesCredentials(t)
@@ -3326,6110 +3326,6110 @@ func TestVSphereKubernetes133UbuntuAuthenticatedRegistryMirrorCuratedPackagesSim
 	runCuratedPackageInstallSimpleFlowRegistryMirror(test)
 }
 
-// Clone mode
-func TestVSphereKubernetes128FullClone(t *testing.T) {
-	diskSize := 30
-	vsphere := framework.NewVSphere(t,
-		framework.WithUbuntu128(),
-		framework.WithFullCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes134FullClone(t *testing.T) {
-	diskSize := 30
-	vsphere := framework.NewVSphere(t,
-		framework.WithUbuntu134(),
-		framework.WithFullCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes128LinkedClone(t *testing.T) {
-	diskSize := 20
-	vsphere := framework.NewVSphere(t,
-		framework.WithUbuntu128(),
-		framework.WithLinkedCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes134LinkedClone(t *testing.T) {
-	diskSize := 20
-	vsphere := framework.NewVSphere(t,
-		framework.WithUbuntu134(),
-		framework.WithLinkedCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes128BottlerocketFullClone(t *testing.T) {
-	diskSize := 30
-	vsphere := framework.NewVSphere(t,
-		framework.WithBottleRocket128(),
-		framework.WithFullCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes134BottlerocketFullClone(t *testing.T) {
-	diskSize := 30
-	vsphere := framework.NewVSphere(t,
-		framework.WithBottleRocket134(),
-		framework.WithFullCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes128BottlerocketLinkedClone(t *testing.T) {
-	diskSize := 22
-	vsphere := framework.NewVSphere(t,
-		framework.WithBottleRocket128(),
-		framework.WithLinkedCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-func TestVSphereKubernetes134BottlerocketLinkedClone(t *testing.T) {
-	diskSize := 22
-	vsphere := framework.NewVSphere(t,
-		framework.WithBottleRocket134(),
-		framework.WithLinkedCloneMode(),
-		framework.WithDiskGiBForAllMachines(diskSize),
-	)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		vsphere,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-	)
-	runVSphereCloneModeFlow(test, vsphere, diskSize)
-}
-
-// Simple Flow
-func TestVSphereKubernetes128Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134Ubuntu2004SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes129Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes130Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes131Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes132Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes133Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(api.WithLicenseToken(licenseToken)),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes133Ubuntu2204NetworksSimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t,
-		// Add worker node group with second network config
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(1)),
-			framework.WithSecondNetwork(),
-		),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-
-	// Create cluster and validate the network is up
-	runSimpleFlowWithSecondNetworkValidation(test, worker0)
-}
-
-func TestVSphereKubernetes128Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes129Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes130Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes131Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes132Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes133Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes134Ubuntu2204SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(api.WithLicenseToken(licenseToken)),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes134Ubuntu2404SimpleFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleFlowWithoutClusterConfigGeneration(test)
-}
-
-func TestVSphereKubernetes128RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat128VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat129VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat130VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131RedHatSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat131VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9128VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9129VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9130VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9131VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9132VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9133VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134RedHat9SimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithRedHat9134VSphere()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134DifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134BottleRocketSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket130(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket131(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket132(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket133(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes134BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134(),
-			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
-	)
-	runSimpleFlow(test)
-}
-
-// Cilium Helm Values Tests - Ubuntu
-func TestVSphereKubernetes128CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes129CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes130CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes131CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes132CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-// Cilium Helm Values Precedence Tests - Validate helmValues overrides deprecated fields
-func TestVSphereKubernetes128CiliumHelmValuesPrecedenceUbuntuFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeDefault)), // This should be ignored
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"policyEnforcementMode": "always", // This should take precedence
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133CiliumHelmValuesPrecedenceUbuntuFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeDefault)), // This should be ignored
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"policyEnforcementMode": "always", // This should take precedence
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-// Cilium Helm Values Complex Configuration Tests
-func TestVSphereKubernetes128CiliumHelmValuesComplexConfigUbuntuFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-				"replicas": 2,
-			},
-			"policyEnforcementMode": "always",
-			"routingMode":           "native",
-			"ipv4NativeRoutingCIDR": "192.168.0.0/16",
-			"autoDirectNodeRoutes":  "true",
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-func TestVSphereKubernetes133CiliumHelmValuesComplexConfigUbuntuFlow(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
-			"prometheus": map[string]interface{}{
-				"enabled": true,
-			},
-			"operator": map[string]interface{}{
-				"prometheus": map[string]interface{}{
-					"enabled": false,
-				},
-				"replicas": 2,
-			},
-			"policyEnforcementMode": "always",
-			"routingMode":           "native",
-			"ipv4NativeRoutingCIDR": "192.168.0.0/16",
-			"autoDirectNodeRoutes":  "true",
-		})),
-	)
-	runSimpleFlow(test)
-}
-
-// NTP Servers test
-func TestVSphereKubernetes128BottleRocketWithNTP(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(
-			t, framework.WithBottleRocket128(),
-			framework.WithNTPServersForAllMachines(),
-			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runNTPFlow(test, v1alpha1.Bottlerocket)
-}
-
-func TestVSphereKubernetes134BottleRocketWithNTP(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(
-			t, framework.WithBottleRocket134(),
-			framework.WithNTPServersForAllMachines(),
-			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runNTPFlow(test, v1alpha1.Bottlerocket)
-}
-
-func TestVSphereKubernetes128UbuntuWithNTP(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(
-			t, framework.WithUbuntu128(),
-			framework.WithNTPServersForAllMachines(),
-			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runNTPFlow(test, v1alpha1.Ubuntu)
-}
-
-func TestVSphereKubernetes134UbuntuWithNTP(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(
-			t, framework.WithUbuntu134(),
-			framework.WithNTPServersForAllMachines(),
-			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runNTPFlow(test, v1alpha1.Ubuntu)
-}
-
-// Bottlerocket Configuration tests
-func TestVSphereKubernetes128BottlerocketWithBottlerocketKubernetesSettings(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(
-			t, framework.WithBottleRocket128(),
-			framework.WithBottlerocketKubernetesSettingsForAllMachines(),
-			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runBottlerocketConfigurationFlow(test)
-}
-
-func TestVSphereKubernetes134BottlerocketWithBottlerocketKubernetesSettings(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(
-			t, framework.WithBottleRocket134(),
-			framework.WithBottlerocketKubernetesSettingsForAllMachines(),
-			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
-		),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-	)
-	runBottlerocketConfigurationFlow(test)
-}
-
-// Stacked Etcd
-func TestVSphereKubernetes128StackedEtcdUbuntu(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-func TestVSphereKubernetes134StackedEtcdUbuntu(t *testing.T) {
-	test := framework.NewClusterE2ETest(t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
-	runStackedEtcdFlow(test)
-}
-
-// Taints
-func TestVSphereKubernetes128UbuntuTaintsUpgradeFlow(t *testing.T) {
-	provider := ubuntu128ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes134UbuntuTaintsUpgradeFlow(t *testing.T) {
-	provider := ubuntu134ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketTaintsUpgradeFlow(t *testing.T) {
-	provider := bottlerocket128ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes134BottlerocketTaintsUpgradeFlow(t *testing.T) {
-	provider := bottlerocket134ProviderWithTaints(t)
-
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runTaintsUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuWorkloadClusterTaintsFlow(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithExternalEtcdTopology(1),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			provider.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			provider.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoExecuteTaint()))),
-		),
-	)
-
-	runWorkloadClusterExistingConfigFlow(test)
-}
-
-// Upgrade
-func TestVSphereKubernetes128UbuntuTo129Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestVSphereKubernetes129UbuntuTo130Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
-	)
-}
-
-func TestVSphereKubernetes130UbuntuTo131Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
-	)
-}
-
-func TestVSphereKubernetes131UbuntuTo132Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
-	)
-}
-
-func TestVSphereKubernetes132UbuntuTo133Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuTo134Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134Ubuntu2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes134Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes134Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134Ubuntu2404Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes134Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
-		api.ClusterToConfigFiller(
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes134Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129RedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat128VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130RedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat129VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131RedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat130VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat131Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9128VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat9129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9129VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9130VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9131VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9132VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134RedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9133VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9134Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129StackedEtcdRedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat128VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130StackedEtcdRedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat129VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131StackedEtcdRedHatUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat130VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat131Template()),
-	)
-}
-
-func TestVSphereKubernetes128To129StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9128VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Redhat9129Template()),
-	)
-}
-
-func TestVSphereKubernetes129To130StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9129VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Redhat9130Template()),
-	)
-}
-
-func TestVSphereKubernetes130To131StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9130VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Redhat9131Template()),
-	)
-}
-
-func TestVSphereKubernetes131To132StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9131VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Redhat9132Template()),
-	)
-}
-
-func TestVSphereKubernetes132To133StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9132VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Redhat9133Template()),
-	)
-}
-
-func TestVSphereKubernetes133To134StackedEtcdRedHat9Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithRedHat9133VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9134Template()),
-	)
-}
-
-func TestVSphereKubernetes128Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes128Template()),
-	)
-}
-
-func TestVSphereKubernetes129Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes129Template()),
-	)
-}
-
-func TestVSphereKubernetes130Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes130Template()),
-	)
-}
-
-func TestVSphereKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes131Template()),
-	)
-}
-
-func TestVSphereKubernetes132Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes132Template()),
-	)
-}
-
-func TestVSphereKubernetes133Ubuntu2004To2204Upgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
-		api.ClusterToConfigFiller(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes133Template()),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuTo129InPlaceUpgradeCPOnly(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	kube128 := v1alpha1.Kube128
-	kube129 := v1alpha1.Kube129
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(kube128),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube128),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-	)
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129TemplateForMachineConfig(providers.GetControlPlaneNodeName(test.ClusterName))),
-	)
-}
-
-func TestVSphereKubernetes132UbuntuTo133InPlaceUpgradeWorkerOnly(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	kube132 := v1alpha1.Kube132
-	kube133 := v1alpha1.Kube133
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(kube133),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-	)
-	test.UpdateClusterConfig(
-		provider.WithKubeVersionAndOSMachineConfig(providers.GetControlPlaneNodeName(test.ClusterName), kube133, framework.Ubuntu2004),
-	)
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()), // this will just set everything to 1.33 as expected
-	)
-}
-
-func TestVSphereKubernetes128UbuntuTo129MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(
-			provider.Ubuntu129Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes129UbuntuTo130MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(
-			provider.Ubuntu130Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes130UbuntuTo131MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(
-			provider.Ubuntu131Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes131UbuntuTo132MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(
-			provider.Ubuntu132Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes132UbuntuTo133MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(
-			provider.Ubuntu133Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuTo134MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(
-			provider.Ubuntu134Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes129UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes130UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes131UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes132UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes129UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes130UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes131UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes132UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes134UbuntuControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes134UbuntuWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketTo129Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
-	)
-}
-
-func TestVSphereKubernetes129BottlerocketTo130Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Bottlerocket130Template()),
-	)
-}
-
-func TestVSphereKubernetes130BottlerocketTo131Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Bottlerocket131Template()),
-	)
-}
-
-func TestVSphereKubernetes131BottlerocketTo132Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Bottlerocket132Template()),
-	)
-}
-
-func TestVSphereKubernetes132BottlerocketTo133Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Bottlerocket133Template()),
-	)
-}
-
-func TestVSphereKubernetes133BottlerocketTo134Upgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Bottlerocket134Template()),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketTo129MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket129Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes129BottlerocketTo130MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket130Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes130BottlerocketTo131MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket131Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes131BottlerocketTo132MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket132Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes132BottlerocketTo133MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket133Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes133BottlerocketTo134MultipleFieldsUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(
-			provider.Bottlerocket134Template(),
-			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
-			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
-			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
-			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
-			// Uncomment once we support tests with multiple machine configs
-			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
-			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
-			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
-			// Uncomment the network field once upgrade starts working with it
-			// api.WithNetwork(vsphereNetwork2UpdateVar),
-		),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes129BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes130BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes131BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes132BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes133BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes129BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes130BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes131BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes132BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes133BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes134BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
-	)
-}
-
-func TestVSphereKubernetes134BottlerocketWorkerNodeUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket134())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuTo129StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestVSphereKubernetes129UbuntuTo130StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
-	)
-}
-
-func TestVSphereKubernetes130UbuntuTo131StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
-	)
-}
-
-func TestVSphereKubernetes131UbuntuTo132StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketTo129StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
-	)
-}
-
-func TestVSphereKubernetes129BottlerocketTo130StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube130,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		provider.WithProviderUpgrade(provider.Bottlerocket130Template()),
-	)
-}
-
-func TestVSphereKubernetes130BottlerocketTo131StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube131,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		provider.WithProviderUpgrade(provider.Bottlerocket131Template()),
-	)
-}
-
-func TestVSphereKubernetes131BottlerocketTo132StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube132,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		provider.WithProviderUpgrade(provider.Bottlerocket132Template()),
-	)
-}
-
-func TestVSphereKubernetes132BottlerocketTo133StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube133,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		provider.WithProviderUpgrade(provider.Bottlerocket133Template()),
-	)
-}
-
-func TestVSphereKubernetes133BottlerocketTo134StackedEtcdUpgrade(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
-	)
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Bottlerocket134Template()),
-	)
-}
-
-func TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube132,
-		provider.WithProviderUpgrade(
-			provider.Redhat9132Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
-	provider := framework.NewVSphere(t)
-	runTestManagementClusterUpgradeSideEffects(t, provider, framework.Ubuntu2004, v1alpha1.Kube133)
-}
-
-func TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube129,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu129Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes129To130UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube129, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube130,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu130Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes130To131UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube130, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube131,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu131Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes131To132UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube131, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube132,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu132Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes132To133UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube133,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu133Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes132To133UbuntuInPlaceUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(
-		t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	)
-	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	test.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithStackedEtcdTopology(),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-	)
-	runInPlaceUpgradeFromReleaseFlow(
-		test,
-		release,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketAndRemoveWorkerNodeGroups(t *testing.T) {
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			"worker-2",
-			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
-		),
-		framework.WithBottleRocket128(),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.RemoveWorkerNodeGroup("workers-2"),
-			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
-		),
-		provider.WithNewVSphereWorkerNodeGroup(
-			"worker-1",
-			framework.WithWorkerNodeGroup(
-				"workers-3",
-				api.WithCount(1),
-			),
-		),
-	)
-}
-
-func TestVSphereKubernetes128To129RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.RedHat8, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube129,
-		provider.WithProviderUpgrade(
-			provider.Redhat129Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes129To130RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube129, framework.RedHat8, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube130,
-		provider.WithProviderUpgrade(
-			provider.Redhat130Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes130To131RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube130, framework.RedHat8, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube131,
-		provider.WithProviderUpgrade(
-			provider.Redhat131Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes128To129Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube129,
-		provider.WithProviderUpgrade(
-			provider.Redhat9129Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes129To130Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube129, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube130,
-		provider.WithProviderUpgrade(
-			provider.Redhat9130Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes130To131Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube130, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube131,
-		provider.WithProviderUpgrade(
-			provider.Redhat9131Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes131To132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube131, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube132,
-		provider.WithProviderUpgrade(
-			provider.Redhat9132Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes132To133Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube133,
-		provider.WithProviderUpgrade(
-			provider.Redhat9133Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes133To134UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube133, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube134,
-		provider.WithProviderUpgrade(
-			provider.Ubuntu134Template(), // Set the template so it doesn't get autoimported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes133To134Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube133, framework.RedHat9, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-	)
-	runUpgradeFromReleaseFlow(
-		test,
-		release,
-		v1alpha1.Kube134,
-		provider.WithProviderUpgrade(
-			provider.Redhat9134Template(), // Set the template so it doesn't get auto-imported
-		),
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithLicenseToken(licenseToken),
-		),
-	)
-}
-
-func TestVSphereKubernetes133To134UbuntuInPlaceUpgradeFromLatestMinorRelease(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	release := latestMinorRelease(t)
-	useBundlesOverride := false
-	provider := framework.NewVSphere(
-		t,
-		framework.WithVSphereFillers(
-			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
-		),
-		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube133, framework.Ubuntu2004, release, useBundlesOverride),
-	)
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	)
-	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	test.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithStackedEtcdTopology(),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-	)
-	runInPlaceUpgradeFromReleaseFlow(
-		test,
-		release,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestVSphereKubernetes134MulticlusterWorkloadClusterAPI(t *testing.T) {
-	vsphere := framework.NewVSphere(t)
-	// add licensetoken for k8s version 1.28 and 1.29
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		vsphere.WithUbuntu134(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu131(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu132(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken),
-			),
-			vsphere.WithUbuntu129(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithUbuntu130(),
-		),
-	)
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes134UpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
-			vsphere.WithUbuntu134(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
-			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes134UpgradeWorkerNodeGroupsUbuntuAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithUbuntu134(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-			api.RemoveWorkerNodeGroup("worker-1"),
-		),
-		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-	)
-}
-
-func TestVSphereKubernetes134MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
-	vsphere := framework.NewVSphere(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		framework.WithFluxGithubConfig(),
-		vsphere.WithUbuntu134(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu134(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithExternalEtcdTopology(1),
-			),
-			vsphere.WithUbuntu134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes134CiliumUbuntuAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu134(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithUbuntu134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.UpdateClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
-			),
-		)
-		wc.ApplyClusterManifest()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes134UpgradeLabelsTaintsBottleRocketGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithBottleRocket134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
-			vsphere.WithBottleRocket134(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
-			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes134UpgradeWorkerNodeGroupsUbuntuGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithUbuntu134(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-			api.RemoveWorkerNodeGroup("worker-1"),
-		),
-		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-	)
-}
-
-func TestVSphereUpgradeKubernetes134CiliumUbuntuGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu134(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithUbuntu134(),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		test.PushWorkloadClusterToGit(wc,
-			api.ClusterToConfigFiller(
-				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
-			),
-			vsphere.WithUbuntu134(),
-		)
-		wc.ValidateClusterState()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes134UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t)
-	test := framework.NewClusterE2ETest(
-		t, provider,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-			api.WithLicenseToken(licenseToken),
-		),
-		provider.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
-		provider.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-		provider.WithNewWorkerNodeGroup("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend"))),
-		provider.WithUbuntu134(),
-	)
-
-	runUpgradeFlowWithAPI(
-		test,
-		api.ClusterToConfigFiller(
-			api.RemoveWorkerNodeGroup("worker-2"),
-			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
-			api.RemoveWorkerNodeGroup("worker-3"),
-		),
-		// Re-adding with no labels and a taint
-		provider.WithWorkerNodeGroupConfiguration("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint()))),
-		provider.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
-	)
-}
-
-func TestVSphereKubernetes132to133UpgradeFromLatestMinorReleaseBottleRocketAPI(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewVSphere(t)
-	useBundlesOverride := false
-	managementCluster := framework.NewClusterE2ETest(
-		t, provider,
-	)
-	managementCluster.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	managementCluster.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-		),
-		api.VSphereToConfigFiller(
-			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
-		),
-		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Bottlerocket1, release, useBundlesOverride),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	wc := framework.NewClusterE2ETest(
-		t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
-	)
-	wc.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
-	wc.UpdateClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithManagementCluster(managementCluster.ClusterName),
-		),
-		api.VSphereToConfigFiller(
-			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
-		),
-		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Bottlerocket1, release, useBundlesOverride),
-	)
-
-	test.WithWorkloadClusters(wc)
-
-	runMulticlusterUpgradeFromReleaseFlowAPI(
-		test,
-		release,
-		wc.ClusterConfig.Cluster.Spec.KubernetesVersion,
-		v1alpha1.Kube133,
-		framework.Bottlerocket1,
-	)
-}
-
-func TestVSphereKubernetes128UbuntuTo129InPlaceUpgrade_1CP_3Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(3),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-	)
-
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuTo134InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-	)
-
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestVSphereKubernetes133RedHat9To134InPlaceUpgrade_1CP_1Worker(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithRedHat9133VSphere())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.RedHat9, nil),
-	)
-
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		provider.WithProviderUpgrade(provider.Redhat9134Template()),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuTo133InPlaceUpgrade(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	var kube129clusterOpts []framework.ClusterE2ETestOpt
-	var kube130clusterOpts []framework.ClusterE2ETestOpt
-	var kube131clusterOpts []framework.ClusterE2ETestOpt
-	var kube132clusterOpts []framework.ClusterE2ETestOpt
-	var kube133clusterOpts []framework.ClusterE2ETestOpt
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-	)
-	kube129clusterOpts = append(
-		kube129clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-	kube130clusterOpts = append(
-		kube130clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube130),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
-	)
-	kube131clusterOpts = append(
-		kube131clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube131),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
-	)
-	kube132clusterOpts = append(
-		kube132clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
-	)
-	kube133clusterOpts = append(
-		kube133clusterOpts,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-	runInPlaceMultipleUpgradesFlow(
-		test,
-		kube129clusterOpts,
-		kube130clusterOpts,
-		kube131clusterOpts,
-		kube132clusterOpts,
-		kube133clusterOpts,
-	)
-}
-
-func TestVSphereKubernetes133UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-	)
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(
-			api.WithControlPlaneCount(3),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuInPlaceCPScaleDown3To1(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(3),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-	)
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(
-			api.WithControlPlaneCount(1),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuInPlaceWorkerScaleUp1To2(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-	)
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeCount(2),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-	)
-}
-
-func TestVSphereKubernetes133UbuntuInPlaceWorkerScaleDown2To1(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(2),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
-	)
-	runInPlaceUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(
-			api.WithWorkerNodeCount(1),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-	)
-}
-
-func TestVSphereKubernetes128UpgradeManagementComponents(t *testing.T) {
-	release := latestMinorRelease(t)
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube128, framework.Ubuntu2004)
-}
-
-func TestVSphereInPlaceUpgradeMulticlusterWorkloadClusterK8sUpgrade128To129(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewVSphere(t, framework.WithUbuntu128())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithKubernetesVersion(v1alpha1.Kube128),
-				api.WithStackedEtcdTopology(),
-				api.WithInPlaceUpgradeStrategy(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			api.VSphereToConfigFiller(
-				api.RemoveEtcdVsphereMachineConfig(),
-			),
-			provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
-		),
-	)
-	runInPlaceWorkloadUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
-	)
-}
-
-func TestVSphereInPlaceUpgradeMulticlusterWorkloadClusterK8sUpgrade132To133(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	provider := framework.NewVSphere(t, framework.WithUbuntu132())
-	managementCluster := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube132),
-			api.WithStackedEtcdTopology(),
-			api.WithInPlaceUpgradeStrategy(),
-			api.WithLicenseToken(licenseToken),
-		),
-		api.VSphereToConfigFiller(
-			api.RemoveEtcdVsphereMachineConfig(),
-		),
-		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t,
-			provider,
-			framework.WithClusterName(test.NewWorkloadClusterName()),
-			framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithKubernetesVersion(v1alpha1.Kube132),
-				api.WithStackedEtcdTopology(),
-				api.WithInPlaceUpgradeStrategy(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			api.VSphereToConfigFiller(
-				api.RemoveEtcdVsphereMachineConfig(),
-			),
-			provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
-		),
-	)
-	runInPlaceWorkloadUpgradeFlow(
-		test,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithInPlaceUpgradeStrategy(),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
-	)
-}
-
-// Workload API
-func TestVSphereKubernetes133MulticlusterWorkloadClusterAPI(t *testing.T) {
-	vsphere := framework.NewVSphere(t)
-	// add licensetoken for k8s version 1.28 and 1.29
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		vsphere.WithUbuntu133(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu131(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu132(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken),
-			),
-			vsphere.WithUbuntu129(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithUbuntu130(),
-		),
-	)
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes133UpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
-			vsphere.WithUbuntu133(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
-			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes133UpgradeWorkerNodeGroupsUbuntuAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithUbuntu133(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPI(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-			api.RemoveWorkerNodeGroup("worker-1"),
-		),
-		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-	)
-}
-
-func TestVSphereKubernetes133MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
-	vsphere := framework.NewVSphere(t)
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-		),
-		framework.WithFluxGithubConfig(),
-		vsphere.WithUbuntu133(),
-	)
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithStackedEtcdTopology(),
-			),
-			vsphere.WithUbuntu133(),
-		),
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithControlPlaneCount(1),
-				api.WithWorkerNodeCount(1),
-				api.WithExternalEtcdTopology(1),
-			),
-			vsphere.WithUbuntu133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes133CiliumUbuntuAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere,
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu133(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithUbuntu133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		wc.ApplyClusterManifest()
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		wc.UpdateClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
-			),
-		)
-		wc.ApplyClusterManifest()
-		wc.ValidateClusterState()
-		wc.DeleteClusterWithKubectl()
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-func TestVSphereKubernetes133UpgradeLabelsTaintsBottleRocketGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithBottleRocket133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
-			vsphere.WithBottleRocket133(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
-			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
-			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
-			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
-		),
-	)
-}
-
-func TestVSphereKubernetes133UpgradeWorkerNodeGroupsUbuntuGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
-			vsphere.WithUbuntu133(),
-		),
-	)
-
-	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
-		api.ClusterToConfigFiller(
-			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
-			api.RemoveWorkerNodeGroup("worker-1"),
-		),
-		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
-	)
-}
-
-func TestVSphereUpgradeKubernetes133CiliumUbuntuGitHubFluxAPI(t *testing.T) {
-	licenseToken := framework.GetLicenseToken()
-	licenseToken2 := framework.GetLicenseToken2()
-	vsphere := framework.NewVSphere(t)
-
-	managementCluster := framework.NewClusterE2ETest(
-		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
-	).WithClusterConfig(
-		api.ClusterToConfigFiller(
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-			api.WithStackedEtcdTopology(),
-			api.WithLicenseToken(licenseToken),
-		),
-		vsphere.WithUbuntu133(),
-		framework.WithFluxGithubConfig(),
-	)
-
-	test := framework.NewMulticlusterE2ETest(t, managementCluster)
-	test.WithWorkloadClusters(
-		framework.NewClusterE2ETest(
-			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
-		).WithClusterConfig(
-			api.ClusterToConfigFiller(
-				api.WithManagementCluster(managementCluster.ClusterName),
-				api.WithExternalEtcdTopology(1),
-				api.WithControlPlaneCount(1),
-				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
-				api.WithLicenseToken(licenseToken2),
-			),
-			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
-			vsphere.WithUbuntu133(),
-		),
-	)
-
-	test.CreateManagementCluster()
-	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
-		test.PushWorkloadClusterToGit(wc)
-		wc.WaitForKubeconfig()
-		wc.ValidateClusterState()
-		test.PushWorkloadClusterToGit(wc,
-			api.ClusterToConfigFiller(
-				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
-			),
-			vsphere.WithUbuntu133(),
-		)
-		wc.ValidateClusterState()
-		test.DeleteWorkloadClusterFromGit(wc)
-		wc.ValidateClusterDelete()
-	})
-	test.ManagementCluster.StopIfFailed()
-	test.DeleteManagementCluster()
-}
-
-// Airgapped tests
-func TestVSphereKubernetes128UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes129UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes130UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes131UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes132UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes133UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes129UbuntuAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes130UbuntuAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes131UbuntuAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes132UbuntuAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes133UbuntuAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes134UbuntuAirgappedRegistryMirror(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
-	)
-
-	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-func TestVSphereKubernetes134UbuntuAirgappedProxy(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
-		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
-		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
-		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
-	)
-
-	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
-}
-
-// Etcd Encryption
-func TestVSphereKubernetesUbuntu128EtcdEncryption(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-		),
-		framework.WithPodIamConfig(),
-	)
-	test.OSFamily = v1alpha1.Ubuntu
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.PostClusterCreateEtcdEncryptionSetup()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
-	test.StopIfFailed()
-	test.ValidateEtcdEncryption()
-	test.DeleteCluster()
-}
-
-func TestVSphereKubernetesUbuntu134EtcdEncryption(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-		),
-		framework.WithPodIamConfig(),
-	)
-	test.OSFamily = v1alpha1.Ubuntu
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.PostClusterCreateEtcdEncryptionSetup()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
-	test.StopIfFailed()
-	test.ValidateEtcdEncryption()
-	test.DeleteCluster()
-}
-
-func TestVSphereKubernetesBottlerocket128EtcdEncryption(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-		),
-		framework.WithPodIamConfig(),
-	)
-	test.OSFamily = v1alpha1.Bottlerocket
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.PostClusterCreateEtcdEncryptionSetup()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
-	test.StopIfFailed()
-	test.DeleteCluster()
-}
-
-func TestVSphereKubernetesBottlerocket134EtcdEncryption(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-		),
-		framework.WithPodIamConfig(),
-	)
-	test.OSFamily = v1alpha1.Bottlerocket
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	test.PostClusterCreateEtcdEncryptionSetup()
-	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
-	test.StopIfFailed()
-	test.DeleteCluster()
-}
-
-func ubuntu128ProviderWithLabels(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithUbuntu128(),
-	)
-}
-
-func bottlerocket128ProviderWithLabels(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithBottleRocket128(),
-	)
-}
-
-func ubuntu134ProviderWithLabels(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithUbuntu134(),
-	)
-}
-
-func bottlerocket134ProviderWithLabels(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
-				api.WithLabel(key1, val2)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
-				api.WithLabel(key2, val2)),
-		),
-		framework.WithBottleRocket134(),
-	)
-}
-
-func ubuntu128ProviderWithTaints(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithUbuntu128(),
-	)
-}
-
-func bottlerocket128ProviderWithTaints(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithBottleRocket128(),
-	)
-}
-
-func ubuntu134ProviderWithTaints(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithUbuntu134(),
-	)
-}
-
-func bottlerocket134ProviderWithTaints(t *testing.T) *framework.VSphere {
-	return framework.NewVSphere(t,
-		framework.WithVSphereWorkerNodeGroup(
-			worker0,
-			framework.NoScheduleWorkerNodeGroup(worker0, 2),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker1,
-			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
-		),
-		framework.WithVSphereWorkerNodeGroup(
-			worker2,
-			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
-		),
-		framework.WithBottleRocket134(),
-	)
-}
-
-func runVSphereCloneModeFlow(test *framework.ClusterE2ETest, vsphere *framework.VSphere, diskSize int) {
-	test.GenerateClusterConfig()
-	test.CreateCluster()
-	vsphere.ValidateNodesDiskGiB(test.GetCapiMachinesForCluster(test.ClusterName), diskSize)
-	test.DeleteCluster()
-}
-
-// Bottlerocket Etcd Scale tests
-func TestVSphereKubernetes128BottlerocketEtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
-
-func TestVSphereKubernetes134BottlerocketEtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
-
-func TestVSphereKubernetes128BottlerocketEtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket128()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
-
-func TestVSphereKubernetes134BottlerocketEtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
-
-func TestVSphereKubernetes128to129BottlerocketEtcdScaleUp(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithExternalEtcdTopology(3),
-		),
-		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
-	)
-}
-
-func TestVSphereKubernetes128to129BottlerocketEtcdScaleDown(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube129,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube129),
-			api.WithExternalEtcdTopology(1),
-		),
-		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
-	)
-}
-
-// Ubuntu Etcd Scale tests
-func TestVSphereKubernetes128UbuntuEtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
-
-func TestVSphereKubernetes134UbuntuEtcdScaleUp(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(3),
-		),
-	)
-}
-
-func TestVSphereKubernetes128UbuntuEtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu128()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube128),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube128,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
-
-func TestVSphereKubernetes134UbuntuEtcdScaleDown(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithExternalEtcdTopology(1),
-		),
-	)
-}
-
-func TestVSphereKubernetes133to134UbuntuEtcdScaleUp(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(1),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(3),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-func TestVSphereKubernetes133to134UbuntuEtcdScaleDown(t *testing.T) {
-	provider := framework.NewVSphere(t, framework.WithUbuntu133())
-	test := framework.NewClusterE2ETest(
-		t,
-		provider,
-		framework.WithClusterFiller(
-			api.WithKubernetesVersion(v1alpha1.Kube133),
-			api.WithExternalEtcdTopology(3),
-			api.WithControlPlaneCount(1),
-			api.WithWorkerNodeCount(1),
-		),
-	)
-
-	runSimpleUpgradeFlow(
-		test,
-		v1alpha1.Kube134,
-		framework.WithClusterUpgrade(
-			api.WithKubernetesVersion(v1alpha1.Kube134),
-			api.WithExternalEtcdTopology(1),
-		),
-		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
-	)
-}
-
-// Kubelet Configuration tests
-func TestVSphereKubernetes129UbuntuKubeletConfiguration(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestVSphereKubernetes134UbuntuKubeletConfiguration(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithUbuntu134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestVSphereKubernetes129BottlerocketKubeletConfiguration(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket129()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
-
-func TestVSphereKubernetes134BottlerocketKubeletConfiguration(t *testing.T) {
-	test := framework.NewClusterE2ETest(
-		t,
-		framework.NewVSphere(t, framework.WithBottleRocket134()),
-		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
-		framework.WithKubeletConfig(),
-	)
-	runKubeletConfigurationFlow(test)
-}
+// // Clone mode
+// func TestVSphereKubernetes128FullClone(t *testing.T) {
+// 	diskSize := 30
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithUbuntu128(),
+// 		framework.WithFullCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes134FullClone(t *testing.T) {
+// 	diskSize := 30
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithUbuntu134(),
+// 		framework.WithFullCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes128LinkedClone(t *testing.T) {
+// 	diskSize := 20
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithUbuntu128(),
+// 		framework.WithLinkedCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes134LinkedClone(t *testing.T) {
+// 	diskSize := 20
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithUbuntu134(),
+// 		framework.WithLinkedCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes128BottlerocketFullClone(t *testing.T) {
+// 	diskSize := 30
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithBottleRocket128(),
+// 		framework.WithFullCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes134BottlerocketFullClone(t *testing.T) {
+// 	diskSize := 30
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithBottleRocket134(),
+// 		framework.WithFullCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes128BottlerocketLinkedClone(t *testing.T) {
+// 	diskSize := 22
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithBottleRocket128(),
+// 		framework.WithLinkedCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// func TestVSphereKubernetes134BottlerocketLinkedClone(t *testing.T) {
+// 	diskSize := 22
+// 	vsphere := framework.NewVSphere(t,
+// 		framework.WithBottleRocket134(),
+// 		framework.WithLinkedCloneMode(),
+// 		framework.WithDiskGiBForAllMachines(diskSize),
+// 	)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		vsphere,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 	)
+// 	runVSphereCloneModeFlow(test, vsphere, diskSize)
+// }
+
+// // Simple Flow
+// func TestVSphereKubernetes128Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134Ubuntu2004SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes129Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes130Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes131Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes132Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes133Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(api.WithLicenseToken(licenseToken)),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes133Ubuntu2204NetworksSimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t,
+// 		// Add worker node group with second network config
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(1)),
+// 			framework.WithSecondNetwork(),
+// 		),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+
+// 	// Create cluster and validate the network is up
+// 	runSimpleFlowWithSecondNetworkValidation(test, worker0)
+// }
+
+// func TestVSphereKubernetes128Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes129Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes130Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes131Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes132Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes133Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes134Ubuntu2204SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(api.WithLicenseToken(licenseToken)),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes134Ubuntu2404SimpleFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleFlowWithoutClusterConfigGeneration(test)
+// }
+
+// func TestVSphereKubernetes128RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat128VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat129VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat130VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131RedHatSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat131VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9128VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9129VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9130VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9131VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9132VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9133VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134RedHat9SimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithRedHat9134VSphere()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134ThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134DifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottleRocketSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottleRocketThreeReplicasFiveWorkersSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(5)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket130(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket131(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket132(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket133(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottleRocketDifferentNamespaceSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134(),
+// 			framework.WithVSphereFillers(api.WithVSphereConfigNamespaceForAllMachinesAndDatacenter(clusterNamespace))),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithClusterNamespace(clusterNamespace)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes128CiliumAlwaysPolicyEnforcementModeSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways)),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Cilium Helm Values Tests - Ubuntu
+// func TestVSphereKubernetes128CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes129CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes130CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes131CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes132CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133CiliumHelmValuesUbuntuSimpleFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Cilium Helm Values Precedence Tests - Validate helmValues overrides deprecated fields
+// func TestVSphereKubernetes128CiliumHelmValuesPrecedenceUbuntuFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeDefault)), // This should be ignored
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"policyEnforcementMode": "always", // This should take precedence
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133CiliumHelmValuesPrecedenceUbuntuFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeDefault)), // This should be ignored
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"policyEnforcementMode": "always", // This should take precedence
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // Cilium Helm Values Complex Configuration Tests
+// func TestVSphereKubernetes128CiliumHelmValuesComplexConfigUbuntuFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 				"replicas": 2,
+// 			},
+// 			"policyEnforcementMode": "always",
+// 			"routingMode":           "native",
+// 			"ipv4NativeRoutingCIDR": "192.168.0.0/16",
+// 			"autoDirectNodeRoutes":  "true",
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// func TestVSphereKubernetes133CiliumHelmValuesComplexConfigUbuntuFlow(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithCiliumHelmValues(map[string]interface{}{
+// 			"prometheus": map[string]interface{}{
+// 				"enabled": true,
+// 			},
+// 			"operator": map[string]interface{}{
+// 				"prometheus": map[string]interface{}{
+// 					"enabled": false,
+// 				},
+// 				"replicas": 2,
+// 			},
+// 			"policyEnforcementMode": "always",
+// 			"routingMode":           "native",
+// 			"ipv4NativeRoutingCIDR": "192.168.0.0/16",
+// 			"autoDirectNodeRoutes":  "true",
+// 		})),
+// 	)
+// 	runSimpleFlow(test)
+// }
+
+// // NTP Servers test
+// func TestVSphereKubernetes128BottleRocketWithNTP(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(
+// 			t, framework.WithBottleRocket128(),
+// 			framework.WithNTPServersForAllMachines(),
+// 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runNTPFlow(test, v1alpha1.Bottlerocket)
+// }
+
+// func TestVSphereKubernetes134BottleRocketWithNTP(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(
+// 			t, framework.WithBottleRocket134(),
+// 			framework.WithNTPServersForAllMachines(),
+// 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runNTPFlow(test, v1alpha1.Bottlerocket)
+// }
+
+// func TestVSphereKubernetes128UbuntuWithNTP(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(
+// 			t, framework.WithUbuntu128(),
+// 			framework.WithNTPServersForAllMachines(),
+// 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runNTPFlow(test, v1alpha1.Ubuntu)
+// }
+
+// func TestVSphereKubernetes134UbuntuWithNTP(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(
+// 			t, framework.WithUbuntu134(),
+// 			framework.WithNTPServersForAllMachines(),
+// 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runNTPFlow(test, v1alpha1.Ubuntu)
+// }
+
+// // Bottlerocket Configuration tests
+// func TestVSphereKubernetes128BottlerocketWithBottlerocketKubernetesSettings(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(
+// 			t, framework.WithBottleRocket128(),
+// 			framework.WithBottlerocketKubernetesSettingsForAllMachines(),
+// 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runBottlerocketConfigurationFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottlerocketWithBottlerocketKubernetesSettings(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(
+// 			t, framework.WithBottleRocket134(),
+// 			framework.WithBottlerocketKubernetesSettingsForAllMachines(),
+// 			framework.WithSSHAuthorizedKeyForAllMachines(""), // set SSH key to empty
+// 		),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 	)
+// 	runBottlerocketConfigurationFlow(test)
+// }
+
+// // Stacked Etcd
+// func TestVSphereKubernetes128StackedEtcdUbuntu(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// func TestVSphereKubernetes134StackedEtcdUbuntu(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(3)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()))
+// 	runStackedEtcdFlow(test)
+// }
+
+// // Taints
+// func TestVSphereKubernetes128UbuntuTaintsUpgradeFlow(t *testing.T) {
+// 	provider := ubuntu128ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UbuntuTaintsUpgradeFlow(t *testing.T) {
+// 	provider := ubuntu134ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketTaintsUpgradeFlow(t *testing.T) {
+// 	provider := bottlerocket128ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134BottlerocketTaintsUpgradeFlow(t *testing.T) {
+// 	provider := bottlerocket134ProviderWithTaints(t)
+
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runTaintsUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeGroup(worker0, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker1, api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup(worker2, api.WithNoTaints()),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuWorkloadClusterTaintsFlow(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			provider.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+// 			provider.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoExecuteTaint()))),
+// 		),
+// 	)
+
+// 	runWorkloadClusterExistingConfigFlow(test)
+// }
+
+// // Upgrade
+// func TestVSphereKubernetes128UbuntuTo129Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129UbuntuTo130Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130UbuntuTo131Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131UbuntuTo132Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132UbuntuTo133Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuTo134Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134Ubuntu2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134Ubuntu2204StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134Ubuntu2404Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134Ubuntu2404StackedEtcdUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2404, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2404Kubernetes134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129RedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat128VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130RedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat129VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131RedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat130VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9128VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat9129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9129VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9130VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9131VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9132VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134RedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9133VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129StackedEtcdRedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat128VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130StackedEtcdRedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat129VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131StackedEtcdRedHatUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat130VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9128VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Redhat9129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9129VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Redhat9130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9130VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Redhat9131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9131VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Redhat9132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9132VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Redhat9133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134StackedEtcdRedHat9Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9133VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes128Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube129, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube130, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube131, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133Ubuntu2004To2204Upgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 	).WithClusterConfig(
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2204, nil),
+// 		api.ClusterToConfigFiller(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// 	runSimpleUpgradeFlowWithoutClusterConfigGeneration(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu2204Kubernetes133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuTo129InPlaceUpgradeCPOnly(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	kube128 := v1alpha1.Kube128
+// 	kube129 := v1alpha1.Kube129
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(kube128),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube128),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 	)
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129TemplateForMachineConfig(providers.GetControlPlaneNodeName(test.ClusterName))),
+// 	)
+// }
+
+// func TestVSphereKubernetes132UbuntuTo133InPlaceUpgradeWorkerOnly(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	kube132 := v1alpha1.Kube132
+// 	kube133 := v1alpha1.Kube133
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube132),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 	)
+// 	test.UpdateClusterConfig(
+// 		provider.WithKubeVersionAndOSMachineConfig(providers.GetControlPlaneNodeName(test.ClusterName), kube133, framework.Ubuntu2004),
+// 	)
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithWorkerKubernetesVersion(nodeGroupLabel1, &kube133)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()), // this will just set everything to 1.33 as expected
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuTo129MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu129Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes129UbuntuTo130MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu130Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes130UbuntuTo131MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu131Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes131UbuntuTo132MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu132Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes132UbuntuTo133MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu133Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuTo134MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu134Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes129UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes130UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes131UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes132UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes129UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes130UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes131UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes132UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UbuntuControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UbuntuWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketTo129Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129BottlerocketTo130Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130BottlerocketTo131Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131BottlerocketTo132Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132BottlerocketTo133Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133BottlerocketTo134Upgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketTo129MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Bottlerocket129Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes129BottlerocketTo130MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Bottlerocket130Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes130BottlerocketTo131MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Bottlerocket131Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes131BottlerocketTo132MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Bottlerocket132Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes132BottlerocketTo133MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Bottlerocket133Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133BottlerocketTo134MultipleFieldsUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(
+// 			provider.Bottlerocket134Template(),
+// 			api.WithNumCPUsForAllMachines(vsphereCpVmNumCpuUpdateVar),
+// 			api.WithMemoryMiBForAllMachines(vsphereCpVmMemoryUpdate),
+// 			api.WithDiskGiBForAllMachines(vsphereCpDiskGiBUpdateVar),
+// 			api.WithFolderForAllMachines(vsphereFolderUpdateVar),
+// 			// Uncomment once we support tests with multiple machine configs
+// 			/*api.WithWorkloadVMsNumCPUs(vsphereWlVmNumCpuUpdateVar),
+// 			api.WithWorkloadVMsMemoryMiB(vsphereWlVmMemoryUpdate),
+// 			api.WithWorkloadDiskGiB(vsphereWlDiskGiBUpdate),*/
+// 			// Uncomment the network field once upgrade starts working with it
+// 			// api.WithNetwork(vsphereNetwork2UpdateVar),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes129BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes130BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes131BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes132BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes133BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes129BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes130BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes131BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes132BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes133BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes134BottlerocketControlPlaneNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithControlPlaneCount(3)),
+// 	)
+// }
+
+// func TestVSphereKubernetes134BottlerocketWorkerNodeUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket134())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(3)),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithWorkerNodeCount(5)),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuTo129StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129UbuntuTo130StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130UbuntuTo131StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131UbuntuTo132StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketTo129StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes129BottlerocketTo130StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket129())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube130,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket130Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes130BottlerocketTo131StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket130())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube131,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket131Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes131BottlerocketTo132StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket131())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube132,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket132Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132BottlerocketTo133StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket132())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube133,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133BottlerocketTo134StackedEtcdUpgrade(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithStackedEtcdTopology()),
+// 	)
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube132,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9132Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133WithOIDCManagementClusterUpgradeFromLatestSideEffects(t *testing.T) {
+// 	provider := framework.NewVSphere(t)
+// 	runTestManagementClusterUpgradeSideEffects(t, provider, framework.Ubuntu2004, v1alpha1.Kube133)
+// }
+
+// func TestVSphereKubernetes128To129UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube129,
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu129Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube129, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube130,
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu130Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube130, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube131,
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu131Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube131, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube132,
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu132Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube133,
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu133Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133UbuntuInPlaceUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(
+// 		t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	)
+// 	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	test.UpdateClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketAndRemoveWorkerNodeGroups(t *testing.T) {
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup("workers-1", api.WithCount(2)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			"worker-2",
+// 			framework.WithWorkerNodeGroup("workers-2", api.WithCount(1)),
+// 		),
+// 		framework.WithBottleRocket128(),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.RemoveWorkerNodeGroup("workers-2"),
+// 			api.WithWorkerNodeGroup("workers-1", api.WithCount(1)),
+// 		),
+// 		provider.WithNewVSphereWorkerNodeGroup(
+// 			"worker-1",
+// 			framework.WithWorkerNodeGroup(
+// 				"workers-3",
+// 				api.WithCount(1),
+// 			),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.RedHat8, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube129,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat129Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube129, framework.RedHat8, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube130,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat130Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131RedhatUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube130, framework.RedHat8, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube131,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat131Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128To129Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube128, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube129,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9129Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes129To130Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube129, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube130,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9130Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes130To131Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube130, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube131,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9131Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes131To132Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube131, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube132,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9132Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes132To133Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube133,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9133Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134UbuntuUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube133, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube134,
+// 		provider.WithProviderUpgrade(
+// 			provider.Ubuntu134Template(), // Set the template so it doesn't get autoimported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134Redhat9UpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.RedHat),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube133, framework.RedHat9, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 	)
+// 	runUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		v1alpha1.Kube134,
+// 		provider.WithProviderUpgrade(
+// 			provider.Redhat9134Template(), // Set the template so it doesn't get auto-imported
+// 		),
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133To134UbuntuInPlaceUpgradeFromLatestMinorRelease(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	release := latestMinorRelease(t)
+// 	useBundlesOverride := false
+// 	provider := framework.NewVSphere(
+// 		t,
+// 		framework.WithVSphereFillers(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Ubuntu),
+// 		),
+// 		framework.WithKubeVersionAndOSForRelease(v1alpha1.Kube133, framework.Ubuntu2004, release, useBundlesOverride),
+// 	)
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	)
+// 	test.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	test.UpdateClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 	)
+// 	runInPlaceUpgradeFromReleaseFlow(
+// 		test,
+// 		release,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes134MulticlusterWorkloadClusterAPI(t *testing.T) {
+// 	vsphere := framework.NewVSphere(t)
+// 	// add licensetoken for k8s version 1.28 and 1.29
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		vsphere.WithUbuntu134(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 			vsphere.WithUbuntu131(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 			vsphere.WithUbuntu132(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken),
+// 			),
+// 			vsphere.WithUbuntu129(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithUbuntu130(),
+// 		),
+// 	)
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes134UpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+// 			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UpgradeWorkerNodeGroupsUbuntuAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 			api.RemoveWorkerNodeGroup("worker-1"),
+// 		),
+// 		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+// 	)
+// }
+
+// func TestVSphereKubernetes134MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
+// 	vsphere := framework.NewVSphere(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		framework.WithFluxGithubConfig(),
+// 		vsphere.WithUbuntu134(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithExternalEtcdTopology(1),
+// 			),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes134CiliumUbuntuAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu134(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.UpdateClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
+// 			),
+// 		)
+// 		wc.ApplyClusterManifest()
+// 		wc.ValidateClusterState()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes134UpgradeLabelsTaintsBottleRocketGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithBottleRocket134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
+// 			vsphere.WithBottleRocket134(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+// 			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UpgradeWorkerNodeGroupsUbuntuGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 			api.RemoveWorkerNodeGroup("worker-1"),
+// 		),
+// 		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+// 	)
+// }
+
+// func TestVSphereUpgradeKubernetes134CiliumUbuntuGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu134(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithUbuntu134(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		test.PushWorkloadClusterToGit(wc,
+// 			api.ClusterToConfigFiller(
+// 				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
+// 			),
+// 			vsphere.WithUbuntu134(),
+// 		)
+// 		wc.ValidateClusterState()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes134UbuntuUpgradeAndRemoveWorkerNodeGroupsAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t)
+// 	test := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		provider.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(2))),
+// 		provider.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+// 		provider.WithNewWorkerNodeGroup("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithLabel("tier", "frontend"))),
+// 		provider.WithUbuntu134(),
+// 	)
+
+// 	runUpgradeFlowWithAPI(
+// 		test,
+// 		api.ClusterToConfigFiller(
+// 			api.RemoveWorkerNodeGroup("worker-2"),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithCount(1)),
+// 			api.RemoveWorkerNodeGroup("worker-3"),
+// 		),
+// 		// Re-adding with no labels and a taint
+// 		provider.WithWorkerNodeGroupConfiguration("worker-3", framework.WithWorkerNodeGroup("worker-3", api.WithCount(1), api.WithTaint(framework.NoScheduleTaint()))),
+// 		provider.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-4", api.WithCount(1))),
+// 	)
+// }
+
+// func TestVSphereKubernetes132to133UpgradeFromLatestMinorReleaseBottleRocketAPI(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewVSphere(t)
+// 	useBundlesOverride := false
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, provider,
+// 	)
+// 	managementCluster.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	managementCluster.UpdateClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
+// 		),
+// 		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Bottlerocket1, release, useBundlesOverride),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	wc := framework.NewClusterE2ETest(
+// 		t, provider, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 	)
+// 	wc.GenerateClusterConfigForVersion(release.Version, "", framework.ExecuteWithEksaRelease(release))
+// 	wc.UpdateClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithManagementCluster(managementCluster.ClusterName),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.WithOsFamilyForAllMachines(v1alpha1.Bottlerocket),
+// 		),
+// 		provider.WithKubeVersionAndOSForRelease(v1alpha1.Kube132, framework.Bottlerocket1, release, useBundlesOverride),
+// 	)
+
+// 	test.WithWorkloadClusters(wc)
+
+// 	runMulticlusterUpgradeFromReleaseFlowAPI(
+// 		test,
+// 		release,
+// 		wc.ClusterConfig.Cluster.Spec.KubernetesVersion,
+// 		v1alpha1.Kube133,
+// 		framework.Bottlerocket1,
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuTo129InPlaceUpgrade_1CP_3Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(3),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 	)
+
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuTo134InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 	)
+
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133RedHat9To134InPlaceUpgrade_1CP_1Worker(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithRedHat9133VSphere())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(api.RemoveEtcdVsphereMachineConfig()),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.RedHat9, nil),
+// 	)
+
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		provider.WithProviderUpgrade(provider.Redhat9134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuTo133InPlaceUpgrade(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	var kube129clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube130clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube131clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube132clusterOpts []framework.ClusterE2ETestOpt
+// 	var kube133clusterOpts []framework.ClusterE2ETestOpt
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 	)
+// 	kube129clusterOpts = append(
+// 		kube129clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// 	kube130clusterOpts = append(
+// 		kube130clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube130),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu130Template()),
+// 	)
+// 	kube131clusterOpts = append(
+// 		kube131clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube131),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu131Template()),
+// 	)
+// 	kube132clusterOpts = append(
+// 		kube132clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu132Template()),
+// 	)
+// 	kube133clusterOpts = append(
+// 		kube133clusterOpts,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// 	runInPlaceMultipleUpgradesFlow(
+// 		test,
+// 		kube129clusterOpts,
+// 		kube130clusterOpts,
+// 		kube131clusterOpts,
+// 		kube132clusterOpts,
+// 		kube133clusterOpts,
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuInPlaceCPScaleUp1To3(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 	)
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(
+// 			api.WithControlPlaneCount(3),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuInPlaceCPScaleDown3To1(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(3),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 	)
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuInPlaceWorkerScaleUp1To2(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 	)
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeCount(2),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UbuntuInPlaceWorkerScaleDown2To1(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(2),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube133, framework.Ubuntu2004, nil),
+// 	)
+// 	runInPlaceUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UpgradeManagementComponents(t *testing.T) {
+// 	release := latestMinorRelease(t)
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	runUpgradeManagementComponentsFlow(t, release, provider, v1alpha1.Kube128, framework.Ubuntu2004)
+// }
+
+// func TestVSphereInPlaceUpgradeMulticlusterWorkloadClusterK8sUpgrade128To129(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu128())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithKubernetesVersion(v1alpha1.Kube128),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			api.VSphereToConfigFiller(
+// 				api.RemoveEtcdVsphereMachineConfig(),
+// 			),
+// 			provider.WithKubeVersionAndOS(v1alpha1.Kube128, framework.Ubuntu2004, nil),
+// 		),
+// 	)
+// 	runInPlaceWorkloadUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu129Template()),
+// 	)
+// }
+
+// func TestVSphereInPlaceUpgradeMulticlusterWorkloadClusterK8sUpgrade132To133(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu132())
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube132),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		api.VSphereToConfigFiller(
+// 			api.RemoveEtcdVsphereMachineConfig(),
+// 		),
+// 		provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t,
+// 			provider,
+// 			framework.WithClusterName(test.NewWorkloadClusterName()),
+// 			framework.WithEnvVar(features.VSphereInPlaceEnvVar, "true"),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithKubernetesVersion(v1alpha1.Kube132),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithInPlaceUpgradeStrategy(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			api.VSphereToConfigFiller(
+// 				api.RemoveEtcdVsphereMachineConfig(),
+// 			),
+// 			provider.WithKubeVersionAndOS(v1alpha1.Kube132, framework.Ubuntu2004, nil),
+// 		),
+// 	)
+// 	runInPlaceWorkloadUpgradeFlow(
+// 		test,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithInPlaceUpgradeStrategy(),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu133Template()),
+// 	)
+// }
+
+// // Workload API
+// func TestVSphereKubernetes133MulticlusterWorkloadClusterAPI(t *testing.T) {
+// 	vsphere := framework.NewVSphere(t)
+// 	// add licensetoken for k8s version 1.28 and 1.29
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		vsphere.WithUbuntu133(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 			vsphere.WithUbuntu131(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 			vsphere.WithUbuntu132(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken),
+// 			),
+// 			vsphere.WithUbuntu129(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithUbuntu130(),
+// 		),
+// 	)
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes133UpgradeLabelsTaintsUbuntuAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+// 			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UpgradeWorkerNodeGroupsUbuntuAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPI(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 			api.RemoveWorkerNodeGroup("worker-1"),
+// 		),
+// 		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+// 	)
+// }
+
+// func TestVSphereKubernetes133MulticlusterWorkloadClusterGitHubFluxAPI(t *testing.T) {
+// 	vsphere := framework.NewVSphere(t)
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 		),
+// 		framework.WithFluxGithubConfig(),
+// 		vsphere.WithUbuntu133(),
+// 	)
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithStackedEtcdTopology(),
+// 			),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithControlPlaneCount(1),
+// 				api.WithWorkerNodeCount(1),
+// 				api.WithExternalEtcdTopology(1),
+// 			),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes133CiliumUbuntuAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere,
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu133(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		wc.ApplyClusterManifest()
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		wc.UpdateClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
+// 			),
+// 		)
+// 		wc.ApplyClusterManifest()
+// 		wc.ValidateClusterState()
+// 		wc.DeleteClusterWithKubectl()
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// func TestVSphereKubernetes133UpgradeLabelsTaintsBottleRocketGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithBottleRocket133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(2), api.WithLabel("key1", "val2"), api.WithTaint(framework.NoScheduleTaint()))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-2", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1), api.WithLabel("key2", "val2"), api.WithTaint(framework.PreferNoScheduleTaint()))),
+// 			vsphere.WithBottleRocket133(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithLabel("key1", "val1"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-1", api.WithLabel("key2", "val2"), api.WithTaint(framework.NoExecuteTaint())),
+// 			api.WithWorkerNodeGroup("worker-2", api.WithNoTaints()),
+// 			api.WithControlPlaneLabel("cpKey1", "cpVal1"),
+// 			api.WithControlPlaneTaints([]corev1.Taint{framework.PreferNoScheduleTaint()}),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133UpgradeWorkerNodeGroupsUbuntuGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithNewWorkerNodeGroup("worker-1", framework.WithWorkerNodeGroup("worker-1", api.WithCount(1))),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 	)
+
+// 	runWorkloadClusterUpgradeFlowAPIWithFlux(test,
+// 		api.ClusterToConfigFiller(
+// 			api.WithWorkerNodeGroup("worker-0", api.WithCount(2)),
+// 			api.RemoveWorkerNodeGroup("worker-1"),
+// 		),
+// 		vsphere.WithWorkerNodeGroupConfiguration("worker-1", framework.WithWorkerNodeGroup("worker-2", api.WithCount(1))),
+// 	)
+// }
+
+// func TestVSphereUpgradeKubernetes133CiliumUbuntuGitHubFluxAPI(t *testing.T) {
+// 	licenseToken := framework.GetLicenseToken()
+// 	licenseToken2 := framework.GetLicenseToken2()
+// 	vsphere := framework.NewVSphere(t)
+
+// 	managementCluster := framework.NewClusterE2ETest(
+// 		t, vsphere, framework.WithFluxGithubEnvVarCheck(), framework.WithFluxGithubCleanup(),
+// 	).WithClusterConfig(
+// 		api.ClusterToConfigFiller(
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 			api.WithStackedEtcdTopology(),
+// 			api.WithLicenseToken(licenseToken),
+// 		),
+// 		vsphere.WithUbuntu133(),
+// 		framework.WithFluxGithubConfig(),
+// 	)
+
+// 	test := framework.NewMulticlusterE2ETest(t, managementCluster)
+// 	test.WithWorkloadClusters(
+// 		framework.NewClusterE2ETest(
+// 			t, vsphere, framework.WithClusterName(test.NewWorkloadClusterName()),
+// 		).WithClusterConfig(
+// 			api.ClusterToConfigFiller(
+// 				api.WithManagementCluster(managementCluster.ClusterName),
+// 				api.WithExternalEtcdTopology(1),
+// 				api.WithControlPlaneCount(1),
+// 				api.RemoveAllWorkerNodeGroups(), // This gives us a blank slate
+// 				api.WithLicenseToken(licenseToken2),
+// 			),
+// 			vsphere.WithNewWorkerNodeGroup("worker-0", framework.WithWorkerNodeGroup("worker-0", api.WithCount(1))),
+// 			vsphere.WithUbuntu133(),
+// 		),
+// 	)
+
+// 	test.CreateManagementCluster()
+// 	test.RunConcurrentlyInWorkloadClusters(func(wc *framework.WorkloadCluster) {
+// 		test.PushWorkloadClusterToGit(wc)
+// 		wc.WaitForKubeconfig()
+// 		wc.ValidateClusterState()
+// 		test.PushWorkloadClusterToGit(wc,
+// 			api.ClusterToConfigFiller(
+// 				api.WithCiliumPolicyEnforcementMode(v1alpha1.CiliumPolicyModeAlways),
+// 			),
+// 			vsphere.WithUbuntu133(),
+// 		)
+// 		wc.ValidateClusterState()
+// 		test.DeleteWorkloadClusterFromGit(wc)
+// 		wc.ValidateClusterDelete()
+// 	})
+// 	test.ManagementCluster.StopIfFailed()
+// 	test.DeleteManagementCluster()
+// }
+
+// // Airgapped tests
+// func TestVSphereKubernetes128UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube128)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes129UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes130UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes131UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes132UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes133UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes129UbuntuAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes130UbuntuAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu130(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube130)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes131UbuntuAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu131(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube131)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes132UbuntuAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu132(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube132)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes133UbuntuAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu133(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube133)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes134UbuntuAirgappedRegistryMirror(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithRegistryMirrorEndpointAndCert(constants.VSphereProviderName),
+// 	)
+
+// 	runAirgapConfigFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// func TestVSphereKubernetes134UbuntuAirgappedProxy(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134(), framework.WithPrivateNetwork()),
+// 		framework.WithClusterFiller(api.WithControlPlaneCount(1)),
+// 		framework.WithClusterFiller(api.WithWorkerNodeCount(1)),
+// 		framework.WithClusterFiller(api.WithExternalEtcdTopology(1)),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithProxy(framework.VsphereProxyRequiredEnvVars),
+// 	)
+
+// 	runAirgapConfigProxyFlow(test, "195.18.0.1/16,196.18.0.1/16")
+// }
+
+// // Etcd Encryption
+// func TestVSphereKubernetesUbuntu128EtcdEncryption(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		framework.WithPodIamConfig(),
+// 	)
+// 	test.OSFamily = v1alpha1.Ubuntu
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.PostClusterCreateEtcdEncryptionSetup()
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
+// 	test.StopIfFailed()
+// 	test.ValidateEtcdEncryption()
+// 	test.DeleteCluster()
+// }
+
+// func TestVSphereKubernetesUbuntu134EtcdEncryption(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		framework.WithPodIamConfig(),
+// 	)
+// 	test.OSFamily = v1alpha1.Ubuntu
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.PostClusterCreateEtcdEncryptionSetup()
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
+// 	test.StopIfFailed()
+// 	test.ValidateEtcdEncryption()
+// 	test.DeleteCluster()
+// }
+
+// func TestVSphereKubernetesBottlerocket128EtcdEncryption(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		framework.WithPodIamConfig(),
+// 	)
+// 	test.OSFamily = v1alpha1.Bottlerocket
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.PostClusterCreateEtcdEncryptionSetup()
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
+// 	test.StopIfFailed()
+// 	test.DeleteCluster()
+// }
+
+// func TestVSphereKubernetesBottlerocket134EtcdEncryption(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 		),
+// 		framework.WithPodIamConfig(),
+// 	)
+// 	test.OSFamily = v1alpha1.Bottlerocket
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	test.PostClusterCreateEtcdEncryptionSetup()
+// 	test.UpgradeClusterWithNewConfig([]framework.ClusterE2ETestOpt{framework.WithEtcdEncrytion()})
+// 	test.StopIfFailed()
+// 	test.DeleteCluster()
+// }
+
+// func ubuntu128ProviderWithLabels(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithUbuntu128(),
+// 	)
+// }
+
+// func bottlerocket128ProviderWithLabels(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithBottleRocket128(),
+// 	)
+// }
+
+// func ubuntu134ProviderWithLabels(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithUbuntu134(),
+// 	)
+// }
+
+// func bottlerocket134ProviderWithLabels(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.WithWorkerNodeGroup(worker0, api.WithCount(2),
+// 				api.WithLabel(key1, val2)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.WithWorkerNodeGroup(worker2, api.WithCount(1),
+// 				api.WithLabel(key2, val2)),
+// 		),
+// 		framework.WithBottleRocket134(),
+// 	)
+// }
+
+// func ubuntu128ProviderWithTaints(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithUbuntu128(),
+// 	)
+// }
+
+// func bottlerocket128ProviderWithTaints(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithBottleRocket128(),
+// 	)
+// }
+
+// func ubuntu134ProviderWithTaints(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithUbuntu134(),
+// 	)
+// }
+
+// func bottlerocket134ProviderWithTaints(t *testing.T) *framework.VSphere {
+// 	return framework.NewVSphere(t,
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker0,
+// 			framework.NoScheduleWorkerNodeGroup(worker0, 2),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker1,
+// 			framework.WithWorkerNodeGroup(worker1, api.WithCount(1)),
+// 		),
+// 		framework.WithVSphereWorkerNodeGroup(
+// 			worker2,
+// 			framework.PreferNoScheduleWorkerNodeGroup(worker2, 1),
+// 		),
+// 		framework.WithBottleRocket134(),
+// 	)
+// }
+
+// func runVSphereCloneModeFlow(test *framework.ClusterE2ETest, vsphere *framework.VSphere, diskSize int) {
+// 	test.GenerateClusterConfig()
+// 	test.CreateCluster()
+// 	vsphere.ValidateNodesDiskGiB(test.GetCapiMachinesForCluster(test.ClusterName), diskSize)
+// 	test.DeleteCluster()
+// }
+
+// // Bottlerocket Etcd Scale tests
+// func TestVSphereKubernetes128BottlerocketEtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134BottlerocketEtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128BottlerocketEtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket128()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134BottlerocketEtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128to129BottlerocketEtcdScaleUp(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes128to129BottlerocketEtcdScaleDown(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithBottleRocket128())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube129,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube129),
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Bottlerocket129Template()),
+// 	)
+// }
+
+// // Ubuntu Etcd Scale tests
+// func TestVSphereKubernetes128UbuntuEtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UbuntuEtcdScaleUp(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes128UbuntuEtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu128()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube128),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube128,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes134UbuntuEtcdScaleDown(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 	)
+// }
+
+// func TestVSphereKubernetes133to134UbuntuEtcdScaleUp(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(1),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(3),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// func TestVSphereKubernetes133to134UbuntuEtcdScaleDown(t *testing.T) {
+// 	provider := framework.NewVSphere(t, framework.WithUbuntu133())
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		provider,
+// 		framework.WithClusterFiller(
+// 			api.WithKubernetesVersion(v1alpha1.Kube133),
+// 			api.WithExternalEtcdTopology(3),
+// 			api.WithControlPlaneCount(1),
+// 			api.WithWorkerNodeCount(1),
+// 		),
+// 	)
+
+// 	runSimpleUpgradeFlow(
+// 		test,
+// 		v1alpha1.Kube134,
+// 		framework.WithClusterUpgrade(
+// 			api.WithKubernetesVersion(v1alpha1.Kube134),
+// 			api.WithExternalEtcdTopology(1),
+// 		),
+// 		provider.WithProviderUpgrade(provider.Ubuntu134Template()),
+// 	)
+// }
+
+// // Kubelet Configuration tests
+// func TestVSphereKubernetes129UbuntuKubeletConfiguration(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestVSphereKubernetes134UbuntuKubeletConfiguration(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithUbuntu134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestVSphereKubernetes129BottlerocketKubeletConfiguration(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket129()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube129)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }
+
+// func TestVSphereKubernetes134BottlerocketKubeletConfiguration(t *testing.T) {
+// 	test := framework.NewClusterE2ETest(
+// 		t,
+// 		framework.NewVSphere(t, framework.WithBottleRocket134()),
+// 		framework.WithClusterFiller(api.WithKubernetesVersion(v1alpha1.Kube134)),
+// 		framework.WithKubeletConfig(),
+// 	)
+// 	runKubeletConfigurationFlow(test)
+// }


### PR DESCRIPTION
*Issue #, if available:*
[#3678](https://github.com/aws/eks-anywhere-internal/issues/3678)

*Description of changes:*
This PR comments out all the non-packages tests temporarily to speed up the curated packages testing for the release. The changes will be reverted once the testing is finished with the staging packages bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

