### PR TITLE
Fix failing TestClusterValidateUpdateProxyConfigurationEqualOrder test by using IP instead of test.com

### DIFF
--- a/pkg/api/v1alpha1/cluster_webhook_test.go
+++ b/pkg/api/v1alpha1/cluster_webhook_test.go
@@ -524,8 +524,8 @@ func TestClusterValidateUpdateClusterNetworkNodesImmutable(t *testing.T) {
 func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
 	cOld := baseCluster()
 	cOld.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{
-		HttpProxy:  "http://test.com:1",
-		HttpsProxy: "https://test.com:1",
+		HttpProxy:  "http://0.0.0.0:1",
+		HttpsProxy: "https://0.0.0.0:1",
 		NoProxy: []string{
 			"noproxy1",
 			"noproxy2",
@@ -534,8 +534,8 @@ func TestClusterValidateUpdateProxyConfigurationEqualOrder(t *testing.T) {
 
 	c := cOld.DeepCopy()
 	c.Spec.ProxyConfiguration = &v1alpha1.ProxyConfiguration{
-		HttpProxy:  "http://test.com:1",
-		HttpsProxy: "https://test.com:1",
+		HttpProxy:  "http://0.0.0.0:1",
+		HttpsProxy: "https://0.0.0.0:1",
 		NoProxy: []string{
 			"noproxy2",
 			"noproxy1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
TestClusterValidateUpdateProxyConfigurationEqualOrder started failing recently in both local runs and presubmit CI. The test uses test.com which has no A record, causing DNS lookup validation to fail. Replace with 0.0.0.0 to bypass DNS lookup
since IP addresses skip the resolver check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

