### PR TITLE
Fix airgap registry setup for packages

### DIFF
--- a/docs/content/en/docs/getting-started/optional/registrymirror.md
+++ b/docs/content/en/docs/getting-started/optional/registrymirror.md
@@ -70,7 +70,7 @@ Note while using `ociNamespaces`, you need to specify __all__ the registries tha
     - registry: "public.ecr.aws"
       namespace: ""
     - registry: "783794618700.dkr.ecr.us-west-2.amazonaws.com"
-      namespace: "curated-packages"
+      namespace: "eks-anywhere"
   ```
 {{% alert title="Warning" color="warning" %}}
 Currently only `public.ecr.aws` registry is supported for mirroring with Bottlerocket OS.
@@ -122,7 +122,6 @@ eks-anywhere
 eks-distro
 eks
 cilium-chart
-curated-packages
 ```
 
 For example, if a registry is available at `private-registry.local`, then the following projects must be created.
@@ -133,7 +132,6 @@ https://private-registry.local/eks-anywhere
 https://private-registry.local/eks-distro
 https://private-registry.local/eks
 https://private-registry.local/cilium-chart
-https://private-registry.local/curated-packages
 ```
 
 ### Admin machine configuration

--- a/docs/content/en/docs/packages/prereq.md
+++ b/docs/content/en/docs/packages/prereq.md
@@ -130,7 +130,7 @@ The `$KUBEVERSION` should be set to the same as the Kubernetes version in `spec.
 
 ```bash
 eksctl anywhere copy packages \
-  ${REGISTRY_MIRROR_URL}/curated-packages \
+  ${REGISTRY_MIRROR_URL}/eks-anywhere \
   --kube-version $KUBEVERSION \
   --src-chart-registry public.ecr.aws/eks-anywhere \
   --src-image-registry ${ECR_PACKAGES_ACCOUNT}.dkr.ecr.${EKSA_AWS_REGION}.amazonaws.com
@@ -145,7 +145,7 @@ metadata:
   name: eksa-packages-bundle-controller
   namespace: eksa-packages
 spec:
-  defaultImageRegistry: ${REGISTRY_MIRROR_URL}/curated-packages
+  defaultImageRegistry: ${REGISTRY_MIRROR_URL}/eks-anywhere
   defaultRegistry: ${REGISTRY_MIRROR_URL}/eks-anywhere
 ```
 


### PR DESCRIPTION
*Description of changes:*
Update the copy packages command destination to `eks-anywhere` to reflect the known limitation. Versions of package controller image that are present in eks-a bundle come from public.ecr.aws/eks-anywhere and are copied to "eks-anywhere" namespace when import images command is run. We need to copy the images that are present in package bundle to the same destination. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

