### PR TITLE
Adds support for k8s 1.35 behind feature flag

### DIFF
--- a/pkg/api/v1alpha1/cluster_types.go
+++ b/pkg/api/v1alpha1/cluster_types.go
@@ -888,6 +888,7 @@ const (
 	Kube132 KubernetesVersion = "1.32"
 	Kube133 KubernetesVersion = "1.33"
 	Kube134 KubernetesVersion = "1.34"
+	Kube135 KubernetesVersion = "1.35"
 )
 
 // KubeVersionToSemver converts kube version to semver for comparisons.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,6 +7,7 @@ const (
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
 	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 	APIServerExtraArgsEnabledEnvVar = "API_SERVER_EXTRA_ARGS_ENABLED"
+	K8s135SupportEnvVar             = "K8S_1_35_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -54,5 +55,13 @@ func APIServerExtraArgsEnabled() Feature {
 	return Feature{
 		Name:     "Configure api server extra args",
 		IsActive: globalFeatures.isActiveForEnvVar(APIServerExtraArgsEnabledEnvVar),
+	}
+}
+
+// K8s135Support is the feature flag for Kubernetes 1.35 support.
+func K8s135Support() Feature {
+	return Feature{
+		Name:     "Kubernetes version 1.35 support",
+		IsActive: globalFeatures.isActiveForEnvVar(K8s135SupportEnvVar),
 	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -85,3 +85,11 @@ func TestAPIServerExtraArgsEnabledFeatureFlag(t *testing.T) {
 	g.Expect(os.Setenv(APIServerExtraArgsEnabledEnvVar, "true")).To(Succeed())
 	g.Expect(IsActive(APIServerExtraArgsEnabled())).To(BeTrue())
 }
+
+func TestWithK8s135FeatureFlag(t *testing.T) {
+	g := NewWithT(t)
+	setupContext(t)
+
+	g.Expect(os.Setenv(K8s135SupportEnvVar, "true")).To(Succeed())
+	g.Expect(IsActive(K8s135Support())).To(BeTrue())
+}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
@@ -381,4 +382,14 @@ func getReleaseManifestFromBundle(clusterSpec v1alpha1.Cluster, bundle *releasev
 	}
 
 	return releaseManifest, nil
+}
+
+// ValidateK8s135Support checks if the 1.35 feature flag is set when using k8s 1.35.
+func ValidateK8s135Support(clusterSpec *cluster.Spec) error {
+	if !features.IsActive(features.K8s135Support()) {
+		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube135 {
+			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube135, features.K8s135SupportEnvVar)
+		}
+	}
+	return nil
 }

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -7,6 +7,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -54,6 +55,14 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
 				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient, v.Opts.BundlesOverride),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.35 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s135SupportEnvVar),
+				Err:         validations.ValidateK8s135Support(v.Opts.Spec),
+				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,6 +9,7 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -127,6 +128,14 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
 				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient, u.Opts.BundlesOverride),
+			}
+		},
+		func() *validations.ValidationResult {
+			return &validations.ValidationResult{
+				Name:        "validate kubernetes version 1.35 support",
+				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s135SupportEnvVar),
+				Err:         validations.ValidateK8s135Support(u.Opts.Spec),
+				Silent:      true,
 			}
 		},
 	}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
+	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -2319,11 +2320,12 @@ func dumpFile(description, path string, t T) {
 func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
 	// Update this variable to equal the feature flagged k8s version when applicable.
 	// For example, if k8s 1.31 is under a feature flag, we would set this to v1alpha1.Kube131
-	var unreleasedK8sVersion v1alpha1.KubernetesVersion
+	unreleasedK8sVersion := v1alpha1.Kube135
 
 	if version == unreleasedK8sVersion {
 		// Set feature flag for the unreleased k8s version when applicable
 		e.T.Logf("Setting k8s version support feature flag...")
+		os.Setenv(features.K8s135SupportEnvVar, "true")
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3695

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

