### PR TITLE
Skip -helm suffix trimming for tinkerbell-helm chart

### DIFF
--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -432,11 +432,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.28"
     nutanix:
       cloudProvider:
@@ -1267,11 +1267,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.29"
     nutanix:
       cloudProvider:
@@ -2102,11 +2102,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.30"
     nutanix:
       cloudProvider:
@@ -2937,11 +2937,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.31"
     nutanix:
       cloudProvider:
@@ -3772,11 +3772,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.32"
     nutanix:
       cloudProvider:
@@ -4607,11 +4607,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.33"
     nutanix:
       cloudProvider:
@@ -5442,11 +5442,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.34"
     nutanix:
       cloudProvider:
@@ -6277,11 +6277,11 @@ spec:
         imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: haproxy
         os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.29.0-eks-a-v0.0.0-dev-build.1
+        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/kind/haproxy:v0.31.0-eks-a-v0.0.0-dev-build.1
     kindnetd:
       manifest:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.29.0/kindnetd.yaml
-      version: v0.29.0+abcdef1
+        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/kind/manifests/kindnetd/v0.31.0/kindnetd.yaml
+      version: v0.31.0+abcdef1
     kubeVersion: "1.35"
     nutanix:
       cloudProvider:

--- a/release/cli/pkg/operations/upload.go
+++ b/release/cli/pkg/operations/upload.go
@@ -143,8 +143,11 @@ func handleImageUpload(_ context.Context, r *releasetypes.ReleaseConfig, package
 	// and then use Helm package and push commands to upload chart to ECR Public
 	// Packages Helm chart modification for dev-release is handled elsewhere, so we are checking for that case and skipping
 	if !r.DryRun && ((strings.HasSuffix(artifact.Image.AssetName, "helm") || strings.HasSuffix(artifact.Image.AssetName, "chart")) && !(artifact.Image.AssetName == "eks-anywhere-packages-helm" && r.DevRelease)) {
-		// Trim -helm on the packages helm chart, but don't need to trim tinkerbell chart since the AssetName is the same as the repoName
-		trimmedAsset := strings.TrimSuffix(artifact.Image.AssetName, "-helm")
+		// Trim -helm on the packages helm chart, but don't need to trim tinkerbell-helm since the AssetName is the same as the repoName
+		trimmedAsset := artifact.Image.AssetName
+		if artifact.Image.AssetName != "tinkerbell-helm" {
+			trimmedAsset = strings.TrimSuffix(artifact.Image.AssetName, "-helm")
+		}
 
 		helmDriver, err := helm.NewHelm()
 		if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tinkerbell-helm chart has its Chart.yaml name set to "tinkerbell-helm" which matches the AssetName. When helm untars a chart, it creates a folder named after the Chart.yaml name field. The release CLI expects this folder to match the trimmedAsset for path resolution.

Previously, trimming -helm from tinkerbell-helm resulted in "tinkerbell", causing a path mismatch since the untarred folder was "tinkerbell-helm".

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

