### PR TITLE
fix workload cluster package e2e no namespace failure

### DIFF
--- a/test/e2e/certmanager.go
+++ b/test/e2e/certmanager.go
@@ -4,8 +4,10 @@
 package e2e
 
 import (
+	"context"
 	"time"
 
+	"github.com/aws/eks-anywhere/pkg/kubeconfig"
 	"github.com/aws/eks-anywhere/test/framework"
 )
 
@@ -23,6 +25,11 @@ func runCertManagerRemoteClusterInstallSimpleFlow(test *framework.MulticlusterE2
 		e.ValidateClusterState()
 		e.VerifyPackageControllerNotInstalled()
 		test.ManagementCluster.SetPackageBundleActive()
+		if err := WaitForPackageNamespace(test.ManagementCluster, context.Background(),
+			kubeconfig.FromClusterName(test.ManagementCluster.ClusterName),
+			e.ClusterName, 5*time.Minute); err != nil {
+			e.T.Fatalf("package namespace not created on management cluster: %v", err)
+		}
 		packageName := "cert-manager"
 		packagePrefix := "test"
 		test.ManagementCluster.InstallCertManagerPackageWithAwsCredentials(packagePrefix, packageName, EksaPackagesNamespace, e.ClusterName)

--- a/test/e2e/emissary.go
+++ b/test/e2e/emissary.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"context"
 	"time"
 
 	"github.com/aws/eks-anywhere/pkg/constants"
@@ -41,6 +42,11 @@ func runCuratedPackageEmissaryRemoteClusterInstallSimpleFlow(test *framework.Mul
 		e.ValidateClusterState()
 		e.VerifyPackageControllerNotInstalled()
 		test.ManagementCluster.SetPackageBundleActive()
+		if err := WaitForPackageNamespace(test.ManagementCluster, context.Background(),
+			kubeconfig.FromClusterName(test.ManagementCluster.ClusterName),
+			e.ClusterName, 5*time.Minute); err != nil {
+			e.T.Fatalf("package namespace not created on management cluster: %v", err)
+		}
 		packageFile := e.BuildPackageConfigFile(emissaryPackageName, emissaryPackagePrefix, EksaPackagesNamespace)
 		test.ManagementCluster.InstallCuratedPackageFile(packageFile, kubeconfig.FromClusterName(test.ManagementCluster.ClusterName))
 		e.VerifyEmissaryPackageInstalled(emissaryPackagePrefix+"-"+emissaryPackageName, withCluster(test.ManagementCluster))


### PR DESCRIPTION
*Issue #, if available:*
workload cluster package tests are failing with namespace not existing error, when applying the package resource in workload cluster packages namespace. Added a wait in the test until package controller creates the namespace.

```
2026-02-26T06:58:23.227Z	V9	docker	{"stderr": "Error from server (NotFound): error when creating \"release-i-035c3-6c337eb-w-0/hello-eks-anywhere.yaml\": namespaces \"eksa-packages-release-i-035c3-6c337eb-w-0\" not found\n"}
Error: Error from server (NotFound): error when creating "release-i-035c3-6c337eb-w-0/hello-eks-anywhere.yaml": namespaces "eksa-packages-release-i-035c3-6c337eb-w-0" not found

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

