### PR TITLE
Update tinkerbell-helm source image tag format for commit SHA support

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -836,7 +836,11 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 				AssetName:            "tinkerbell-helm",
 				TrimVersionSignifier: true,
 				ImageTagConfiguration: assettypes.ImageTagConfiguration{
-					NonProdSourceImageTagFormat: "<gitTag>",
+					// When GIT_TAG is a commit SHA, the helm chart version must be valid semver.
+					// The 0.0.1- prefix wraps the commit SHA to satisfy helm's semver requirement.
+					// This must match the HELM_TAG override in eks-anywhere-build-tooling tinkerbell Makefile.
+					NonProdSourceImageTagFormat: "0.0.1-<gitTag>",
+					ProdSourceImageTagFormat:    "0.0.1-<gitTag>",
 				},
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When the tinkerbell GIT_TAG is a commit SHA, the build-tooling pushes the helm chart to ECR with a 0.0.1- semver prefix (required by helm). Update NonProd and Prod source image tag formats to match so the release CLI looks up the chart with the correct tag.

This only affects the source image lookup URI used during the release process. The release image URI in the bundle manifest is unchanged.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

