### PR TITLE
[release-0.23] Adds support bundle collection to failing e2e tests (#10503)

### DIFF
--- a/test/e2e/api_server_extra_args.go
+++ b/test/e2e/api_server_extra_args.go
@@ -9,6 +9,7 @@ import (
 
 func runAPIServerExtraArgsUpgradeFlow(test *framework.ClusterE2ETest, clusterOpts ...[]framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	for _, opts := range clusterOpts {
 		test.UpgradeClusterWithNewConfig(opts)

--- a/test/e2e/autoimport.go
+++ b/test/e2e/autoimport.go
@@ -12,6 +12,7 @@ import (
 
 func runAutoImportFlow(test *framework.ClusterE2ETest, provider *framework.VSphere) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	templates := getMachineConfigs(test)
 	test.DeleteCluster()

--- a/test/e2e/awsiamauth.go
+++ b/test/e2e/awsiamauth.go
@@ -12,6 +12,7 @@ import (
 
 func runAWSIamAuthFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateAWSIamAuth()
 	test.StopIfFailed()
@@ -20,6 +21,7 @@ func runAWSIamAuthFlow(test *framework.ClusterE2ETest) {
 
 func runUpgradeFlowWithAWSIamAuth(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateAWSIamAuth()
 	test.UpgradeClusterWithNewConfig(clusterOpts)
@@ -32,6 +34,7 @@ func runUpgradeFlowWithAWSIamAuth(test *framework.ClusterE2ETest, updateVersion 
 func runTinkerbellAWSIamAuthFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.ValidateAWSIamAuth()
 	test.StopIfFailed()
@@ -43,6 +46,7 @@ func runAWSIamAuthFlowWorkload(test *framework.MulticlusterE2ETest) {
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfig()
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster()
 		w.ValidateAWSIamAuth()
 		w.StopIfFailed()

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -13,6 +13,7 @@ import (
 
 func runConformanceFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.RunConformanceTests()
 	test.StopIfFailed()
@@ -22,6 +23,7 @@ func runConformanceFlow(test *framework.ClusterE2ETest) {
 func runTinkerbellConformanceFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.RunConformanceTests()
 	test.StopIfFailed()

--- a/test/e2e/host_os_config.go
+++ b/test/e2e/host_os_config.go
@@ -10,6 +10,7 @@ import (
 
 func runNTPFlow(test *framework.ClusterE2ETest, osFamily v1alpha1.OSFamily) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateNTPConfig(osFamily)
 	test.DeleteCluster()
@@ -17,6 +18,7 @@ func runNTPFlow(test *framework.ClusterE2ETest, osFamily v1alpha1.OSFamily) {
 
 func runBottlerocketConfigurationFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateBottlerocketKubernetesSettings()
 	test.DeleteCluster()

--- a/test/e2e/kubeletconfig.go
+++ b/test/e2e/kubeletconfig.go
@@ -9,6 +9,7 @@ import (
 
 func runKubeletConfigurationFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateKubeletConfig()
 	test.StopIfFailed()
@@ -18,6 +19,7 @@ func runKubeletConfigurationFlow(test *framework.ClusterE2ETest) {
 func runKubeletConfigurationTinkerbellFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateKubeletConfig()
 	test.StopIfFailed()

--- a/test/e2e/labels.go
+++ b/test/e2e/labels.go
@@ -10,6 +10,7 @@ import (
 
 func runLabelsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeLabels)
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneLabels)

--- a/test/e2e/multicluster.go
+++ b/test/e2e/multicluster.go
@@ -17,6 +17,7 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 	licenseToken2 := framework.GetLicenseToken2()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfigWithLicenseToken(licenseToken2)
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster()
 		w.DeleteCluster()
 	})
@@ -27,6 +28,7 @@ func runWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 func runWorkloadClusterExistingConfigFlow(test *framework.MulticlusterE2ETest) {
 	test.CreateManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster()
 		w.DeleteCluster()
 	})
@@ -38,6 +40,7 @@ func runWorkloadClusterPrevVersionCreateFlow(test *framework.MulticlusterE2ETest
 	test.CreateManagementClusterWithConfig()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfigForVersion(latestMinorRelease.Version, "", framework.ExecuteWithEksaRelease(latestMinorRelease))
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster(framework.ExecuteWithEksaRelease(latestMinorRelease))
 		w.DeleteCluster()
 	})
@@ -49,6 +52,7 @@ func runWorkloadClusterFlowWithGitOps(test *framework.MulticlusterE2ETest, clust
 	licenseToken := framework.GetLicenseToken2()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfigWithLicenseToken(licenseToken)
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster()
 		w.UpgradeWithGitOps(clusterOpts...)
 		time.Sleep(5 * time.Minute)
@@ -94,6 +98,7 @@ func runTinkerbellWorkloadClusterFlow(test *framework.MulticlusterE2ETest) {
 	licenseToken2 := framework.GetLicenseToken2()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfigWithLicenseToken(licenseToken2)
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 		w.StopIfFailed()
 		w.DeleteCluster()
@@ -121,6 +126,7 @@ func runSimpleWorkloadUpgradeFlowForBareMetal(test *framework.MulticlusterE2ETes
 	test.CreateTinkerbellManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
 		w.GenerateClusterConfig()
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 		time.Sleep(2 * time.Minute)
 		w.UpgradeCluster(clusterOpts)
@@ -154,6 +160,7 @@ func runWorkloadClusterUpgradeFlowWithAPIForBareMetal(test *framework.Multiclust
 func runInPlaceWorkloadUpgradeFlow(test *framework.MulticlusterE2ETest, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.CreateManagementCluster()
 	test.RunInWorkloadClusters(func(w *framework.WorkloadCluster) {
+		w.GenerateSupportBundleOnCleanupIfTestFailed()
 		w.CreateCluster()
 		w.UpgradeClusterWithNewConfig(clusterOpts)
 		w.ValidateClusterState()

--- a/test/e2e/oidc.go
+++ b/test/e2e/oidc.go
@@ -10,6 +10,7 @@ import (
 
 func runOIDCFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateOIDC()
 	test.StopIfFailed()
@@ -19,6 +20,7 @@ func runOIDCFlow(test *framework.ClusterE2ETest) {
 func runTinkerbellOIDCFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.ValidateOIDC()
 	test.StopIfFailed()
@@ -28,6 +30,7 @@ func runTinkerbellOIDCFlow(test *framework.ClusterE2ETest) {
 
 func runUpgradeFlowWithOIDC(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateOIDC()
 	test.UpgradeClusterWithNewConfig(clusterOpts)

--- a/test/e2e/singlenode.go
+++ b/test/e2e/singlenode.go
@@ -10,6 +10,7 @@ import (
 func runTinkerbellSingleNodeFlow(test *framework.ClusterE2ETest) {
 	test.GenerateClusterConfig()
 	test.GenerateHardwareConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneNoTaints, framework.ValidateControlPlaneLabels)
 	test.DeleteCluster()

--- a/test/e2e/taints.go
+++ b/test/e2e/taints.go
@@ -10,6 +10,7 @@ import (
 
 func runTaintsUpgradeFlow(test *framework.ClusterE2ETest, updateVersion v1alpha1.KubernetesVersion, clusterOpts ...framework.ClusterE2ETestOpt) {
 	test.GenerateClusterConfig()
+	test.GenerateSupportBundleOnCleanupIfTestFailed()
 	test.CreateCluster()
 	test.ValidateWorkerNodes(framework.ValidateWorkerNodeTaints)
 	test.ValidateControlPlaneNodes(framework.ValidateControlPlaneTaints)


### PR DESCRIPTION
*Description of changes:*
Manual cherry-pick of https://github.com/aws/eks-anywhere/pull/10503

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

