### PR TITLE
Disable cgroupv1 failure for docker

### DIFF
--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -700,6 +700,7 @@ rules:
 						KubeletExtraArgs: map[string]string{
 							"cgroup-driver":     "cgroupfs",
 							"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+							"fail-cgroupv1":     "false",
 							"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 						},
 					},
@@ -710,6 +711,7 @@ rules:
 						KubeletExtraArgs: map[string]string{
 							"cgroup-driver":     "cgroupfs",
 							"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+							"fail-cgroupv1":     "false",
 							"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 						},
 					},

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -353,6 +353,11 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 				cpKubeletConfig["resolvConf"] = clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf.Path
 			}
 		}
+
+		if _, ok := cpKubeletConfig["failCgroupV1"]; !ok {
+			cpKubeletConfig["failCgroupV1"] = false
+		}
+
 		kcString, err := yaml.Marshal(cpKubeletConfig)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling control plane node Kubelet Configuration while building CAPI template %v", err)
@@ -371,6 +376,8 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		if cgroupDriverArgs != nil {
 			kubeletExtraArgs.Append(cgroupDriverArgs)
 		}
+
+		kubeletExtraArgs.Append(clusterapi.ExtraArgs{"fail-cgroupv1": "false"})
 
 		values["kubeletExtraArgs"] = kubeletExtraArgs.ToPartialYaml()
 	}
@@ -415,6 +422,11 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 				wnKubeletConfig["resolvConf"] = clusterSpec.Cluster.Spec.ClusterNetwork.DNS.ResolvConf.Path
 			}
 		}
+
+		if _, ok := wnKubeletConfig["failCgroupV1"]; !ok {
+			wnKubeletConfig["failCgroupV1"] = false
+		}
+
 		kcString, err := yaml.Marshal(wnKubeletConfig)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling Kubelet Configuration for worker node %s: %v", workerNodeGroupConfiguration.Name, err)
@@ -436,6 +448,8 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 		if cgroupDriverArgs != nil {
 			kubeletExtraArgs.Append(cgroupDriverArgs)
 		}
+
+		kubeletExtraArgs.Append(clusterapi.ExtraArgs{"fail-cgroupv1": "false"})
 
 		values["kubeletExtraArgs"] = kubeletExtraArgs.ToPartialYaml()
 	}

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -266,6 +266,7 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
+          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -274,6 +275,7 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
+          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 1

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -266,6 +266,7 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
+          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -274,6 +275,7 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
+          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 1

--- a/pkg/providers/docker/workers_test.go
+++ b/pkg/providers/docker/workers_test.go
@@ -146,6 +146,7 @@ func TestWorkersSpecUpgradeClusterRemoveLabels(t *testing.T) {
 		"cgroup-driver":     "cgroupfs",
 		"node-labels":       "foo=bar",
 		"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+		"fail-cgroupv1":     "false",
 	}
 
 	currentGroup1 := clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
@@ -186,6 +187,7 @@ func TestWorkersSpecUpgradeClusterRemoveLabels(t *testing.T) {
 		"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 		"cgroup-driver":     "cgroupfs",
 		"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+		"fail-cgroupv1":     "false",
 	}
 	expectedGroup1.KubeadmConfigTemplate.Name = "test-md-0-2"
 	expectedGroup1.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
@@ -399,6 +401,7 @@ func kubeadmConfigTemplate(opts ...func(*bootstrapv1.KubeadmConfigTemplate)) *bo
 								"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 								"cgroup-driver":     "cgroupfs",
 								"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
+								"fail-cgroupv1":     "false",
 							},
 							Taints: []corev1.Taint{},
 						},


### PR DESCRIPTION
*Description of changes:*
kubelet fail-cgroupv1 defaults to true starting k8s 1.35
Some of our ec2 instances used in e2e and presubmit instances
use AL2 shipped with cgroup v1.

Temporarily disable this behaviour until we upgrade above instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

