### PR TITLE
Set `override_path = true` in hosts.toml

### DIFF
--- a/internal/test/registrymirror.go
+++ b/internal/test/registrymirror.go
@@ -51,8 +51,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerify() []bootstrapv1beta2.File {
 		{
 			Content: `server = "https://0.0.0.0:5000"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			Owner: "root:root",
@@ -61,8 +62,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerify() []bootstrapv1beta2.File {
 		{
 			Content: `server = "https://public.ecr.aws"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			Owner: "root:root",
@@ -90,8 +92,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerifyAndCACert() []bootstrapv1beta2.F
 		{
 			Content: `server = "https://0.0.0.0:5000"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
   skip_verify = true
 `,
@@ -101,8 +104,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerifyAndCACert() []bootstrapv1beta2.F
 		{
 			Content: `server = "https://public.ecr.aws"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
   skip_verify = true
 `,

--- a/pkg/clusterapi/config/hosts.toml
+++ b/pkg/clusterapi/config/hosts.toml
@@ -2,6 +2,7 @@ server = "https://{{ .server }}"
 
 [host."https://{{ .host }}"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 {{- if .registryCACert }}
   ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
 {{- end }}

--- a/pkg/clusterapi/registry_mirror.go
+++ b/pkg/clusterapi/registry_mirror.go
@@ -129,7 +129,7 @@ func registryMirrorConfig(registryMirrorConfig *v1alpha1.RegistryMirrorConfigura
 	}
 
 	// Mirror base hosts.toml
-	mirrorBaseContent, err := hostsFileContent(registryMirror, registryMirror.BaseRegistry, registryMirror.BaseRegistry)
+	mirrorBaseContent, err := hostsFileContent(registryMirror, registryMirror.BaseRegistry, containerd.ToAPIEndpoint(registryMirror.BaseRegistry))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clusterapi/registry_mirror_test.go
+++ b/pkg/clusterapi/registry_mirror_test.go
@@ -58,8 +58,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -70,6 +71,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -80,6 +82,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -113,8 +116,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
@@ -123,17 +127,18 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1beta2.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 		wantRegistryConfigEtcd: &etcdbootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 	},
 	{
@@ -162,8 +167,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
@@ -173,19 +179,20 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1beta2.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 			CACert:   "xyz",
 		},
 		wantRegistryConfigEtcd: &etcdbootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 			CACert:   "xyz",
 		},
 	},

--- a/pkg/executables/config/hosts.toml
+++ b/pkg/executables/config/hosts.toml
@@ -2,6 +2,7 @@ server = "https://{{.Server}}"
 
 [host."https://{{.Host}}"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 {{- if .CACertPath }}
   ca = "{{.CACertPath}}"
 {{- else }}

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -311,7 +311,7 @@ func (k *Kind) setupRegistryMirror(clusterSpec *cluster.Spec, registryMirror *re
 	// Setup configuration for the mirror registry
 	err := setupRegistryConfig(RegistryConfig{
 		Server:     mirrorBase,
-		Host:       mirrorBase,
+		Host:       containerd.ToAPIEndpoint(mirrorBase),
 		CACertPath: mountedCACertPath,
 		AuthHeader: authHeader,
 		OutputDir:  filepath.Join(certsBasePath, mirrorBase),

--- a/pkg/executables/testdata/hosts_toml_insecure_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_insecure_public_ecr_aws.toml
@@ -2,4 +2,5 @@ server = "https://public.ecr.aws"
 
 [host."https://registry-mirror.test:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true

--- a/pkg/executables/testdata/hosts_toml_insecure_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_insecure_registry_mirror.toml
@@ -1,5 +1,6 @@
 server = "https://registry-mirror.test:443"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true

--- a/pkg/executables/testdata/hosts_toml_with_auth_783794618700_dkr_ecr.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_783794618700_dkr_ecr.toml
@@ -2,6 +2,7 @@ server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
 
 [host."https://registry-mirror.test:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
   [host."https://registry-mirror.test:443/v2/curated-packages".header]
     authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_auth_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_public_ecr_aws.toml
@@ -2,6 +2,7 @@ server = "https://public.ecr.aws"
 
 [host."https://registry-mirror.test:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
   [host."https://registry-mirror.test:443/v2/eks-anywhere".header]
     authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_auth_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_registry_mirror.toml
@@ -1,7 +1,8 @@
 server = "https://registry-mirror.test:443"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
-  [host."https://registry-mirror.test:443".header]
+  [host."https://registry-mirror.test:443/v2".header]
     authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_ca_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_with_ca_public_ecr_aws.toml
@@ -1,5 +1,6 @@
 server = "https://public.ecr.aws"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/registry-mirror.test:443/ca.crt"

--- a/pkg/executables/testdata/hosts_toml_with_ca_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_with_ca_registry_mirror.toml
@@ -1,5 +1,6 @@
 server = "https://registry-mirror.test:443"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/registry-mirror.test:443/ca.crt"

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -284,9 +284,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -300,9 +301,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/cloudstack/config/template-md.yaml
+++ b/pkg/providers/cloudstack/config/template-md.yaml
@@ -74,9 +74,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -90,9 +91,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -224,6 +224,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		if len(registryMirror.CACertContent) > 0 {
@@ -408,6 +409,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		if len(registryMirror.CACertContent) > 0 {
 			values["registryCACert"] = registryMirror.CACertContent

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -186,9 +186,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -198,7 +199,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .registryAuth }}
-          [host."https://{{ .mirrorBase }}".header]
+          [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
             authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
         {{- end }}
       owner: root:root
@@ -206,9 +207,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -60,9 +60,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -72,7 +73,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -80,9 +81,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -672,6 +672,7 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
+	values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 	values["insecureSkip"] = registryMirror.InsecureSkipVerify
 	values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 	if len(registryMirror.CACertContent) > 0 {

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -310,9 +310,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -322,7 +323,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .registryAuth }}
-          [host."https://{{ .mirrorBase }}".header]
+          [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
             authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
         {{- end }}
       owner: root:root
@@ -330,9 +331,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -308,9 +308,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -320,7 +321,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -328,9 +329,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -262,6 +262,7 @@ func buildTemplateMapCP(
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		if len(registryMirror.CACertContent) > 0 {
@@ -453,6 +454,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		if len(registryMirror.CACertContent) > 0 {

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -195,20 +195,22 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           skip_verify = true
-          [host."https://1.2.3.4:1234".header]
+          [host."https://1.2.3.4:1234/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           skip_verify = true
           [host."https://1.2.3.4:1234/v2/eks-anywhere".header]

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror_md.yaml
@@ -112,20 +112,22 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
             skip_verify = true
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
             skip_verify = true
             [host."https://1.2.3.4:1234/v2/eks-anywhere".header]

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -285,8 +285,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -297,6 +298,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -341,8 +343,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -353,6 +356,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -363,6 +367,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -392,8 +397,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
@@ -402,14 +408,15 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1beta2.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 	},
 	{
@@ -431,8 +438,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 `,
 			},
 			{
@@ -440,13 +448,14 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1beta2.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 	},
 	{
@@ -475,8 +484,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
@@ -486,15 +496,16 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1beta2.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 			CACert:   "xyz",
 		},
 	},

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -430,9 +430,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -442,7 +443,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -450,9 +451,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -238,9 +238,10 @@ spec:
           path: "/etc/containerd/config_append.toml"
         - content: |
             server = "https://{{ .mirrorBase }}"
-            
-            [host."https://{{ .mirrorBase }}"]
+
+            [host."https://{{ .mirrorBaseAPIEndpoint }}"]
               capabilities = ["pull", "resolve"]
+              override_path = true
             {{- if or .registryCACert .insecureSkip }}
             {{- if .registryCACert }}
               ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -250,7 +251,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .registryAuth }}
-              [host."https://{{ .mirrorBase }}".header]
+              [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
                 authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
             {{- end }}
           owner: root:root
@@ -258,9 +259,10 @@ spec:
         {{- range $orig, $mirror := .registryMirrorMap }}
         - content: |
             server = "https://{{ $orig }}"
-            
+
             [host."https://{{ $mirror }}"]
               capabilities = ["pull", "resolve"]
+              override_path = true
             {{- if or $.registryCACert $.insecureSkip }}
             {{- if $.registryCACert }}
               ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -876,19 +876,21 @@ spec:
       path: /etc/containerd/config_append.toml
     - content: |
         server = "https://:"
-        
-        [host."https://:"]
+
+        [host."https://:/v2"]
           capabilities = ["pull", "resolve"]
-          [host."https://:".header]
+          override_path = true
+          [host."https://:/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: /etc/containerd/certs.d/:/hosts.toml
     - content: |
         server = "https://public.ecr.aws"
-        
-        [host."https://:"]
+
+        [host."https://:/v2"]
           capabilities = ["pull", "resolve"]
-          [host."https://:".header]
+          override_path = true
+          [host."https://:/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: /etc/containerd/certs.d/public.ecr.aws/hosts.toml

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -538,6 +538,7 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
+	values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 	values["insecureSkip"] = registryMirror.InsecureSkipVerify
 	values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 	values["coreEKSAMirror"] = registryMirror.CoreEKSAMirror()

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -383,9 +383,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -395,7 +396,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .registryAuth }}
-          [host."https://{{ .mirrorBase }}".header]
+          [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
             authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
         {{- end }}
       owner: root:root
@@ -403,9 +404,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -130,9 +130,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -142,7 +143,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -150,9 +151,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -260,6 +260,7 @@ func buildTemplateMapCP(
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		if len(registryMirror.CACertContent) > 0 {
@@ -498,6 +499,7 @@ func buildTemplateMapMD(
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		if len(registryMirror.CACertContent) > 0 {

--- a/pkg/registrymirror/containerd/utils.go
+++ b/pkg/registrymirror/containerd/utils.go
@@ -16,6 +16,8 @@ func ToAPIEndpoint(url string) string {
 	}
 	if u.Path != "" {
 		u.Path = filepath.Join("v2", u.Path)
+	} else {
+		u.Path = "v2"
 	}
 	return strings.TrimPrefix(u.String(), "//")
 }

--- a/pkg/registrymirror/containerd/utils_test.go
+++ b/pkg/registrymirror/containerd/utils_test.go
@@ -18,12 +18,12 @@ func TestToAPIEndpoint(t *testing.T) {
 		{
 			name: "no namespace",
 			URL:  "oci://1.2.3.4:443",
-			want: "oci://1.2.3.4:443",
+			want: "oci://1.2.3.4:443/v2",
 		},
 		{
 			name: "no namespace",
 			URL:  "registry-mirror.test:443",
-			want: "registry-mirror.test:443",
+			want: "registry-mirror.test:443/v2",
 		},
 		{
 			name: "with namespace",
@@ -57,7 +57,7 @@ func TestToAPIEndpoints(t *testing.T) {
 				constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/curated-packages",
 			},
 			want: map[string]string{
-				constants.DefaultCoreEKSARegistry:        "1.2.3.4:443",
+				constants.DefaultCoreEKSARegistry:        "1.2.3.4:443/v2",
 				constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/v2/curated-packages",
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*
#10212 introduced a regression while migrating the registry mirror config from config.toml (registry.mirrors endpoint format) to `hosts.toml` format. When oci namespaces are configured, ToAPIEndpoints() prepends /v2/ to t
he namespace path in the host URL. In the old `config.toml` format this was used as-is. In `hosts.toml` format, containerd's parser [auto-appends](https://github.com/containerd/containerd/blob/release/1.7/remotes/docker/config/hosts.go#L432-L434.) an additional /v2/ to the host path, causing a double /v2/ in requests: `/v2/<
namespace>/v2/<repo>/manifests/<tag>` resulting in 404.

*Description of changes:*
Add `override_path = true` to namespaced `hosts.toml` entries. This instructs containerd to use the host path as is without auto-appending /v2/. For base mirror entry (no path) we always append /v2/ for direct repo references so that `override_path` can be set unconditionally safely.

*Testing (if applicable):*
Pre-fix (setup a test ns rahul-tst in our CI registry and validate the image pull URIs from the node):
Hosts.toml: 
```toml
server = "https://public.ecr.aws"

[host."https://10.80.148.51:443/v2/rahul-test"]
  capabilities = ["pull", "resolve"]
  ca = "/etc/containerd/certs.d/10.80.148.51:443/ca.crt"
  [host."https://10.80.148.51:443/v2/rahul-test".header]
    authorization = "Basic YWRtaW46eENnd3hqN0Y="
```
Image pull logs:
`May 08 23:02:02 containerd[1404]: level=debug msg="fetch response received" response.status="404 Not Found" url="https://10.80.148.51:443/v2/rahul-test/v2/eks/cilium/cilium/manifests/v1.19.1-0?ns=public.ecr.aws" 
`

Post-fix:
Hosts.toml:
```toml
server = "https://public.ecr.aws"

[host."https://10.80.148.51:443/v2/rahul-test"]
  capabilities = ["pull", "resolve"]
  override_path = true
  ca = "/etc/containerd/certs.d/10.80.148.51:443/ca.crt"
  [host."https://10.80.148.51:443/v2/rahul-test".header]
    authorization = "Basic YWRtaW46eENnd3hqN0Y="
```
`response.status="200 OK" content-type=application/vnd.oci.image.manifest.v1+json url="https://10.80.148.51:443/v2/rahul-test/eks/cilium/cilium/manifests/v1.19.1-0?ns=public.ecr.aws"`

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

