### PR TITLE
Migrate crs and docker capi resources to v1beta2

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -24,12 +24,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,7 +65,6 @@ func init() {
 	utilruntime.Must(controlplanev1beta2.AddToScheme(scheme.Scheme))
 	utilruntime.Must(bootstrapv1beta2.AddToScheme(scheme.Scheme))
 	utilruntime.Must(vspherev1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(dockerv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(dockerv1beta2.AddToScheme(scheme.Scheme))
 	utilruntime.Must(cloudstackv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme.Scheme))

--- a/manager/main.go
+++ b/manager/main.go
@@ -20,12 +20,11 @@ import (
 	"k8s.io/klog/v2"
 	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	capiflags "sigs.k8s.io/cluster-api/util/flags"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -56,7 +55,6 @@ func init() {
 	utilruntime.Must(controlplanev1beta2.AddToScheme(scheme))
 	utilruntime.Must(vspherev1.AddToScheme(scheme))
 	utilruntime.Must(cloudstackv1.AddToScheme(scheme))
-	utilruntime.Must(dockerv1.AddToScheme(scheme))
 	utilruntime.Must(dockerv1beta2.AddToScheme(scheme))
 	utilruntime.Must(etcdv1.AddToScheme(scheme))
 	utilruntime.Must(bootstrapv1beta2.AddToScheme(scheme))

--- a/pkg/clients/kubernetes/runtimeclient_test.go
+++ b/pkg/clients/kubernetes/runtimeclient_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -97,8 +97,8 @@ func TestObjectsToRuntimeObjects(t *testing.T) {
 	}
 }
 
-func dockerCluster() *dockerv1.DockerCluster {
-	return &dockerv1.DockerCluster{}
+func dockerCluster() *dockerv1beta2.DockerCluster {
+	return &dockerv1beta2.DockerCluster{}
 }
 
 func TestMachineSetWarningFilter_HandleWarningHeader(t *testing.T) {

--- a/pkg/clients/kubernetes/scheme.go
+++ b/pkg/clients/kubernetes/scheme.go
@@ -7,11 +7,10 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
@@ -32,7 +31,6 @@ var schemeAdders = []schemeAdder{
 	anywherev1.AddToScheme,
 	snowv1.AddToScheme,
 	cloudstackv1.AddToScheme,
-	dockerv1.AddToScheme,
 	dockerv1beta2.AddToScheme,
 	releasev1.AddToScheme,
 	eksdv1alpha1.AddToScheme,

--- a/pkg/clusterapi/controlplane_test.go
+++ b/pkg/clusterapi/controlplane_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/aws/eks-anywhere/internal/test"
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/controller/clientutil"
 )
 
-type dockerControlPlane = clusterapi.ControlPlane[*dockerv1.DockerCluster, *dockerv1.DockerMachineTemplate]
+type dockerControlPlane = clusterapi.ControlPlane[*dockerv1beta2.DockerCluster, *dockerv1beta2.DockerMachineTemplate]
 
 func TestControlPlaneObjects(t *testing.T) {
 	tests := []struct {
@@ -236,16 +236,16 @@ func capiCluster() *clusterv1beta2.Cluster {
 	return &clusterv1beta2.Cluster{}
 }
 
-func dockerCluster() *dockerv1.DockerCluster {
-	return &dockerv1.DockerCluster{}
+func dockerCluster() *dockerv1beta2.DockerCluster {
+	return &dockerv1beta2.DockerCluster{}
 }
 
 func kubeadmControlPlane() *controlplanev1beta2.KubeadmControlPlane {
 	return &controlplanev1beta2.KubeadmControlPlane{}
 }
 
-func dockerMachineTemplate() *dockerv1.DockerMachineTemplate {
-	return &dockerv1.DockerMachineTemplate{
+func dockerMachineTemplate() *dockerv1beta2.DockerMachineTemplate {
+	return &dockerv1beta2.DockerMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "DockerMachineTemplate",
 		},

--- a/pkg/clusterapi/name_test.go
+++ b/pkg/clusterapi/name_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
@@ -365,22 +365,22 @@ func TestInitialTemplateNamesForWorkers(t *testing.T) {
 	}
 }
 
-func dummyRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
+func dummyRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1beta2.DockerMachineTemplate, error) {
 	return dockerMachineTemplate(), nil
 }
 
-func errorRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
+func errorRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1beta2.DockerMachineTemplate, error) {
 	return nil, errors.New("reading object")
 }
 
-func notFoundRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1.DockerMachineTemplate, error) {
+func notFoundRetriever(_ context.Context, _ kubernetes.Client, _, _ string) (*dockerv1beta2.DockerMachineTemplate, error) {
 	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
 }
 
-func noChangesCompare(_, _ *dockerv1.DockerMachineTemplate) bool {
+func noChangesCompare(_, _ *dockerv1beta2.DockerMachineTemplate) bool {
 	return true
 }
 
-func withChangesCompare(_, _ *dockerv1.DockerMachineTemplate) bool {
+func withChangesCompare(_, _ *dockerv1beta2.DockerMachineTemplate) bool {
 	return false
 }

--- a/pkg/clusterapi/resourceset.go
+++ b/pkg/clusterapi/resourceset.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addons "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/yaml"
 

--- a/pkg/clusterapi/testdata/expected_crs_clusterrole.yaml
+++ b/pkg/clusterapi/testdata/expected_crs_clusterrole.yaml
@@ -31,7 +31,7 @@ metadata:
   namespace: default
 
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:
@@ -45,6 +45,5 @@ spec:
   resources:
   - kind: ConfigMap
     name: coredns-role
-status: {}
 
 ---

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/internal/test"
@@ -19,8 +19,8 @@ import (
 )
 
 type (
-	dockerGroup   = clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]
-	dockerWorkers = clusterapi.Workers[*dockerv1.DockerMachineTemplate]
+	dockerGroup   = clusterapi.WorkerGroup[*dockerv1beta2.DockerMachineTemplate]
+	dockerWorkers = clusterapi.Workers[*dockerv1beta2.DockerMachineTemplate]
 )
 
 func TestWorkersUpdateImmutableObjectNamesError(t *testing.T) {

--- a/pkg/clusterapi/yaml/controlplane_test.go
+++ b/pkg/clusterapi/yaml/controlplane_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/eks-anywhere/internal/test"
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/eks-anywhere/pkg/yamlutil"
 )
 
-type dockerControlPlane = clusterapi.ControlPlane[*dockerv1.DockerCluster, *dockerv1.DockerMachineTemplate]
+type dockerControlPlane = clusterapi.ControlPlane[*dockerv1beta2.DockerCluster, *dockerv1beta2.DockerMachineTemplate]
 
 func TestNewControlPlaneParserAndBuilderSuccessParsing(t *testing.T) {
 	g := NewWithT(t)
@@ -27,14 +27,14 @@ func TestNewControlPlaneParserAndBuilderSuccessParsing(t *testing.T) {
 		test.NewNullLogger(),
 		yamlutil.NewMapping(
 			"DockerCluster",
-			func() *dockerv1.DockerCluster {
-				return &dockerv1.DockerCluster{}
+			func() *dockerv1beta2.DockerCluster {
+				return &dockerv1beta2.DockerCluster{}
 			},
 		),
 		yamlutil.NewMapping(
 			"DockerMachineTemplate",
-			func() *dockerv1.DockerMachineTemplate {
-				return &dockerv1.DockerMachineTemplate{}
+			func() *dockerv1beta2.DockerMachineTemplate {
+				return &dockerv1beta2.DockerMachineTemplate{}
 			},
 		),
 	)
@@ -67,14 +67,14 @@ func TestNewControlPlaneParserAndBuilderErrorFromMappings(t *testing.T) {
 		test.NewNullLogger(),
 		yamlutil.NewMapping(
 			"Cluster",
-			func() *dockerv1.DockerCluster {
-				return &dockerv1.DockerCluster{}
+			func() *dockerv1beta2.DockerCluster {
+				return &dockerv1beta2.DockerCluster{}
 			},
 		),
 		yamlutil.NewMapping(
 			"DockerMachineTemplate",
-			func() *dockerv1.DockerMachineTemplate {
-				return &dockerv1.DockerMachineTemplate{}
+			func() *dockerv1beta2.DockerMachineTemplate {
+				return &dockerv1beta2.DockerMachineTemplate{}
 			},
 		),
 	)
@@ -322,11 +322,11 @@ func kubeadmControlPlane() *controlplanev1beta2.KubeadmControlPlane {
 	}
 }
 
-func dockerCluster() *dockerv1.DockerCluster {
-	return &dockerv1.DockerCluster{
+func dockerCluster() *dockerv1beta2.DockerCluster {
+	return &dockerv1beta2.DockerCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DockerCluster",
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster",
@@ -335,11 +335,11 @@ func dockerCluster() *dockerv1.DockerCluster {
 	}
 }
 
-func dockerMachineTemplate(name string) *dockerv1.DockerMachineTemplate {
-	return &dockerv1.DockerMachineTemplate{
+func dockerMachineTemplate(name string) *dockerv1beta2.DockerMachineTemplate {
+	return &dockerv1beta2.DockerMachineTemplate{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DockerMachineTemplate",
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/clusterapi/yaml/workers_test.go
+++ b/pkg/clusterapi/yaml/workers_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	dockerv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	dockerv1beta2 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 
 	"github.com/aws/eks-anywhere/internal/test"
 	"github.com/aws/eks-anywhere/pkg/clusterapi"
@@ -17,8 +17,8 @@ import (
 )
 
 type (
-	dockerWorkers     = clusterapi.Workers[*dockerv1.DockerMachineTemplate]
-	dockerWorkerGroup = clusterapi.WorkerGroup[*dockerv1.DockerMachineTemplate]
+	dockerWorkers     = clusterapi.Workers[*dockerv1beta2.DockerMachineTemplate]
+	dockerWorkerGroup = clusterapi.WorkerGroup[*dockerv1beta2.DockerMachineTemplate]
 )
 
 func TestNewWorkersParserAndBuilderSuccessParsing(t *testing.T) {
@@ -27,8 +27,8 @@ func TestNewWorkersParserAndBuilderSuccessParsing(t *testing.T) {
 		test.NewNullLogger(),
 		yamlutil.NewMapping(
 			"DockerMachineTemplate",
-			func() *dockerv1.DockerMachineTemplate {
-				return &dockerv1.DockerMachineTemplate{}
+			func() *dockerv1beta2.DockerMachineTemplate {
+				return &dockerv1beta2.DockerMachineTemplate{}
 			},
 		),
 	)
@@ -59,7 +59,7 @@ spec:
         kind: DockerMachineTemplate
         name: workers-1
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: workers-1
@@ -89,7 +89,7 @@ spec:
         kind: DockerMachineTemplate
         name: workers-2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: workers-2
@@ -108,8 +108,8 @@ func TestNewWorkersParserAndBuilderErrorFromMappings(t *testing.T) {
 		test.NewNullLogger(),
 		yamlutil.NewMapping(
 			"MachineDeployment",
-			func() *dockerv1.DockerMachineTemplate {
-				return &dockerv1.DockerMachineTemplate{}
+			func() *dockerv1beta2.DockerMachineTemplate {
+				return &dockerv1beta2.DockerMachineTemplate{}
 			},
 		),
 	)

--- a/pkg/executables/kubectl.go
+++ b/pkg/executables/kubectl.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	cloudstackv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addons "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/executables/kubectl_test.go
+++ b/pkg/executables/kubectl_test.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addons "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2281,7 +2281,7 @@ func TestKubectlGetClusterResourceSet(t *testing.T) {
 	resourceSetName := "Bundle-name"
 	wantResourceSet := &addons.ClusterResourceSet{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "addons.cluster.x-k8s.io/v1beta1",
+			APIVersion: "addons.cluster.x-k8s.io/v1beta2",
 			Kind:       "ClusterResourceSet",
 		},
 		Spec: addons.ClusterResourceSetSpec{

--- a/pkg/executables/testdata/kubectl_clusterresourceset.json
+++ b/pkg/executables/testdata/kubectl_clusterresourceset.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "addons.cluster.x-k8s.io/v1beta1",
+    "apiVersion": "addons.cluster.x-k8s.io/v1beta2",
     "kind": "ClusterResourceSet", 
     "spec": {
         "clusterSelector": {

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -891,7 +891,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: {{.clusterName}}-nutanix-ccm-crs

--- a/pkg/providers/nutanix/controlplane.go
+++ b/pkg/providers/nutanix/controlplane.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	nutanixv1 "github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"

--- a/pkg/providers/nutanix/reconciler/reconciler_test.go
+++ b/pkg/providers/nutanix/reconciler/reconciler_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -651,7 +651,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -585,7 +585,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -585,7 +585,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_cluster_ccm_exclude_node_ips.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_ccm_exclude_node_ips.yaml
@@ -584,7 +584,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_cp.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cp.yaml
@@ -587,7 +587,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
@@ -589,7 +589,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_bootType.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_bootType.yaml
@@ -585,7 +585,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
@@ -635,7 +635,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
@@ -665,7 +665,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -645,7 +645,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
@@ -659,7 +659,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_failure_domains.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_failure_domains.yaml
@@ -604,7 +604,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_gpus.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_gpus.yaml
@@ -584,7 +584,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -629,7 +629,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -586,7 +586,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_multi_worker_fds.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_multi_worker_fds.yaml
@@ -600,7 +600,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -596,7 +596,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -588,7 +588,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -588,7 +588,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -593,7 +593,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -649,7 +649,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/nutanix/testdata/expected_results_worker_fds.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_worker_fds.yaml
@@ -600,7 +600,7 @@ data:
               configMap:
                 name: nutanix-config
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: eksa-unit-test-nutanix-ccm-crs

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -620,7 +620,7 @@ spec:
 {{- end }}
   version: {{.kubernetesVersion}}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/pkg/providers/vsphere/controlplane.go
+++ b/pkg/providers/vsphere/controlplane.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 
 	"github.com/aws/eks-anywhere/pkg/clients/kubernetes"
 	"github.com/aws/eks-anywhere/pkg/cluster"

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addons "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addons "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -466,7 +466,7 @@ func configMap() *corev1.ConfigMap {
 func clusterResourceSet() *addons.ClusterResourceSet {
 	return &addons.ClusterResourceSet{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "addons.cluster.x-k8s.io/v1beta1",
+			APIVersion: "addons.cluster.x-k8s.io/v1beta2",
 			Kind:       "ClusterResourceSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
-	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -388,7 +388,7 @@ spec:
       type: RollingUpdate
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -388,7 +388,7 @@ spec:
       type: RollingUpdate
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/pkg/providers/vsphere/testdata/expected_kcp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp.yaml
@@ -391,7 +391,7 @@ spec:
       type: RollingUpdate
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
@@ -425,7 +425,7 @@ spec:
       type: RollingUpdate
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
@@ -429,7 +429,7 @@ spec:
       type: RollingUpdate
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
@@ -393,7 +393,7 @@ spec:
       type: RollingUpdate
   version: v1.19.8-eks-1-19-4
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3790

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

