### PR TITLE
docs: Add harbor namespace and storage prerequisites

### DIFF
--- a/docs/content/en/docs/packages/harbor/addharbor.md
+++ b/docs/content/en/docs/packages/harbor/addharbor.md
@@ -25,6 +25,12 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
    export KUBECONFIG=<path to management cluster kubeconfig>
    ```
 
+1. Create the `harbor` namespace on the workload cluster (or management cluster if installing there)
+
+   ```bash
+   kubectl create namespace harbor
+   ```
+
 1. Generate the package configuration
    ```bash
    eksctl anywhere generate package harbor --cluster <cluster-name> > harbor.yaml
@@ -42,6 +48,7 @@ Be sure to refer to the [troubleshooting guide]({{< relref "../troubleshoot" >}}
       kubectl create secret tls harbor-tls-secret --cert=[path to certificate file] --key=[path to key file] -n eksa-packages
       ```
    * `secretKey` has to be set as a string of 16 characters for encryption.
+   * Harbor requires persistent storage by default. Ensure your cluster has a StorageClass configured (e.g., vSphere CSI driver for vSphere clusters). If no StorageClass is available, you can disable persistence for testing purposes by adding `persistence.enabled: false` to the config, but this is not recommended for production use.
    {{% /alert %}}
 
    TLS example with auto certificate generation


### PR DESCRIPTION
## Description

This PR adds two missing prerequisites to the Harbor package installation documentation:

1. **Create harbor namespace** - Added a step to create the `harbor` namespace before installing the package. Without this, the package installation fails with `namespaces "harbor" not found` error.

2. **StorageClass requirement** - Added a note explaining that Harbor requires persistent storage by default and a StorageClass must be configured. Also documented the `persistence.enabled: false` option for testing environments without persistent storage.

## Testing

Validated these changes by installing Harbor on a vSphere cluster:

```
eksctl anywhere get packages --cluster pjshah-ubuntu

Command "package" is deprecated, use `kubectl get packages` instead
NAME                               PACKAGE                            AGE   STATE       CURRENTVERSION                                               TARGETVERSION                                                         DETAIL
ecr-credential-provider-package    credential-provider-package        11m   installed   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e               0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e (latest)               
eks-anywhere-packages              eks-anywhere-packages              11m   installed   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e-latest-helm   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e-latest-helm (latest)   
eks-anywhere-packages-crds         eks-anywhere-packages-crds         10m   installed   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e-latest-helm   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e-latest-helm (latest)   
eks-anywhere-packages-migrations   eks-anywhere-packages-migrations   10m   installed   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e-latest-helm   0.0.0-0a2c5d9bf3b4ef3bbdc8882f938ba8a00fd5ee2e-latest-helm (latest)   
my-harbor                          harbor                             63s   installed   2.12.2-latest-helm                                           2.12.2-latest-helm (latest)
```
and
```
kubectl get pods -n harbor

NAME                                    READY   STATUS    RESTARTS      AGE
my-harbor-core-846f6dcbdc-gjwtv         1/1     Running   0             83s
my-harbor-database-0                    1/1     Running   0             82s
my-harbor-jobservice-588f98fbc7-xwl4v   1/1     Running   2 (71s ago)   83s
my-harbor-nginx-f7dcb4b5f-2qt5d         1/1     Running   0             82s
my-harbor-portal-857b7fbcd9-8l5qd       1/1     Running   0             82s
my-harbor-redis-0                       1/1     Running   0             82s
my-harbor-registry-5b979896df-mmgrf     2/2     Running   0             83s
```