### PR TITLE
Restore 1-34 Ubuntu RTOS e2e tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -195,13 +195,6 @@ skipped_tests:
 - TestTinkerbellKubernetes131ThreeReplicasTwoWorkersConformanceFlow
 - TestTinkerbellKubernetes132ThreeReplicasTwoWorkersConformanceFlow
 
-# Tinkerbell 134 RTOS tests
-# These tests need to be skipped until the 1.34 RTOS image from cannonical is available
-- TestTinkerbellKubernetes134Ubuntu2204To2404GenericUpgrade
-- TestTinkerbellKubernetes134Ubuntu2404RTOSSimpleFlow
-- TestTinkerbellKubernetes134Ubuntu2404GenericSimpleFlow
-- TestTinkerbellKubernetes134Ubuntu2204To2404RTOSUpgrade
-
 # Vsphere 
 # Auto import tests fail from time to time if the underlying template doesn't go well with the content library.
 # Currently there's no fix for this and issue has been brought up with the BR team multiple times.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With 1-34 RTOS images now available, re-enabling Ubuntu 1-34 RTOS tests by removing them from the skip list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

