### PR TITLE
Add missing mkdir step for CAPI backup directory

### DIFF
--- a/docs/content/en/docs/clustermgmt/cluster-backup-restore/backup-cluster.md
+++ b/docs/content/en/docs/clustermgmt/cluster-backup-restore/backup-cluster.md
@@ -46,6 +46,9 @@ MGMT_CLUSTER="mgmt"
 MGMT_CLUSTER_KUBECONFIG=${MGMT_CLUSTER}/${MGMT_CLUSTER}-eks-a-cluster.kubeconfig
 BACKUP_DIRECTORY=backup-mgmt
 
+# Create the backup directory
+mkdir -p ${BACKUP_DIRECTORY}
+
 # Substitute the EKS Anywhere release version with whatever CLI version you are using
 EKSA_RELEASE_VERSION=v0.23.0
 BUNDLE_MANIFEST_URL=$(curl -s https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml | yq ".spec.releases[] | select(.version==\"$EKSA_RELEASE_VERSION\").bundleManifestUrl")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3705
*Description of changes:*
- Add missing mkdir step for CAPI backup directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

