### PR TITLE
Migrate snow provider containerd config to v2 format

### DIFF
--- a/pkg/clusterapi/config/containerd_config_append.toml
+++ b/pkg/clusterapi/config/containerd_config_append.toml
@@ -1,14 +1,2 @@
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-{{- range $orig, $mirror := .registryMirrorMap }}
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ $orig }}"]
-    endpoint = ["https://{{ $mirror }}"]
-{{- end }}
-{{- if or .registryCACert .insecureSkip }}
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .mirrorBase }}".tls]
-{{- if .registryCACert }}
-    ca_file = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
-{{- end }}
-{{- if .insecureSkip }}
-    insecure_skip_verify = {{.insecureSkip}}
-{{- end }}
-{{- end }}
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"

--- a/pkg/clusterapi/config/hosts.toml
+++ b/pkg/clusterapi/config/hosts.toml
@@ -1,0 +1,10 @@
+server = "https://{{ .server }}"
+
+[host."https://{{ .host }}"]
+  capabilities = ["pull", "resolve"]
+{{- if .registryCACert }}
+  ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
+{{- end }}
+{{- if .insecureSkip }}
+  skip_verify = true
+{{- end }}

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -265,16 +265,34 @@ var registryMirrorTests = []struct {
 			{
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
-				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://1.2.3.4:443/v2/eks-anywhere"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
-    ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"`,
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+`,
 			},
 			{
 				Path:    "/etc/containerd/certs.d/1.2.3.4:443/ca.crt",
 				Owner:   "root:root",
 				Content: "xyz",
+			},
+			{
+				Path:  "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://1.2.3.4:443"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://public.ecr.aws"
+
+[host."https://1.2.3.4:443/v2/eks-anywhere"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+`,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
@@ -303,18 +321,44 @@ var registryMirrorTests = []struct {
 			{
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
-				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."783794618700.dkr.ecr.us-west-2.amazonaws.com"]
-    endpoint = ["https://1.2.3.4:443/v2/curated-packages"]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://1.2.3.4:443/v2/eks-anywhere"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
-    ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"`,
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+`,
 			},
 			{
 				Path:    "/etc/containerd/certs.d/1.2.3.4:443/ca.crt",
 				Owner:   "root:root",
 				Content: "xyz",
+			},
+			{
+				Path:  "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://1.2.3.4:443"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
+
+[host."https://1.2.3.4:443/v2/curated-packages"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://public.ecr.aws"
+
+[host."https://1.2.3.4:443/v2/eks-anywhere"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+`,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
@@ -333,11 +377,29 @@ var registryMirrorTests = []struct {
 			{
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
-				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://1.2.3.4:443"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
-    insecure_skip_verify = true`,
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://1.2.3.4:443"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://public.ecr.aws"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true
+`,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
@@ -354,9 +416,27 @@ var registryMirrorTests = []struct {
 			{
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
-				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://1.2.3.4:443"]`,
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://1.2.3.4:443"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://public.ecr.aws"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+`,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
@@ -375,17 +455,36 @@ var registryMirrorTests = []struct {
 			{
 				Path:  "/etc/containerd/config_append.toml",
 				Owner: "root:root",
-				Content: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."public.ecr.aws"]
-    endpoint = ["https://1.2.3.4:443"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."1.2.3.4:443".tls]
-    ca_file = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
-    insecure_skip_verify = true`,
+				Content: `[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+`,
 			},
 			{
 				Path:    "/etc/containerd/certs.d/1.2.3.4:443/ca.crt",
 				Owner:   "root:root",
 				Content: "xyz",
+			},
+			{
+				Path:  "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://1.2.3.4:443"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+  skip_verify = true
+`,
+			},
+			{
+				Path:  "/etc/containerd/certs.d/public.ecr.aws/hosts.toml",
+				Owner: "root:root",
+				Content: `server = "https://public.ecr.aws"
+
+[host."https://1.2.3.4:443"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
+  skip_verify = true
+`,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
@@ -403,11 +502,23 @@ func TestKubeadmControlPlaneWithRegistryMirrorUbuntu(t *testing.T) {
 			controlPlaneMachineTemplate := snow.MachineTemplate("snow-test-control-plane-1", g.machineConfigs[g.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.MachineGroupRef.Name], nil)
 			got, err := snow.KubeadmControlPlane(g.logger, g.clusterSpec, controlPlaneMachineTemplate)
 			g.Expect(err).To(Succeed())
-			want := wantKubeadmControlPlane("1.21")
-			want.Spec.KubeadmConfigSpec.Files = append(want.Spec.KubeadmConfigSpec.Files, tt.wantFiles...)
-			want.Spec.KubeadmConfigSpec.PreKubeadmCommands = append(want.Spec.KubeadmConfigSpec.PreKubeadmCommands, wantRegistryMirrorCommands()...)
-			want.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = []string{"DirAvailable--etc-kubernetes-manifests"}
-			g.Expect(got).To(BeComparableTo(want))
+
+			// Verify PreKubeadmCommands
+			g.Expect(got.Spec.KubeadmConfigSpec.PreKubeadmCommands).To(ContainElements(
+				"/etc/eks/bootstrap.sh",
+				"cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml",
+				"sudo systemctl daemon-reload",
+				"sudo systemctl restart containerd",
+			))
+
+			// Verify IgnorePreflightErrors
+			g.Expect(got.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors).To(ContainElement("DirAvailable--etc-kubernetes-manifests"))
+
+			// Verify Files - check that each expected file is present
+			g.Expect(got.Spec.KubeadmConfigSpec.Files).To(HaveLen(len(tt.wantFiles) + 1)) // +1 for kube-vip
+			for _, wantFile := range tt.wantFiles {
+				g.Expect(got.Spec.KubeadmConfigSpec.Files).To(ContainElement(wantFile))
+			}
 		})
 	}
 }


### PR DESCRIPTION
*Description of changes:*
Migrates registry mirror containerd configuration to v2 format, which was missed in previous PR https://github.com/aws/eks-anywhere/pull/10212

*Testing (if applicable):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

