### PR TITLE
Update TinkerbellBundle to use mono-repo images

### DIFF
--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -1,51 +1,71 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs:
-    - HTTP_PROXY=1.2.3.4
-    - HTTPS_PROXY=1.2.3.4
-    - NO_PROXY=localhost,.svc
-    osieUrl:
-      host: my-local-web-server
-      path: /hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs:
+      - HTTP_PROXY=1.2.3.4
+      - HTTPS_PROXY=1.2.3.4
+      - NO_PROXY=localhost,.svc
+      ipxeHttpScriptOsieURL: https://my-local-web-server/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -54,24 +74,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -1,49 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: false
-  http:
-    additionalKernelArgs:
-    - tink_worker_image=127.0.0.1/embedded/tink-worker
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: false
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -52,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -1,49 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: false
-  http:
-    additionalKernelArgs:
-    - tink_worker_image=127.0.0.1/embedded/tink-worker
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: false
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: true
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -52,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://my-local-web-server/hook.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://my-local-web-server/hook.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: my-local-web-server
-      path: /hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://my-local-web-server/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: true
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -1,48 +1,68 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -51,24 +71,12 @@ stack:
       value: "true"
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -1,48 +1,69 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs: []
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs: []
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+    sourceInterface: test-interface
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -52,25 +73,12 @@ stack:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
     interface: test-interface
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-    sourceInterface: test-interface
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -1,51 +1,71 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs:
-    - HTTP_PROXY=1.2.3.4:3128
-    - HTTPS_PROXY=1.2.3.4:3128
-    - NO_PROXY=
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs:
+      - HTTP_PROXY=1.2.3.4:3128
+      - HTTPS_PROXY=1.2.3.4:3128
+      - NO_PROXY=
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -54,24 +74,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -1,51 +1,71 @@
-hegel:
-  image: public.ecr.aws/eks-anywhere/hegel:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  trustedProxies:
-  - 192.168.0.0/16
-rufio:
-  additionalArgs:
-  - -metrics-bind-address=127.0.0.1:8080
-  - -max-concurrent-reconciles=10
-  image: public.ecr.aws/eks-anywhere/rufio:latest
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-smee:
-  deploy: true
-  http:
-    additionalKernelArgs:
-    - insecure_registries=1.2.3.4:443
-    - registry_username=username
-    - registry_password=password
-    osieUrl:
-      host: anywhere-assests.eks.amazonaws.com
-      path: /tinkerbell/hook
-      port: ""
-      scheme: https
+deployment:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
+        weight: 1
+  agentImage: 127.0.0.1/embedded/tink-worker
+  agentImageTag: ""
+  envs:
+    globals:
+      backend: kube
+      backendKubeNamespace: eksa-system
+      enableCRDMigrations: false
+      enableRufioController: true
+      enableSecondstar: false
+      enableSmee: true
+      enableTinkController: true
+      enableTinkServer: true
+      enableTootles: true
+    rufio:
+      enableLeaderElection: true
+    smee:
+      dhcpEnabled: true
+      dhcpIPForPacket: 1.2.3.4
+      dhcpIpxeHttpBinaryHost: 1.2.3.4
+      dhcpIpxeHttpBinaryPort: 7171
+      dhcpIpxeHttpScriptHost: 1.2.3.4
+      dhcpIpxeHttpScriptPort: 7171
+      dhcpMode: reservation
+      dhcpSyslogIP: 1.2.3.4
+      dhcpTftpIP: 1.2.3.4
+      ipxeHttpScriptBindPort: 7171
+      ipxeHttpScriptExtraKernelArgs:
+      - insecure_registries=1.2.3.4:443
+      - registry_username=username
+      - registry_password=password
+      ipxeHttpScriptOsieURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook
+      ipxeScriptTinkServerAddrPort: 1.2.3.4:42113
+      ipxeScriptTinkServerInsecureTLS: true
+      isoEnabled: true
+      isoStaticIPAMEnabled: true
+      isoUpstreamURL: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
+      syslogEnabled: true
+      tftpServerEnabled: true
+    tinkController:
+      enableLeaderElection: true
     tinkServer:
-      insecureTLS: true
-      ip: 1.2.3.4
-      port: "42113"
-  image: public.ecr.aws/eks-anywhere/boots:latest
-  iso:
-    enabled: true
-    staticIPAMEnabled: true
-    url: https://anywhere-assests.eks.amazonaws.com/tinkerbell/hook/hook-x86_64-efi-initrd.iso
-  publicIP: 1.2.3.4
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-  tinkWorkerImage: 127.0.0.1/embedded/tink-worker
-  trustedProxies:
-  - 192.168.0.0/16
-stack:
-  hook:
-    enabled: false
+      bindPort: 42113
+    tootles:
+      bindPort: 7172
   hostNetwork: false
-  image: public.ecr.aws/eks-anywhere/nginx:latest
+  image: public.ecr.aws/eks-anywhere/tinkerbell
+  imageTag: latest
+  init:
+    enabled: false
+    image: public.ecr.aws/eks-anywhere/tink-relay-init:latest
+    interfaceMode: macvlan
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+name: tinkerbell
+optional:
+  hookos:
+    enabled: false
   kubevip:
     additionalEnv:
     - name: prometheus_server
@@ -54,24 +74,12 @@ stack:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+publicIP: 1.2.3.4
+rbac:
+  type: Role
+service:
+  lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4
-  relay:
-    enabled: false
-    image: public.ecr.aws/eks-anywhere/tink-relay:latest
-    initImage: public.ecr.aws/eks-anywhere/tink-relay-init:latest
-  service:
-    enabled: false
-  singleNodeClusterConfig:
-    controlPlaneTolerationsEnabled: true
-    nodeAffinityWeight: 1
-tink:
-  controller:
-    image: public.ecr.aws/eks-anywhere/tink-controller:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
-  server:
-    image: public.ecr.aws/eks-anywhere/tink-server:latest
-    singleNodeClusterConfig:
-      controlPlaneTolerationsEnabled: true
-      nodeAffinityWeight: 1
+  type: LoadBalancer
+trustedProxies:
+- 192.168.0.0/16

--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -838,6 +838,24 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			"projectPath",
 		},
 	},
+	// Tinkerbell mono-repo artifacts (unified binary)
+	{
+		ProjectName: "tinkerbell",
+		ProjectPath: "projects/tinkerbell/tinkerbell",
+		Images: []*assettypes.Image{
+			{
+				RepoName: "tinkerbell",
+			},
+			{
+				RepoName: "tink-agent",
+			},
+		},
+		ImageRepoPrefix: "tinkerbell/tinkerbell",
+		ImageTagOptions: []string{
+			"gitTag",
+			"projectPath",
+		},
+	},
 	// Tinkerbell chart artifacts
 	{
 		ProjectName: "tinkerbell-chart",

--- a/release/cli/pkg/bundles/tinkerbell.go
+++ b/release/cli/pkg/bundles/tinkerbell.go
@@ -28,7 +28,7 @@ import (
 )
 
 func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.ImageDigestsTable) (anywherev1alpha1.TinkerbellBundle, error) {
-	projectsInBundle := []string{"cluster-api-provider-tinkerbell", "kube-vip", "envoy", "tink", "hegel", "boots", "hub", "hook", "rufio", "stack", "tinkerbell-chart", "tinkerbell-crds"}
+	projectsInBundle := []string{"cluster-api-provider-tinkerbell", "kube-vip", "envoy", "tinkerbell", "tink", "hub", "hook", "stack", "tinkerbell-chart", "tinkerbell-crds"}
 	tinkerbellBundleArtifacts := map[string][]releasetypes.Artifact{}
 	for _, project := range projectsInBundle {
 		projectArtifacts, err := r.BundleArtifactsTable.Load(project)
@@ -140,8 +140,8 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests releasetype
 				Reboot:      bundleImageArtifacts["reboot"],
 				WriteFile:   bundleImageArtifacts["writefile"],
 			},
-			Boots: bundleImageArtifacts["boots"],
-			Hegel: bundleImageArtifacts["hegel"],
+			Boots: bundleImageArtifacts["tinkerbell"],
+			Hegel: bundleImageArtifacts["tinkerbell"],
 			Hook: anywherev1alpha1.HookBundle{
 				Bootkit: bundleImageArtifacts["hook-bootkit"],
 				Docker:  bundleImageArtifacts["hook-docker"],
@@ -159,15 +159,15 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests releasetype
 					Amd: bundleArchiveArtifacts["vmlinuz-x86_64"],
 				},
 			},
-			Rufio: bundleImageArtifacts["rufio"],
+			Rufio: bundleImageArtifacts["tinkerbell"],
 			Stack: bundleImageArtifacts["stack-helm"],
 			Tink: anywherev1alpha1.TinkBundle{
 				Nginx:          bundleImageArtifacts["nginx"],
 				TinkRelay:      bundleImageArtifacts["tink-relay"],
 				TinkRelayInit:  bundleImageArtifacts["tink-relay-init"],
-				TinkController: bundleImageArtifacts["tink-controller"],
-				TinkServer:     bundleImageArtifacts["tink-server"],
-				TinkWorker:     bundleImageArtifacts["tink-worker"],
+				TinkController: bundleImageArtifacts["tinkerbell"],
+				TinkServer:     bundleImageArtifacts["tinkerbell"],
+				TinkWorker:     bundleImageArtifacts["tink-agent"],
 			},
 			TinkebellChart: bundleImageArtifacts["tinkerbell-chart"],
 			TinkerbellCrds: bundleImageArtifacts["tinkerbell-crds-helm"],

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -10,7 +10,7 @@ spec:
   versionsBundles:
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -19,7 +19,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -28,10 +28,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -160,7 +160,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -169,13 +169,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -184,7 +184,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -193,13 +193,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -208,7 +208,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -217,15 +217,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -234,7 +234,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -243,10 +243,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -269,7 +269,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -357,7 +357,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -381,7 +381,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -394,7 +394,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -403,7 +403,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -412,7 +412,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -421,8 +421,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -447,7 +447,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -469,7 +469,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -527,7 +527,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -549,11 +549,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -571,9 +571,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -634,20 +634,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -713,11 +713,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -737,11 +737,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -764,20 +764,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -787,8 +787,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -821,7 +821,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -830,7 +830,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -845,7 +845,7 @@ spec:
       version: v1.13.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -854,7 +854,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -863,10 +863,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -876,7 +876,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-multi-network
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-29-56-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-29-57-eks-a-v0.0.0-dev-build.1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -902,7 +902,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-29-56-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-29-57-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -995,7 +995,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -1004,13 +1004,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -1019,7 +1019,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1028,13 +1028,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -1043,7 +1043,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1052,15 +1052,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1069,7 +1069,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1078,10 +1078,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -1104,7 +1104,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1132,10 +1132,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.29.15-eks-d-1-29-56-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.29.15-eks-d-1-29-57-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.29.15
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-29/kubernetes-1-29-eks-56.yaml
-      name: kubernetes-1-29-eks-56
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-29/kubernetes-1-29-eks-57.yaml
+      name: kubernetes-1-29-eks-57
       ova:
         bottlerocket: {}
       raw:
@@ -1192,7 +1192,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -1216,7 +1216,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -1229,7 +1229,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -1238,7 +1238,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -1247,7 +1247,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -1256,8 +1256,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -1282,7 +1282,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -1304,7 +1304,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -1351,7 +1351,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-29-56-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-29-57-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.2.8/infrastructure-components.yaml
       kubeVip:
@@ -1362,7 +1362,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1384,11 +1384,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -1406,9 +1406,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -1469,20 +1469,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -1548,11 +1548,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -1572,11 +1572,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -1599,20 +1599,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -1622,8 +1622,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -1633,7 +1633,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-29-56-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-29-57-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -1656,7 +1656,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -1665,7 +1665,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1680,7 +1680,7 @@ spec:
       version: v1.13.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -1689,7 +1689,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1698,10 +1698,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -1711,7 +1711,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-multi-network
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-30-49-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-30-50-eks-a-v0.0.0-dev-build.1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -1737,7 +1737,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-30-49-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-30-50-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -1830,7 +1830,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -1839,13 +1839,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -1854,7 +1854,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1863,13 +1863,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -1878,7 +1878,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -1887,15 +1887,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -1904,7 +1904,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -1913,10 +1913,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -1939,7 +1939,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -1967,10 +1967,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.30.14-eks-d-1-30-49-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.30.14-eks-d-1-30-50-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.30.14
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-30/kubernetes-1-30-eks-49.yaml
-      name: kubernetes-1-30-eks-49
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-30/kubernetes-1-30-eks-50.yaml
+      name: kubernetes-1-30-eks-50
       ova:
         bottlerocket: {}
       raw:
@@ -2027,7 +2027,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -2051,7 +2051,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -2064,7 +2064,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -2073,7 +2073,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -2082,7 +2082,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -2091,8 +2091,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -2117,7 +2117,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -2139,7 +2139,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -2186,7 +2186,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-30-49-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-30-50-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.2.8/infrastructure-components.yaml
       kubeVip:
@@ -2197,7 +2197,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2219,11 +2219,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -2241,9 +2241,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -2304,20 +2304,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -2383,11 +2383,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -2407,11 +2407,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -2434,20 +2434,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -2457,8 +2457,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -2468,7 +2468,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-30-49-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-30-50-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -2491,7 +2491,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -2500,7 +2500,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2515,7 +2515,7 @@ spec:
       version: v1.13.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -2524,7 +2524,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2533,10 +2533,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -2546,7 +2546,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-multi-network
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-31-38-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-31-39-eks-a-v0.0.0-dev-build.1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -2572,7 +2572,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-31-38-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-31-39-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -2665,7 +2665,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -2674,13 +2674,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -2689,7 +2689,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2698,13 +2698,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -2713,7 +2713,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -2722,15 +2722,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -2739,7 +2739,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -2748,10 +2748,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -2774,7 +2774,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -2802,10 +2802,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.31.14-eks-d-1-31-38-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.31.14-eks-d-1-31-39-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.31.14
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-38.yaml
-      name: kubernetes-1-31-eks-38
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-31/kubernetes-1-31-eks-39.yaml
+      name: kubernetes-1-31-eks-39
       ova:
         bottlerocket: {}
       raw:
@@ -2862,7 +2862,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -2886,7 +2886,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -2899,7 +2899,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -2908,7 +2908,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -2917,7 +2917,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -2926,8 +2926,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -2952,7 +2952,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -2974,7 +2974,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -3021,7 +3021,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-31-38-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-31-39-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.2.8/infrastructure-components.yaml
       kubeVip:
@@ -3032,7 +3032,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3054,11 +3054,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -3076,9 +3076,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -3139,20 +3139,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -3218,11 +3218,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -3242,11 +3242,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -3269,20 +3269,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -3292,8 +3292,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -3303,7 +3303,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-31-38-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-31-39-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -3326,7 +3326,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -3335,7 +3335,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3350,7 +3350,7 @@ spec:
       version: v1.13.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -3359,7 +3359,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3368,10 +3368,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -3381,7 +3381,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-multi-network
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-32-31-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-32-32-eks-a-v0.0.0-dev-build.1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -3407,7 +3407,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-32-31-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-32-32-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -3500,7 +3500,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -3509,13 +3509,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -3524,7 +3524,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3533,13 +3533,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -3548,7 +3548,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -3557,15 +3557,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -3574,7 +3574,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3583,10 +3583,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -3609,7 +3609,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -3637,10 +3637,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.32.11-eks-d-1-32-31-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.32.11-eks-d-1-32-32-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.32.11
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-32/kubernetes-1-32-eks-31.yaml
-      name: kubernetes-1-32-eks-31
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-32/kubernetes-1-32-eks-32.yaml
+      name: kubernetes-1-32-eks-32
       ova:
         bottlerocket: {}
       raw:
@@ -3697,7 +3697,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -3721,7 +3721,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -3734,7 +3734,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -3743,7 +3743,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -3752,7 +3752,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -3761,8 +3761,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -3787,7 +3787,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -3809,7 +3809,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -3856,7 +3856,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-32-31-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-32-32-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.2.8/infrastructure-components.yaml
       kubeVip:
@@ -3867,7 +3867,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -3889,11 +3889,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -3911,9 +3911,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -3974,20 +3974,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -4053,11 +4053,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -4077,11 +4077,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -4104,20 +4104,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -4127,8 +4127,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -4138,7 +4138,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-32-31-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-32-32-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -4161,7 +4161,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -4170,7 +4170,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -4185,7 +4185,7 @@ spec:
       version: v1.13.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -4194,7 +4194,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4203,10 +4203,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -4216,7 +4216,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-multi-network
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-33-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-33-22-eks-a-v0.0.0-dev-build.1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -4242,7 +4242,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-33-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-33-22-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -4335,7 +4335,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -4344,13 +4344,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -4359,7 +4359,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4368,13 +4368,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -4383,7 +4383,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -4392,15 +4392,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -4409,7 +4409,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -4418,10 +4418,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -4444,7 +4444,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -4472,10 +4472,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.33.7-eks-d-1-33-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.33.7-eks-d-1-33-22-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.33.7
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-33/kubernetes-1-33-eks-21.yaml
-      name: kubernetes-1-33-eks-21
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-33/kubernetes-1-33-eks-22.yaml
+      name: kubernetes-1-33-eks-22
       ova:
         bottlerocket: {}
       raw:
@@ -4532,7 +4532,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -4556,7 +4556,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -4569,7 +4569,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -4578,7 +4578,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -4587,7 +4587,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -4596,8 +4596,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -4622,7 +4622,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -4644,7 +4644,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -4691,7 +4691,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-33-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-33-22-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.2.8/infrastructure-components.yaml
       kubeVip:
@@ -4702,7 +4702,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -4724,11 +4724,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -4746,9 +4746,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -4809,20 +4809,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -4888,11 +4888,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -4912,11 +4912,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -4939,20 +4939,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -4962,8 +4962,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -4973,7 +4973,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-33-21-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-33-22-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -4996,7 +4996,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -5005,7 +5005,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -5020,7 +5020,7 @@ spec:
       version: v1.13.1+abcdef1
   - bootstrap:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/bootstrap-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/bootstrap-components.yaml
       controller:
         arch:
         - amd64
@@ -5029,7 +5029,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-bootstrap-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -5038,10 +5038,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/bootstrap-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     bottlerocketBootstrapContainers:
       multiNetworkBootstrap:
         arch:
@@ -5051,7 +5051,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-multi-network
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-34-12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-multi-network:v1-34-13-eks-a-v0.0.0-dev-build.1
     bottlerocketHostContainers:
       admin:
         arch:
@@ -5077,7 +5077,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-34-12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap:v1-34-13-eks-a-v0.0.0-dev-build.1
     certManager:
       acmesolver:
         arch:
@@ -5170,7 +5170,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -5179,13 +5179,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
       version: v0.6.1+abcdef1
     clusterAPI:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/core-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/core-components.yaml
       controller:
         arch:
         - amd64
@@ -5194,7 +5194,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/cluster-api-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -5203,13 +5203,13 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     controlPlane:
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/control-plane-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/control-plane-components.yaml
       controller:
         arch:
         - amd64
@@ -5218,7 +5218,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kubeadm-control-plane-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.12.2-eks-a-v0.0.0-dev-build.1
       kubeProxy:
         arch:
         - amd64
@@ -5227,15 +5227,15 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/control-plane-kubeadm/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     docker:
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/cluster-template-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/cluster-template-development.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/infrastructure-components-development.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/infrastructure-components-development.yaml
       kubeProxy:
         arch:
         - amd64
@@ -5244,7 +5244,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -5253,10 +5253,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-docker
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api/capd-manager:v1.12.2-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.1/metadata.yaml
-      version: v1.12.1+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/infrastructure-docker/v1.12.2/metadata.yaml
+      version: v1.12.2+abcdef1
     eksD:
       ami:
         bottlerocket: {}
@@ -5279,7 +5279,7 @@ spec:
         os: linux
         sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         sha512: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.34.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cri-tools/v1.35.0/cri-tools-v0.0.0-dev-build.0-linux-amd64.tar.gz
       etcdadm:
         arch:
         - amd64
@@ -5307,10 +5307,10 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kind-node
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.34.3-eks-d-1-34-12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/node:v1.34.3-eks-d-1-34-13-eks-a-v0.0.0-dev-build.1
       kubeVersion: v1.34.3
-      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-34/kubernetes-1-34-eks-12.yaml
-      name: kubernetes-1-34-eks-12
+      manifestUrl: https://distro.eks.amazonaws.com/kubernetes-1-34/kubernetes-1-34-eks-13.yaml
+      name: kubernetes-1-34-eks-13
       ova:
         bottlerocket: {}
       raw:
@@ -5367,7 +5367,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-bootstrap-provider/manifests/bootstrap-etcdadm-bootstrap/v1.0.18/metadata.yaml
       version: v1.0.18+abcdef1
@@ -5391,7 +5391,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/etcdadm-controller/manifests/bootstrap-etcdadm-controller/v1.0.26/metadata.yaml
       version: v1.0.26+abcdef1
@@ -5404,7 +5404,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: helm-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/helm-controller:v1.4.5-eks-a-v0.0.0-dev-build.1
       kustomizeController:
         arch:
         - amd64
@@ -5413,7 +5413,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kustomize-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/kustomize-controller:v1.7.3-eks-a-v0.0.0-dev-build.1
       notificationController:
         arch:
         - amd64
@@ -5422,7 +5422,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: notification-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.1-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/fluxcd/notification-controller:v1.7.5-eks-a-v0.0.0-dev-build.1
       sourceController:
         arch:
         - amd64
@@ -5431,8 +5431,8 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: source-controller
         os: linux
-        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.0-eks-a-v0.0.0-dev-build.1
-      version: v2.7.0+abcdef1
+        uri: public.ecr.aws/release-container-registry/fluxcd/source-controller:v1.7.4-eks-a-v0.0.0-dev-build.1
+      version: v2.7.5+abcdef1
     haproxy:
       image:
         arch:
@@ -5457,7 +5457,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cloud-provider-nutanix
         os: linux
-        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.5.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.6.0-eks-a-v0.0.0-dev-build.1
       clusterAPIController:
         arch:
         - amd64
@@ -5479,7 +5479,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-nutanix/manifests/infrastructure-nutanix/v1.6.1/metadata.yaml
       version: v1.6.1+abcdef1
@@ -5526,7 +5526,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: bottlerocket-bootstrap-snow
         os: linux
-        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-34-12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/bottlerocket-bootstrap-snow:v1-34-13-eks-a-v0.0.0-dev-build.1
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-aws-snow/manifests/infrastructure-snow/v0.2.8/infrastructure-components.yaml
       kubeVip:
@@ -5537,7 +5537,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64
@@ -5559,11 +5559,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-tinkerbell
         os: linux
-        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.5-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/tinkerbell/cluster-api-provider-tinkerbell:v0.6.6-eks-a-v0.0.0-dev-build.1
       clusterTemplate:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/cluster-template.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/cluster-template.yaml
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/infrastructure-components.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/infrastructure-components.yaml
       envoy:
         arch:
         - amd64
@@ -5581,9 +5581,9 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.5/metadata.yaml
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-tinkerbell/manifests/infrastructure-tinkerbell/v0.6.6/metadata.yaml
       tinkerbellStack:
         actions:
           cexec:
@@ -5644,20 +5644,20 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for boots image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: boots
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/boots:v0.15.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hegel:
           arch:
           - amd64
           - arm64
-          description: Container image for hegel image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: hegel
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/hegel:v0.14.2-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -5723,11 +5723,11 @@ spec:
           arch:
           - amd64
           - arm64
-          description: Container image for rufio image
+          description: Container image for tinkerbell image
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: rufio
+          name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/rufio:126069b950a57d571df90dfec7cd98e6d64692be-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -5747,11 +5747,11 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-controller image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-controller
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-controller:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkRelay:
             arch:
             - amd64
@@ -5774,20 +5774,20 @@ spec:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-server image
+            description: Container image for tinkerbell image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-server
+            name: tinkerbell
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-server:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
           tinkWorker:
             arch:
             - amd64
             - arm64
-            description: Container image for tink-worker image
+            description: Container image for tink-agent image
             imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-            name: tink-worker
+            name: tink-agent
             os: linux
-            uri: public.ecr.aws/release-container-registry/tinkerbell/tink/tink-worker:v0.12.2-eks-a-v0.0.0-dev-build.1
+            uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tink-agent:v0.22.1-eks-a-v0.0.0-dev-build.1
         tinkerbellChart:
           description: Helm chart for tinkerbell-chart
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -5797,8 +5797,8 @@ spec:
           description: Helm chart for tinkerbell-crds
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell-crds
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.2.6-eks-a-v0.0.0-dev-build.1
-      version: v0.6.5+abcdef1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell-crds:0.22.1-eks-a-v0.0.0-dev-build.1
+      version: v0.6.6+abcdef1
     upgrader:
       upgrader:
         arch:
@@ -5808,7 +5808,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: upgrader
         os: linux
-        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-34-12-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/aws/upgrader:v1-34-13-eks-a-v0.0.0-dev-build.1
     vSphere:
       clusterAPIController:
         arch:
@@ -5831,7 +5831,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
       kubeVip:
         arch:
         - amd64
@@ -5840,7 +5840,7 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
         os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.2-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
       manager:
         arch:
         - amd64


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3823
https://github.com/aws/eks-anywhere-internal/issues/3825

*Description of changes:*
Migrate Tinkerbell stack to use the unified mono-repo binary instead of separate boots, hegel, rufio, and tink-* images.

The tinkerbell mono-repo (github.com/tinkerbell/tinkerbell) consolidates smee (boots), hegel, rufio, tink-controller, and tink-server into a single binary. This change updates the release CLI and stack installer to use the new image structure.

Changes:
- release/cli/pkg/assets/config/bundle_release.go: Add tinkerbell project
  config for mono-repo images (tinkerbell, tink-agent)
- release/cli/pkg/bundles/tinkerbell.go: Update bundle mapping to use
  tinkerbell image for Boots, Hegel, Rufio, TinkController, TinkServer
  and tink-agent for TinkWorker
- pkg/providers/tinkerbell/stack/stack.go: Rewrite createValuesOverride()
  for mono-repo helm chart structure with unified deployment section,
  enable flags, and TINKERBELL_* env var prefix for Docker boots
- pkg/providers/tinkerbell/stack/stack_test.go: Update test bundle to use
  mono-repo image URIs
- pkg/providers/tinkerbell/stack/testdata/*.yaml: Update golden files

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

