### PR TITLE
Use tinkerbell-helm as asset name for stack helm chart

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -880,8 +880,8 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 		ProjectPath: "projects/tinkerbell/tinkerbell",
 		Images: []*assettypes.Image{
 			{
-				RepoName:             "tinkerbell",
-				AssetName:            "stack-helm",
+				RepoName:             "tinkerbell-helm",
+				AssetName:            "tinkerbell-helm",
 				TrimVersionSignifier: true,
 				ImageTagConfiguration: assettypes.ImageTagConfiguration{
 					NonProdSourceImageTagFormat: "<gitTag>",

--- a/release/cli/pkg/bundles/tinkerbell.go
+++ b/release/cli/pkg/bundles/tinkerbell.go
@@ -160,7 +160,7 @@ func GetTinkerbellBundle(r *releasetypes.ReleaseConfig, imageDigests releasetype
 				},
 			},
 			Rufio: bundleImageArtifacts["tinkerbell"],
-			Stack: bundleImageArtifacts["stack-helm"],
+			Stack: bundleImageArtifacts["tinkerbell-helm"],
 			Tink: anywherev1alpha1.TinkBundle{
 				Nginx:          bundleImageArtifacts["nginx"],
 				TinkRelay:      bundleImageArtifacts["tink-relay"],

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -719,10 +719,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -1554,10 +1554,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -2389,10 +2389,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -3224,10 +3224,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -4059,10 +4059,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -4894,10 +4894,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -5729,10 +5729,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:
@@ -6564,10 +6564,10 @@ spec:
           os: linux
           uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
         stack:
-          description: Helm chart for stack
+          description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          name: stack
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:0.22.1-eks-a-v0.0.0-dev-build.1
+          name: tinkerbell
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
         tink:
           nginx:
             arch:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the release CLI to use "tinkerbell-helm" as the asset name for the tinkerbell mono-repo stack helm chart. This matches the chart name set in build-tooling and avoids collision with the "tinkerbell" container image in the bundle artifacts map.

The release CLI's GetHelmDest function expects the chart folder name (from Chart.yaml name field) to match the AssetName for the untar path to resolve correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

