### PR TITLE
Fix workload cluster package controller installation

### DIFF
--- a/config/manifest/eksa-components.yaml
+++ b/config/manifest/eksa-components.yaml
@@ -8197,6 +8197,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -257,7 +257,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch
 // +kubebuilder:rbac:groups="",namespace=eksa-system,resources=secrets,verbs=patch;update
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;create;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;create;delete;patch;update
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=anywhere.eks.amazonaws.com,resources=clusters;gitopsconfigs;snowmachineconfigs;snowdatacenterconfigs;snowippools;vspheredatacenterconfigs;vspheremachineconfigs;dockerdatacenterconfigs;tinkerbellmachineconfigs;tinkerbelltemplateconfigs;tinkerbelldatacenterconfigs;cloudstackdatacenterconfigs;cloudstackmachineconfigs;nutanixdatacenterconfigs;nutanixmachineconfigs;oidcconfigs;fluxconfigs,verbs=get;list;watch;update;patch


### PR DESCRIPTION
*Issue #, if available:*
workload cluster package controller helm chart installation is failing with error. 
```
{"ts":1772165967398.0298,"caller":"curatedpackages/packagecontrollerclient.go:134","msg":"Enabling curated packages full lifecycle","controller":"cluster","controllerGroup":"anywhere.eks.amazonaws.com","controllerKind":"Cluster","Cluster":{"name":"eksa-test-69a202a-w-0","namespace":"default"},"namespace":"default","name":"eksa-test-69a202a-w-0","reconcileID":"db60a5a2-168e-4216-b62b-777844ca414e","clusterName":"eksa-test-69a202a-w-0","err":"Pulled: public.ecr.aws/x3k6m8v0/eks-anywhere-packages:0.0.0-e7cfbf96fd0a2bb25eaf9b27ef0d3889859db621\nDigest: sha256:c2b5f468ac56952336a47541c77bf7ab8b3df84ca22cd5c9967b573427a03c47\nError: namespaces \"eksa-packages\" is forbidden: User \"system:serviceaccount:eksa-system:eksa-controller-manager\" cannot patch resource \"namespaces\" in API group \"\" in the namespace \"eksa-packages\"\n"}
{"ts":1772165967398.073,"caller":"controllers/cluster_controller.go:537","msg":"Updating cluster status","controller":"cluster","controllerGroup":"anywhere.eks.amazonaws.com","controllerKind":"Cluster","Cluster":{"name":"eksa-test-69a202a-w-0","namespace":"default"},"namespace":"default","name":"eksa-test-69a202a-w-0","reconcileID":"db60a5a2-168e-4216-b62b-777844ca414e","v":0}
{"ts":1772165967421.5068,"caller":"controller/controller.go:474","msg":"Reconciler error","controller":"cluster","controllerGroup":"anywhere.eks.amazonaws.com","controllerKind":"Cluster","Cluster":{"name":"eksa-test-69a202a-w-0","namespace":"default"},"namespace":"default","name":"eksa-test-69a202a-w-0","reconcileID":"db60a5a2-168e-4216-b62b-777844ca414e","err":"packages client error: Pulled: public.ecr.aws/x3k6m8v0/eks-anywhere-packages:0.0.0-e7cfbf96fd0a2bb25eaf9b27ef0d3889859db621\nDigest: sha256:c2b5f468ac56952336a47541c77bf7ab8b3df84ca22cd5c9967b573427a03c47\nError: namespaces \"eksa-packages\" is forbidden: User \"system:serviceaccount:eksa-system:eksa-controller-manager\" cannot patch resource \"namespaces\" in API group \"\" in the namespace \"eksa-packages\"\n"}
```
New version of helm v4 in the latest release switched to using __server-side apply (SSA)__. 

Package controller installation on management cluster was succeeding because it was run via cli with root level privileges. And workload cluster installation is done by eksa-cluster-controller.

*Testing*
Tested the fix on a broken cluster with added permissions and triggering reconcile of the workload cluster. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

