### PR TITLE
fix(e2e): Clear stale bootstrap IP annotation in bare metal API upgrade flow

### DIFF
--- a/test/e2e/upgrade.go
+++ b/test/e2e/upgrade.go
@@ -134,6 +134,12 @@ func runUpgradeFlowForBareMetalWithAPI(test *framework.ClusterE2ETest, fillers .
 	test.GenerateHardwareConfig()
 	test.CreateCluster(framework.WithControlPlaneWaitTimeout("20m"))
 	test.LoadClusterConfigGeneratedByCLI()
+	// The CLI-generated config file is written before the bootstrap cluster pivot,
+	// so it still contains the tinkerbell-bootstrap-ip annotation. This annotation
+	// causes the controller to use the bootstrap IP when regenerating machine templates,
+	// creating a diff with the existing templates (which were updated during pivot to
+	// use the tinkerbellIP). Clear it so the kubectl apply doesn't re-add it.
+	test.ClusterConfig.Cluster.ClearTinkerbellIPAnnotation()
 	test.UpdateClusterConfig(fillers...)
 	test.ApplyClusterManifest()
 	test.ValidateClusterState()


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
The CLI-generated config file is written before the bootstrap-to-management cluster pivot, so it retains the tinkerbell-bootstrap-ip annotation. When the test re-applies this config via kubectl apply, the annotation gets re-added to the Cluster CR, causing the controller to regenerate machine templates with the bootstrap IP instead of the tinkerbellIP. This creates a template diff that triggers unintended rollouts which blocks the reconciliation.

*Testing (if applicable):*
Locally tested the fix.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

