### PR TITLE
fix pkg ctlr installation due to unavailable webhook race

### DIFF
--- a/pkg/curatedpackages/packageinstaller_test.go
+++ b/pkg/curatedpackages/packageinstaller_test.go
@@ -68,6 +68,7 @@ func TestPackageInstallerSuccess(t *testing.T) {
 
 func TestPackageInstallerFailWhenControllerFails(t *testing.T) {
 	tt := newPackageInstallerTest(t)
+	tt.command.WithRetries(0, 0)
 
 	tt.packageControllerClient.EXPECT().Enable(tt.ctx).Return(errors.New("controller installation failed"))
 


### PR DESCRIPTION
*Issue #, if available:*
package controller installation helm chart has a race issue as it contains package and pbc resources which are validated by webhook deployed by the same helm chart. 
```
2026-02-24T20:15:21.866-0800    V9      docker  {"stderr": "Pulled: public.ecr.aws/x3k6m8v0/eks-anywhere-packages:0.0.0-d8e2354800c3e823d7d0073cc59a846d7651b07c\nDigest: sha256:350f0652947a1cd848093f3695ab77146e60a47871e10a1b59dbbd2fcd624ce6\nI0225 04:15:21.596363    8889 warnings.go:107] \"Warning: spec.privateKey.rotationPolicy: In cert-manager >= v1.18.0, the default value changed from `Never` to `Always`.\"\nError: Internal error occurred: failed calling webhook \"vpackage.kb.io\": failed to call webhook: Post \"https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc:443/validate-packages-eks-amazonaws-com-v1alpha1-package?timeout=10s\": dial tcp 10.106.153.9:443: connect: connection refused\nInternal error occurred: failed calling webhook \"vpackage.kb.io\": failed to call webhook: Post \"https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc:443/validate-packages-eks-amazonaws-com-v1alpha1-package?timeout=10s\": dial tcp 10.106.153.9:443: connect: connection refused\nInternal error occurred: failed calling webhook \"vpackagebundlecontroller.kb.io\": failed to call webhook: Post \"https://eks-anywhere-packages-eks-anywhere-packages-webhook-service.eksa-packages.svc:443/validate-packages-eks-amazonaws-com-v1alpha1-packagebundlecontroller?timeout=10s\": dial tcp 10.106.153.9:443: connect: connection refused\n"}
```

*Description of changes:*
Added retry to give time for the deployment to come up to finish resources apply for package and pbc successfully. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

