### PR TITLE
fix missed v1beta1 patchhelpers for capi v1beta2 resources

### DIFF
--- a/controllers/kubeadmcontrolplane_controller.go
+++ b/controllers/kubeadmcontrolplane_controller.go
@@ -33,7 +33,7 @@ import (
 	controlplanev1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/annotations"
-	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -85,7 +85,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	patchHelper, err := v1beta1patch.NewHelper(kcp, r.client)
+	patchHelper, err := patch.NewHelper(kcp, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -128,7 +128,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, log logr.
 		}
 		return ctrl.Result{}, fmt.Errorf("getting MachineHealthCheck %s: %v", cpMachineHealthCheckName(kcp.ObjectMeta.Name), err)
 	}
-	mhcPatchHelper, err := v1beta1patch.NewHelper(mhc, r.client)
+	mhcPatchHelper, err := patch.NewHelper(mhc, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -212,12 +212,12 @@ func (r *KubeadmControlPlaneReconciler) validateStackedEtcd(kcp *controlplanev1b
 	return nil
 }
 
-func pauseMachineHealthCheck(ctx context.Context, mhc *clusterv1beta2.MachineHealthCheck, mhcPatchHelper *v1beta1patch.Helper) error {
+func pauseMachineHealthCheck(ctx context.Context, mhc *clusterv1beta2.MachineHealthCheck, mhcPatchHelper *patch.Helper) error {
 	annotations.AddAnnotations(mhc, map[string]string{clusterv1beta2.PausedAnnotation: "true"})
 	return mhcPatchHelper.Patch(ctx, mhc)
 }
 
-func resumeMachineHealthCheck(ctx context.Context, mhc *clusterv1beta2.MachineHealthCheck, mhcPatchHelper *v1beta1patch.Helper) error {
+func resumeMachineHealthCheck(ctx context.Context, mhc *clusterv1beta2.MachineHealthCheck, mhcPatchHelper *patch.Helper) error {
 	delete(mhc.Annotations, clusterv1beta2.PausedAnnotation)
 	return mhcPatchHelper.Patch(ctx, mhc)
 }

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -83,7 +83,7 @@ func (r *MachineDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	patchHelper, err := v1beta1patch.NewHelper(md, r.client)
+	patchHelper, err := patch.NewHelper(md, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -126,7 +126,7 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, log logr.Lo
 		}
 		return ctrl.Result{}, fmt.Errorf("getting MachineHealthCheck %s: %v", mdMachineHealthCheckName(md.ObjectMeta.Name), err)
 	}
-	mhcPatchHelper, err := v1beta1patch.NewHelper(mhc, r.client)
+	mhcPatchHelper, err := patch.NewHelper(mhc, r.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3692


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

