### PR TITLE
scope down GitHub token permissions for stale-labeler workflow

### DIFF
--- a/.github/workflows/stale-labeler.yaml
+++ b/.github/workflows/stale-labeler.yaml
@@ -13,6 +13,9 @@ on:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:
+permissions:
+  issues: write
+  pull-requests: write
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*
Talos security finding: https://t.corp.amazon.com/V2034867204

*Description of changes:*
Scope down permission for stale-labeler workflow.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

