### PR TITLE
Change hegels to use new port 7172

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -29,12 +29,13 @@ warnings:
 // DefaultActions constructs a set of default actions for the given osFamily.
 func DefaultActions(clusterSpec *Cluster, osImageOverride, tinkerbellLocalIP, tinkerbellLBIP string, osFamily OSFamily) []ActionOpt {
 	// The metadata string will have two URLs:
-	// 1. one that will be used initially for bootstrap and will point to hegel running on kind.
-	// 2. one that will be used when the workload cluster is up and will point to hegel running on
+	// 1. one that will be used initially for bootstrap and will point to tootles running on kind.
+	// 2. one that will be used when the workload cluster is up and will point to tootles running on
 	//    the workload cluster.
+	// Port 7172 is the tootles (metadata service) port in the mono-repo tinkerbell chart.
 	metadataURLs := []string{
-		fmt.Sprintf("http://%s:50061", tinkerbellLocalIP),
-		fmt.Sprintf("http://%s:50061", tinkerbellLBIP),
+		fmt.Sprintf("http://%s:7172", tinkerbellLocalIP),
+		fmt.Sprintf("http://%s:7172", tinkerbellLBIP),
 	}
 
 	additionalEnvVar := make(map[string]string)

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -12,8 +12,8 @@ import (
 func TestWithDefaultActionsFromBundle(t *testing.T) {
 	tinkerbellLocalIp := "127.0.0.1"
 	tinkerbellLBIP := "1.2.3.4"
-	metadataString := fmt.Sprintf("http://%s:50061,http://%s:50061", tinkerbellLocalIp, tinkerbellLBIP)
-	rhelMetadataString := fmt.Sprintf("'http://%s:50061','http://%s:50061'", tinkerbellLocalIp, tinkerbellLBIP)
+	metadataString := fmt.Sprintf("http://%s:7172,http://%s:7172", tinkerbellLocalIp, tinkerbellLBIP)
+	rhelMetadataString := fmt.Sprintf("'http://%s:7172','http://%s:7172'", tinkerbellLocalIp, tinkerbellLBIP)
 	cloudInit := `datasource:
   Ec2:
     metadata_urls: [%s]

--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -173,8 +173,13 @@ func (h *Helm) Delete(ctx context.Context, kubeconfigFilePath, installName, name
 }
 
 // ListCharts lists helm charts filtered on the given regex filter.
-func (h *Helm) ListCharts(ctx context.Context, kubeconfigFilePath, filter string) ([]string, error) {
+// If namespace is provided, it lists charts in that namespace; otherwise uses helm's default behavior.
+func (h *Helm) ListCharts(ctx context.Context, kubeconfigFilePath, filter, namespace string) ([]string, error) {
 	params := []string{"list", "-q", "--kubeconfig", kubeconfigFilePath}
+
+	if namespace != "" {
+		params = append(params, "--namespace", namespace)
+	}
 
 	if len(filter) > 0 {
 		params = append(params, "--filter", filter)

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -6,7 +6,7 @@ import "context"
 type Client interface {
 	PushChart(ctx context.Context, chart, registry string) error
 	PullChart(ctx context.Context, ociURI, version string) error
-	ListCharts(ctx context.Context, kubeconfigFilePath, filter string) ([]string, error)
+	ListCharts(ctx context.Context, kubeconfigFilePath, filter, namespace string) ([]string, error)
 	SaveChart(ctx context.Context, ociURI, version, folder string) error
 	Delete(ctx context.Context, kubeconfigFilePath, installName, namespace string) error
 	UpgradeInstallChartWithValuesFile(ctx context.Context, chart, ociURI, version, kubeconfigFilePath, namespace, valuesFilePath string, opts ...Opt) error

--- a/pkg/helm/mocks/client.go
+++ b/pkg/helm/mocks/client.go
@@ -64,18 +64,18 @@ func (mr *MockClientMockRecorder) InstallChart(ctx, chart, ociURI, version, kube
 }
 
 // ListCharts mocks base method.
-func (m *MockClient) ListCharts(ctx context.Context, kubeconfigFilePath, filter string) ([]string, error) {
+func (m *MockClient) ListCharts(ctx context.Context, kubeconfigFilePath, filter, namespace string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCharts", ctx, kubeconfigFilePath, filter)
+	ret := m.ctrl.Call(m, "ListCharts", ctx, kubeconfigFilePath, filter, namespace)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListCharts indicates an expected call of ListCharts.
-func (mr *MockClientMockRecorder) ListCharts(ctx, kubeconfigFilePath, filter interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListCharts(ctx, kubeconfigFilePath, filter, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharts", reflect.TypeOf((*MockClient)(nil).ListCharts), ctx, kubeconfigFilePath, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharts", reflect.TypeOf((*MockClient)(nil).ListCharts), ctx, kubeconfigFilePath, filter, namespace)
 }
 
 // PullChart mocks base method.

--- a/pkg/providers/tinkerbell/assert.go
+++ b/pkg/providers/tinkerbell/assert.go
@@ -173,7 +173,7 @@ func AssertHookRetrievableWithoutProxy(spec *ClusterSpec) error {
 	return nil
 }
 
-// AssertPortsNotInUse ensures that ports 80, 42113, and 50061 are available.
+// AssertPortsNotInUse ensures that ports 80, 42113, and 7172 are available.
 func AssertPortsNotInUse(client networkutils.NetClient) ClusterSpecAssertion {
 	return func(spec *ClusterSpec) error {
 		host := "0.0.0.0"

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -1291,7 +1291,7 @@ tasks:
       DIRMODE: "0700"
       FS_TYPE: ext4
       GID: "0"
-      HEGEL_URLS: http://2.2.2.2:50061,http://2.2.2.2:50061
+      HEGEL_URLS: http://2.2.2.2:7172,http://2.2.2.2:7172
       MODE: "0644"
       UID: "0"
     image: 127.0.0.1/embedded/writefile

--- a/pkg/providers/tinkerbell/stack/mocks/stack.go
+++ b/pkg/providers/tinkerbell/stack/mocks/stack.go
@@ -109,18 +109,18 @@ func (m *MockHelm) EXPECT() *MockHelmMockRecorder {
 }
 
 // ListCharts mocks base method.
-func (m *MockHelm) ListCharts(ctx context.Context, kubeconfigFilePath, filter string) ([]string, error) {
+func (m *MockHelm) ListCharts(ctx context.Context, kubeconfigFilePath, filter, namespace string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCharts", ctx, kubeconfigFilePath, filter)
+	ret := m.ctrl.Call(m, "ListCharts", ctx, kubeconfigFilePath, filter, namespace)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListCharts indicates an expected call of ListCharts.
-func (mr *MockHelmMockRecorder) ListCharts(ctx, kubeconfigFilePath, filter interface{}) *gomock.Call {
+func (mr *MockHelmMockRecorder) ListCharts(ctx, kubeconfigFilePath, filter, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharts", reflect.TypeOf((*MockHelm)(nil).ListCharts), ctx, kubeconfigFilePath, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharts", reflect.TypeOf((*MockHelm)(nil).ListCharts), ctx, kubeconfigFilePath, filter, namespace)
 }
 
 // RegistryLogin mocks base method.
@@ -238,19 +238,19 @@ func (mr *MockStackInstallerMockRecorder) GetNamespace() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockStackInstaller)(nil).GetNamespace))
 }
 
-// HasLegacyChart mocks base method.
-func (m *MockStackInstaller) HasLegacyChart(ctx context.Context, bundle v1alpha1.TinkerbellBundle, kubeconfig string) (bool, error) {
+// HasChart mocks base method.
+func (m *MockStackInstaller) HasChart(ctx context.Context, chartName, kubeconfig, namespace string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasLegacyChart", ctx, bundle, kubeconfig)
+	ret := m.ctrl.Call(m, "HasChart", ctx, chartName, kubeconfig, namespace)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// HasLegacyChart indicates an expected call of HasLegacyChart.
-func (mr *MockStackInstallerMockRecorder) HasLegacyChart(ctx, bundle, kubeconfig interface{}) *gomock.Call {
+// HasChart indicates an expected call of HasChart.
+func (mr *MockStackInstallerMockRecorder) HasChart(ctx, chartName, kubeconfig, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasLegacyChart", reflect.TypeOf((*MockStackInstaller)(nil).HasLegacyChart), ctx, bundle, kubeconfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasChart", reflect.TypeOf((*MockStackInstaller)(nil).HasChart), ctx, chartName, kubeconfig, namespace)
 }
 
 // Install mocks base method.
@@ -272,18 +272,18 @@ func (mr *MockStackInstallerMockRecorder) Install(ctx, bundle, tinkerbellIP, kub
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockStackInstaller)(nil).Install), varargs...)
 }
 
-// Uninstall mocks base method.
-func (m *MockStackInstaller) Uninstall(ctx context.Context, bundle v1alpha1.TinkerbellBundle, kubeconfig string) error {
+// UninstallChart mocks base method.
+func (m *MockStackInstaller) UninstallChart(ctx context.Context, chartName, kubeconfig, namespace string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Uninstall", ctx, bundle, kubeconfig)
+	ret := m.ctrl.Call(m, "UninstallChart", ctx, chartName, kubeconfig, namespace)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Uninstall indicates an expected call of Uninstall.
-func (mr *MockStackInstallerMockRecorder) Uninstall(ctx, bundle, kubeconfig interface{}) *gomock.Call {
+// UninstallChart indicates an expected call of UninstallChart.
+func (mr *MockStackInstallerMockRecorder) UninstallChart(ctx, chartName, kubeconfig, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Uninstall", reflect.TypeOf((*MockStackInstaller)(nil).Uninstall), ctx, bundle, kubeconfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallChart", reflect.TypeOf((*MockStackInstaller)(nil).UninstallChart), ctx, chartName, kubeconfig, namespace)
 }
 
 // UninstallLocal mocks base method.

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -542,11 +542,11 @@ func TestUninstall(t *testing.T) {
 	err := s.Upgrade(ctx, getTinkBundle(), testIP, cluster.KubeconfigFile, "")
 	assert.NoError(t, err)
 
-	err = s.Uninstall(ctx, getTinkBundle(), cluster.KubeconfigFile)
+	err = s.UninstallChart(ctx, getTinkBundle().TinkerbellStack.TinkebellChart.Name, cluster.KubeconfigFile, "")
 	assert.NoError(t, err)
 }
 
-func TestHasLegacyChart(t *testing.T) {
+func TestHasChart(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	docker := mocks.NewMockDocker(mockCtrl)
 	helm := mocks.NewMockHelm(mockCtrl)
@@ -556,8 +556,8 @@ func TestHasLegacyChart(t *testing.T) {
 	ctx := context.Background()
 
 	s := stack.NewInstaller(docker, writer, helm, "", constants.EksaSystemNamespace, "192.168.0.0/16", nil, nil)
-	helm.EXPECT().ListCharts(ctx, cluster.KubeconfigFile, "tinkerbell-chart")
+	helm.EXPECT().ListCharts(ctx, cluster.KubeconfigFile, "tinkerbell-chart", constants.EksaSystemNamespace)
 
-	_, err := s.HasLegacyChart(ctx, getTinkBundle(), cluster.KubeconfigFile)
+	_, err := s.HasChart(ctx, "tinkerbell-chart", cluster.KubeconfigFile, constants.EksaSystemNamespace)
 	assert.NoError(t, err)
 }

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -75,8 +75,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -72,8 +72,6 @@ optional:
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -74,8 +74,6 @@ optional:
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
     interface: test-interface
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -75,8 +75,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -8,7 +8,7 @@ deployment:
             operator: DoesNotExist
         weight: 1
   agentImage: 127.0.0.1/embedded/tink-worker
-  agentImageTag: ""
+  agentImageTag: "latest"
   envs:
     globals:
       backend: kube
@@ -75,8 +75,6 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
 publicIP: 1.2.3.4
-rbac:
-  type: Role
 service:
   lbClass: kube-vip.io/kube-vip-class
   loadBalancerIP: 1.2.3.4

--- a/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/cluster_tinkerbell_bottlerocket_minimal_registry_mirror.yaml
@@ -173,7 +173,7 @@ spec:
               GID: "0"
               MODE: "0644"
               UID: "0"
-              HEGEL_URLS: http://1.2.3.4:50061
+              HEGEL_URLS: http://1.2.3.4:7172
             image: writefile:v1.0.0
             name: write-user-data
             timeout: 90

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
@@ -400,7 +400,7 @@ spec:
               CONTENTS: |
                 datasource:
                   Ec2:
-                    metadata_urls: [http://0.0.0.0:50061,http://5.6.7.8:50061]
+                    metadata_urls: [http://0.0.0.0:7172,http://5.6.7.8:7172]
                     strict_id: false
                 manage_etc_hosts: localhost
                 warnings:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
@@ -400,7 +400,7 @@ spec:
               CONTENTS: |
                 datasource:
                   Ec2:
-                    metadata_urls: [http://0.0.0.0:50061,http://5.6.7.8:50061]
+                    metadata_urls: [http://0.0.0.0:7172,http://5.6.7.8:7172]
                     strict_id: false
                 manage_etc_hosts: localhost
                 warnings:

--- a/pkg/providers/tinkerbell/testdata/expected_kct.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kct.yaml
@@ -122,7 +122,7 @@ spec:
               CONTENTS: |
                 datasource:
                   Ec2:
-                    metadata_urls: [http://0.0.0.0:50061,http://5.6.7.8:50061]
+                    metadata_urls: [http://0.0.0.0:7172,http://5.6.7.8:7172]
                     strict_id: false
                 manage_etc_hosts: localhost
                 warnings:

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
@@ -128,7 +128,7 @@ spec:
               CONTENTS: |
                 datasource:
                   Ec2:
-                    metadata_urls: [http://0.0.0.0:50061,http://5.6.7.8:50061]
+                    metadata_urls: [http://0.0.0.0:7172,http://5.6.7.8:7172]
                     strict_id: false
                 manage_etc_hosts: localhost
                 warnings:

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
@@ -128,7 +128,7 @@ spec:
               CONTENTS: |
                 datasource:
                   Ec2:
-                    metadata_urls: [http://0.0.0.0:50061,http://5.6.7.8:50061]
+                    metadata_urls: [http://0.0.0.0:7172,http://5.6.7.8:7172]
                     strict_id: false
                 manage_etc_hosts: localhost
                 warnings:

--- a/pkg/providers/tinkerbell/tinkerbell.go
+++ b/pkg/providers/tinkerbell/tinkerbell.go
@@ -38,7 +38,7 @@ const (
 var (
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	tinkerbellStackPorts                 = []int{42113, 50051, 50061}
+	tinkerbellStackPorts                 = []int{42113, 50051, 7172}
 
 	// errExternalEtcdUnsupported is returned from create or update when the user attempts to create
 	// or upgrade a cluster with an external etcd configuration.

--- a/pkg/providers/tinkerbell/validate.go
+++ b/pkg/providers/tinkerbell/validate.go
@@ -249,7 +249,7 @@ func validatePortsAvailable(client networkutils.NetClient, host string) error {
 }
 
 func getPortsUnavailable(client networkutils.NetClient, host string) []string {
-	ports := []string{"80", "42113", "50061"}
+	ports := []string{"80", "42113", "7172"}
 	var unavailablePorts []string
 	for _, port := range ports {
 		if networkutils.IsPortInUse(client, host, port) {

--- a/test/framework/testdata/tinkerbell/custom_config.yaml
+++ b/test/framework/testdata/tinkerbell/custom_config.yaml
@@ -91,7 +91,7 @@ spec:
           CONTENTS: |
             datasource:
               Ec2:
-                metadata_urls: [http://__TINKERBELL_LOCAL_IP__:50061, http://__TINKERBELL_LB_IP__:50061]
+                metadata_urls: [http://__TINKERBELL_LOCAL_IP__:7172, http://__TINKERBELL_LB_IP__:7172]
                 strict_id: false
             manage_etc_hosts: localhost
             warnings:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Change hegels to use port 7172 as mono repo uses this one. 
- Remove tinkerbell stack override role
- Add image tag of tink-worker that is embedded in the hook os

*Testing (if applicable):*
Created baremetal eksa-cluster using the mono repo changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

