### PR TITLE
docs: add HTTP Range request warning for ISO hosting and document vlan_id field

### DIFF
--- a/docs/content/en/docs/getting-started/baremetal/bare-preparation.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-preparation.md
@@ -96,6 +96,9 @@ For example, a `TinkerbellMachineConfig` with a `hardwareSelector` containing `t
 The device name of the disk on which the operating system will be installed.
 For example, it could be `/dev/sda` for the first SCSI disk or `/dev/nvme0n1` for the first NVME storage device.
 
+### vlan_id (optional)
+The VLAN ID to assign to the machine's network interface. Use this field when machines need to be provisioned on a specific VLAN.
+
 ## Hardware Management 
 
 ### Hardware Objects and Spare Nodes

--- a/docs/content/en/docs/getting-started/baremetal/bare-prereq.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-prereq.md
@@ -61,6 +61,16 @@ Here are other network requirements:
 
 > **_NOTE:_** If you have another DHCP service running on the network, you need to prevent it from interfering with the EKS Anywhere DHCP service. You can do that by configuring the other DHCP service to explicitly block all MAC addresses and exclude all IP addresses that you plan to use with your EKS Anywhere clusters.
 
+{{% alert title="Verifying Layer 2 Connectivity (PXE boot mode)" color="primary" %}}
+If machines are not PXE booting, verify layer 2 connectivity between the Admin machine and the machines being provisioned. DHCP requests from the machines should appear in the Boots (Smee) logs.
+
+To verify DHCP traffic is reaching the Admin machine, run on the Admin machine:
+```bash
+sudo tcpdump -i any port 67 or port 68
+```
+When a machine attempts to PXE boot, you should see DHCP DISCOVER/REQUEST packets. If no packets appear, there is a layer 2 network connectivity issue (VLAN misconfiguration, switch port settings, etc.).
+{{% /alert %}}
+
 * If you have not followed the [steps for airgapped environments]({{< relref "../airgapped" >}}), then the administrative machine and the target workload environment need network access (TCP/443) to:
 
   * `public.ecr.aws`

--- a/docs/content/en/docs/getting-started/baremetal/bare-spec.md
+++ b/docs/content/en/docs/getting-started/baremetal/bare-spec.md
@@ -292,6 +292,21 @@ Optional field (string URL) to override the default AWS hosted location for the 
 Use this field to host the HookOS ISO locally.
 See [Boot Modes]({{< relref "customize/bare-metal-boot-modes/#iso-boot" >}}) for details.
 
+{{% alert title="Important: HTTP Server Requirements for Hosting HookOS" color="warning" %}}
+When hosting HookOS images locally, your HTTP server **must support HTTP Range requests** (RFC 7233). BMC virtual media uses Range requests to stream the ISO in chunks.
+
+**Servers that work:** Apache, nginx, or any server that returns `206 Partial Content` for Range requests.
+
+**Servers that do NOT work:** Python's built-in `python3 -m http.server` (returns `200 OK` for Range requests, ignoring the Range header).
+
+If ISO boot fails with no clear error, verify your server supports Range requests:
+```bash
+curl -I -H "Range: bytes=0-1000" http://your-server/hook.iso
+# Should return: HTTP/1.1 206 Partial Content
+# NOT: HTTP/1.1 200 OK
+```
+{{% /alert %}}
+
 #### Example `TinkerbellDatacenterConfig.spec`
 ```yaml
 spec:


### PR DESCRIPTION
*Issue #, if available:*
Smee iso streaming won't work when upstream server doesn't handle 206 requests appropriately.

*Description of changes:*
- Add warning about Python http.server not supporting Range requests for ISO boot
- Document vlan_id field in hardware CSV specification
- Add L2 connectivity troubleshooting with tcpdump for PXE boot issues"

*Testing (if applicable):*
Ran a quick test for partial content requests in default python server vs custom script:

```
#default server always returns full content - 200
python3 -m http.server 9900 --directory /tmp
Serving HTTP on :: port 9900 (http://[::]:9900/) ...
::1 - - [14/Jan/2026 14:00:33] "HEAD /hook-test.iso HTTP/1.1" 200 -

#custom server returns partial content that BMC expects - 206 
rahulgab@bcd07465f13c 1-30 % python3 range_server.py 9901 /tmp
Serving /tmp on port 9901 with Range request support...
127.0.0.1 - - [14/Jan/2026 14:00:33] "HEAD /hook-test.iso HTTP/1.1" 206 -

rahulgab@bcd07465f13c 1-30 % curl -s -I --header "Range: bytes=0-1000" "http://localhost:9900/hook-test.iso"
HTTP/1.0 200 OK
Server: SimpleHTTP/0.6 Python/3.13.0
Date: Wed, 14 Jan 2026 22:02:35 GMT
Content-type: application/x-iso9660-image
Content-Length: 10485761
Last-Modified: Wed, 14 Jan 2026 21:59:46 GMT

rahulgab@bcd07465f13c 1-30 % echo "=== range_server.py (port 9901) - Range request ==="
curl -s -I --header "Range: bytes=0-1000" "http://localhost:9901/hook-test.iso"
=== range_server.py (port 9901) - Range request ===
rahulgab@bcd07465f13c 1-30 % curl -s -I --header "Range: bytes=0-1000" "http://localhost:9901/hook-test.iso"
HTTP/1.0 206 Partial Content
Server: SimpleHTTP/0.6 Python/3.13.0
Date: Wed, 14 Jan 2026 22:02:44 GMT
Content-type: application/x-iso9660-image
Content-Length: 1001
Content-Range: bytes 0-1000/10485761
Accept-Ranges: bytes
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

