### PR TITLE
fix oci namespace registry path

### DIFF
--- a/pkg/executables/helm.go
+++ b/pkg/executables/helm.go
@@ -98,13 +98,26 @@ func (h *Helm) PushChart(ctx context.Context, chart, registry string) error {
 }
 
 func (h *Helm) RegistryLogin(ctx context.Context, registry, username, password string) error {
-	logger.Info("Logging in to helm registry", "registry", registry)
-	params := []string{"registry", "login", registry, "--username", username, "--password-stdin"}
+	// Helm registry login only accepts host:port, not host:port/path.
+	// Strip any path component to avoid validation errors in newer Helm versions.
+	loginRegistry := registryHostOnly(registry)
+	logger.Info("Logging in to helm registry", "registry", loginRegistry)
+	params := []string{"registry", "login", loginRegistry, "--username", username, "--password-stdin"}
 	if h.helmConfig.Insecure {
 		params = append(params, "--insecure")
 	}
 	_, err := h.executable.Command(ctx, params...).WithEnvVars(h.env).WithStdIn([]byte(password)).Run()
 	return err
+}
+
+// registryHostOnly extracts just the host:port portion from a registry string
+// that may contain a path (e.g., "192.168.1.1:443/namespace" -> "192.168.1.1:443").
+func registryHostOnly(registry string) string {
+	slashIdx := strings.Index(registry, "/")
+	if slashIdx == -1 {
+		return registry
+	}
+	return registry[:slashIdx]
 }
 
 func (h *Helm) SaveChart(ctx context.Context, ociURI, version, folder string) error {

--- a/pkg/executables/helm_test.go
+++ b/pkg/executables/helm_test.go
@@ -374,6 +374,30 @@ func TestHelmRegistryLoginSuccessWithInsecure(t *testing.T) {
 	tt.Expect(tt.h.RegistryLogin(tt.ctx, registry, username, password)).To(Succeed())
 }
 
+func TestHelmRegistryLoginWithPathStripsPath(t *testing.T) {
+	tt := newHelmTest(t)
+	// Registry with a namespace path - RegistryLogin should strip the path
+	registry := "192.168.1.1:443/eks-a-test"
+	username := "username"
+	password := "password"
+
+	// Expect the command to receive only host:port, not the full path
+	expectCommand(tt.e, tt.ctx, "registry", "login", "192.168.1.1:443", "--username", username, "--password-stdin").withEnvVars(tt.envVars).withStdIn([]byte(password)).to().Return(bytes.Buffer{}, nil)
+	tt.Expect(tt.h.RegistryLogin(tt.ctx, registry, username, password)).To(Succeed())
+}
+
+func TestHelmRegistryLoginWithPathAndInsecureStripsPath(t *testing.T) {
+	tt := newHelmTest(t, helm.WithInsecure())
+	// Registry with a namespace path - RegistryLogin should strip the path
+	registry := "10.0.0.1:5000/org/team"
+	username := "username"
+	password := "password"
+
+	// Expect the command to receive only host:port, not the full path
+	expectCommand(tt.e, tt.ctx, "registry", "login", "10.0.0.1:5000", "--username", username, "--password-stdin", "--insecure").withEnvVars(tt.envVars).withStdIn([]byte(password)).to().Return(bytes.Buffer{}, nil)
+	tt.Expect(tt.h.RegistryLogin(tt.ctx, registry, username, password)).To(Succeed())
+}
+
 func TestHelmUpgradeChartWithValues(s *testing.T) {
 	url := "url"
 	version := "1.1"

--- a/pkg/helm/import.go
+++ b/pkg/helm/import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/utils/oci"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
@@ -27,13 +28,25 @@ func NewChartRegistryImporter(client Client, srcFolder, registry, username, pass
 }
 
 func (i *ChartRegistryImporter) Import(ctx context.Context, charts ...string) error {
-	if err := i.client.RegistryLogin(ctx, i.registry, i.username, i.password); err != nil {
+	// Extract host:port for registry login. Newer Helm versions do not accept
+	// a path component in the registry argument for login or when validating
+	// the --insecure-skip-tls-verify flag. The path/namespace is only used when
+	// constructing the OCI push URL.
+	registryHost, registryPath := splitRegistryHostAndPath(i.registry)
+
+	if err := i.client.RegistryLogin(ctx, registryHost, i.username, i.password); err != nil {
 		return fmt.Errorf("importing charts: %v", err)
 	}
 
 	for _, chart := range uniqueCharts(charts) {
 		pushChartURL := oci.ChartPushURL(chart)
-		pushChartURL = urls.ReplaceHost(pushChartURL, i.registry)
+		pushChartURL = urls.ReplaceHost(pushChartURL, registryHost)
+
+		// If the registry includes a namespace path (e.g., "host:port/namespace"),
+		// inject the namespace into the OCI URL path after the host.
+		if registryPath != "" {
+			pushChartURL = injectNamespace(pushChartURL, registryPath)
+		}
 
 		chartFilepath := filepath.Join(i.srcFolder, ChartFileName(chart))
 		if err := i.client.PushChart(ctx, chartFilepath, pushChartURL); err != nil {
@@ -42,4 +55,63 @@ func (i *ChartRegistryImporter) Import(ctx context.Context, charts ...string) er
 	}
 
 	return nil
+}
+
+// splitRegistryHostAndPath splits a registry string into host:port and path components.
+// For example:
+//
+//	"192.168.1.1:443/my-namespace" -> ("192.168.1.1:443", "my-namespace")
+//	"192.168.1.1:443"             -> ("192.168.1.1:443", "")
+//	"myregistry.com/namespace"    -> ("myregistry.com", "namespace")
+func splitRegistryHostAndPath(registry string) (host, path string) {
+	return SplitRegistryHostAndPath(registry)
+}
+
+// SplitRegistryHostAndPath splits a registry string into host:port and path components.
+// For example:
+//
+//	"192.168.1.1:443/my-namespace" -> ("192.168.1.1:443", "my-namespace")
+//	"192.168.1.1:443"             -> ("192.168.1.1:443", "")
+//	"myregistry.com/namespace"    -> ("myregistry.com", "namespace")
+func SplitRegistryHostAndPath(registry string) (host, path string) {
+	// Find the first slash that is not part of a scheme (no "://" present in registry values)
+	slashIdx := strings.Index(registry, "/")
+	if slashIdx == -1 {
+		return registry, ""
+	}
+	return registry[:slashIdx], registry[slashIdx+1:]
+}
+
+// injectNamespace inserts a namespace path segment into an OCI URL right after the host.
+// For example:
+//
+//	injectNamespace("oci://192.168.1.1:443/eks/cilium", "my-namespace")
+//	-> "oci://192.168.1.1:443/my-namespace/eks/cilium"
+func injectNamespace(ociURL, namespace string) string {
+	return InjectNamespace(ociURL, namespace)
+}
+
+// InjectNamespace inserts a namespace path segment into an OCI URL right after the host.
+// For example:
+//
+//	InjectNamespace("oci://192.168.1.1:443/eks/cilium", "my-namespace")
+//	-> "oci://192.168.1.1:443/my-namespace/eks/cilium"
+func InjectNamespace(ociURL, namespace string) string {
+	if namespace == "" {
+		return ociURL
+	}
+	const prefix = oci.OCIPrefix
+	if strings.HasPrefix(ociURL, prefix) {
+		withoutPrefix := strings.TrimPrefix(ociURL, prefix)
+		// Find the first slash separating host from path
+		slashIdx := strings.Index(withoutPrefix, "/")
+		if slashIdx == -1 {
+			// No path, just append namespace
+			return prefix + withoutPrefix + "/" + namespace
+		}
+		host := withoutPrefix[:slashIdx]
+		path := withoutPrefix[slashIdx+1:]
+		return prefix + host + "/" + namespace + "/" + path
+	}
+	return ociURL
 }

--- a/pkg/helm/import_test.go
+++ b/pkg/helm/import_test.go
@@ -31,6 +31,55 @@ func TestChartRegistryImporterImport(t *testing.T) {
 	g.Expect(i.Import(ctx, charts...)).To(Succeed())
 }
 
+func TestChartRegistryImporterImportWithNamespacePath(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	user := "u"
+	password := "pass"
+	// Registry with a namespace/path component (OCI namespace scenario)
+	registry := "192.168.1.1:443/eks-a-test"
+	srcFolder := "folder"
+	charts := []string{"public.ecr.aws/eks/cilium/cilium:1.17.15-1", "public.ecr.aws/w9m0f3l5/eks-anywhere-packages:0.4.9-eks-a-121"}
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+
+	// RegistryLogin should only receive host:port, NOT the path
+	client.EXPECT().RegistryLogin(ctx, "192.168.1.1:443", user, password)
+	// PushChart should receive OCI URL with namespace injected between host and original path
+	// "public.ecr.aws/eks/cilium/cilium:1.17.15-1" -> ChartPushURL -> "oci://public.ecr.aws/eks/cilium"
+	// ReplaceHost with "192.168.1.1:443" -> "oci://192.168.1.1:443/eks/cilium"
+	// injectNamespace with "eks-a-test" -> "oci://192.168.1.1:443/eks-a-test/eks/cilium"
+	client.EXPECT().PushChart(ctx, "folder/cilium-1.17.15-1.tgz", "oci://192.168.1.1:443/eks-a-test/eks/cilium")
+	// "public.ecr.aws/w9m0f3l5/eks-anywhere-packages:0.4.9-eks-a-121" -> ChartPushURL -> "oci://public.ecr.aws/w9m0f3l5"
+	// ReplaceHost with "192.168.1.1:443" -> "oci://192.168.1.1:443/w9m0f3l5"
+	// injectNamespace with "eks-a-test" -> "oci://192.168.1.1:443/eks-a-test/w9m0f3l5"
+	client.EXPECT().PushChart(ctx, "folder/eks-anywhere-packages-0.4.9-eks-a-121.tgz", "oci://192.168.1.1:443/eks-a-test/w9m0f3l5")
+
+	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
+	g.Expect(i.Import(ctx, charts...)).To(Succeed())
+}
+
+func TestChartRegistryImporterImportWithMultiLevelNamespacePath(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	user := "u"
+	password := "pass"
+	// Registry with multi-level namespace path
+	registry := "10.0.0.1:5000/org/team"
+	srcFolder := "folder"
+	charts := []string{"ecr.com/project/chart1:v1.1.0"}
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+
+	// RegistryLogin should only receive host:port
+	client.EXPECT().RegistryLogin(ctx, "10.0.0.1:5000", user, password)
+	// Chart push URL should include the full namespace path
+	client.EXPECT().PushChart(ctx, "folder/chart1-v1.1.0.tgz", "oci://10.0.0.1:5000/org/team/project")
+
+	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
+	g.Expect(i.Import(ctx, charts...)).To(Succeed())
+}
+
 func TestChartRegistryImporterImportLoginError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -46,6 +95,24 @@ func TestChartRegistryImporterImportLoginError(t *testing.T) {
 
 	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
 	g.Expect(i.Import(ctx, charts...)).To(MatchError(ContainSubstring("importing charts: logging error")))
+}
+
+func TestChartRegistryImporterImportLoginErrorWithNamespacePath(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	user := "u"
+	password := "pass"
+	registry := "192.168.1.1:443/eks-a-test"
+	srcFolder := "folder"
+	charts := []string{"ecr.com/project/chart1:v1.1.0"}
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+
+	// Login should be attempted with host:port only
+	client.EXPECT().RegistryLogin(ctx, "192.168.1.1:443", user, password).Return(errors.New("login failed"))
+
+	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
+	g.Expect(i.Import(ctx, charts...)).To(MatchError(ContainSubstring("importing charts: login failed")))
 }
 
 func TestChartRegistryImporterImportPushError(t *testing.T) {
@@ -64,4 +131,113 @@ func TestChartRegistryImporterImportPushError(t *testing.T) {
 
 	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
 	g.Expect(i.Import(ctx, charts...)).To(MatchError(ContainSubstring("pushing chart [ecr.com/project/chart1:v1.1.0] to registry [registry.com:443]: pushing error")))
+}
+
+func TestChartRegistryImporterImportPushErrorWithNamespacePath(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	user := "u"
+	password := "pass"
+	registry := "192.168.1.1:443/eks-a-test"
+	srcFolder := "folder"
+	charts := []string{"ecr.com/project/chart1:v1.1.0"}
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+
+	client.EXPECT().RegistryLogin(ctx, "192.168.1.1:443", user, password)
+	client.EXPECT().PushChart(ctx, "folder/chart1-v1.1.0.tgz", "oci://192.168.1.1:443/eks-a-test/project").Return(errors.New("pushing error"))
+
+	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
+	g.Expect(i.Import(ctx, charts...)).To(MatchError(ContainSubstring("pushing chart [ecr.com/project/chart1:v1.1.0] to registry [192.168.1.1:443/eks-a-test]: pushing error")))
+}
+
+func TestSplitRegistryHostAndPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		registry     string
+		expectedHost string
+		expectedPath string
+	}{
+		{
+			name:         "host:port only",
+			registry:     "192.168.1.1:443",
+			expectedHost: "192.168.1.1:443",
+			expectedPath: "",
+		},
+		{
+			name:         "host:port with single namespace",
+			registry:     "192.168.1.1:443/eks-a-test",
+			expectedHost: "192.168.1.1:443",
+			expectedPath: "eks-a-test",
+		},
+		{
+			name:         "host:port with multi-level namespace",
+			registry:     "10.0.0.1:5000/org/team",
+			expectedHost: "10.0.0.1:5000",
+			expectedPath: "org/team",
+		},
+		{
+			name:         "hostname without port",
+			registry:     "myregistry.com",
+			expectedHost: "myregistry.com",
+			expectedPath: "",
+		},
+		{
+			name:         "hostname with path",
+			registry:     "myregistry.com/namespace",
+			expectedHost: "myregistry.com",
+			expectedPath: "namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			host, path := helm.SplitRegistryHostAndPath(tt.registry)
+			g.Expect(host).To(Equal(tt.expectedHost))
+			g.Expect(path).To(Equal(tt.expectedPath))
+		})
+	}
+}
+
+func TestInjectNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		ociURL    string
+		namespace string
+		expected  string
+	}{
+		{
+			name:      "inject single namespace",
+			ociURL:    "oci://192.168.1.1:443/eks/cilium",
+			namespace: "eks-a-test",
+			expected:  "oci://192.168.1.1:443/eks-a-test/eks/cilium",
+		},
+		{
+			name:      "inject multi-level namespace",
+			ociURL:    "oci://10.0.0.1:5000/project",
+			namespace: "org/team",
+			expected:  "oci://10.0.0.1:5000/org/team/project",
+		},
+		{
+			name:      "url without path",
+			ociURL:    "oci://192.168.1.1:443",
+			namespace: "eks-a-test",
+			expected:  "oci://192.168.1.1:443/eks-a-test",
+		},
+		{
+			name:      "empty namespace returns original",
+			ociURL:    "oci://192.168.1.1:443/project",
+			namespace: "",
+			expected:  "oci://192.168.1.1:443/project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := helm.InjectNamespace(tt.ociURL, tt.namespace)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix helm chart import failure when registry contains OCI namespace path

Newer Helm versions strictly validate the --insecure-skip-tls-verify flag
and reject registry URLs containing a path component (e.g.,
"192.168.1.1:443/eks-a-test"). Helm attempts to parse "443/eks-a-test" as
a port number via strconv.Atoi, which fails.

This broke the OCI namespace registry mirror e2e tests in staging where
the cli-tools image contains the newer Helm binary.

The fix separates the registry host:port from the namespace path before
passing it to Helm commands, then injects the namespace into the OCI push
URL path instead.

*Testing (if applicable):*
- Unit test pass

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

