### PR TITLE
Add necessary permission for external.GetObjectFromContractVersionedRef

### DIFF
--- a/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_clusters.yaml
@@ -290,9 +290,8 @@ spec:
                             node.
                           type: string
                         timeAdded:
-                          description: |-
-                            TimeAdded represents the time at which the taint was added.
-                            It is only written for NoExecute taints.
+                          description: TimeAdded represents the time at which the
+                            taint was added.
                           format: date-time
                           type: string
                         value:
@@ -702,9 +701,8 @@ spec:
                               a node.
                             type: string
                           timeAdded:
-                            description: |-
-                              TimeAdded represents the time at which the taint was added.
-                              It is only written for NoExecute taints.
+                            description: TimeAdded represents the time at which the
+                              taint was added.
                             format: date-time
                             type: string
                           value:

--- a/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
+++ b/config/crd/bases/anywhere.eks.amazonaws.com_tinkerbellmachineconfigs.yaml
@@ -41,11 +41,155 @@ spec:
             description: TinkerbellMachineConfigSpec defines the desired state of
               TinkerbellMachineConfig.
             properties:
+              hardwareAffinity:
+                description: |-
+                  HardwareAffinity allows advanced hardware selection using required
+                  and preferred affinity terms. Mutually exclusive with HardwareSelector.
+                properties:
+                  preferred:
+                    description: |-
+                      Preferred are the preferred hardware affinity terms. Hardware matching
+                      these terms are preferred according to the weights provided.
+                    items:
+                      description: WeightedHardwareAffinityTerm is a HardwareAffinityTerm
+                        with an associated weight.
+                      properties:
+                        hardwareAffinityTerm:
+                          description: HardwareAffinityTerm is the term associated
+                            with the weight.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to select hardware
+                                by labels.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - labelSelector
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            term, in range 1-100.
+                          format: int32
+                          maximum: 100
+                          minimum: 1
+                          type: integer
+                      required:
+                      - hardwareAffinityTerm
+                      - weight
+                      type: object
+                    type: array
+                  required:
+                    description: |-
+                      Required are the required hardware affinity terms. The terms are OR'd
+                      together - hardware must match at least one term to be considered.
+                      At least one required term must be specified.
+                    items:
+                      description: HardwareAffinityTerm defines a single hardware
+                        affinity term.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to select hardware by
+                            labels.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - labelSelector
+                      type: object
+                    type: array
+                required:
+                - required
+                type: object
               hardwareSelector:
                 additionalProperties:
                   type: string
-                description: HardwareSelector models a simple key-value selector used
-                  in Tinkerbell provisioning.
+                description: |-
+                  HardwareSelector is a simple key-value selector for hardware.
+                  Use this for straightforward single-label hardware selection.
+                  Mutually exclusive with HardwareAffinity.
                 type: object
               hostOSConfiguration:
                 description: HostOSConfiguration defines the configuration settings
@@ -299,7 +443,6 @@ spec:
                   type: object
                 type: array
             required:
-            - hardwareSelector
             - osFamily
             type: object
           status:

--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -4276,9 +4276,8 @@ spec:
                             node.
                           type: string
                         timeAdded:
-                          description: |-
-                            TimeAdded represents the time at which the taint was added.
-                            It is only written for NoExecute taints.
+                          description: TimeAdded represents the time at which the
+                            taint was added.
                           format: date-time
                           type: string
                         value:
@@ -4688,9 +4687,8 @@ spec:
                               a node.
                             type: string
                           timeAdded:
-                            description: |-
-                              TimeAdded represents the time at which the taint was added.
-                              It is only written for NoExecute taints.
+                            description: TimeAdded represents the time at which the
+                              taint was added.
                             format: date-time
                             type: string
                           value:
@@ -7098,11 +7096,155 @@ spec:
             description: TinkerbellMachineConfigSpec defines the desired state of
               TinkerbellMachineConfig.
             properties:
+              hardwareAffinity:
+                description: |-
+                  HardwareAffinity allows advanced hardware selection using required
+                  and preferred affinity terms. Mutually exclusive with HardwareSelector.
+                properties:
+                  preferred:
+                    description: |-
+                      Preferred are the preferred hardware affinity terms. Hardware matching
+                      these terms are preferred according to the weights provided.
+                    items:
+                      description: WeightedHardwareAffinityTerm is a HardwareAffinityTerm
+                        with an associated weight.
+                      properties:
+                        hardwareAffinityTerm:
+                          description: HardwareAffinityTerm is the term associated
+                            with the weight.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to select hardware
+                                by labels.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - labelSelector
+                          type: object
+                        weight:
+                          description: Weight associated with matching the corresponding
+                            term, in range 1-100.
+                          format: int32
+                          maximum: 100
+                          minimum: 1
+                          type: integer
+                      required:
+                      - hardwareAffinityTerm
+                      - weight
+                      type: object
+                    type: array
+                  required:
+                    description: |-
+                      Required are the required hardware affinity terms. The terms are OR'd
+                      together - hardware must match at least one term to be considered.
+                      At least one required term must be specified.
+                    items:
+                      description: HardwareAffinityTerm defines a single hardware
+                        affinity term.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to select hardware by
+                            labels.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - labelSelector
+                      type: object
+                    type: array
+                required:
+                - required
+                type: object
               hardwareSelector:
                 additionalProperties:
                   type: string
-                description: HardwareSelector models a simple key-value selector used
-                  in Tinkerbell provisioning.
+                description: |-
+                  HardwareSelector is a simple key-value selector for hardware.
+                  Use this for straightforward single-label hardware selection.
+                  Mutually exclusive with HardwareAffinity.
                 type: object
               hostOSConfiguration:
                 description: HostOSConfiguration defines the configuration settings
@@ -7356,7 +7498,6 @@ spec:
                   type: object
                 type: array
             required:
-            - hardwareSelector
             - osFamily
             type: object
           status:
@@ -8198,6 +8339,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - bmc.tinkerbell.org

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,18 +13,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create  
-- apiGroups:
   - ""
   resources:
   - events
@@ -183,6 +171,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - bmc.tinkerbell.org

--- a/controllers/controlplaneupgrade_controller.go
+++ b/controllers/controlplaneupgrade_controller.go
@@ -75,6 +75,7 @@ func NewControlPlaneUpgradeReconciler(client client.Client, remoteClientRegistry
 //+kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=controlplaneupgrades/finalizers,verbs=update
 //+kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigs,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=tinkerbellmachines;vspheremachines,verbs=get;list;update;patch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
 // Reconcile reconciles a ControlPlaneUpgrade object.
 // nolint:gocyclo


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3785

*Description of changes:*
Missed in https://github.com/aws/eks-anywhere/pull/10556
```
References on Cluster, KubeadmControlPlane, MachineDeployment, MachinePool, MachineSet and Machine are now using the ContractVersionedObjectReference type instead of corev1.ObjectReference. These references can now be resolved with external.GetObjectFromContractVersionedRef instead of external.Get:


external.GetObjectFromContractVersionedRef(ctx, r.Client, cluster.Spec.InfrastructureRef, cluster.Namespace)
This functions requires the permissions to get, list and watch objects of the type customresourcedefinitions to identify the used contract version.

// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

