### PR TITLE
Use public registry to fix failing helm pull

### DIFF
--- a/test/e2e/curatedpackages.go
+++ b/test/e2e/curatedpackages.go
@@ -102,7 +102,7 @@ func runCuratedPackageInstallSimpleFlowRegistryMirror(test *framework.ClusterE2E
 
 	test.DownloadImages()
 	test.ImportImages()
-	test.CopyPackages(alias, pkgRegistry)
+	test.CopyPackages(alias, "public.ecr.aws/"+alias, pkgRegistry)
 
 	bundlePath := "./eks-anywhere-downloads/bundle-release.yaml"
 	test.CreateCluster(framework.WithBundlesOverride(bundlePath))

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -737,7 +737,7 @@ func (e *ClusterE2ETest) GetPackageControlleChartRepo() (string, error) {
 }
 
 // CopyPackages runs the EKS-A `copy packages` command to copy curated packages to the registry mirror.
-func (e *ClusterE2ETest) CopyPackages(packageMirrorAlias string, packageRegistry string, opts ...CommandOpt) {
+func (e *ClusterE2ETest) CopyPackages(packageMirrorAlias string, packageChartRegistry string, packageRegistry string, opts ...CommandOpt) {
 	clusterConfig := e.ClusterConfig.Cluster
 	registyMirrorEndpoint, registryMirrorPort := clusterConfig.Spec.RegistryMirrorConfiguration.Endpoint, clusterConfig.Spec.RegistryMirrorConfiguration.Port
 	registryMirrorHost := net.JoinHostPort(registyMirrorEndpoint, registryMirrorPort)
@@ -750,7 +750,7 @@ func (e *ClusterE2ETest) CopyPackages(packageMirrorAlias string, packageRegistry
 		"copy", "packages",
 		registryMirrorHost + "/" + packageMirrorAlias,
 		"--kube-version", kubeVersion,
-		"--src-chart-registry", packageRegistry,
+		"--src-chart-registry", packageChartRegistry,
 		"--src-image-registry", packageRegistry,
 		"--dst-insecure",
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3276

*Description of changes:*
package registry mirror tests are failing during copy packages when using regional private registry for charts for some reason. Circumventing this issue by using public repo for now. Even customers are instructed today to use public chart registry for copy packages command. So, this is more representative anyways. Will need a permanent fix before we customers to migrate too along with deprecating non regional registry. 

```
Error: cannot get chart values 067575901363.dkr.ecr.us-west-2.amazonaws.com/eks-anywhere-packages:0.0.0-95303a1cdd475a94bbbc813936031cdcce44bce9: failed to perform "FetchReference" on source: GET "https://067575901363.dkr.ecr.us-west-2.amazonaws.com/v2/eks-anywhere-packages/manifests/0.0.0-95303a1cdd475a94bbbc813936031cdcce44bce9": basic credential not found
    cluster.go:1038: Command failed, scanning output for error
    cluster.go:1058: Command eksctl anywhere [copy packages 196.18.89.98:443/x3k6m8v0 --kube-version 1.33 --src-chart-registry 067575901363.dkr.ecr.us-west-2.amazonaws.com --src-image-registry 067575901363.dkr.ecr.us-west-2.amazonaws.com --dst-insecure] failed with error: exit status 255: Error: cannot get chart values 067575901363.dkr.ecr.us-west-2.amazonaws.com/eks-anywhere-packages:0.0.0-95303a1cdd475a94bbbc813936031cdcce44bce9: failed to perform "FetchReference" on source: GET "https://067575901363.dkr.ecr.us-west-2.amazonaws.com/v2/eks-anywhere-packages/manifests/0.0.0-95303a1cdd475a94bbbc813936031cdcce44bce9": basic credential not found

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

