### PR TITLE
Adopt upstream tinkerbell changes and setup concurrency in controllers

### DIFF
--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults.go
@@ -161,7 +161,7 @@ func withNetplanAction(disk string, osFamily OSFamily) ActionOpt {
             match:
                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
             addresses:
-                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             routes:
@@ -183,7 +183,7 @@ func withNetplanAction(disk string, osFamily OSFamily) ActionOpt {
             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
             link: mainif
             addresses:
-            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -342,7 +342,7 @@ autoconnect-priority=10
 mac-address={{ (index .Hardware.Interfaces 0).DHCP.MAC }}
 
 [ipv4]
-address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
 dns={{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}};{{end}}{{$ns}}{{end}};
 gateway={{ (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
 method=manual
@@ -367,7 +367,7 @@ id={{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
 mac-address={{ (index .Hardware.Interfaces 0).DHCP.MAC }}
 
 [ipv4]
-address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
 dns={{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}};{{end}}{{$ns}}{{end}};
 gateway={{ (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
 method=manual

--- a/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
+++ b/pkg/api/v1alpha1/tinkerbelltemplateconfig_defaults_test.go
@@ -220,7 +220,7 @@ id={{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
 mac-address={{ (index .Hardware.Interfaces 0).DHCP.MAC }}
 
 [ipv4]
-address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
 dns={{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}};{{end}}{{$ns}}{{end}};
 gateway={{ (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
 method=manual
@@ -238,7 +238,7 @@ autoconnect-priority=10
 mac-address={{ (index .Hardware.Interfaces 0).DHCP.MAC }}
 
 [ipv4]
-address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+address1={{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
 dns={{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}};{{end}}{{$ns}}{{end}};
 gateway={{ (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
 method=manual
@@ -346,7 +346,7 @@ method=ignore
             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
             link: mainif
             addresses:
-            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -362,7 +362,7 @@ method=ignore
             match:
                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
             addresses:
-                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             routes:
@@ -468,7 +468,7 @@ method=ignore
             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
             link: mainif
             addresses:
-            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -484,7 +484,7 @@ method=ignore
             match:
                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
             addresses:
-                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             routes:
@@ -605,7 +605,7 @@ method=ignore
             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
             link: mainif
             addresses:
-            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -621,7 +621,7 @@ method=ignore
             match:
                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
             addresses:
-                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
             nameservers:
                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
             routes:

--- a/pkg/providers/tinkerbell/create.go
+++ b/pkg/providers/tinkerbell/create.go
@@ -49,7 +49,7 @@ func (p *Provider) PreCAPIInstallOnBootstrap(ctx context.Context, cluster *types
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
 		stack.WithLoadBalancerInterface(p.datacenterConfig.Spec.LoadBalancerInterface),
-		stack.WithBootsOnDocker(),
+		stack.WithSmeeOnDocker(),
 		stack.WithHostNetworkEnabled(true), // enable host network on bootstrap cluster
 		stack.WithLoadBalancerEnabled(false),
 		stack.WithStackServiceEnabled(false),
@@ -112,7 +112,7 @@ func (p *Provider) PostWorkloadInit(ctx context.Context, cluster *types.Cluster,
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
 		stack.WithLoadBalancerInterface(p.datacenterConfig.Spec.LoadBalancerInterface),
-		stack.WithBootsOnKubernetes(),
+		stack.WithSmeeOnKubernetes(),
 		stack.WithHostNetworkEnabled(false), // disable host network on workload cluster
 		stack.WithStackServiceEnabled(true), // use stack service on workload cluster
 		stack.WithDHCPRelayEnabled(true),

--- a/pkg/providers/tinkerbell/stack/stack_test.go
+++ b/pkg/providers/tinkerbell/stack/stack_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	overridesFileName = "tinkerbell-chart-overrides.yaml"
-	boots             = "boots"
+	smee              = "smee"
 	testIP            = "1.2.3.4"
 
 	helmChartPath    = "public.ecr.aws/eks-anywhere/tinkerbell/tinkerbell-chart"
@@ -133,12 +133,12 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 			name:            "with_boots_on_docker",
 			expectedFile:    "testdata/expected_with_boots_on_docker.yaml",
 			installOnDocker: true,
-			opts:            []stack.InstallOption{stack.WithBootsOnDocker()},
+			opts:            []stack.InstallOption{stack.WithSmeeOnDocker()},
 		},
 		{
 			name:         "with_boots_on_kubernetes",
 			expectedFile: "testdata/expected_with_boots_on_kubernetes.yaml",
-			opts:         []stack.InstallOption{stack.WithBootsOnKubernetes()},
+			opts:         []stack.InstallOption{stack.WithSmeeOnKubernetes()},
 		},
 		{
 			name:         "with_host_port_enabled_true",
@@ -169,7 +169,7 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 			name:         "with_kubernetes_options",
 			expectedFile: "testdata/expected_with_kubernetes_options.yaml",
 			opts: []stack.InstallOption{
-				stack.WithBootsOnKubernetes(),
+				stack.WithSmeeOnKubernetes(),
 				stack.WithLoadBalancerEnabled(true),
 			},
 		},
@@ -178,7 +178,7 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 			expectedFile:    "testdata/expected_with_docker_options.yaml",
 			installOnDocker: true,
 			opts: []stack.InstallOption{
-				stack.WithBootsOnDocker(),
+				stack.WithSmeeOnDocker(),
 				stack.WithHostNetworkEnabled(true),
 				stack.WithLoadBalancerEnabled(false),
 			},
@@ -240,7 +240,7 @@ func TestTinkerbellStackInstallWithDifferentOptions(t *testing.T) {
 
 			if stackTest.installOnDocker {
 				docker.EXPECT().Run(ctx, "public.ecr.aws/eks-anywhere/tinkerbell:latest",
-					boots,
+					smee,
 					[]string{}, // Mono-repo binary uses env vars, not command line args
 					"-v", gomock.Any(),
 					"--network", "host",
@@ -311,7 +311,7 @@ func TestTinkerbellStackUninstallLocalSucess(t *testing.T) {
 
 	s := stack.NewInstaller(docker, writer, helm, "", constants.EksaSystemNamespace, "192.168.0.0/16", nil, nil)
 
-	docker.EXPECT().ForceRemove(ctx, boots)
+	docker.EXPECT().ForceRemove(ctx, smee)
 
 	err := s.UninstallLocal(ctx)
 	if err != nil {
@@ -330,7 +330,7 @@ func TestTinkerbellStackUninstallLocalFailure(t *testing.T) {
 
 	dockerError := "docker error"
 	expectedError := fmt.Sprintf("removing local boots container: %s", dockerError)
-	docker.EXPECT().ForceRemove(ctx, boots).Return(errors.New(dockerError))
+	docker.EXPECT().ForceRemove(ctx, smee).Return(errors.New(dockerError))
 
 	err := s.UninstallLocal(ctx)
 	assert.EqualError(t, err, expectedError, "Error should be: %v, got: %v", expectedError, err)
@@ -345,8 +345,8 @@ func TestTinkerbellStackCheckLocalBootsExistenceDoesNotExist(t *testing.T) {
 
 	s := stack.NewInstaller(docker, writer, helm, "", constants.EksaSystemNamespace, "192.168.0.0/16", nil, nil)
 
-	docker.EXPECT().CheckContainerExistence(ctx, "boots").Return(true, nil)
-	docker.EXPECT().ForceRemove(ctx, "boots")
+	docker.EXPECT().CheckContainerExistence(ctx, "smee").Return(true, nil)
+	docker.EXPECT().ForceRemove(ctx, "smee")
 
 	err := s.CleanupLocalBoots(ctx, true)
 	assert.NoError(t, err)
@@ -362,7 +362,7 @@ func TestTinkerbellStackCheckLocalBootsExistenceDoesExist(t *testing.T) {
 	s := stack.NewInstaller(docker, writer, helm, "", constants.EksaSystemNamespace, "192.168.0.0/16", nil, nil)
 	expectedErrorMsg := "boots container already exists, delete the container manually"
 
-	docker.EXPECT().CheckContainerExistence(ctx, "boots").Return(true, nil)
+	docker.EXPECT().CheckContainerExistence(ctx, "smee").Return(true, nil)
 
 	err := s.CleanupLocalBoots(ctx, false)
 	assert.EqualError(t, err, expectedErrorMsg, "Error should be: %v, got: %v", expectedErrorMsg, err)
@@ -377,7 +377,7 @@ func TestTinkerbellStackCheckLocalBootsExistenceDockerError(t *testing.T) {
 
 	s := stack.NewInstaller(docker, writer, helm, "", constants.EksaSystemNamespace, "192.168.0.0/16", nil, nil)
 
-	docker.EXPECT().CheckContainerExistence(ctx, "boots").Return(false, nil)
+	docker.EXPECT().CheckContainerExistence(ctx, "smee").Return(false, nil)
 
 	err := s.CleanupLocalBoots(ctx, true)
 	assert.NoError(t, err)

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -47,6 +48,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -44,6 +45,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -47,6 +48,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -22,6 +22,7 @@ deployment:
       enableTootles: true
     rufio:
       enableLeaderElection: true
+      maxConcurrentReconciles: 10
     smee:
       dhcpEnabled: true
       dhcpIPForPacket: 1.2.3.4
@@ -47,6 +48,7 @@ deployment:
       tftpServerEnabled: true
     tinkController:
       enableLeaderElection: true
+      maxConcurrentReconciles: 5
     tinkServer:
       bindPort: 42113
     tootles:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
@@ -350,7 +350,7 @@ spec:
                             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
                             link: mainif
                             addresses:
-                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -366,7 +366,7 @@ spec:
                             match:
                                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
                             addresses:
-                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             routes:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
@@ -350,7 +350,7 @@ spec:
                             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
                             link: mainif
                             addresses:
-                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -366,7 +366,7 @@ spec:
                             match:
                                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
                             addresses:
-                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             routes:

--- a/pkg/providers/tinkerbell/testdata/expected_kct.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kct.yaml
@@ -72,7 +72,7 @@ spec:
                             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
                             link: mainif
                             addresses:
-                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -88,7 +88,7 @@ spec:
                             match:
                                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
                             addresses:
-                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             routes:

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
@@ -80,7 +80,7 @@ spec:
                             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
                             link: mainif
                             addresses:
-                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -96,7 +96,7 @@ spec:
                             match:
                                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
                             addresses:
-                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             routes:

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
@@ -80,7 +80,7 @@ spec:
                             id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
                             link: mainif
                             addresses:
-                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -96,7 +96,7 @@ spec:
                             match:
                                 macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
                             addresses:
-                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                                - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                             nameservers:
                                 addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                             routes:

--- a/pkg/providers/tinkerbell/upgrade.go
+++ b/pkg/providers/tinkerbell/upgrade.go
@@ -555,7 +555,7 @@ func (p *Provider) PreCoreComponentsUpgrade(
 		cluster.KubeconfigFile,
 		p.datacenterConfig.Spec.HookImagesURLPath,
 		stack.WithLoadBalancerInterface(p.datacenterConfig.Spec.LoadBalancerInterface),
-		stack.WithBootsOnKubernetes(),
+		stack.WithSmeeOnKubernetes(),
 		stack.WithStackServiceEnabled(true),
 		stack.WithDHCPRelayEnabled(true),
 		stack.WithLoadBalancerEnabled(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use netmaskToPrefixLength template func from upstream, rename boots container to smee, and add maxConcurrentReconciles for Tink and Rufio controllers. Update tests and golden files accordingly.

Ref: https://github.com/tinkerbell/tinkerbell/pull/550, https://github.com/tinkerbell/tinkerbell/pull/411

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

