### PR TITLE
Fix aws-iam-authenticator user in v0.7.10

### DIFF
--- a/pkg/awsiamauth/config/aws-iam-authenticator.yaml
+++ b/pkg/awsiamauth/config/aws-iam-authenticator.yaml
@@ -133,6 +133,7 @@ spec:
         - --kubeconfig-pregenerated=true
 
         securityContext:
+          runAsUser: 65532
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -160,7 +161,7 @@ spec:
       initContainers:
       - name: chown
         image: {{.initContainerImage}}
-        command: ['sh', '-c', 'chown 10000:10000 /var/aws-iam-authenticator/cert.pem; chown 10000:10000 /var/aws-iam-authenticator/key.pem; chown 10000:10000 /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml']
+        command: ['sh', '-c', 'chown 65532:65532 /var/aws-iam-authenticator/cert.pem; chown 65532:65532 /var/aws-iam-authenticator/key.pem; chown 65532:65532 /etc/kubernetes/aws-iam-authenticator/kubeconfig.yaml']
         volumeMounts:
         - name: cert
           mountPath: /var/aws-iam-authenticator/cert.pem


### PR DESCRIPTION
*Issue #, if available:*
AWS Iam authentication started failing with latest versions of eks-distro shipped with [new version of aws-iam-authenticator](https://distro.eks.amazonaws.com/releases/1-30/50/). 

aws-iam-authenticator pod fails to come up with error
```
time="2026-01-29T22:17:12Z" level=fatal msg="could not load/generate a certificate" error="open /var/aws-iam-authenticator/cert.pem: permission denied"
```

```
docker pull public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.7.10-eks-1-30-50
docker inspect public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.7.10-eks-1-30-50 --format='{{.Config.User}}'

Output: 65532
```

```
docker pull public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.7.9-eks-1-30-49
docker inspect public.ecr.aws/eks-distro/kubernetes-sigs/aws-iam-authenticator:v0.7.9-eks-1-30-49 --format='{{.Config.User}}'

Output: aws-iam-authenticator
```

Upstream PR that broke the functionality - https://github.com/aws/eks-distro/commit/da22b54830a4faf74a95b2d38cd50ec09602b56e

*Description of changes:*
Change the chown user id in the init container that sets the owner for the file in the error above. Also added runAsUser to shield us from future regression.


*Testing (if applicable):*
```
Fixed a cluster with broken aws iam authenticator pod by making the changes in this PR manually in the daemonset spec
```

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

