### PR TITLE
Update stack helm chart ECR path for tinkerbell mono-repo

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -880,7 +880,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		ProjectPath: "projects/tinkerbell/tinkerbell",
 		Images: []*assettypes.Image{
 			{
-				RepoName:             "tinkerbell-chart",
+				RepoName:             "tinkerbell",
 				AssetName:            "stack-helm",
 				TrimVersionSignifier: true,
 				ImageTagConfiguration: assettypes.ImageTagConfiguration{

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -722,7 +722,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -1557,7 +1557,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -2392,7 +2392,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -3227,7 +3227,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -4062,7 +4062,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -4897,7 +4897,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -5732,7 +5732,7 @@ spec:
           description: Helm chart for stack
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-chart:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the stack entry in bundle_release.go to use RepoName "tinkerbell" instead of "tinkerbell-chart" to match the chart name in the upstream mono-repo's Chart.yaml. The full ECR path is now tinkerbell/tinkerbell/tinkerbell.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

