### PR TITLE
Migrate capi machine and machineset resources to v1beta2

### DIFF
--- a/controllers/cluster_controller_test_test.go
+++ b/controllers/cluster_controller_test_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -558,7 +558,7 @@ type MockClient struct {
 
 func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	// Check if we're trying to list MachineList objects
-	if _, ok := list.(*clusterv1.MachineList); ok {
+	if _, ok := list.(*clusterv1beta2.MachineList); ok {
 		return fmt.Errorf("simulated client error during machine list operation")
 	}
 	// For all other list operations, delegate to the real client

--- a/controllers/kubeadmcontrolplane_controller.go
+++ b/controllers/kubeadmcontrolplane_controller.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
@@ -188,7 +187,7 @@ func (r *KubeadmControlPlaneReconciler) machinesToUpgrade(ctx context.Context, k
 	if err != nil {
 		return nil, err
 	}
-	machineList := &clusterv1.MachineList{}
+	machineList := &clusterv1beta2.MachineList{}
 	if err := r.client.List(ctx, machineList, &client.ListOptions{LabelSelector: selector, Namespace: kcp.ObjectMeta.Namespace}); err != nil {
 		return nil, err
 	}

--- a/controllers/kubeadmcontrolplane_controller_test.go
+++ b/controllers/kubeadmcontrolplane_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/utils/ptr"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -31,7 +30,7 @@ const (
 )
 
 type kcpObjects struct {
-	machines  []*clusterv1.Machine
+	machines  []*clusterv1beta2.Machine
 	cpUpgrade *anywherev1.ControlPlaneUpgrade
 	kcp       *controlplanev1beta2.KubeadmControlPlane
 	mhc       *clusterv1beta2.MachineHealthCheck
@@ -278,7 +277,7 @@ func getObjectsForKCP() kcpObjects {
 	machine2.Labels = map[string]string{
 		"cluster.x-k8s.io/control-plane-name": kcp.Name,
 	}
-	machines := []*clusterv1.Machine{machine1, machine2}
+	machines := []*clusterv1beta2.Machine{machine1, machine2}
 	cpUpgrade := generateCPUpgrade(machines)
 	cpUpgrade.Name = kcp.Name + "-cp-upgrade"
 	cpUpgrade.OwnerReferences = []metav1.OwnerReference{{

--- a/controllers/nodeupgrade_controller.go
+++ b/controllers/nodeupgrade_controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -85,7 +86,7 @@ func (r *NodeUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	machineToBeUpgraded := &clusterv1.Machine{}
+	machineToBeUpgraded := &clusterv1beta2.Machine{}
 	if err := r.client.Get(ctx, GetNamespacedNameType(nodeUpgrade.Spec.Machine.Name, nodeUpgrade.Spec.Machine.Namespace), machineToBeUpgraded); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -95,7 +96,7 @@ func (r *NodeUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if machineToBeUpgraded.Status.NodeRef == nil {
+	if !machineToBeUpgraded.Status.NodeRef.IsDefined() {
 		return ctrl.Result{}, fmt.Errorf("machine %s is missing nodeRef", machineToBeUpgraded.Name)
 	}
 
@@ -145,7 +146,7 @@ func (r *NodeUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return r.reconcile(ctx, log, machineToBeUpgraded, nodeUpgrade, rClient)
 }
 
-func (r *NodeUpgradeReconciler) reconcile(ctx context.Context, log logr.Logger, machineToBeUpgraded *clusterv1.Machine, nodeUpgrade *anywherev1.NodeUpgrade, remoteClient client.Client) (ctrl.Result, error) {
+func (r *NodeUpgradeReconciler) reconcile(ctx context.Context, log logr.Logger, machineToBeUpgraded *clusterv1beta2.Machine, nodeUpgrade *anywherev1.NodeUpgrade, remoteClient client.Client) (ctrl.Result, error) {
 	node := &corev1.Node{}
 	if err := remoteClient.Get(ctx, types.NamespacedName{Name: machineToBeUpgraded.Status.NodeRef.Name}, node); err != nil {
 		return reconcile.Result{}, err

--- a/controllers/nodeupgrade_controller_test.go
+++ b/controllers/nodeupgrade_controller_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -231,7 +230,7 @@ func TestNodeUpgradeReconcilerReconcileDeleteUpgraderPodAlreadyDeleted(t *testin
 	g.Expect(err).To(MatchError("pods \"node01-node-upgrader\" not found"))
 }
 
-func getObjectsForNodeUpgradeTest() (*clusterv1beta2.Cluster, *clusterv1.Machine, *corev1.Node, *anywherev1.NodeUpgrade, *corev1.ConfigMap) {
+func getObjectsForNodeUpgradeTest() (*clusterv1beta2.Cluster, *clusterv1beta2.Machine, *corev1.Node, *anywherev1.NodeUpgrade, *corev1.ConfigMap) {
 	cluster := generateCluster()
 	node := generateNode()
 	bootstrapConfig := generateKubeadmConfig()
@@ -250,7 +249,7 @@ func nodeUpgradeRequest(nodeUpgrade *anywherev1.NodeUpgrade) reconcile.Request {
 	}
 }
 
-func generateNodeUpgrade(machine *clusterv1.Machine) *anywherev1.NodeUpgrade {
+func generateNodeUpgrade(machine *clusterv1beta2.Machine) *anywherev1.NodeUpgrade {
 	return &anywherev1.NodeUpgrade{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-upgrade-request",
@@ -266,24 +265,23 @@ func generateNodeUpgrade(machine *clusterv1.Machine) *anywherev1.NodeUpgrade {
 	}
 }
 
-func generateMachine(cluster *clusterv1beta2.Cluster, node *corev1.Node, bootstrapConfig *bootstrapv1beta2.KubeadmConfig) *clusterv1.Machine {
-	return &clusterv1.Machine{
+func generateMachine(cluster *clusterv1beta2.Cluster, node *corev1.Node, bootstrapConfig *bootstrapv1beta2.KubeadmConfig) *clusterv1beta2.Machine {
+	return &clusterv1beta2.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine01",
 			Namespace: "eksa-system",
 		},
-		Spec: clusterv1.MachineSpec{
-			Version:     ptr.String("v1.27.8-eks-1-27-18"),
+		Spec: clusterv1beta2.MachineSpec{
+			Version:     "v1.27.8-eks-1-27-18",
 			ClusterName: cluster.Name,
-			Bootstrap: clusterv1.Bootstrap{
-				ConfigRef: &corev1.ObjectReference{
-					Name:      bootstrapConfig.Name,
-					Namespace: bootstrapConfig.Namespace,
+			Bootstrap: clusterv1beta2.Bootstrap{
+				ConfigRef: clusterv1beta2.ContractVersionedObjectReference{
+					Name: bootstrapConfig.Name,
 				},
 			},
 		},
-		Status: clusterv1.MachineStatus{
-			NodeRef: &corev1.ObjectReference{
+		Status: clusterv1beta2.MachineStatus{
+			NodeRef: clusterv1beta2.MachineNodeReference{
 				Name: node.Name,
 			},
 		},

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -27,7 +27,6 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
@@ -62,7 +61,6 @@ func init() {
 	// Register CRDs in Scheme in init so fake clients benefit from it
 	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(releasev1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterv1beta2.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clusterctlv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(controlplanev1beta2.AddToScheme(scheme.Scheme))

--- a/manager/main.go
+++ b/manager/main.go
@@ -23,7 +23,6 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
@@ -52,7 +51,6 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(anywherev1.AddToScheme(scheme))
 	utilruntime.Must(releasev1.AddToScheme(scheme))
-	utilruntime.Must(clusterv1.AddToScheme(scheme))
 	utilruntime.Must(clusterv2.AddToScheme(scheme))
 	utilruntime.Must(clusterctlv1.AddToScheme(scheme))
 	utilruntime.Must(controlplanev1beta2.AddToScheme(scheme))

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -156,7 +156,7 @@ func PopulateConfig(ctx context.Context, cfg *RenewalConfig, kubeClient kubernet
 func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var controlPlaneIPs []string
 
-	machineList := &clusterv1.MachineList{}
+	machineList := &clusterv1beta2.MachineList{}
 
 	namespaceOpt := kubernetes.ListOptions{
 		Namespace: constants.EksaSystemNamespace,
@@ -171,7 +171,7 @@ func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, clust
 			_, hasControlPlaneLabel := machine.Labels[controlPlaneLabel]
 			if hasControlPlaneLabel {
 				for _, address := range machine.Status.Addresses {
-					if address.Type == clusterv1.MachineExternalIP && address.Address != "" {
+					if address.Type == clusterv1beta2.MachineExternalIP && address.Address != "" {
 						controlPlaneIPs = append(controlPlaneIPs, address.Address)
 						break
 					}
@@ -186,7 +186,7 @@ func getControlPlaneIPs(ctx context.Context, kubeClient kubernetes.Client, clust
 func getEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *types.Cluster) ([]string, error) {
 	var etcdIPs []string
 
-	machineList := &clusterv1.MachineList{}
+	machineList := &clusterv1beta2.MachineList{}
 
 	namespaceOpt := kubernetes.ListOptions{
 		Namespace: constants.EksaSystemNamespace,
@@ -199,7 +199,7 @@ func getEtcdIPs(ctx context.Context, kubeClient kubernetes.Client, cluster *type
 	for _, machine := range machineList.Items {
 		if machine.Labels[clusterNameLabel] == cluster.Name && machine.Labels[externalEtcdLabel] == cluster.Name+"-etcd" {
 			for _, address := range machine.Status.Addresses {
-				if address.Type == clusterv1.MachineExternalIP && address.Address != "" {
+				if address.Type == clusterv1beta2.MachineExternalIP && address.Address != "" {
 					etcdIPs = append(etcdIPs, address.Address)
 					break
 				}

--- a/pkg/certificates/config_test.go
+++ b/pkg/certificates/config_test.go
@@ -9,7 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/certificates"
@@ -29,14 +29,14 @@ const (
 )
 
 // helper to generate a Machine with the given labels and external IP.
-func buildMachine(labels map[string]string, ip string) clusterv1.Machine {
-	return clusterv1.Machine{
+func buildMachine(labels map[string]string, ip string) clusterv1beta2.Machine {
+	return clusterv1beta2.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: labels,
 		},
-		Status: clusterv1.MachineStatus{
-			Addresses: []clusterv1.MachineAddress{
-				{Type: clusterv1.MachineExternalIP, Address: ip},
+		Status: clusterv1beta2.MachineStatus{
+			Addresses: []clusterv1beta2.MachineAddress{
+				{Type: clusterv1beta2.MachineExternalIP, Address: ip},
 			},
 		},
 	}
@@ -485,8 +485,8 @@ func TestPopulateConfig_ControlPlaneSuccess(t *testing.T) {
 
 	k := kubemocks.NewMockClient(ctrl)
 
-	machines := &clusterv1.MachineList{
-		Items: []clusterv1.Machine{
+	machines := &clusterv1beta2.MachineList{
+		Items: []clusterv1beta2.Machine{
 			buildMachine(map[string]string{
 				clusterNameLabel:  clusterLabel,
 				controlPlaneLabel: "",
@@ -497,14 +497,14 @@ func TestPopulateConfig_ControlPlaneSuccess(t *testing.T) {
 	k.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, l any, _ ...any) error {
-			*l.(*clusterv1.MachineList) = *machines
+			*l.(*clusterv1beta2.MachineList) = *machines
 			return nil
 		})
 
 	k.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, l any, _ ...any) error {
-			*l.(*clusterv1.MachineList) = *machines
+			*l.(*clusterv1beta2.MachineList) = *machines
 			return nil
 		})
 
@@ -527,12 +527,12 @@ func TestPopulateConfig_EtcdSuccess(t *testing.T) {
 
 	k := kubemocks.NewMockClient(ctrl)
 
-	cpMachines := &clusterv1.MachineList{
-		Items: []clusterv1.Machine{},
+	cpMachines := &clusterv1beta2.MachineList{
+		Items: []clusterv1beta2.Machine{},
 	}
 
-	etcdMachines := &clusterv1.MachineList{
-		Items: []clusterv1.Machine{
+	etcdMachines := &clusterv1beta2.MachineList{
+		Items: []clusterv1beta2.Machine{
 			buildMachine(map[string]string{
 				clusterNameLabel:  clusterLabel,
 				externalEtcdLabel: clusterLabel + "-etcd",
@@ -543,14 +543,14 @@ func TestPopulateConfig_EtcdSuccess(t *testing.T) {
 	k.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, l any, _ ...any) error {
-			*l.(*clusterv1.MachineList) = *cpMachines
+			*l.(*clusterv1beta2.MachineList) = *cpMachines
 			return nil
 		})
 
 	k.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, l any, _ ...any) error {
-			*l.(*clusterv1.MachineList) = *etcdMachines
+			*l.(*clusterv1beta2.MachineList) = *etcdMachines
 			return nil
 		})
 
@@ -573,8 +573,8 @@ func TestPopulateConfig_EtcdListError(t *testing.T) {
 
 	k := kubemocks.NewMockClient(ctrl)
 
-	cpMachines := &clusterv1.MachineList{
-		Items: []clusterv1.Machine{
+	cpMachines := &clusterv1beta2.MachineList{
+		Items: []clusterv1beta2.Machine{
 			buildMachine(map[string]string{
 				clusterNameLabel:  clusterLabel,
 				controlPlaneLabel: "",
@@ -585,7 +585,7 @@ func TestPopulateConfig_EtcdListError(t *testing.T) {
 	k.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, l interface{}, _ ...interface{}) error {
-			*l.(*clusterv1.MachineList) = *cpMachines
+			*l.(*clusterv1beta2.MachineList) = *cpMachines
 			return nil
 		})
 
@@ -612,8 +612,8 @@ func TestPopulateConfig_Success(t *testing.T) {
 
 	k := kubemocks.NewMockClient(ctrl)
 
-	all := &clusterv1.MachineList{
-		Items: []clusterv1.Machine{
+	all := &clusterv1beta2.MachineList{
+		Items: []clusterv1beta2.Machine{
 			buildMachine(map[string]string{
 				clusterNameLabel:  clusterLabel,
 				controlPlaneLabel: "",
@@ -628,7 +628,7 @@ func TestPopulateConfig_Success(t *testing.T) {
 	k.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, l interface{}, _ ...interface{}) error {
-			*l.(*clusterv1.MachineList) = *all
+			*l.(*clusterv1beta2.MachineList) = *all
 			return nil
 		}).Times(2)
 

--- a/pkg/certificates/scanner.go
+++ b/pkg/certificates/scanner.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -74,7 +74,7 @@ func (s *Scanner) CheckCertificateExpiry(ctx context.Context, cluster *anywherev
 func (s *Scanner) getControlPlaneMachines(ctx context.Context, cluster *anywherev1.Cluster) ([]MachineInfo, error) {
 	var machines []MachineInfo
 
-	machineList := &clusterv1.MachineList{}
+	machineList := &clusterv1beta2.MachineList{}
 	selector := client.MatchingLabels{
 		clusterNameLabel:  cluster.Name,
 		controlPlaneLabel: "",
@@ -86,7 +86,7 @@ func (s *Scanner) getControlPlaneMachines(ctx context.Context, cluster *anywhere
 
 	for _, machine := range machineList.Items {
 		for _, address := range machine.Status.Addresses {
-			if address.Type == clusterv1.MachineExternalIP {
+			if address.Type == clusterv1beta2.MachineExternalIP {
 				machines = append(machines, MachineInfo{
 					Name: machine.Name,
 					IP:   address.Address,
@@ -102,7 +102,7 @@ func (s *Scanner) getControlPlaneMachines(ctx context.Context, cluster *anywhere
 func (s *Scanner) getEtcdMachines(ctx context.Context, cluster *anywherev1.Cluster) ([]MachineInfo, error) {
 	var machines []MachineInfo
 
-	machineList := &clusterv1.MachineList{}
+	machineList := &clusterv1beta2.MachineList{}
 	selector := client.MatchingLabels{
 		clusterNameLabel:  cluster.Name,
 		externalEtcdLabel: cluster.Name + "-etcd",
@@ -114,7 +114,7 @@ func (s *Scanner) getEtcdMachines(ctx context.Context, cluster *anywherev1.Clust
 
 	for _, machine := range machineList.Items {
 		for _, address := range machine.Status.Addresses {
-			if address.Type == clusterv1.MachineExternalIP {
+			if address.Type == clusterv1beta2.MachineExternalIP {
 				machines = append(machines, MachineInfo{
 					Name: machine.Name,
 					IP:   address.Address,

--- a/pkg/certificates/scanner_test.go
+++ b/pkg/certificates/scanner_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -21,7 +21,7 @@ import (
 func newFakeClientBuilder() *fake.ClientBuilder {
 	scheme := runtime.NewScheme()
 	_ = anywherev1.AddToScheme(scheme)
-	_ = clusterv1.AddToScheme(scheme)
+	_ = clusterv1beta2.AddToScheme(scheme)
 	return fake.NewClientBuilder().WithScheme(scheme)
 }
 
@@ -45,8 +45,8 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 	tests := []struct {
 		name                 string
 		cluster              *anywherev1.Cluster
-		controlPlaneMachines []clusterv1.Machine
-		etcdMachines         []clusterv1.Machine
+		controlPlaneMachines []clusterv1beta2.Machine
+		etcdMachines         []clusterv1beta2.Machine
 	}{
 		{
 			name: "successful certificate check with control plane only",
@@ -56,7 +56,7 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 					Namespace: constants.EksaSystemNamespace,
 				},
 			},
-			controlPlaneMachines: []clusterv1.Machine{
+			controlPlaneMachines: []clusterv1beta2.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cluster-control-plane-abc123",
@@ -66,10 +66,10 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 							"cluster.x-k8s.io/control-plane": "",
 						},
 					},
-					Status: clusterv1.MachineStatus{
-						Addresses: []clusterv1.MachineAddress{
+					Status: clusterv1beta2.MachineStatus{
+						Addresses: []clusterv1beta2.MachineAddress{
 							{
-								Type:    clusterv1.MachineExternalIP,
+								Type:    clusterv1beta2.MachineExternalIP,
 								Address: endpoint,
 							},
 						},
@@ -93,7 +93,7 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 					},
 				},
 			},
-			controlPlaneMachines: []clusterv1.Machine{
+			controlPlaneMachines: []clusterv1beta2.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cluster-control-plane-abc123",
@@ -103,17 +103,17 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 							"cluster.x-k8s.io/control-plane": "",
 						},
 					},
-					Status: clusterv1.MachineStatus{
-						Addresses: []clusterv1.MachineAddress{
+					Status: clusterv1beta2.MachineStatus{
+						Addresses: []clusterv1beta2.MachineAddress{
 							{
-								Type:    clusterv1.MachineExternalIP,
+								Type:    clusterv1beta2.MachineExternalIP,
 								Address: endpoint,
 							},
 						},
 					},
 				},
 			},
-			etcdMachines: []clusterv1.Machine{
+			etcdMachines: []clusterv1beta2.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cluster-etcd-xyz789",
@@ -123,10 +123,10 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 							"cluster.x-k8s.io/etcd-cluster": "test-cluster-etcd",
 						},
 					},
-					Status: clusterv1.MachineStatus{
-						Addresses: []clusterv1.MachineAddress{
+					Status: clusterv1beta2.MachineStatus{
+						Addresses: []clusterv1beta2.MachineAddress{
 							{
-								Type:    clusterv1.MachineExternalIP,
+								Type:    clusterv1beta2.MachineExternalIP,
 								Address: endpoint,
 							},
 						},
@@ -150,7 +150,7 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 					},
 				},
 			},
-			controlPlaneMachines: []clusterv1.Machine{},
+			controlPlaneMachines: []clusterv1beta2.Machine{},
 		},
 		{
 			name: "machine without external IP address",
@@ -165,7 +165,7 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 					},
 				},
 			},
-			controlPlaneMachines: []clusterv1.Machine{
+			controlPlaneMachines: []clusterv1beta2.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cluster-control-plane-abc123",
@@ -175,10 +175,10 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 							"cluster.x-k8s.io/control-plane": "",
 						},
 					},
-					Status: clusterv1.MachineStatus{
-						Addresses: []clusterv1.MachineAddress{
+					Status: clusterv1beta2.MachineStatus{
+						Addresses: []clusterv1beta2.MachineAddress{
 							{
-								Type: clusterv1.MachineInternalIP,
+								Type: clusterv1beta2.MachineInternalIP,
 							},
 						},
 					},
@@ -199,7 +199,7 @@ func TestScanner_CheckCertificateExpiry_Success(t *testing.T) {
 					},
 				},
 			},
-			controlPlaneMachines: []clusterv1.Machine{},
+			controlPlaneMachines: []clusterv1beta2.Machine{},
 		},
 	}
 
@@ -230,7 +230,7 @@ func TestScanner_UpdateClusterCertificateStatus_Success(t *testing.T) {
 	tests := []struct {
 		name     string
 		cluster  *anywherev1.Cluster
-		machines []clusterv1.Machine
+		machines []clusterv1beta2.Machine
 	}{
 		{
 			name: "successfully updates cluster certificate status",
@@ -245,7 +245,7 @@ func TestScanner_UpdateClusterCertificateStatus_Success(t *testing.T) {
 					},
 				},
 			},
-			machines: []clusterv1.Machine{
+			machines: []clusterv1beta2.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cluster-control-plane-abc123",
@@ -255,10 +255,10 @@ func TestScanner_UpdateClusterCertificateStatus_Success(t *testing.T) {
 							"cluster.x-k8s.io/control-plane": "",
 						},
 					},
-					Status: clusterv1.MachineStatus{
-						Addresses: []clusterv1.MachineAddress{
+					Status: clusterv1beta2.MachineStatus{
+						Addresses: []clusterv1beta2.MachineAddress{
 							{
-								Type:    clusterv1.MachineExternalIP,
+								Type:    clusterv1beta2.MachineExternalIP,
 								Address: endpoint,
 							},
 						},
@@ -282,7 +282,7 @@ func TestScanner_UpdateClusterCertificateStatus_Success(t *testing.T) {
 					},
 				},
 			},
-			machines: []clusterv1.Machine{},
+			machines: []clusterv1beta2.Machine{},
 		},
 		{
 			name: "handles cluster with empty endpoint host",
@@ -300,7 +300,7 @@ func TestScanner_UpdateClusterCertificateStatus_Success(t *testing.T) {
 					},
 				},
 			},
-			machines: []clusterv1.Machine{},
+			machines: []clusterv1beta2.Machine{},
 		},
 		{
 			name: "UpdateClusterCertificateStatus no error", // UpdateClusterCertificateStatus will never return an error even if there is any error.
@@ -318,7 +318,7 @@ func TestScanner_UpdateClusterCertificateStatus_Success(t *testing.T) {
 					},
 				},
 			},
-			machines: []clusterv1.Machine{},
+			machines: []clusterv1beta2.Machine{},
 		},
 	}
 

--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -10,7 +10,6 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
@@ -26,7 +25,6 @@ type schemeAdder func(s *runtime.Scheme) error
 var schemeAdders = []schemeAdder{
 	// clientgoscheme adds all the native K8s kinds
 	clientgoscheme.AddToScheme,
-	clusterv1.AddToScheme,
 	clusterv1beta2.AddToScheme,
 	controlplanev1beta2.AddToScheme,
 	bootstrapv1beta2.AddToScheme,

--- a/pkg/clients/kubernetes/unauth_test.go
+++ b/pkg/clients/kubernetes/unauth_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -37,8 +37,8 @@ func TestUnAuthClientGetSuccess(t *testing.T) {
 		{
 			name:             "capi cluster",
 			namespace:        "eksa-system",
-			obj:              &clusterapiv1.Cluster{},
-			wantResourceType: "Cluster.v1beta1.cluster.x-k8s.io",
+			obj:              &clusterv1beta2.Cluster{},
+			wantResourceType: "Cluster.v1beta2.cluster.x-k8s.io",
 			options:          kubernetes.KubectlGetOptions{Name: "capi cluster", Namespace: "eksa-system"},
 		},
 		{
@@ -111,7 +111,7 @@ func TestUnAuthClientDeleteSuccess(t *testing.T) {
 		},
 		{
 			name: "capi cluster",
-			obj: &clusterapiv1.Cluster{
+			obj: &clusterv1beta2.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "capi-cluster",
 					Namespace: "eksa-system",
@@ -123,7 +123,7 @@ func TestUnAuthClientDeleteSuccess(t *testing.T) {
 					Namespace: "eksa-system",
 				},
 			},
-			wantResourceType: "Cluster.v1beta1.cluster.x-k8s.io",
+			wantResourceType: "Cluster.v1beta2.cluster.x-k8s.io",
 		},
 	}
 	for _, tt := range tests {
@@ -158,7 +158,7 @@ func TestUnAuthClientApplySuccess(t *testing.T) {
 		{
 			name:      "capi cluster",
 			namespace: "eksa-system",
-			obj:       &clusterapiv1.Cluster{},
+			obj:       &clusterv1beta2.Cluster{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -56,7 +56,7 @@ func eksaClusterLabels(clusterSpec *cluster.Spec) map[string]string {
 
 func capiClusterLabel(clusterSpec *cluster.Spec) map[string]string {
 	return map[string]string{
-		clusterv1.ClusterNameLabel: ClusterName(clusterSpec.Cluster),
+		clusterv1beta2.ClusterNameLabel: ClusterName(clusterSpec.Cluster),
 	}
 }
 

--- a/pkg/clusterapi/resourceset.go
+++ b/pkg/clusterapi/resourceset.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/yaml"
 
 	"github.com/aws/eks-anywhere/pkg/templater"
@@ -47,14 +47,14 @@ func (c ClusterResourceSet) buildSet() *addons.ClusterResourceSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-crs", c.clusterName),
 			Labels: map[string]string{
-				clusterv1.ClusterNameLabel: c.clusterName,
+				clusterv1beta2.ClusterNameLabel: c.clusterName,
 			},
 			Namespace: c.namespace,
 		},
 		Spec: addons.ClusterResourceSetSpec{
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					clusterv1.ClusterNameLabel: c.clusterName,
+					clusterv1beta2.ClusterNameLabel: c.clusterName,
 				},
 			},
 			Resources: c.resourceRefs(),

--- a/pkg/clustermanager/cluster_manager.go
+++ b/pkg/clustermanager/cluster_manager.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/integer"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/yaml"
 
@@ -289,7 +288,7 @@ func (c *ClusterManager) backupCAPI(ctx context.Context, cluster *types.Cluster,
 
 func (c *ClusterManager) MoveCAPI(ctx context.Context, from, to *types.Cluster, clusterName string, clusterSpec *cluster.Spec, checkers ...types.NodeReadyChecker) error {
 	logger.V(3).Info("Waiting for management machines to be ready before move")
-	labels := []string{clusterv1.MachineControlPlaneNameLabel, clusterv1beta2.MachineDeploymentNameLabel}
+	labels := []string{clusterv1beta2.MachineControlPlaneNameLabel, clusterv1beta2.MachineDeploymentNameLabel}
 	if err := c.waitForNodesReady(ctx, from, clusterName, labels, checkers...); err != nil {
 		return err
 	}
@@ -581,7 +580,7 @@ func (c *ClusterManager) getNodesCount(ctx context.Context, managementCluster *t
 		labelsMap[label] = nil
 	}
 
-	if _, ok := labelsMap[clusterv1.MachineControlPlaneNameLabel]; ok {
+	if _, ok := labelsMap[clusterv1beta2.MachineControlPlaneNameLabel]; ok {
 		kcp, err := c.clusterClient.GetKubeadmControlPlane(ctx, managementCluster, clusterName, executables.WithCluster(managementCluster), executables.WithNamespace(constants.EksaSystemNamespace))
 		if err != nil {
 			return 0, fmt.Errorf("getting KubeadmControlPlane for cluster %s: %v", clusterName, err)

--- a/pkg/controller/clientutil/delete_test.go
+++ b/pkg/controller/clientutil/delete_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -25,7 +25,7 @@ func TestDeleteYamlSuccess(t *testing.T) {
 			initialObjs: []client.Object{
 				cluster("cluster-1"),
 			},
-			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: cluster-1
@@ -37,7 +37,7 @@ spec:
 		},
 		{
 			name: "delete multiple objects",
-			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: cluster-1
@@ -45,7 +45,7 @@ metadata:
 spec:
   paused: true
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: cluster-2
@@ -72,7 +72,7 @@ spec:
 					Name:      o.GetName(),
 				}
 
-				cluster := &clusterapiv1.Cluster{}
+				cluster := &clusterv1beta2.Cluster{}
 				err := c.Get(ctx, key, cluster)
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Object should have been deleted")
 			}
@@ -80,11 +80,11 @@ spec:
 	}
 }
 
-func cluster(name string) *clusterapiv1.Cluster {
-	c := &clusterapiv1.Cluster{
+func cluster(name string) *clusterv1beta2.Cluster {
+	c := &clusterv1beta2.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Cluster",
-			APIVersion: clusterapiv1.GroupVersion.String(),
+			APIVersion: clusterv1beta2.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -108,14 +108,14 @@ func TestDeleteYamlError(t *testing.T) {
 		},
 		{
 			name: "error deleting",
-			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta1
+			yaml: []byte(`apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: cluster-1
   namespace: default
 spec:
   paused: true`),
-			wantErr: "deleting object cluster.x-k8s.io/v1beta1, Kind=Cluster, default/cluster-1",
+			wantErr: "deleting object cluster.x-k8s.io/v1beta2, Kind=Cluster, default/cluster-1",
 		},
 	}
 	ctx := context.Background()

--- a/pkg/controller/clusterapi.go
+++ b/pkg/controller/clusterapi.go
@@ -6,7 +6,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -97,7 +96,7 @@ func GetMachineDeployment(ctx context.Context, client client.Client, machineDepl
 func GetMachineDeployments(ctx context.Context, c client.Client, cluster *anywherev1.Cluster) ([]clusterv1beta2.MachineDeployment, error) {
 	machineDeployments := &clusterv1beta2.MachineDeploymentList{}
 
-	err := c.List(ctx, machineDeployments, client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name}, client.InNamespace(constants.EksaSystemNamespace))
+	err := c.List(ctx, machineDeployments, client.MatchingLabels{clusterv1beta2.ClusterNameLabel: cluster.Name}, client.InNamespace(constants.EksaSystemNamespace))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/clusterapi_test.go
+++ b/pkg/controller/clusterapi_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -105,7 +104,7 @@ func TestGetMachineDeploymentsSuccess(t *testing.T) {
 	md1.Name = "md-1"
 
 	md1.Labels = map[string]string{
-		clusterv1.ClusterNameLabel: eksaCluster.Name,
+		clusterv1beta2.ClusterNameLabel: eksaCluster.Name,
 	}
 
 	md2 := md1.DeepCopy()
@@ -123,13 +122,13 @@ func TestGetMachineDeploymentsMachineDeploymentsInDifferentClusters(t *testing.T
 	machineDeployment1 := machineDeployment()
 	machineDeployment1.Name = "md-1"
 	machineDeployment1.Labels = map[string]string{
-		clusterv1.ClusterNameLabel: eksaCluster.Name,
+		clusterv1beta2.ClusterNameLabel: eksaCluster.Name,
 	}
 
 	machineDeployment2 := machineDeployment()
 	machineDeployment2.Name = "md-2"
 	machineDeployment2.Labels = map[string]string{
-		clusterv1.ClusterNameLabel: "other-cluster",
+		clusterv1beta2.ClusterNameLabel: "other-cluster",
 	}
 
 	client := fake.NewClientBuilder().WithObjects(eksaCluster, machineDeployment1, machineDeployment2).Build()

--- a/pkg/controller/clusters/controlplane.go
+++ b/pkg/controller/clusters/controlplane.go
@@ -12,7 +12,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -170,7 +169,7 @@ func reconcileEtcdChanges(ctx context.Context, log logr.Logger, c client.Client,
 	// etcd endpoints change.
 	if !annotations.HasPaused(currentKCP) {
 		log.Info("Pausing KCP before making any etcd changes", "kcp", klog.KObj(currentKCP))
-		clientutil.AddAnnotation(currentKCP, clusterv1.PausedAnnotation, "true")
+		clientutil.AddAnnotation(currentKCP, clusterv1beta2.PausedAnnotation, "true")
 		if err := c.Update(ctx, currentKCP); err != nil {
 			return controller.Result{}, err
 		}
@@ -227,7 +226,7 @@ func reconcileControlPlaneNodeChanges(ctx context.Context, log logr.Logger, c cl
 			return controller.Result{}, errors.Wrap(err, "reading updates kubeadm control plane to unpause")
 		}
 
-		delete(kcp.Annotations, clusterv1.PausedAnnotation)
+		delete(kcp.Annotations, clusterv1beta2.PausedAnnotation)
 		log.Info("Unpausing KCP after update to start reconciliation", klog.KObj(currentKCP))
 		if err := c.Update(ctx, kcp); err != nil {
 			return controller.Result{}, err

--- a/pkg/controller/clusters/controlplane_test.go
+++ b/pkg/controller/clusters/controlplane_test.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -150,7 +149,7 @@ func TestReconcileControlPlaneExternalEtcdUpgradeWithDiff(t *testing.T) {
 		kcp,
 		func(g Gomega) {
 			g.Expect(kcp.Annotations).To(
-				HaveKeyWithValue(clusterv1.PausedAnnotation, "true"),
+				HaveKeyWithValue(clusterv1beta2.PausedAnnotation, "true"),
 				"kcp paused annotation should have been added",
 			)
 			g.Expect(kcp.Spec.Replicas).To(
@@ -212,7 +211,7 @@ func TestReconcileControlPlaneExternalEtcdReadyControlPlaneUpgrade(t *testing.T)
 	var oldCPReplicas int32 = 3
 	var newCPReplicas int32 = 4
 	cp.KubeadmControlPlane.Spec.Replicas = ptr.Int32(oldCPReplicas)
-	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1.PausedAnnotation, "true")
+	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1beta2.PausedAnnotation, "true")
 	// an existing kcp should already have etcd endpoints
 	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = []string{"https://1.1.1.1:2379"}
 	envtest.CreateObjs(ctx, t, c, cp.AllObjects()...)
@@ -269,7 +268,7 @@ func TestReconcileControlPlaneExternalEtcdWithPlaceholderEndpoints(t *testing.T)
 	var oldCPReplicas int32 = 3
 	var newCPReplicas int32 = 4
 	cp.KubeadmControlPlane.Spec.Replicas = ptr.Int32(oldCPReplicas)
-	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1.PausedAnnotation, "true")
+	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1beta2.PausedAnnotation, "true")
 	// Set placeholder endpoint in existing kcp
 	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = []string{constants.PlaceholderExternalEtcdEndpoint}
 	envtest.CreateObjs(ctx, t, c, cp.AllObjects()...)
@@ -328,7 +327,7 @@ func TestReconcileControlPlaneExternalEtcdWithMultipleEndpoints(t *testing.T) {
 	var oldCPReplicas int32 = 3
 	var newCPReplicas int32 = 4
 	cp.KubeadmControlPlane.Spec.Replicas = ptr.Int32(oldCPReplicas)
-	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1.PausedAnnotation, "true")
+	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1beta2.PausedAnnotation, "true")
 	// Set multiple real etcd endpoints in existing kcp
 	multipleEndpoints := []string{"https://1.1.1.1:2379", "https://2.2.2.2:2379", "https://3.3.3.3:2379"}
 	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = multipleEndpoints
@@ -387,7 +386,7 @@ func TestReconcileControlPlaneExternalEtcdWithEmptyEndpoints(t *testing.T) {
 	var oldCPReplicas int32 = 3
 	var newCPReplicas int32 = 4
 	cp.KubeadmControlPlane.Spec.Replicas = ptr.Int32(oldCPReplicas)
-	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1.PausedAnnotation, "true")
+	clientutil.AddAnnotation(cp.KubeadmControlPlane, clusterv1beta2.PausedAnnotation, "true")
 	// Set placeholder endpoints in existing kcp (v1beta2 requires non-empty endpoints)
 	cp.KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.Endpoints = []string{constants.PlaceholderExternalEtcdEndpoint}
 	envtest.CreateObjs(ctx, t, c, cp.AllObjects()...)

--- a/pkg/controller/clusters/status_test.go
+++ b/pkg/controller/clusters/status_test.go
@@ -683,7 +683,7 @@ func TestUpdateClusterCertificateStatusSuccess(t *testing.T) {
 		name         string
 		cluster      *anywherev1.Cluster
 		conditions   []anywherev1.Condition
-		machines     []clusterv1.Machine
+		machines     []clusterv1beta2.Machine
 		expectedCert []anywherev1.ClusterCertificateInfo
 	}{
 		{
@@ -708,7 +708,7 @@ func TestUpdateClusterCertificateStatusSuccess(t *testing.T) {
 					Status: "True",
 				},
 			},
-			machines: []clusterv1.Machine{
+			machines: []clusterv1beta2.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cluster-control-plane-abc123",
@@ -718,10 +718,10 @@ func TestUpdateClusterCertificateStatusSuccess(t *testing.T) {
 							"cluster.x-k8s.io/control-plane": "",
 						},
 					},
-					Status: clusterv1.MachineStatus{
-						Addresses: []clusterv1.MachineAddress{
+					Status: clusterv1beta2.MachineStatus{
+						Addresses: []clusterv1beta2.MachineAddress{
 							{
-								Type:    clusterv1.MachineExternalIP,
+								Type:    clusterv1beta2.MachineExternalIP,
 								Address: "127.0.0.1",
 							},
 						},
@@ -752,7 +752,7 @@ func TestUpdateClusterCertificateStatusSuccess(t *testing.T) {
 					Status: "False",
 				},
 			},
-			machines: []clusterv1.Machine{},
+			machines: []clusterv1beta2.Machine{},
 			expectedCert: []anywherev1.ClusterCertificateInfo{
 				{
 					Machine:       "should-be-there",
@@ -903,7 +903,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Generation = 1
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.ObservedGeneration = 0
 				}),
@@ -936,7 +936,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Generation = 1
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.ObservedGeneration = 0
 				}),
@@ -973,7 +973,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(1)
 					md.Status.ReadyReplicas = ptr.Int32(1)
@@ -982,7 +982,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(2)
 					md.Status.ReadyReplicas = ptr.Int32(2)
@@ -1017,7 +1017,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(1)
 					md.Status.ReadyReplicas = ptr.Int32(1)
@@ -1026,7 +1026,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(2)
 					md.Status.ReadyReplicas = ptr.Int32(2)
@@ -1062,7 +1062,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(0)
 					md.Status.ReadyReplicas = ptr.Int32(0)
@@ -1071,7 +1071,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(2)
 					md.Status.ReadyReplicas = ptr.Int32(2)
@@ -1106,7 +1106,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(2)
 					md.Status.ReadyReplicas = ptr.Int32(2)
@@ -1115,7 +1115,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(2)
 					md.Status.ReadyReplicas = ptr.Int32(2)
@@ -1150,7 +1150,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.ReadyReplicas = ptr.Int32(1)
 					md.Status.Replicas = ptr.Int32(1)
@@ -1159,7 +1159,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.ReadyReplicas = ptr.Int32(0)
 					md.Status.Replicas = ptr.Int32(2)
@@ -1191,7 +1191,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.ReadyReplicas = ptr.Int32(1)
 					md.Status.Replicas = ptr.Int32(1)
@@ -1238,7 +1238,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(1)
 					md.Status.ReadyReplicas = ptr.Int32(1)
@@ -1247,7 +1247,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.ObjectMeta.Annotations = map[string]string{
 						clusterapi.NodeGroupMinSizeAnnotation: "3",
@@ -1289,7 +1289,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(1)
 					md.Status.ReadyReplicas = ptr.Int32(1)
@@ -1298,7 +1298,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.ObjectMeta.Annotations = map[string]string{
 						clusterapi.NodeGroupMinSizeAnnotation: "1",
@@ -1334,7 +1334,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-0"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(1)
 					md.Status.ReadyReplicas = ptr.Int32(1)
@@ -1343,7 +1343,7 @@ func TestUpdateClusterStatusForWorkers(t *testing.T) {
 				*test.MachineDeployment(func(md *clusterv1beta2.MachineDeployment) {
 					md.ObjectMeta.Name = "md-1"
 					md.ObjectMeta.Labels = map[string]string{
-						clusterv1.ClusterNameLabel: clusterName,
+						clusterv1beta2.ClusterNameLabel: clusterName,
 					}
 					md.Status.Replicas = ptr.Int32(2)
 					md.Status.ReadyReplicas = ptr.Int32(2)

--- a/pkg/controller/clusters/workers_test.go
+++ b/pkg/controller/clusters/workers_test.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -60,7 +59,7 @@ func TestReconcileWorkersSuccess(t *testing.T) {
 	existingMachineDeployment1 := machineDeployment("my-cluster-md-1", ns)
 	existingMachineDeployment2 := machineDeployment("my-cluster-md-2", ns)
 	existingMachineDeployment3 := machineDeployment("my-other-cluster-md-1", ns)
-	existingMachineDeployment3.Labels[clusterv1.ClusterNameLabel] = "my-other-cluster"
+	existingMachineDeployment3.Labels[clusterv1beta2.ClusterNameLabel] = "my-other-cluster"
 	envtest.CreateObjs(ctx, t, c,
 		existingMachineDeployment1,
 		existingMachineDeployment2,
@@ -167,7 +166,7 @@ func machineDeployment(name, namespace string) *clusterv1beta2.MachineDeployment
 			Namespace: namespace,
 			Name:      name,
 			Labels: map[string]string{
-				clusterv1.ClusterNameLabel: "my-cluster",
+				clusterv1beta2.ClusterNameLabel: "my-cluster",
 			},
 		},
 		Spec: clusterv1beta2.MachineDeploymentSpec{

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -29,7 +29,6 @@ import (
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -60,22 +59,22 @@ const (
 )
 
 var (
-	capiClustersResourceType             = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
-	capiProvidersResourceType            = fmt.Sprintf("providers.clusterctl.%s", clusterv1.GroupVersion.Group)
-	capiMachinesType                     = fmt.Sprintf("machines.%s", clusterv1.GroupVersion.Group)
-	capiMachineDeploymentsType           = fmt.Sprintf("machinedeployments.%s", clusterv1.GroupVersion.Group)
-	capiMachineSetsType                  = fmt.Sprintf("machinesets.%s", clusterv1.GroupVersion.Group)
+	capiClustersResourceType             = fmt.Sprintf("clusters.%s", clusterv1beta2.GroupVersion.Group)
+	capiProvidersResourceType            = fmt.Sprintf("providers.clusterctl.%s", clusterv1beta2.GroupVersion.Group)
+	capiMachinesType                     = fmt.Sprintf("machines.%s", clusterv1beta2.GroupVersion.Group)
+	capiMachineDeploymentsType           = fmt.Sprintf("machinedeployments.%s", clusterv1beta2.GroupVersion.Group)
+	capiMachineSetsType                  = fmt.Sprintf("machinesets.%s", clusterv1beta2.GroupVersion.Group)
 	eksaClusterResourceType              = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 	eksaVSphereDatacenterResourceType    = fmt.Sprintf("vspheredatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaVSphereMachineResourceType       = fmt.Sprintf("vspheremachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	vsphereMachineTemplatesType          = fmt.Sprintf("vspheremachinetemplates.infrastructure.%s", clusterv1.GroupVersion.Group)
+	vsphereMachineTemplatesType          = fmt.Sprintf("vspheremachinetemplates.infrastructure.%s", clusterv1beta2.GroupVersion.Group)
 	eksaTinkerbellDatacenterResourceType = fmt.Sprintf("tinkerbelldatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaTinkerbellMachineResourceType    = fmt.Sprintf("tinkerbellmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	TinkerbellHardwareResourceType       = fmt.Sprintf("hardware.%s", tinkv1alpha1.GroupVersion.Group)
 	rufioMachineResourceType             = fmt.Sprintf("machines.%s", rufiov1alpha1.GroupVersion.Group)
 	eksaCloudStackDatacenterResourceType = fmt.Sprintf("cloudstackdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaCloudStackMachineResourceType    = fmt.Sprintf("cloudstackmachineconfigs.%s", v1alpha1.GroupVersion.Group)
-	cloudstackMachineTemplatesType       = fmt.Sprintf("cloudstackmachinetemplates.infrastructure.%s", clusterv1.GroupVersion.Group)
+	cloudstackMachineTemplatesType       = fmt.Sprintf("cloudstackmachinetemplates.infrastructure.%s", clusterv1beta2.GroupVersion.Group)
 	eksaNutanixDatacenterResourceType    = fmt.Sprintf("nutanixdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaNutanixMachineResourceType       = fmt.Sprintf("nutanixmachineconfigs.%s", v1alpha1.GroupVersion.Group)
 	eksaAwsResourceType                  = fmt.Sprintf("awsdatacenterconfigs.%s", v1alpha1.GroupVersion.Group)
@@ -86,7 +85,7 @@ var (
 	etcdadmClustersResourceType          = fmt.Sprintf("etcdadmclusters.%s", etcdv1.GroupVersion.Group)
 	bundlesResourceType                  = fmt.Sprintf("bundles.%s", releasev1alpha1.GroupVersion.Group)
 	clusterResourceSetResourceType       = fmt.Sprintf("clusterresourcesets.%s", addons.GroupVersion.Group)
-	kubeadmControlPlaneResourceType      = fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", clusterv1.GroupVersion.Group)
+	kubeadmControlPlaneResourceType      = fmt.Sprintf("kubeadmcontrolplanes.controlplane.%s", clusterv1beta2.GroupVersion.Group)
 	eksdReleaseType                      = fmt.Sprintf("releases.%s", eksdv1alpha1.GroupVersion.Group)
 	eksaPackagesType                     = fmt.Sprintf("packages.%s", packagesv1.GroupVersion.Group)
 	eksaPackagesBundleControllerType     = fmt.Sprintf("packagebundlecontroller.%s", packagesv1.GroupVersion.Group)
@@ -141,11 +140,11 @@ func WithNetworkFaultBackoffFactor(factor float64) KubectlConfigOpt {
 }
 
 type capiMachinesResponse struct {
-	Items []clusterv1.Machine
+	Items []clusterv1beta2.Machine
 }
 
 // GetCAPIMachines returns all the CAPI machines for the provided clusterName.
-func (k *Kubectl) GetCAPIMachines(ctx context.Context, cluster *types.Cluster, clusterName string) ([]clusterv1.Machine, error) {
+func (k *Kubectl) GetCAPIMachines(ctx context.Context, cluster *types.Cluster, clusterName string) ([]clusterv1beta2.Machine, error) {
 	params := []string{
 		"get", capiMachinesType, "-o", "json", "--kubeconfig", cluster.KubeconfigFile,
 		"--selector=cluster.x-k8s.io/cluster-name=" + clusterName,
@@ -1112,10 +1111,10 @@ func (k *Kubectl) GetMachines(ctx context.Context, cluster *types.Cluster, clust
 }
 
 type machineSetResponse struct {
-	Items []clusterv1.MachineSet `json:"items,omitempty"`
+	Items []clusterv1beta2.MachineSet `json:"items,omitempty"`
 }
 
-func (k *Kubectl) GetMachineSets(ctx context.Context, machineDeploymentName string, cluster *types.Cluster) ([]clusterv1.MachineSet, error) {
+func (k *Kubectl) GetMachineSets(ctx context.Context, machineDeploymentName string, cluster *types.Cluster) ([]clusterv1beta2.MachineSet, error) {
 	params := []string{
 		"get", capiMachineSetsType, "-o", "json", "--kubeconfig", cluster.KubeconfigFile,
 		"--selector=cluster.x-k8s.io/deployment-name=" + machineDeploymentName,

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -23,7 +23,6 @@ import (
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -60,7 +59,7 @@ var nutanixMachineConfigsJSON string
 //go:embed testdata/nutanix/datacenterConfigs.json
 var nutanixDatacenterConfigsJSON string
 
-var capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
+var capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1beta2.GroupVersion.Group)
 
 func newKubectl(t *testing.T) (*executables.Kubectl, context.Context, *types.Cluster, *mockexecutables.MockExecutable) {
 	kubeconfigFile := "c.kubeconfig"
@@ -3925,7 +3924,7 @@ func TestGetMachineDeploymentsForCluster(t *testing.T) {
 	}
 
 	params := []string{
-		"get", fmt.Sprintf("machinedeployments.%s", clusterv1.GroupVersion.Group), "-o", "json",
+		"get", fmt.Sprintf("machinedeployments.%s", clusterv1beta2.GroupVersion.Group), "-o", "json",
 		fmt.Sprintf("--selector=cluster.x-k8s.io/cluster-name=%s", clusterName),
 	}
 	e.EXPECT().Execute(ctx, gomock.Eq(params)).Return(*bytes.NewBufferString(""), nil).Return(*bytes.NewBufferString(fileContent), nil)

--- a/pkg/validations/createvalidations/cluster_test.go
+++ b/pkg/validations/createvalidations/cluster_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -118,6 +118,6 @@ func TestValidateManagementClusterCRDs(t *testing.T) {
 }
 
 var (
-	capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
+	capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1beta2.GroupVersion.Group)
 	eksaClusterResourceType  = fmt.Sprintf("clusters.%s", v1alpha1.GroupVersion.Group)
 )

--- a/pkg/validations/upgradevalidations/cluster_test.go
+++ b/pkg/validations/upgradevalidations/cluster_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -65,4 +65,4 @@ func TestValidateClusterPresent(t *testing.T) {
 	}
 }
 
-var capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1.GroupVersion.Group)
+var capiClustersResourceType = fmt.Sprintf("clusters.%s", clusterv1beta2.GroupVersion.Group)

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
@@ -77,7 +77,7 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 		func() *validations.ValidationResult {
 			return &validations.ValidationResult{
 				Name:        "cluster object present on workload cluster",
-				Remediation: fmt.Sprintf("ensure that the CAPI cluster object %s representing cluster %s is present", clusterv1.GroupVersion, u.Opts.WorkloadCluster.Name),
+				Remediation: fmt.Sprintf("ensure that the CAPI cluster object %s representing cluster %s is present", clusterv1beta2.GroupVersion, u.Opts.WorkloadCluster.Name),
 				Err:         ValidateClusterObjectExists(ctx, k, u.Opts.ManagementCluster),
 			}
 		},


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3785

*Description of changes:*

*Testing (if applicable):*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

