### PR TITLE
Fix tinkerbell e2e inplace upgrade test config

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -263,7 +263,7 @@ func TestTinkerbellKubernetes134UbuntuTo135InPlaceUpgrade_1CP_1Worker(t *testing
 	)
 	runInPlaceUpgradeFlowForBareMetal(
 		test,
-		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube134), api.WithInPlaceUpgradeStrategy()),
+		framework.WithClusterUpgrade(api.WithKubernetesVersion(v1alpha1.Kube135), api.WithInPlaceUpgradeStrategy()),
 		provider.WithProviderUpgrade(framework.Ubuntu135Image()),
 	)
 }
@@ -290,7 +290,7 @@ func TestTinkerbellKubernetes134UbuntuTo135SingleNodeInPlaceUpgrade(t *testing.T
 		test,
 		framework.WithUpgradeClusterConfig(
 			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
+				api.WithKubernetesVersion(v1alpha1.Kube135),
 				api.WithInPlaceUpgradeStrategy(),
 			),
 			api.TinkerbellToConfigFiller(
@@ -323,14 +323,14 @@ func TestTinkerbellKubernetes134RedHat9To135SingleNodeInPlaceUpgrade(t *testing.
 		test,
 		framework.WithUpgradeClusterConfig(
 			api.ClusterToConfigFiller(
-				api.WithKubernetesVersion(v1alpha1.Kube134),
+				api.WithKubernetesVersion(v1alpha1.Kube135),
 				api.WithInPlaceUpgradeStrategy(),
 			),
 			api.TinkerbellToConfigFiller(
 				api.RemoveTinkerbellWorkerMachineConfig(),
 			),
 		),
-		provider.WithProviderUpgrade(framework.RedHat9Kubernetes134Image()),
+		provider.WithProviderUpgrade(framework.RedHat9Kubernetes135Image()),
 	)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix tinkerbell e2e inplace upgrade test config for 135 upgrades


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

