### PR TITLE
Add ReleaseImageTagFormat for tinkerbell helm chart to prefix version…

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -841,6 +841,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 					// This must match the HELM_TAG override in eks-anywhere-build-tooling tinkerbell Makefile.
 					NonProdSourceImageTagFormat: "0.0.1-<gitTag>",
 					ProdSourceImageTagFormat:    "0.0.1-<gitTag>",
+					ReleaseImageTagFormat:       "0.0.1-<gitTag>",
 				},
 			},
 		},

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -638,7 +638,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -704,7 +704,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:
@@ -1410,7 +1410,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -1476,7 +1476,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:
@@ -2182,7 +2182,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -2248,7 +2248,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:
@@ -2954,7 +2954,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -3020,7 +3020,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:
@@ -3726,7 +3726,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -3792,7 +3792,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:
@@ -4498,7 +4498,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -4564,7 +4564,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:
@@ -5270,7 +5270,7 @@ spec:
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
           os: linux
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:v0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell:58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         hook:
           bootkit:
             arch:
@@ -5336,7 +5336,7 @@ spec:
           description: Helm chart for tinkerbell
           imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           name: tinkerbell
-          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.22.1-eks-a-v0.0.0-dev-build.1
+          uri: public.ecr.aws/release-container-registry/tinkerbell/tinkerbell/tinkerbell-helm:0.0.1-58b84f7d3bc93eda2c5f064665ba582d3618ef52-eks-a-v0.0.0-dev-build.1
         tink:
           tinkRelayInit:
             arch:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set ReleaseImageTagFormat to "0.0.1-<gitTag>" for the tinkerbell helm chart asset config, matching the existing NonProd and Prod source image tag formats. This ensures the release image tag includes the 0.0.1 prefix, changing the tinkerbell-helm URI from  tinkerbell-helm:<gitTag>-eks-a-...to  tinkerbell-helm:0.0.1-<gitTag>-eks-a-...

Update bundle release testdata to reflect the new tag format.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

