### PR TITLE
Set DHCP relay sourceInterface from LoadBalancerInterface config

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -670,6 +670,7 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 
 	if loadBalancerInterface != "" {
 		valuesMap[stack].(map[string]interface{})[kubevip].(map[string]interface{})[kubevipInterface] = loadBalancerInterface
+		valuesMap[stack].(map[string]interface{})[relay].(map[string]interface{})["sourceInterface"] = loadBalancerInterface
 	}
 
 	return valuesMap

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -57,6 +57,7 @@ stack:
     enabled: false
     image: public.ecr.aws/eks-anywhere/tink-relay:latest
     initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    sourceInterface: test-interface
   service:
     enabled: false
   singleNodeClusterConfig:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3731
*Description of changes:*
Set DHCP relay sourceInterface from LoadBalancerInterface config.

When LoadBalancerInterface is configured in TinkerbellDatacenterConfig, propagate the same interface to the DHCP relay's sourceInterface. This ensures the relay listens for DHCP broadcasts on the correct network interface where bare metal machines are located.

Previously only kube-vip used this interface setting, leaving the relay to auto-detect which could pick the wrong interface in multi-NIC setups.

*Testing (if applicable):*

Specified a dummy interface in `loadbalancerinterface` in TinkerbellDatacenterConfig and tried to create a cluster and verified that relay has the specified interface in the args

<img width="656" height="245" alt="Screenshot 2025-12-05 at 4 03 21 PM" src="https://github.com/user-attachments/assets/9cf2d66d-5139-40fc-8079-4f80846612ff" />
<img width="832" height="304" alt="Screenshot 2025-12-05 at 4 02 51 PM" src="https://github.com/user-attachments/assets/b4534d78-9aee-4838-b8ed-23f063fceac6" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

