### PR TITLE
Fix registry mirror hosts.toml double /v2/ regression from containerd v2 migration

### DIFF
--- a/internal/test/registrymirror.go
+++ b/internal/test/registrymirror.go
@@ -51,8 +51,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerify() []bootstrapv1.File {
 		{
 			Content: `server = "https://0.0.0.0:5000"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			Owner: "root:root",
@@ -61,8 +62,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerify() []bootstrapv1.File {
 		{
 			Content: `server = "https://public.ecr.aws"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			Owner: "root:root",
@@ -90,8 +92,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerifyAndCACert() []bootstrapv1.File {
 		{
 			Content: `server = "https://0.0.0.0:5000"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
   skip_verify = true
 `,
@@ -101,8 +104,9 @@ func RegistryMirrorConfigFilesInsecureSkipVerifyAndCACert() []bootstrapv1.File {
 		{
 			Content: `server = "https://public.ecr.aws"
 
-[host."https://0.0.0.0:5000"]
+[host."https://0.0.0.0:5000/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
   skip_verify = true
 `,

--- a/pkg/clusterapi/config/hosts.toml
+++ b/pkg/clusterapi/config/hosts.toml
@@ -2,6 +2,7 @@ server = "https://{{ .server }}"
 
 [host."https://{{ .host }}"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 {{- if .registryCACert }}
   ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
 {{- end }}

--- a/pkg/clusterapi/registry_mirror.go
+++ b/pkg/clusterapi/registry_mirror.go
@@ -129,7 +129,7 @@ func registryMirrorConfig(registryMirrorConfig *v1alpha1.RegistryMirrorConfigura
 	}
 
 	// Mirror base hosts.toml
-	mirrorBaseContent, err := hostsFileContent(registryMirror, registryMirror.BaseRegistry, registryMirror.BaseRegistry)
+	mirrorBaseContent, err := hostsFileContent(registryMirror, registryMirror.BaseRegistry, containerd.ToAPIEndpoint(registryMirror.BaseRegistry))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clusterapi/registry_mirror_test.go
+++ b/pkg/clusterapi/registry_mirror_test.go
@@ -58,8 +58,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -70,6 +71,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -80,6 +82,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -113,8 +116,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
@@ -123,17 +127,18 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 		wantRegistryConfigEtcd: &etcdbootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 	},
 	{
@@ -162,8 +167,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
@@ -173,19 +179,20 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 			CACert:   "xyz",
 		},
 		wantRegistryConfigEtcd: &etcdbootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 			CACert:   "xyz",
 		},
 	},

--- a/pkg/executables/config/hosts.toml
+++ b/pkg/executables/config/hosts.toml
@@ -2,6 +2,7 @@ server = "https://{{.Server}}"
 
 [host."https://{{.Host}}"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 {{- if .CACertPath }}
   ca = "{{.CACertPath}}"
 {{- else }}

--- a/pkg/executables/kind.go
+++ b/pkg/executables/kind.go
@@ -311,7 +311,7 @@ func (k *Kind) setupRegistryMirror(clusterSpec *cluster.Spec, registryMirror *re
 	// Setup configuration for the mirror registry
 	err := setupRegistryConfig(RegistryConfig{
 		Server:     mirrorBase,
-		Host:       mirrorBase,
+		Host:       containerd.ToAPIEndpoint(mirrorBase),
 		CACertPath: mountedCACertPath,
 		AuthHeader: authHeader,
 		OutputDir:  filepath.Join(certsBasePath, mirrorBase),

--- a/pkg/executables/testdata/hosts_toml_insecure_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_insecure_public_ecr_aws.toml
@@ -2,4 +2,5 @@ server = "https://public.ecr.aws"
 
 [host."https://registry-mirror.test:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true

--- a/pkg/executables/testdata/hosts_toml_insecure_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_insecure_registry_mirror.toml
@@ -1,5 +1,6 @@
 server = "https://registry-mirror.test:443"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true

--- a/pkg/executables/testdata/hosts_toml_with_auth_783794618700_dkr_ecr.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_783794618700_dkr_ecr.toml
@@ -2,6 +2,7 @@ server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
 
 [host."https://registry-mirror.test:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
   [host."https://registry-mirror.test:443/v2/curated-packages".header]
     authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_auth_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_public_ecr_aws.toml
@@ -2,6 +2,7 @@ server = "https://public.ecr.aws"
 
 [host."https://registry-mirror.test:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
   [host."https://registry-mirror.test:443/v2/eks-anywhere".header]
     authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_auth_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_with_auth_registry_mirror.toml
@@ -1,7 +1,8 @@
 server = "https://registry-mirror.test:443"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
-  [host."https://registry-mirror.test:443".header]
+  [host."https://registry-mirror.test:443/v2".header]
     authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/executables/testdata/hosts_toml_with_ca_public_ecr_aws.toml
+++ b/pkg/executables/testdata/hosts_toml_with_ca_public_ecr_aws.toml
@@ -1,5 +1,6 @@
 server = "https://public.ecr.aws"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/registry-mirror.test:443/ca.crt"

--- a/pkg/executables/testdata/hosts_toml_with_ca_registry_mirror.toml
+++ b/pkg/executables/testdata/hosts_toml_with_ca_registry_mirror.toml
@@ -1,5 +1,6 @@
 server = "https://registry-mirror.test:443"
 
-[host."https://registry-mirror.test:443"]
+[host."https://registry-mirror.test:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/registry-mirror.test:443/ca.crt"

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -274,9 +274,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -290,9 +291,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/cloudstack/config/template-md.yaml
+++ b/pkg/providers/cloudstack/config/template-md.yaml
@@ -71,9 +71,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -87,9 +88,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/cloudstack/template.go
+++ b/pkg/providers/cloudstack/template.go
@@ -224,6 +224,7 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		if len(registryMirror.CACertContent) > 0 {
@@ -408,6 +409,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		if len(registryMirror.CACertContent) > 0 {
 			values["registryCACert"] = registryMirror.CACertContent

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_cp.yaml
@@ -325,16 +325,18 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:443"
-        
-        [host."https://1.2.3.4:443"]
+
+        [host."https://1.2.3.4:443/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:443/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_md.yaml
@@ -24,16 +24,18 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:443"
-          
-          [host."https://1.2.3.4:443"]
+
+          [host."https://1.2.3.4:443/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:443/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -345,17 +345,19 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:443"
-        
-        [host."https://1.2.3.4:443"]
+
+        [host."https://1.2.3.4:443/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
-        [host."https://1.2.3.4:443"]
+
+        [host."https://1.2.3.4:443/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
@@ -433,7 +435,7 @@ spec:
       - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
     registryMirror:
-      endpoint: 1.2.3.4:443
+      endpoint: 1.2.3.4:443/v2
       caCert: |
         -----BEGIN CERTIFICATE-----
         MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -44,17 +44,19 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:443"
-          
-          [host."https://1.2.3.4:443"]
+
+          [host."https://1.2.3.4:443/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:443/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
-          [host."https://1.2.3.4:443"]
+
+          [host."https://1.2.3.4:443/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_cp.yaml
@@ -336,18 +336,20 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://0.0.0.0:5000"
-        
-        [host."https://0.0.0.0:5000"]
+
+        [host."https://0.0.0.0:5000/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
           skip_verify = true
       owner: root:root
       path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
-        [host."https://0.0.0.0:5000"]
+
+        [host."https://0.0.0.0:5000/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
           skip_verify = true
       owner: root:root
@@ -426,7 +428,7 @@ spec:
       - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
     registryMirror:
-      endpoint: 0.0.0.0:5000
+      endpoint: 0.0.0.0:5000/v2
       caCert: |
         -----BEGIN CERTIFICATE-----
         8wHMSjm0Mzf0VtaqLcoNXEYv3rWB08wydabTAxSAlFMmDJbFyXmI1tYgeps0n/Mt

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_and_cert_md.yaml
@@ -35,18 +35,20 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://0.0.0.0:5000"
-          
-          [host."https://0.0.0.0:5000"]
+
+          [host."https://0.0.0.0:5000/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
             skip_verify = true
         owner: root:root
         path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
-          [host."https://0.0.0.0:5000"]
+
+          [host."https://0.0.0.0:5000/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/0.0.0.0:5000/ca.crt"
             skip_verify = true
         owner: root:root

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_cp.yaml
@@ -325,17 +325,19 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://0.0.0.0:5000"
-        
-        [host."https://0.0.0.0:5000"]
+
+        [host."https://0.0.0.0:5000/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           skip_verify = true
       owner: root:root
       path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
-        [host."https://0.0.0.0:5000"]
+
+        [host."https://0.0.0.0:5000/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           skip_verify = true
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
@@ -413,7 +415,7 @@ spec:
       - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
       sudo: ALL=(ALL) NOPASSWD:ALL
     registryMirror:
-      endpoint: 0.0.0.0:5000
+      endpoint: 0.0.0.0:5000/v2
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta3
     kind: CloudStackMachineTemplate

--- a/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_md.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_results_mirror_config_with_insecure_skip_md.yaml
@@ -24,17 +24,19 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://0.0.0.0:5000"
-          
-          [host."https://0.0.0.0:5000"]
+
+          [host."https://0.0.0.0:5000/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             skip_verify = true
         owner: root:root
         path: "/etc/containerd/certs.d/0.0.0.0:5000/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
-          [host."https://0.0.0.0:5000"]
+
+          [host."https://0.0.0.0:5000/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             skip_verify = true
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -180,9 +180,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -192,7 +193,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .registryAuth }}
-          [host."https://{{ .mirrorBase }}".header]
+          [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
             authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
         {{- end }}
       owner: root:root
@@ -200,9 +201,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -59,9 +59,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -71,7 +72,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -79,9 +80,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -805,6 +805,7 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
+	values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 	values["insecureSkip"] = registryMirror.InsecureSkipVerify
 	values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 	if len(registryMirror.CACertContent) > 0 {

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_cp.yaml
@@ -271,16 +271,18 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:

--- a/pkg/providers/docker/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_config_md.yaml
@@ -22,16 +22,18 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -292,19 +292,21 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-          [host."https://1.2.3.4:1234".header]
+          [host."https://1.2.3.4:1234/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           [host."https://1.2.3.4:1234/v2/eks-anywhere".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_auth_config_md.yaml
@@ -43,19 +43,21 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
             [host."https://1.2.3.4:1234/v2/eks-anywhere".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_cp.yaml
@@ -292,17 +292,19 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_md.yaml
+++ b/pkg/providers/docker/testdata/expected_results_mirror_with_cert_config_md.yaml
@@ -43,17 +43,19 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -300,9 +300,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -312,7 +313,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .registryAuth }}
-          [host."https://{{ .mirrorBase }}".header]
+          [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
             authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
         {{- end }}
       owner: root:root
@@ -320,9 +321,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/nutanix/config/md-template.yaml
+++ b/pkg/providers/nutanix/config/md-template.yaml
@@ -305,9 +305,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -317,7 +318,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -325,9 +326,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/nutanix/template.go
+++ b/pkg/providers/nutanix/template.go
@@ -262,6 +262,7 @@ func buildTemplateMapCP(
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		if len(registryMirror.CACertContent) > 0 {
@@ -453,6 +454,7 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupMachineSpec v1
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		if len(registryMirror.CACertContent) > 0 {

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -186,20 +186,22 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           skip_verify = true
-          [host."https://1.2.3.4:1234".header]
+          [host."https://1.2.3.4:1234/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           skip_verify = true
           [host."https://1.2.3.4:1234/v2/eks-anywhere".header]

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror_md.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror_md.yaml
@@ -112,20 +112,22 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
             skip_verify = true
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
             skip_verify = true
             [host."https://1.2.3.4:1234/v2/eks-anywhere".header]

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -279,8 +279,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -291,6 +292,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -335,8 +337,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -347,6 +350,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/curated-packages"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -357,6 +361,7 @@ var registryMirrorTests = []struct {
 
 [host."https://1.2.3.4:443/v2/eks-anywhere"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
 `,
 			},
@@ -386,8 +391,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
@@ -396,14 +402,15 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 	},
 	{
@@ -425,8 +432,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 `,
 			},
 			{
@@ -434,13 +442,14 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 		},
 	},
 	{
@@ -469,8 +478,9 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://1.2.3.4:443"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
@@ -480,15 +490,16 @@ var registryMirrorTests = []struct {
 				Owner: "root:root",
 				Content: `server = "https://public.ecr.aws"
 
-[host."https://1.2.3.4:443"]
+[host."https://1.2.3.4:443/v2"]
   capabilities = ["pull", "resolve"]
+  override_path = true
   ca = "/etc/containerd/certs.d/1.2.3.4:443/ca.crt"
   skip_verify = true
 `,
 			},
 		},
 		wantRegistryConfig: bootstrapv1.RegistryMirrorConfiguration{
-			Endpoint: "1.2.3.4:443",
+			Endpoint: "1.2.3.4:443/v2",
 			CACert:   "xyz",
 		},
 	},

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -419,9 +419,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -431,7 +432,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -439,9 +440,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -178,9 +178,10 @@ spec:
           path: "/etc/containerd/config_append.toml"
         - content: |
             server = "https://{{ .mirrorBase }}"
-            
-            [host."https://{{ .mirrorBase }}"]
+
+            [host."https://{{ .mirrorBaseAPIEndpoint }}"]
               capabilities = ["pull", "resolve"]
+              override_path = true
             {{- if or .registryCACert .insecureSkip }}
             {{- if .registryCACert }}
               ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -190,7 +191,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .registryAuth }}
-              [host."https://{{ .mirrorBase }}".header]
+              [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
                 authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
             {{- end }}
           owner: root:root
@@ -198,9 +199,10 @@ spec:
         {{- range $orig, $mirror := .registryMirrorMap }}
         - content: |
             server = "https://{{ $orig }}"
-            
+
             [host."https://{{ $mirror }}"]
               capabilities = ["pull", "resolve"]
+              override_path = true
             {{- if or $.registryCACert $.insecureSkip }}
             {{- if $.registryCACert }}
               ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -863,19 +863,21 @@ spec:
       path: /etc/containerd/config_append.toml
     - content: |
         server = "https://:"
-        
-        [host."https://:"]
+
+        [host."https://:/v2"]
           capabilities = ["pull", "resolve"]
-          [host."https://:".header]
+          override_path = true
+          [host."https://:/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: /etc/containerd/certs.d/:/hosts.toml
     - content: |
         server = "https://public.ecr.aws"
-        
-        [host."https://:"]
+
+        [host."https://:/v2"]
           capabilities = ["pull", "resolve"]
-          [host."https://:".header]
+          override_path = true
+          [host."https://:/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: /etc/containerd/certs.d/public.ecr.aws/hosts.toml

--- a/pkg/providers/tinkerbell/template.go
+++ b/pkg/providers/tinkerbell/template.go
@@ -727,6 +727,7 @@ func populateRegistryMirrorValues(clusterSpec *cluster.Spec, values map[string]i
 	registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 	values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 	values["mirrorBase"] = registryMirror.BaseRegistry
+	values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 	values["insecureSkip"] = registryMirror.InsecureSkipVerify
 	values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 	values["coreEKSAMirror"] = registryMirror.CoreEKSAMirror()

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_auth.yaml
@@ -46,7 +46,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
@@ -113,7 +113,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_cp_registry_mirror_with_cert.yaml
@@ -46,7 +46,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
@@ -113,7 +113,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_auth.yaml
@@ -144,7 +144,7 @@ spec:
           imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
           imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
         registryMirror:
-          endpoint: 1.2.3.4:1234
+          endpoint: 1.2.3.4:1234/v2
           caCert: |
             -----BEGIN CERTIFICATE-----
             MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_bottlerocket_md_registry_mirror_with_cert.yaml
@@ -144,7 +144,7 @@ spec:
           imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
           imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
         registryMirror:
-          endpoint: 1.2.3.4:1234
+          endpoint: 1.2.3.4:1234/v2
           caCert: |
             -----BEGIN CERTIFICATE-----
             MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_minimal_registry_mirror.yaml
@@ -293,16 +293,18 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     preKubeadmCommands:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_auth.yaml
@@ -313,21 +313,23 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_cp_registry_mirror_with_cert.yaml
@@ -313,25 +313,28 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
-          
+
           [host."https://1.2.3.4:1234/v2/curated-packages"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_minimal_registry_mirror.yaml
@@ -170,16 +170,18 @@ spec:
           path: "/etc/containerd/config_append.toml"
         - content: |
             server = "https://1.2.3.4:1234"
-            
-            [host."https://1.2.3.4:1234"]
+
+            [host."https://1.2.3.4:1234/v2"]
               capabilities = ["pull", "resolve"]
+              override_path = true
           owner: root:root
           path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
         - content: |
             server = "https://public.ecr.aws"
-            
+
             [host."https://1.2.3.4:1234/v2/eks-anywhere"]
               capabilities = ["pull", "resolve"]
+              override_path = true
           owner: root:root
           path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_auth.yaml
@@ -186,21 +186,23 @@ spec:
           path: "/etc/containerd/config_append.toml"
         - content: |
             server = "https://1.2.3.4:1234"
-            
-            [host."https://1.2.3.4:1234"]
+
+            [host."https://1.2.3.4:1234/v2"]
               capabilities = ["pull", "resolve"]
+              override_path = true
               ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-              [host."https://1.2.3.4:1234".header]
+              [host."https://1.2.3.4:1234/v2".header]
                 authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
           owner: root:root
           path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
         - content: |
             server = "https://public.ecr.aws"
-            
-            [host."https://1.2.3.4:1234"]
+
+            [host."https://1.2.3.4:1234/v2"]
               capabilities = ["pull", "resolve"]
+              override_path = true
               ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-              [host."https://1.2.3.4:1234".header]
+              [host."https://1.2.3.4:1234/v2".header]
                 authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
           owner: root:root
           path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_md_registry_mirror_with_cert.yaml
@@ -190,25 +190,28 @@ spec:
           path: "/etc/containerd/config_append.toml"
         - content: |
             server = "https://1.2.3.4:1234"
-            
-            [host."https://1.2.3.4:1234"]
+
+            [host."https://1.2.3.4:1234/v2"]
               capabilities = ["pull", "resolve"]
+              override_path = true
               ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           owner: root:root
           path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
         - content: |
             server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
-            
+
             [host."https://1.2.3.4:1234/v2/curated-packages"]
               capabilities = ["pull", "resolve"]
+              override_path = true
               ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           owner: root:root
           path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
         - content: |
             server = "https://public.ecr.aws"
-            
+
             [host."https://1.2.3.4:1234/v2/eks-anywhere"]
               capabilities = ["pull", "resolve"]
+              override_path = true
               ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
           owner: root:root
           path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_results_cluster_tinkerbell_upgrade_registry_mirror.yaml
@@ -314,16 +314,18 @@ spec:
     - content: |
         server = "https://10.10.10.10:443"
 
-        [host."https://10.10.10.10:443"]
+        [host."https://10.10.10.10:443/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/10.10.10.10:443/ca.crt"
       owner: root:root
       path: /etc/containerd/certs.d/10.10.10.10:443/hosts.toml
     - content: |
         server = "https://public.ecr.aws"
 
-        [host."https://10.10.10.10:443"]
+        [host."https://10.10.10.10:443/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/10.10.10.10:443/ca.crt"
       owner: root:root
       path: /etc/containerd/certs.d/public.ecr.aws/hosts.toml

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -373,9 +373,10 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://{{ .mirrorBase }}"
-        
-        [host."https://{{ .mirrorBase }}"]
+
+        [host."https://{{ .mirrorBaseAPIEndpoint }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or .registryCACert .insecureSkip }}
         {{- if .registryCACert }}
           ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -385,7 +386,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .registryAuth }}
-          [host."https://{{ .mirrorBase }}".header]
+          [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
             authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
         {{- end }}
       owner: root:root
@@ -393,9 +394,10 @@ spec:
     {{- range $orig, $mirror := .registryMirrorMap }}
     - content: |
         server = "https://{{ $orig }}"
-        
+
         [host."https://{{ $mirror }}"]
           capabilities = ["pull", "resolve"]
+          override_path = true
         {{- if or $.registryCACert $.insecureSkip }}
         {{- if $.registryCACert }}
           ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/vsphere/config/template-md.yaml
+++ b/pkg/providers/vsphere/config/template-md.yaml
@@ -126,9 +126,10 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://{{ .mirrorBase }}"
-          
-          [host."https://{{ .mirrorBase }}"]
+
+          [host."https://{{ .mirrorBaseAPIEndpoint }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or .registryCACert .insecureSkip }}
           {{- if .registryCACert }}
             ca = "/etc/containerd/certs.d/{{ .mirrorBase }}/ca.crt"
@@ -138,7 +139,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .registryAuth }}
-            [host."https://{{ .mirrorBase }}".header]
+            [host."https://{{ .mirrorBaseAPIEndpoint }}".header]
               authorization = "Basic {{ printf "%s:%s" .registryUsername .registryPassword | b64enc }}"
           {{- end }}
         owner: root:root
@@ -146,9 +147,10 @@ spec:
       {{- range $orig, $mirror := .registryMirrorMap }}
       - content: |
           server = "https://{{ $orig }}"
-          
+
           [host."https://{{ $mirror }}"]
             capabilities = ["pull", "resolve"]
+            override_path = true
           {{- if or $.registryCACert $.insecureSkip }}
           {{- if $.registryCACert }}
             ca = "/etc/containerd/certs.d/{{ $.mirrorBase }}/ca.crt"

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -260,6 +260,7 @@ func buildTemplateMapCP(
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		if len(registryMirror.CACertContent) > 0 {
@@ -498,6 +499,7 @@ func buildTemplateMapMD(
 		registryMirror := registrymirror.FromCluster(clusterSpec.Cluster)
 		values["registryMirrorMap"] = containerd.ToAPIEndpoints(registryMirror.NamespacedRegistryMap)
 		values["mirrorBase"] = registryMirror.BaseRegistry
+		values["mirrorBaseAPIEndpoint"] = containerd.ToAPIEndpoint(registryMirror.BaseRegistry)
 		values["insecureSkip"] = registryMirror.InsecureSkipVerify
 		values["publicMirror"] = containerd.ToAPIEndpoint(registryMirror.CoreEKSAMirror())
 		if len(registryMirror.CACertContent) > 0 {

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_cp.yaml
@@ -96,7 +96,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
@@ -388,7 +388,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
@@ -475,7 +475,7 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
     registryMirror:
-      endpoint: 1.2.3.4:1234
+      endpoint: 1.2.3.4:1234/v2
       caCert: |
         -----BEGIN CERTIFICATE-----
         MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_auth_md.yaml
@@ -14,7 +14,7 @@ spec:
           imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
           imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
         registryMirror:
-          endpoint: 1.2.3.4:1234
+          endpoint: 1.2.3.4:1234/v2
           caCert: |
             -----BEGIN CERTIFICATE-----
             MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_cp.yaml
@@ -96,7 +96,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
@@ -388,7 +388,7 @@ spec:
         imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
         imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
       registryMirror:
-        endpoint: 1.2.3.4:1234
+        endpoint: 1.2.3.4:1234/v2
         caCert: |
           -----BEGIN CERTIFICATE-----
           MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV
@@ -475,7 +475,7 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
     registryMirror:
-      endpoint: 1.2.3.4:1234
+      endpoint: 1.2.3.4:1234/v2
       caCert: |
         -----BEGIN CERTIFICATE-----
         MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_bottlerocket_mirror_config_with_cert_md.yaml
@@ -14,7 +14,7 @@ spec:
           imageRepository: public.ecr.aws/l0g8r8j6/bottlerocket-bootstrap
           imageTag: v1-21-4-eks-a-v0.0.0-dev-build.158
         registryMirror:
-          endpoint: 1.2.3.4:1234
+          endpoint: 1.2.3.4:1234/v2
           caCert: |
             -----BEGIN CERTIFICATE-----
             MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_cp.yaml
@@ -339,16 +339,18 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
     initConfiguration:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_md.yaml
@@ -25,16 +25,18 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
       preKubeadmCommands:

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_cp.yaml
@@ -359,25 +359,28 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
-        
+
         [host."https://1.2.3.4:1234/v2/curated-packages"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
+
         [host."https://1.2.3.4:1234/v2/eks-anywhere"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_config_with_cert_md.yaml
@@ -45,25 +45,28 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://783794618700.dkr.ecr.us-west-2.amazonaws.com"
-          
+
           [host."https://1.2.3.4:1234/v2/curated-packages"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/783794618700.dkr.ecr.us-west-2.amazonaws.com/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
+
           [host."https://1.2.3.4:1234/v2/eks-anywhere"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_cp.yaml
@@ -359,21 +359,23 @@ spec:
       path: "/etc/containerd/config_append.toml"
     - content: |
         server = "https://1.2.3.4:1234"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-          [host."https://1.2.3.4:1234".header]
+          [host."https://1.2.3.4:1234/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
     - content: |
         server = "https://public.ecr.aws"
-        
-        [host."https://1.2.3.4:1234"]
+
+        [host."https://1.2.3.4:1234/v2"]
           capabilities = ["pull", "resolve"]
+          override_path = true
           ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-          [host."https://1.2.3.4:1234".header]
+          [host."https://1.2.3.4:1234/v2".header]
             authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
       owner: root:root
       path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"
@@ -464,7 +466,7 @@ spec:
           - 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC1BK73XhIzjX+meUr7pIYh6RHbvI3tmHeQIXY5lv7aztN1UoX+bhPo3dwo2sfSQn5kuxgQdnxIZ/CTzy0p0GkEYVv3gwspCeurjmu0XmrdmaSGcGxCEWT/65NtvYrQtUE5ELxJ+N/aeZNlK2B7IWANnw/82913asXH4VksV1NYNduP0o1/G4XcwLLSyVFB078q/oEnmvdNIoS61j4/o36HVtENJgYr0idcBvwJdvcGxGnPaqOhx477t+kfJAa5n5dSA5wilIaoXH5i1Tf/HsTCM52L+iNCARvQzJYZhzbWI1MDQwzILtIBEQCJsl2XSqIupleY8CxqQ6jCXt2mhae+wPc3YmbO5rFvr2/EvC57kh3yDs1Nsuj8KOvD78KeeujbR8n8pScm3WDp62HFQ8lEKNdeRNj6kB8WnuaJvPnyZfvzOhwG65/9w13IBl7B1sWxbFnq2rMpm5uHVK7mAmjL0Tt8zoDhcE1YJEnp9xte3/pvmKPkST5Q/9ZtR9P5sI+02jY0fvPkPyC03j2gsPixG7rpOCwpOdbny4dcj0TDeeXJX8er+oVfJuLYz0pNWJcT2raDdFfcqvYA0B0IyNYlj5nWX4RuEcyT3qocLReWPnZojetvAG/H8XwOh7fEVGqHAKOVSnPXCSQJPl6s0H12jPJBDJMTydtYPEszl4/CeQ=='
         sudo: ALL=(ALL) NOPASSWD:ALL
     registryMirror:
-      endpoint: 1.2.3.4:1234
+      endpoint: 1.2.3.4:1234/v2
       caCert: |
         -----BEGIN CERTIFICATE-----
         MIICxjCCAa6gAwIBAgIJAInAeEdpH2uNMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNV

--- a/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_md.yaml
+++ b/pkg/providers/vsphere/testdata/expected_results_mirror_with_auth_config_md.yaml
@@ -45,21 +45,23 @@ spec:
         path: "/etc/containerd/config_append.toml"
       - content: |
           server = "https://1.2.3.4:1234"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/1.2.3.4:1234/hosts.toml"
       - content: |
           server = "https://public.ecr.aws"
-          
-          [host."https://1.2.3.4:1234"]
+
+          [host."https://1.2.3.4:1234/v2"]
             capabilities = ["pull", "resolve"]
+            override_path = true
             ca = "/etc/containerd/certs.d/1.2.3.4:1234/ca.crt"
-            [host."https://1.2.3.4:1234".header]
+            [host."https://1.2.3.4:1234/v2".header]
               authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
         owner: root:root
         path: "/etc/containerd/certs.d/public.ecr.aws/hosts.toml"

--- a/pkg/registrymirror/containerd/utils.go
+++ b/pkg/registrymirror/containerd/utils.go
@@ -16,6 +16,8 @@ func ToAPIEndpoint(url string) string {
 	}
 	if u.Path != "" {
 		u.Path = filepath.Join("v2", u.Path)
+	} else {
+		u.Path = "v2"
 	}
 	return strings.TrimPrefix(u.String(), "//")
 }

--- a/pkg/registrymirror/containerd/utils_test.go
+++ b/pkg/registrymirror/containerd/utils_test.go
@@ -18,12 +18,12 @@ func TestToAPIEndpoint(t *testing.T) {
 		{
 			name: "no namespace",
 			URL:  "oci://1.2.3.4:443",
-			want: "oci://1.2.3.4:443",
+			want: "oci://1.2.3.4:443/v2",
 		},
 		{
 			name: "no namespace",
 			URL:  "registry-mirror.test:443",
-			want: "registry-mirror.test:443",
+			want: "registry-mirror.test:443/v2",
 		},
 		{
 			name: "with namespace",
@@ -57,7 +57,7 @@ func TestToAPIEndpoints(t *testing.T) {
 				constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/curated-packages",
 			},
 			want: map[string]string{
-				constants.DefaultCoreEKSARegistry:        "1.2.3.4:443",
+				constants.DefaultCoreEKSARegistry:        "1.2.3.4:443/v2",
 				constants.DefaultCuratedPackagesRegistry: "1.2.3.4:443/v2/curated-packages",
 			},
 		},


### PR DESCRIPTION
Manual backport of https://github.com/aws/eks-anywhere/pull/10765
 
*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

