### PR TITLE
Disable cgroup v1 failure for k8s 1.31+

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -1,3 +1,4 @@
+{{- $kube_minor_version := (index (splitList "." (trimPrefix "v" .KubernetesVersion)) 1) -}}
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
@@ -35,6 +36,18 @@ kubeadmConfigPatches:
             mountPath: /var/log/kubernetes
             readOnly: false
             pathType: DirectoryOrCreate
+{{- if (ge (atoi $kube_minor_version) 31) }}
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        fail-cgroupv1: "false"
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        fail-cgroupv1: "false"
+{{- end }}
 {{- if (ne .RegistryConfigDir "") }}
 containerdConfigPatches:
   - |

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -700,7 +700,6 @@ rules:
 						KubeletExtraArgs: map[string]string{
 							"cgroup-driver":     "cgroupfs",
 							"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
-							"fail-cgroupv1":     "false",
 							"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 						},
 					},
@@ -711,7 +710,6 @@ rules:
 						KubeletExtraArgs: map[string]string{
 							"cgroup-driver":     "cgroupfs",
 							"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
-							"fail-cgroupv1":     "false",
 							"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 						},
 					},

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -354,8 +354,19 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 			}
 		}
 
-		if _, ok := cpKubeletConfig["failCgroupV1"]; !ok {
-			cpKubeletConfig["failCgroupV1"] = false
+		// fail-cgroupv1 flag was introduced in Kubernetes 1.31
+		clusterKubeVersionSemver, err := v1alpha1.KubeVersionToSemver(clusterSpec.Cluster.Spec.KubernetesVersion)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", clusterSpec.Cluster.Spec.KubernetesVersion, err)
+		}
+		kube131Semver, err := v1alpha1.KubeVersionToSemver(v1alpha1.Kube131)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", v1alpha1.Kube131, err)
+		}
+		if clusterKubeVersionSemver.Compare(kube131Semver) >= 0 {
+			if _, ok := cpKubeletConfig["failCgroupV1"]; !ok {
+				cpKubeletConfig["failCgroupV1"] = false
+			}
 		}
 
 		kcString, err := yaml.Marshal(cpKubeletConfig)
@@ -377,7 +388,18 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 			kubeletExtraArgs.Append(cgroupDriverArgs)
 		}
 
-		kubeletExtraArgs.Append(clusterapi.ExtraArgs{"fail-cgroupv1": "false"})
+		// fail-cgroupv1 flag was introduced in Kubernetes 1.31
+		clusterKubeVersionSemver, err := v1alpha1.KubeVersionToSemver(clusterSpec.Cluster.Spec.KubernetesVersion)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", clusterSpec.Cluster.Spec.KubernetesVersion, err)
+		}
+		kube131Semver, err := v1alpha1.KubeVersionToSemver(v1alpha1.Kube131)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", v1alpha1.Kube131, err)
+		}
+		if clusterKubeVersionSemver.Compare(kube131Semver) >= 0 {
+			kubeletExtraArgs.Append(clusterapi.ExtraArgs{"fail-cgroupv1": "false"})
+		}
 
 		values["kubeletExtraArgs"] = kubeletExtraArgs.ToPartialYaml()
 	}
@@ -423,8 +445,23 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 			}
 		}
 
-		if _, ok := wnKubeletConfig["failCgroupV1"]; !ok {
-			wnKubeletConfig["failCgroupV1"] = false
+		// fail-cgroupv1 flag was introduced in Kubernetes 1.31
+		kubeVersion := clusterSpec.Cluster.Spec.KubernetesVersion
+		if workerNodeGroupConfiguration.KubernetesVersion != nil {
+			kubeVersion = *workerNodeGroupConfiguration.KubernetesVersion
+		}
+		workerKubeVersionSemver, err := v1alpha1.KubeVersionToSemver(kubeVersion)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", kubeVersion, err)
+		}
+		kube131Semver, err := v1alpha1.KubeVersionToSemver(v1alpha1.Kube131)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", v1alpha1.Kube131, err)
+		}
+		if workerKubeVersionSemver.Compare(kube131Semver) >= 0 {
+			if _, ok := wnKubeletConfig["failCgroupV1"]; !ok {
+				wnKubeletConfig["failCgroupV1"] = false
+			}
 		}
 
 		kcString, err := yaml.Marshal(wnKubeletConfig)
@@ -449,7 +486,18 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 			kubeletExtraArgs.Append(cgroupDriverArgs)
 		}
 
-		kubeletExtraArgs.Append(clusterapi.ExtraArgs{"fail-cgroupv1": "false"})
+		// fail-cgroupv1 flag was introduced in Kubernetes 1.31
+		workerKubeVersionSemver, err := v1alpha1.KubeVersionToSemver(kubeVersion)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", kubeVersion, err)
+		}
+		kube131Semver, err := v1alpha1.KubeVersionToSemver(v1alpha1.Kube131)
+		if err != nil {
+			return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", v1alpha1.Kube131, err)
+		}
+		if workerKubeVersionSemver.Compare(kube131Semver) >= 0 {
+			kubeletExtraArgs.Append(clusterapi.ExtraArgs{"fail-cgroupv1": "false"})
+		}
 
 		values["kubeletExtraArgs"] = kubeletExtraArgs.ToPartialYaml()
 	}

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -266,7 +266,6 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
-          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -275,7 +274,6 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
-          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 1

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -266,7 +266,6 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
-          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
     joinConfiguration:
@@ -275,7 +274,6 @@ spec:
         kubeletExtraArgs:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cgroup-driver: cgroupfs
-          fail-cgroupv1: "false"
           tls-cipher-suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         taints: []
   replicas: 1

--- a/pkg/providers/docker/workers_test.go
+++ b/pkg/providers/docker/workers_test.go
@@ -146,7 +146,6 @@ func TestWorkersSpecUpgradeClusterRemoveLabels(t *testing.T) {
 		"cgroup-driver":     "cgroupfs",
 		"node-labels":       "foo=bar",
 		"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
-		"fail-cgroupv1":     "false",
 	}
 
 	currentGroup1 := clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]{
@@ -187,7 +186,6 @@ func TestWorkersSpecUpgradeClusterRemoveLabels(t *testing.T) {
 		"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 		"cgroup-driver":     "cgroupfs",
 		"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
-		"fail-cgroupv1":     "false",
 	}
 	expectedGroup1.KubeadmConfigTemplate.Name = "test-md-0-2"
 	expectedGroup1.MachineDeployment.Spec.Template.Spec.Bootstrap.ConfigRef.Name = "test-md-0-2"
@@ -401,7 +399,6 @@ func kubeadmConfigTemplate(opts ...func(*bootstrapv1.KubeadmConfigTemplate)) *bo
 								"tls-cipher-suites": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 								"cgroup-driver":     "cgroupfs",
 								"eviction-hard":     "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%",
-								"fail-cgroupv1":     "false",
 							},
 							Taints: []corev1.Taint{},
 						},


### PR DESCRIPTION
*Description of changes:*
* Add condition for fail-cgroupv1 kubelet flag as it's only supported in k8s 1.31+
* Adds the flag for kind bootstrap clusters in eks-anywhere instead of patching kind for all k8s versions in build-tooling https://github.com/aws/eks-anywhere-build-tooling/pull/5149

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

