### PR TITLE
docs: Clarify baremetal network requirements and kubectl capabilities

### DIFF
--- a/docs/content/en/docs/clustermgmt/cluster-scale/baremetal-scale.md
+++ b/docs/content/en/docs/clustermgmt/cluster-scale/baremetal-scale.md
@@ -65,7 +65,7 @@ If you don't have any available hardware that match this requirement in the clus
     ```
     As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.
 
-2. **kubectl CLI**: The cluster lifecycle feature lets you use kubectl to talk to the Kubernetes API to upgrade a workload cluster. To use kubectl, run:
+2. **kubectl CLI**: The cluster lifecycle feature lets you use kubectl to talk to the Kubernetes API to scale a workload cluster. kubectl can also be used for management cluster scaling, except when upgrading the EKS Anywhere CLI version which requires `eksctl anywhere upgrade`. To use kubectl, run:
      ```bash
      kubectl apply -f eksa-w01-cluster.yaml --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig
      ```

--- a/docs/content/en/docs/clustermgmt/cluster-upgrades/baremetal-upgrades.md
+++ b/docs/content/en/docs/clustermgmt/cluster-upgrades/baremetal-upgrades.md
@@ -136,9 +136,9 @@ and then you will run the [upgrade cluster command]({{< relref "baremetal-upgrad
 
 
 #### Upgrade cluster command
-* **kubectl CLI**: The cluster lifecycle feature lets you use kubectl to talk to the Kubernetes API to upgrade a workload cluster. To use kubectl, run:
+* **kubectl CLI**: The cluster lifecycle feature lets you use kubectl to talk to the Kubernetes API to upgrade a workload cluster. kubectl can also be used for management cluster upgrades (Kubernetes version, scaling, configuration changes), except when upgrading the EKS Anywhere CLI version which requires `eksctl anywhere upgrade`. To use kubectl, run:
    ```bash
-   kubectl apply -f eksa-w01-cluster.yaml 
+   kubectl apply -f eksa-w01-cluster.yaml
   --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig
    ```
  

--- a/docs/content/en/docs/getting-started/baremetal/bare-preparation.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-preparation.md
@@ -25,12 +25,30 @@ Once the hardware is in place, you need to:
 
 ## Prepare hardware inventory
 Create a CSV file to provide information about all physical machines that you are ready to add to your target Bare Metal cluster.
-This file will be used:
 
-* When you generate the hardware file to be included in the cluster creation process described in the Create Bare Metal production cluster Getting Started guide.
-* To provide information that is passed to each machine from the Tinkerbell DHCP server when the machine is initially network booted.
+{{% alert title="Hardware CSV vs kubectl: When to Use Each" color="primary" %}}
+**Hardware CSV** creates the initial hardware catalog (Hardware objects, BMC Machines, credentials).
 
-**NOTE**:While using kubectl, GitOps and Terraform for workload cluster creation, please make sure to refer [this]({{< relref "./baremetal-getstarted/#create-separate-workload-clusters" >}}) section.
+**Use hardware CSV for**:
+- Initial cluster creation
+- Adding new hardware when insufficient hardware available for scaling/upgrades
+
+**Use kubectl for hardware management**:
+- Adding hardware after initial creation: `eksctl anywhere generate hardware -z hardware.csv > hardware.yaml && kubectl apply -f hardware.yaml`
+
+**For cluster operations (scaling, upgrades)**:
+- Update `count` in cluster specification
+- System automatically selects from available hardware (those without `ownerName` label)
+- If insufficient hardware: Add more via hardware CSV with `--hardware-csv` flag or kubectl apply, then perform operation
+
+**Do NOT use CSV for**:
+- Removing hardware from cluster (use CAPI machine delete annotations)
+- Trying to force specific hardware selection during operations (system auto-selects based on availability)
+
+See [Scale Bare Metal Cluster]({{< relref "../../clustermgmt/cluster-scale/baremetal-scale" >}}) for operational examples.
+{{% /alert %}}
+
+**NOTE**: While using kubectl, GitOps and Terraform for workload cluster creation, please make sure to refer to [this section]({{< relref "./baremetal-getstarted/#create-separate-workload-clusters" >}}).
 
 The following is an example of an EKS Anywhere Bare Metal hardware CSV file:
 

--- a/docs/content/en/docs/getting-started/baremetal/baremetal-getstarted.md
+++ b/docs/content/en/docs/getting-started/baremetal/baremetal-getstarted.md
@@ -184,7 +184,7 @@ Follow these steps if you want to use your initial cluster to create and manage 
      ```
      As noted earlier, adding the `--kubeconfig` option tells `eksctl` to use the management cluster identified by that kubeconfig file to create a different workload cluster.
 
-   * **kubectl CLI**: The cluster lifecycle feature lets you use kubectl to talks to the Kubernetes API to create a workload cluster. To use kubectl, run:
+   * **kubectl CLI**: The cluster lifecycle feature lets you use kubectl to talk to the Kubernetes API to create a workload cluster. kubectl can also be used for management cluster operations (scaling, Kubernetes version upgrades), except when upgrading the EKS Anywhere CLI version which requires `eksctl anywhere upgrade`. To use kubectl, run:
       ```bash
       kubectl apply -f eksa-w01-cluster.yaml --kubeconfig mgmt/mgmt-eks-a-cluster.kubeconfig
       ```


### PR DESCRIPTION
*Description of changes:*



- Qualify L2 network as network/PXE boot only, not required for ISO boot
- Clarify DHCP only needed for network/PXE boot mode
- Add TinkerbellIP vs Control Plane Endpoint explanation
- Clarify kubectl works for management and workload cluster operations
- Add hardware CSV operational guidance (when to use CSV vs kubectl)
- Add cross-references between related documentation

These changes address common customer confusion about network requirements for different boot modes and the scope of kubectl usage for cluster lifecycle management.
