### PR TITLE
Skip 135 canonical tests

### DIFF
--- a/test/e2e/SKIPPED_TESTS.yaml
+++ b/test/e2e/SKIPPED_TESTS.yaml
@@ -1,5 +1,11 @@
 skipped_tests:
 
+# Skipping until we get 1.35 images from Canonical
+- TestTinkerbellKubernetes135Ubuntu2404GenericSimpleFlow
+- TestTinkerbellKubernetes135Ubuntu2404RTOSSimpleFlow
+- TestTinkerbellKubernetes135Ubuntu2204To2404RTOSUpgrade
+- TestTinkerbellKubernetes135Ubuntu2204To2404GenericUpgrade
+
 # CloudStack
 # Airgapped tests due to an airgapped network not being setup properly on the cloudstack CI env.
 - TestCloudStackKubernetes132RedhatAirgappedProxy


### PR DESCRIPTION
Skipping until we get 1.35 images from Canonical team

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

