### PR TITLE
Fix GitFlux Vsphere E2E test by setting NumCPUs to 2

### DIFF
--- a/test/framework/flux.go
+++ b/test/framework/flux.go
@@ -551,7 +551,7 @@ func (e *ClusterE2ETest) validateWorkerNodeMultiConfigUpdates(ctx context.Contex
 		}
 		vsphereMachineConfigs[workerName].Spec.DiskGiB = vsphereMachineConfigs[workerName].Spec.DiskGiB + 10
 		vsphereMachineConfigs[workerName].Spec.MemoryMiB = 10196
-		vsphereMachineConfigs[workerName].Spec.NumCPUs = 1
+		vsphereMachineConfigs[workerName].Spec.NumCPUs = 2
 
 		// update replica
 		clusterSpec, err := e.clusterSpecFromGit()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The machinedeployment of GitFlux Vsphere E2E throw the following error
```
'failed to create InfraMachine: failed to apply VSphereMachine:
            VSphereMachine.infrastructure.cluster.x-k8s.io "main-i-0b5d1-e48e063-md-0-fbwd2-zpffp"
            is invalid: spec.numCPUs: Invalid value: 1: spec.numCPUs in body should
            be greater than or equal to 2'
```

Hence change numCPUs to 2 to fix this issue (This might be new validation in CAPV v1.16.1)


*Testing (if applicable):*
E2E test `TestVSphereKubernetes135GitFlux` on my branch pass: https://tiny.amazon.com/17d9d5lp8/IsenLink

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

