### PR TITLE
increase package controller install timeout

### DIFF
--- a/pkg/curatedpackages/packagecontrollerclient.go
+++ b/pkg/curatedpackages/packagecontrollerclient.go
@@ -371,7 +371,7 @@ const packageBundleControllerResource string = "packageBundleController"
 //
 // If no timeout is specified, a default of 3 minutes is used.
 func (pc *PackageControllerClient) waitForActiveBundle(ctx context.Context) error {
-	timeout := 3 * time.Minute
+	timeout := 4 * time.Minute
 	if pc.activeBundleTimeout > 0 {
 		timeout = pc.activeBundleTimeout
 	}


### PR DESCRIPTION
*Issue #, if available:*
With recent changes in package controller installation logic to get around cyclic dependencies of webhook and custom resources installation in same helm chart using retries. Package installation might take a little longer causing some of the e2e tests to timeout. 

*Description of changes:*
Increase the installation timeout from 3 min to 4 min. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

