### PR TITLE
Fix(tinkerbell): Use cluster spec for worker maxSurge validation insead of generated CAPI object

### DIFF
--- a/pkg/providers/tinkerbell/reconciler/reconciler.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler.go
@@ -441,9 +441,9 @@ func (r *Reconciler) validateHardwareReqForMachineDeployments(ctx context.Contex
 			}
 		}
 		if currentMachineDeployment != nil && currentMachineDeployment.Spec.Template.Spec.InfrastructureRef.Name != wg.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name {
-			upgradeStrategy := wg.MachineDeployment.Spec.Strategy
-			if upgradeStrategy != nil && upgradeStrategy.Type == clusterv1.RollingUpdateMachineDeploymentStrategyType {
-				maxSurge = int(upgradeStrategy.RollingUpdate.MaxSurge.IntVal)
+			upgradeStrategy := workerNodeGroup.UpgradeRolloutStrategy
+			if upgradeStrategy != nil && upgradeStrategy.Type == anywherev1.RollingUpdateStrategyType {
+				maxSurge = upgradeStrategy.RollingUpdate.MaxSurge
 			}
 			if err := requirements.Add(tinkerbellClusterSpec.WorkerNodeGroupMachineConfig(workerNodeGroup).Spec.HardwareSelector, maxSurge); err != nil {
 				return nil, err

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -1857,3 +1857,51 @@ func tinkWorker(clusterName string, opts ...workerOpt) *tinkerbell.Workers {
 	}
 	return w
 }
+
+func TestReconcilerValidateHardwareWorkerRollingUpdateMaxSurgeRespected(t *testing.T) {
+	tt := newReconcilerTest(t)
+
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tt.kcp)
+
+	// Create existing MachineDeployment with a DIFFERENT InfrastructureRef name
+	// to simulate a template change (e.g., from a previous version)
+	worker := tinkWorker(tt.cluster.Name, func(w *tinkerbell.Workers) {
+		w.Groups[0].MachineDeployment.Name = "workload-cluster-md-0"
+		w.Groups[0].MachineDeployment.Spec.Template.Spec.InfrastructureRef.Name = "workload-cluster-md-0-0"
+		w.Groups[0].ProviderMachineTemplate.Name = "workload-cluster-md-0-0"
+	})
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, worker.Groups[0].MachineDeployment)
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, worker.Groups[0].ProviderMachineTemplate)
+
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tinkHardware("hw1", "worker"))
+	tt.eksaSupportObjs = append(tt.eksaSupportObjs, tinkHardware("hw-cp", "cp"))
+
+	tt.withFakeClient()
+
+	logger := test.NewNullLogger()
+	scope := tt.buildScope()
+
+	scope.ClusterSpec.Config.Cluster.Spec.WorkerNodeGroupConfigurations[0].UpgradeRolloutStrategy = &anywherev1.WorkerNodesUpgradeRolloutStrategy{
+		Type: anywherev1.RollingUpdateStrategyType,
+		RollingUpdate: &anywherev1.WorkerNodesRollingUpdateParams{
+			MaxSurge:       3,
+			MaxUnavailable: 0,
+		},
+	}
+
+	wngRef := scope.ClusterSpec.Config.Cluster.Spec.WorkerNodeGroupConfigurations[0].MachineGroupRef.Name
+	scope.ClusterSpec.Config.TinkerbellMachineConfigs[wngRef].Spec.OSImageURL = "new-os-image"
+
+	_, err := tt.reconciler().GenerateSpec(tt.ctx, logger, scope)
+	tt.Expect(err).NotTo(HaveOccurred())
+
+	_, err = tt.reconciler().DetectOperation(tt.ctx, logger, scope)
+	tt.Expect(err).NotTo(HaveOccurred())
+
+	result, err := tt.reconciler().ValidateHardware(tt.ctx, logger, scope)
+
+	tt.Expect(err).ToNot(BeNil())
+	tt.Expect(result).To(Equal(controller.Result{}))
+	tt.Expect(*tt.cluster.Status.FailureMessage).To(ContainSubstring("minimum hardware count not met for selector"))
+	tt.Expect(tt.cluster.Status.FailureReason).To(HaveValue(Equal(anywherev1.HardwareInvalidReason)))
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3776

*Description of changes:*
The hardware validation for worker node rollouts was reading maxSurge from the generated MachineDeployment's Strategy.Type field. However, the template generation code only sets Strategy.Type for InPlace upgrades, leaving it empty for RollingUpdate. This caused the maxSurge check to be skipped, defaulting to 1 instead of using the user-configured value.
For example, with maxSurge=3 configured, validation would only require 1 spare hardware instead of 3, potentially causing mid-rollout failures.

The fix reads the upgrade strategy directly from the EKS-A cluster spec (workerNodeGroup.UpgradeRolloutStrategy) instead of the generated CAPI object, consistent with how KCP validation already works.

Added unit tests to verify:
- Validation fails when hardware count doesn't meet maxSurge requirement

*Testing (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

