### PR TITLE
test: use AL2023 AMI with cgroup v2 for Kubernetes 1.35+ E2E tests

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -24,6 +24,9 @@ kubeadmConfigPatches:
           audit-log-maxsize: "512"
           audit-log-path: /var/log/kubernetes/api-audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+{{- if (ge (atoi $kube_minor_version) 31) }}
+          feature-gates: "FailCgroupV1=false"
+{{- end }}
         # mount new files / directories on the control plane
         extraVolumes:
           - name: audit-policies
@@ -36,6 +39,14 @@ kubeadmConfigPatches:
             mountPath: /var/log/kubernetes
             readOnly: false
             pathType: DirectoryOrCreate
+{{- if (ge (atoi $kube_minor_version) 31) }}
+    controllerManager:
+        extraArgs:
+          feature-gates: "FailCgroupV1=false"
+    scheduler:
+        extraArgs:
+          feature-gates: "FailCgroupV1=false"
+{{- end }}
 {{- if (ge (atoi $kube_minor_version) 31) }}
   - |
     kind: InitConfiguration

--- a/test/e2e/E2E_AMI_FILTER_VARS
+++ b/test/e2e/E2E_AMI_FILTER_VARS
@@ -1,3 +1,6 @@
+# AL2023 AMI with cgroup v2 support for Kubernetes 1.35+
+# Built from: eks-anywhere-build-tooling/projects/aws/eks-a-admin-image
+# AMI ID: ami-0344caed7e3017472 (us-west-2)
 AMI_OWNER_ID_FILTER=857151390494
-AMI_NAME_FILTER=eksa-integration-test-AL2-*
-AMI_DESCRIPTION_FILTER="*Kernel version 5.X*"
+AMI_NAME_FILTER=eksa-integration-test-AL2023-*
+AMI_DESCRIPTION_FILTER="*cgroup v2*"


### PR DESCRIPTION
## Problem

Kubernetes 1.35+ enables `FailCgroupV1=true` by default, causing Kind bootstrap clusters to fail on cgroup v1 hosts (AL2):

```
cgroup v1 is deprecated in Kubernetes and will not be supported in a future kind release
kube-apiserver is not healthy after 4m0.000710459s
```

## Solution

Update the E2E test runner AMI to use AL2023 which has cgroup v2 enabled by default (kernel 6.x).

**New AMI:** `ami-0344caed7e3017472` (us-west-2)
- Base: AL2023 with kernel 6.12
- Docker 25.x with systemd cgroup driver
- cgroup v2 verified
- Kind v0.23.0, kubectl, Go 1.22.4, AWS CLI v2
peirulu@7cf34dd42630 ~ % aws ec2 describe-images \
  --owners 857151390494 \            
  --filters "Name=name,Values=eksa-integration-test-AL2023-*" \                
  --query 'Images[*].[ImageId,Name,CreationDate,Description]' \
  --output table \  
  --region us-west-2
| AMI ID | Name | Created | Description |
|--------|------|---------|-------------|
| ami-0344caed7e3017472 | eksa-integration-test-AL2023-20260617191450 | 2026-06-17T19:19:15.000Z | EKS Anywhere E2E Test Runner - AL2023 - Kernel 6.x - cgroup v2 |

## Testing

Please trigger:
```
/test TestDockerKubernetes136SimpleFlow
```

## Related

Fixes `TestDockerKubernetes136SimpleFlow` failure due to cgroup v1 incompatibility.