### PR TITLE
[E2E] Add test for bottlerocket and rhel9 on second network interface

### DIFF
--- a/test/e2e/vsphere_test.go
+++ b/test/e2e/vsphere_test.go
@@ -3372,7 +3372,7 @@ func TestVSphereKubernetes134BottlerocketNetworksSimpleFlow(t *testing.T) {
 		t,
 		provider,
 	).WithClusterConfig(
-		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Bottlerocket134Template, nil),
+		provider.WithKubeVersionAndOS(v1alpha1.Kube134, framework.Bottlerocket1, nil),
 		api.ClusterToConfigFiller(
 			api.WithLicenseToken(licenseToken),
 		),


### PR DESCRIPTION
*Description of changes:*
- Add e2e test for second network interface for OS bottlerocket and redhat9
- PR for ubuntu e2e test: #10284 

*Testing (if applicable):*
- Run test on CodeBuild with Override(Redhat): https://tiny.amazon.com/118r9mnuu/IsenLink

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

