### PR TITLE
Use netmaskToPrefixLength in custom tempalte in e2e

### DIFF
--- a/test/framework/testdata/tinkerbell/custom_config.yaml
+++ b/test/framework/testdata/tinkerbell/custom_config.yaml
@@ -32,7 +32,7 @@ spec:
                         id: {{ (index .Hardware.Interfaces 0).DHCP.VLANID }}
                         link: mainif
                         addresses:
-                        - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                        - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                         nameservers:
                             addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                         {{- if (index .Hardware.Interfaces 0).DHCP.IP.Gateway }}
@@ -48,7 +48,7 @@ spec:
                         match:
                             macaddress: {{ (index .Hardware.Interfaces 0).DHCP.MAC }}
                         addresses:
-                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToCIDR (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
+                            - {{ (index .Hardware.Interfaces 0).DHCP.IP.Address }}/{{ netmaskToPrefixLength (index .Hardware.Interfaces 0).DHCP.IP.Netmask }}
                         nameservers:
                             addresses: [{{ range $i, $ns := (index .Hardware.Interfaces 0).DHCP.NameServers }}{{if $i}}, {{end}}{{$ns}}{{end}}]
                         routes:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since we no longer use netmaskToCIDR in new mono repo tinkerbell, e2e test is failing. Updating to use netmaskToPrefixLength in custom tempalte in e2e

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

