### PR TITLE
Add support for skipping BMC contact checks for specific Rufio Machines

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,6 +68,10 @@ const (
 	// ClusterctlMoveLabelName adds the clusterctl move label.
 	ClusterctlMoveLabelName = "clusterctl.cluster.x-k8s.io/move"
 
+	// SkipBMCContactCheckLabel is the label to skip BMC contact check for RufioMachines.
+	// When set to "true", the machine will be excluded from BMC contactable validation.
+	SkipBMCContactCheckLabel = "bmc.tinkerbell.org/skip-contact-check"
+
 	// CloudstackFailureDomainPlaceholder Provider specific keywork placeholder.
 	CloudstackFailureDomainPlaceholder = "ds.meta_data.failuredomain"
 

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -447,8 +447,11 @@ func (k *Kubectl) WaitForPod(ctx context.Context, cluster *types.Cluster, timeou
 }
 
 // WaitForRufioMachines blocks until all Rufio Machines have the desired condition.
+// RufioMachines with the skip-contactability-check label set to "true" are excluded from the wait.
 func (k *Kubectl) WaitForRufioMachines(ctx context.Context, cluster *types.Cluster, timeout string, condition string, namespace string) error {
-	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, rufioMachineResourceType, namespace, WithWaitAll())
+	// Use label selector to exclude machines with skip-contactability-check=true
+	labelSelector := fmt.Sprintf("%s!=true", constants.SkipBMCContactCheckLabel)
+	return k.Wait(ctx, cluster.KubeconfigFile, timeout, condition, rufioMachineResourceType, namespace, WithWaitAll(), WithSelector(labelSelector))
 }
 
 // WaitForJobCompleted waits for a job resource to reach desired condition before returning.

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -3238,7 +3238,7 @@ func TestWaitForRufioMachines(t *testing.T) {
 
 	kt.e.EXPECT().Execute(
 		kt.ctx,
-		"wait", "--timeout", expectedTimeout, "--for=condition=Contactable", "machines.bmc.tinkerbell.org", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system", "--all",
+		"wait", "--timeout", expectedTimeout, "--for=condition=Contactable", "machines.bmc.tinkerbell.org", "--kubeconfig", kt.cluster.KubeconfigFile, "-n", "eksa-system", "--all", "--selector=bmc.tinkerbell.org/skip-contact-check!=true",
 	).Return(bytes.Buffer{}, nil)
 
 	kt.Expect(kt.k.WaitForRufioMachines(kt.ctx, kt.cluster, timeout, "Contactable", "eksa-system")).To(Succeed())

--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -469,6 +469,12 @@ func (r *Reconciler) ValidateRufioMachines(ctx context.Context, log logr.Logger,
 	}
 
 	for _, rm := range kubeReader.GetCatalogue().AllBMCs() {
+		// Skip contactability check if the machine has the skip label set to "true"
+		if skipValue, hasSkipLabel := rm.Labels[constants.SkipBMCContactCheckLabel]; hasSkipLabel && skipValue == "true" {
+			log.Info("Skipping BMC contactability check for machine with skip label", "machine", rm.Name)
+			continue
+		}
+
 		if err := r.checkContactable(rm); err != nil {
 			log.Error(err, "rufio machine check failure")
 			failureMessage := err.Error()

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -714,6 +714,71 @@ func TestReconcilerValidateRufioMachinesFail(t *testing.T) {
 	tt.cleanup()
 }
 
+func TestReconcilerValidateRufioMachinesWithSkipLabel(t *testing.T) {
+	tt := newReconcilerTest(t)
+	logger := test.NewNullLogger()
+
+	// Machine with skip label set to "true" - should be skipped even though it's not contactable
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, &rufiov1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bmc-skip",
+			Namespace: constants.EksaSystemNamespace,
+			Labels: map[string]string{
+				constants.SkipBMCContactCheckLabel: "true",
+			},
+		},
+		Spec: rufiov1alpha1.MachineSpec{
+			Connection: rufiov1alpha1.Connection{
+				Host: "192.168.1.1",
+			},
+		},
+		Status: rufiov1alpha1.MachineStatus{
+			Conditions: []rufiov1alpha1.MachineCondition{
+				{
+					Type:    rufiov1alpha1.Contactable,
+					Status:  rufiov1alpha1.ConditionFalse,
+					Message: "bmc connection failure but should be skipped",
+				},
+			},
+		},
+	})
+
+	// Machine without skip label - must be contactable
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, &rufiov1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bmc-normal",
+			Namespace: constants.EksaSystemNamespace,
+		},
+		Spec: rufiov1alpha1.MachineSpec{
+			Connection: rufiov1alpha1.Connection{
+				Host: "192.168.1.2",
+			},
+		},
+		Status: rufiov1alpha1.MachineStatus{
+			Conditions: []rufiov1alpha1.MachineCondition{
+				{
+					Type:   rufiov1alpha1.Contactable,
+					Status: rufiov1alpha1.ConditionTrue,
+				},
+			},
+		},
+	})
+
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tinkHardware("hw1", "cp"))
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tinkHardware("hw2", "worker"))
+
+	tt.withFakeClient()
+
+	scope := tt.buildScope()
+	result, err := tt.reconciler().ValidateRufioMachines(tt.ctx, logger, scope)
+
+	// Should succeed because bmc-skip is skipped and bmc-normal is contactable
+	tt.Expect(err).To(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}))
+	tt.Expect(tt.cluster.Status.FailureMessage).To(BeNil())
+	tt.cleanup()
+}
+
 func TestReconcilerDetectOperationK8sVersionUpgrade(t *testing.T) {
 	tt := newReconcilerTest(t)
 	tt.createAllObjs()


### PR DESCRIPTION
*Issue #, if available:*
In management clusters with large hardware pools managing multiple workload clusters, a single unreachable BMC blocks entire cluster operations (create/upgrade) even if that BMC is not relevant to the current operation. This is problematic when:
- Hardware failures are common across large server fleets
- Network connectivity issues affect individual BMCs
- Maintenance windows require operations to proceed despite isolated issues

*Description of changes:*
This change introduces a mechanism to skip BMC contact validation for specific RufioMachines in large-scale production environments where hardware failures or network issues may affect individual BMCs.

- Update WaitForRufioMachines to use label selector excluding machines with
  skip label set to "true"
- Update ValidateRufioMachines in reconciler to skip contact check
  for machines with the skip label

Usage:
Users manually apply the label to RufioMachine resources:
```
kubectl label machine.bmc.tinkerbell.org <machine-name> \
  bmc.tinkerbell.org/skip-contact-check=true \
  -n eksa-system
```
*Testing (if applicable):*
Updated bmc secret with wrong password to make a machine not contactable. 

*Before the changes it fails at bmc contact check*
<img width="1175" height="790" alt="Screenshot 2025-11-14 at 12 40 28 AM" src="https://github.com/user-attachments/assets/365bfac2-dcdb-4271-82fe-4896101f41a4" />

*After the changes, it went pass the bmc contact check even though bmc-eksa-dev29 is not contactable*
<img width="1182" height="862" alt="Screenshot 2025-11-14 at 1 31 42 AM" src="https://github.com/user-attachments/assets/15c96023-7a03-4397-8885-ef70664b603a" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

