### PR TITLE
Fix import images command failing with OCI namespace in --registry flag

### DIFF
--- a/cmd/eksctl-anywhere/cmd/import_images.go
+++ b/cmd/eksctl-anywhere/cmd/import_images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -69,6 +70,8 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 		return err
 	}
 
+	registryHost, _ := splitRegistryHostNamespace(c.RegistryEndpoint)
+
 	factory := dependencies.NewFactory()
 	deps, err := factory.
 		WithManifestReader().
@@ -116,7 +119,7 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 	deps, err = factory.
 		WithExecutableMountDirs(dirsToMount...).
 		WithRegistryMirror(&registrymirror.RegistryMirror{
-			BaseRegistry: c.RegistryEndpoint,
+			BaseRegistry: registryHost,
 			NamespacedRegistryMap: map[string]string{
 				constants.DefaultCoreEKSARegistry:        c.RegistryEndpoint,
 				constants.DefaultCuratedPackagesRegistry: c.RegistryEndpoint,
@@ -150,4 +153,14 @@ func (c ImportImagesCommand) Call(ctx context.Context) error {
 	}
 
 	return importArtifacts.Run(context.WithValue(ctx, types.InsecureRegistry, c.insecure))
+}
+
+// splitRegistryHostNamespace separates a registry endpoint like "host:port/namespace"
+// into host ("host:port") and namespace ("namespace") components.
+func splitRegistryHostNamespace(registry string) (host, namespace string) {
+	slashIdx := strings.Index(registry, "/")
+	if slashIdx == -1 {
+		return registry, ""
+	}
+	return registry[:slashIdx], registry[slashIdx+1:]
 }

--- a/pkg/curatedpackages/oras/import.go
+++ b/pkg/curatedpackages/oras/import.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/eks-anywhere/pkg/curatedpackages"
 	"github.com/aws/eks-anywhere/pkg/logger"
+	"github.com/aws/eks-anywhere/pkg/utils/oci"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 )
@@ -28,9 +29,13 @@ func NewFileRegistryImporter(registry, username, password, srcFolder string) *Fi
 }
 
 func (fr *FileRegistryImporter) Push(ctx context.Context, bundles *releasev1.Bundles) {
+	host, namespace := splitRegistryNamespace(fr.registry)
 	artifacts := ReadFilesFromBundles(bundles)
 	for _, a := range UniqueCharts(artifacts) {
-		updatedChartURL := urls.ReplaceHost(a, fr.registry)
+		updatedChartURL := urls.ReplaceHost(a, host)
+		if namespace != "" {
+			updatedChartURL = insertNamespace(updatedChartURL, namespace)
+		}
 		fileName := ChartFileName(a)
 		chartFilepath := filepath.Join(fr.srcFolder, fileName)
 		data, err := os.ReadFile(chartFilepath)
@@ -43,6 +48,33 @@ func (fr *FileRegistryImporter) Push(ctx context.Context, bundles *releasev1.Bun
 			logger.Info("Warning: Failed  to push to registry", "error", err)
 		}
 	}
+}
+
+// splitRegistryNamespace separates a registry string into host:port and optional namespace.
+func splitRegistryNamespace(registry string) (host, namespace string) {
+	slashIdx := strings.Index(registry, "/")
+	if slashIdx == -1 {
+		return registry, ""
+	}
+	return registry[:slashIdx], registry[slashIdx+1:]
+}
+
+// insertNamespace inserts a namespace path segment after the host in a URL.
+func insertNamespace(url, namespace string) string {
+	prefix := oci.OCIPrefix
+	if !strings.HasPrefix(url, prefix) {
+		slashIdx := strings.Index(url, "/")
+		if slashIdx == -1 {
+			return url + "/" + namespace
+		}
+		return url[:slashIdx] + "/" + namespace + url[slashIdx:]
+	}
+	withoutScheme := strings.TrimPrefix(url, prefix)
+	slashIdx := strings.Index(withoutScheme, "/")
+	if slashIdx == -1 {
+		return prefix + withoutScheme + "/" + namespace
+	}
+	return prefix + withoutScheme[:slashIdx] + "/" + namespace + withoutScheme[slashIdx:]
 }
 
 func ChartFileName(chart string) string {

--- a/pkg/helm/import.go
+++ b/pkg/helm/import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/utils/oci"
 	"github.com/aws/eks-anywhere/pkg/utils/urls"
@@ -27,13 +28,18 @@ func NewChartRegistryImporter(client Client, srcFolder, registry, username, pass
 }
 
 func (i *ChartRegistryImporter) Import(ctx context.Context, charts ...string) error {
-	if err := i.client.RegistryLogin(ctx, i.registry, i.username, i.password); err != nil {
+	host, namespace := splitRegistryNamespace(i.registry)
+
+	if err := i.client.RegistryLogin(ctx, host, i.username, i.password); err != nil {
 		return fmt.Errorf("importing charts: %v", err)
 	}
 
 	for _, chart := range uniqueCharts(charts) {
 		pushChartURL := oci.ChartPushURL(chart)
-		pushChartURL = urls.ReplaceHost(pushChartURL, i.registry)
+		pushChartURL = urls.ReplaceHost(pushChartURL, host)
+		if namespace != "" {
+			pushChartURL = insertNamespace(pushChartURL, namespace)
+		}
 
 		chartFilepath := filepath.Join(i.srcFolder, ChartFileName(chart))
 		if err := i.client.PushChart(ctx, chartFilepath, pushChartURL); err != nil {
@@ -42,4 +48,32 @@ func (i *ChartRegistryImporter) Import(ctx context.Context, charts ...string) er
 	}
 
 	return nil
+}
+
+// splitRegistryNamespace separates a registry string into a host:port and an
+// optional namespace. For example "192.168.1.1:443/eks-a-test" returns
+// ("192.168.1.1:443", "eks-a-test") and "192.168.1.1:443" returns
+// ("192.168.1.1:443", "").
+func splitRegistryNamespace(registry string) (host, namespace string) {
+	slashIdx := strings.Index(registry, "/")
+	if slashIdx == -1 {
+		return registry, ""
+	}
+	return registry[:slashIdx], registry[slashIdx+1:]
+}
+
+// insertNamespace inserts a namespace path segment after the host in an OCI URL.
+// For example, given "oci://192.168.1.1:443/project" and namespace "eks-a-test",
+// it returns "oci://192.168.1.1:443/eks-a-test/project".
+func insertNamespace(ociURL, namespace string) string {
+	prefix := oci.OCIPrefix
+	if !strings.HasPrefix(ociURL, prefix) {
+		return namespace + "/" + ociURL
+	}
+	withoutScheme := strings.TrimPrefix(ociURL, prefix)
+	slashIdx := strings.Index(withoutScheme, "/")
+	if slashIdx == -1 {
+		return prefix + withoutScheme + "/" + namespace
+	}
+	return prefix + withoutScheme[:slashIdx] + "/" + namespace + withoutScheme[slashIdx:]
 }

--- a/pkg/helm/import_test.go
+++ b/pkg/helm/import_test.go
@@ -31,6 +31,27 @@ func TestChartRegistryImporterImport(t *testing.T) {
 	g.Expect(i.Import(ctx, charts...)).To(Succeed())
 }
 
+func TestChartRegistryImporterImportWithNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	user := "u"
+	password := "pass"
+	registry := "192.168.1.1:443/eks-a-test"
+	srcFolder := "folder"
+	charts := []string{"ecr.com/project/chart1:v1.1.0", "ecr.com/project/chart2:v2.2.0", "ecr.com/project/chart1:v1.1.0"}
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+
+	// RegistryLogin should only receive host:port, not the namespace
+	client.EXPECT().RegistryLogin(ctx, "192.168.1.1:443", user, password)
+	// PushChart URLs should include the namespace between host and the original path
+	client.EXPECT().PushChart(ctx, "folder/chart1-v1.1.0.tgz", "oci://192.168.1.1:443/eks-a-test/project")
+	client.EXPECT().PushChart(ctx, "folder/chart2-v2.2.0.tgz", "oci://192.168.1.1:443/eks-a-test/project")
+
+	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
+	g.Expect(i.Import(ctx, charts...)).To(Succeed())
+}
+
 func TestChartRegistryImporterImportLoginError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -64,4 +85,22 @@ func TestChartRegistryImporterImportPushError(t *testing.T) {
 
 	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
 	g.Expect(i.Import(ctx, charts...)).To(MatchError(ContainSubstring("pushing chart [ecr.com/project/chart1:v1.1.0] to registry [registry.com:443]: pushing error")))
+}
+
+func TestChartRegistryImporterImportLoginErrorWithNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	user := "u"
+	password := "pass"
+	registry := "192.168.1.1:443/my-namespace"
+	srcFolder := "folder"
+	charts := []string{"ecr.com/project/chart1:v1.1.0"}
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockClient(ctrl)
+
+	// Login should only use host:port
+	client.EXPECT().RegistryLogin(ctx, "192.168.1.1:443", user, password).Return(errors.New("logging error"))
+
+	i := helm.NewChartRegistryImporter(client, srcFolder, registry, user, password)
+	g.Expect(i.Import(ctx, charts...)).To(MatchError(ContainSubstring("importing charts: logging error")))
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

  **Problem**

  eksctl anywhere import images --registry host:port/namespace fails with two errors when the registry
  endpoint includes an OCI namespace path (All Ocinamespace e2e test failed):

  1. helm registry login rejects the path because it only accepts host:port, not a repository path
  2. Port parsing fails (strconv.Atoi: parsing "443/namespace": invalid syntax) because downstream consumers split on : expecting pure host:port

  The E2E test framework correctly constructs --registry 196.18.8.18:443/eks-a-test by combining the registry mirror host with OCI namespaces, but the CLI command treats the entire string as a registry host throughout its execution path.

  **Fix**

  Separate the registry string into host (for authentication and config) and namespace (for path prefix insertion) at each consumption point:

  - pkg/helm/import.go — RegistryLogin receives only host:port; push URLs get the namespace inserted after the host (e.g., oci://host:port/namespace/project)
  - cmd/eksctl-anywhere/cmd/import_images.go — BaseRegistry is set to only the host portion (satisfying its host:port contract); full endpoint is preserved for Docker image references
  - pkg/curatedpackages/oras/import.go — Same host/namespace split applied to ORAS file push URLs


*Testing (if applicable):*
Run E2E on codebuild with my branch `peirulu:fix-oci-namespace-registry` and the test pass

[Note] The e2e related to ocinamespaces previously all failed, I check the error for bottlerocket 1-33 + the error is not related to ocinamespace (controlplane not ready).

<img width="1652" height="639" alt="Screenshot 2026-06-08 at 09 45 44" src="https://github.com/user-attachments/assets/4d75bd64-2cdf-4880-acf5-1c7c4b67ab46" />

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

