### PR TITLE
Fix Kind and CAPD cluster for Kubernetes 1.36

### DIFF
--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -24,6 +24,9 @@ kubeadmConfigPatches:
           audit-log-maxsize: "512"
           audit-log-path: /var/log/kubernetes/api-audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+{{- if (ge (atoi $kube_minor_version) 31) }}
+          feature-gates: "FailCgroupV1=false"
+{{- end }}
         # mount new files / directories on the control plane
         extraVolumes:
           - name: audit-policies
@@ -36,6 +39,14 @@ kubeadmConfigPatches:
             mountPath: /var/log/kubernetes
             readOnly: false
             pathType: DirectoryOrCreate
+{{- if (ge (atoi $kube_minor_version) 31) }}
+    controllerManager:
+        extraArgs:
+          feature-gates: "FailCgroupV1=false"
+    scheduler:
+        extraArgs:
+          feature-gates: "FailCgroupV1=false"
+{{- end }}
 {{- if (ge (atoi $kube_minor_version) 31) }}
   - |
     kind: InitConfiguration

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -40,14 +40,6 @@ kubeadmConfigPatches:
             readOnly: false
             pathType: DirectoryOrCreate
 {{- if (ge (atoi $kube_minor_version) 31) }}
-    controllerManager:
-        extraArgs:
-          feature-gates: "FailCgroupV1=false"
-    scheduler:
-        extraArgs:
-          feature-gates: "FailCgroupV1=false"
-{{- end }}
-{{- if (ge (atoi $kube_minor_version) 31) }}
   - |
     kind: InitConfiguration
     nodeRegistration:

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -24,9 +24,7 @@ kubeadmConfigPatches:
           audit-log-maxsize: "512"
           audit-log-path: /var/log/kubernetes/api-audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
-{{- if (ge (atoi $kube_minor_version) 31) }}
-          feature-gates: "FailCgroupV1=false"
-{{- end }}
+
         # mount new files / directories on the control plane
         extraVolumes:
           - name: audit-policies

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -21,6 +21,11 @@ kubeadmConfigPatches:
 {{- end }}
     imageRepository: {{.KubernetesRepository}}
     kubernetesVersion: {{.KubernetesVersion}}
+{{- if (ge (atoi $kube_minor_version) 36) }}
+    pause:
+      imageRepository: {{.KubernetesRepository}}
+      imageTag: {{.KubernetesVersion}}
+{{- end }}
     apiServer:
         # enable auditing flags on the API server
         extraArgs:

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -41,6 +41,11 @@ kubeadmConfigPatches:
             mountPath: /var/log/kubernetes
             readOnly: false
             pathType: DirectoryOrCreate
+{{- if (ge (atoi $kube_minor_version) 36) }}
+  - |
+    kind: KubeletConfiguration
+    sandboxImage: {{.KubernetesRepository}}/pause:{{.KubernetesVersion}}
+{{- end }}
 {{- if (ge (atoi $kube_minor_version) 31) }}
   - |
     kind: InitConfiguration

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -12,8 +12,13 @@ kubeadmConfigPatches:
       imageTag: {{.CorednsVersion}}
     etcd:
       local:
+{{- if (ge (atoi $kube_minor_version) 36) }}
+        imageRepository: registry.k8s.io
+        imageTag: 3.6.8-0
+{{- else }}
         imageRepository: {{.EtcdRepository}}
         imageTag: {{.EtcdVersion}}
+{{- end }}
     imageRepository: {{.KubernetesRepository}}
     kubernetesVersion: {{.KubernetesVersion}}
     apiServer:
@@ -24,7 +29,6 @@ kubeadmConfigPatches:
           audit-log-maxsize: "512"
           audit-log-path: /var/log/kubernetes/api-audit.log
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
-
         # mount new files / directories on the control plane
         extraVolumes:
           - name: audit-policies

--- a/pkg/executables/config/kind.yaml
+++ b/pkg/executables/config/kind.yaml
@@ -58,11 +58,18 @@ kubeadmConfigPatches:
       kubeletExtraArgs:
         fail-cgroupv1: "false"
 {{- end }}
-{{- if (ne .RegistryConfigDir "") }}
+{{- if or (ge (atoi $kube_minor_version) 36) (ne .RegistryConfigDir "") }}
 containerdConfigPatches:
+{{- if (ge (atoi $kube_minor_version) 36) }}
+  - |
+    [plugins."io.containerd.grpc.v1.cri"]
+      sandbox_image = "{{.KubernetesRepository}}/pause:{{.KubernetesVersion}}"
+{{- end }}
+{{- if (ne .RegistryConfigDir "") }}
   - |
     [plugins."io.containerd.grpc.v1.cri".registry]
       config_path = "/etc/containerd/certs.d"
+{{- end }}
 {{- end }}
 nodes:
 - role: control-plane

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -63,6 +63,11 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       imageRepository: {{.kubernetesRepository}}
+{{- if .pauseRepository }}
+      pause:
+        imageRepository: {{.pauseRepository}}
+        imageTag: {{.pauseTag}}
+{{- end }}
       etcd:
 {{- if .externalEtcd }}
         external:
@@ -180,8 +185,15 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
     - content: |
+{{- if .pauseRepository }}
+        [plugins."io.containerd.grpc.v1.cri"]
+          sandbox_image = "{{.pauseRepository}}:{{.pauseTag}}"
         [plugins."io.containerd.grpc.v1.cri".registry]
           config_path = "/etc/containerd/certs.d"
+{{- else }}
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
+{{- end }}
       owner: root:root
       path: "/etc/containerd/config_append.toml"
     - content: |
@@ -227,6 +239,13 @@ spec:
       path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
     {{- end }}
 {{- end }}
+{{- if and .pauseRepository (not .registryMirrorMap) }}
+    - content: |
+        [plugins."io.containerd.grpc.v1.cri"]
+          sandbox_image = "{{.pauseRepository}}:{{.pauseTag}}"
+      owner: root:root
+      path: "/etc/containerd/config_append.toml"
+{{- end }}
 {{- if .awsIamAuth}}
     - content: |
         # clusters refers to the remote service.
@@ -266,11 +285,15 @@ spec:
 {{- end}}
     initConfiguration:
 {{- if .kubeletConfiguration }}
-      patches: 
+      patches:
         directory: /etc/kubernetes/patches
 {{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
+{{- if .pauseRepository }}
+        ignorePreflightErrors:
+        - ImagePull
+{{- end }}
 {{- if not .kubeletConfiguration }}
         kubeletExtraArgs:
         - name: eviction-hard
@@ -297,11 +320,15 @@ spec:
 {{- end }}
     joinConfiguration:
 {{- if .kubeletConfiguration }}
-      patches: 
+      patches:
         directory: /etc/kubernetes/patches
 {{- end }}
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
+{{- if .pauseRepository }}
+        ignorePreflightErrors:
+        - ImagePull
+{{- end }}
 {{- if not .kubeletConfiguration }}
         kubeletExtraArgs:
         - name: eviction-hard
@@ -326,7 +353,7 @@ spec:
 {{- end }}
         {{- end }}
 {{- end }}
-{{- if .registryMirrorMap }}
+{{- if or .registryMirrorMap .pauseRepository }}
     preKubeadmCommands:
     - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
     - systemctl daemon-reload

--- a/pkg/providers/docker/config/template-md.yaml
+++ b/pkg/providers/docker/config/template-md.yaml
@@ -8,11 +8,15 @@ spec:
     spec:
       joinConfiguration:
 {{- if .kubeletConfiguration }}
-        patches: 
+        patches:
           directory: /etc/kubernetes/patches
 {{- end }}
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
+{{- if .pauseRepository }}
+          ignorePreflightErrors:
+          - ImagePull
+{{- end }}
 {{- if .workerNodeGroupTaints }}
           taints:{{ range .workerNodeGroupTaints}}
             - key: {{ .Key }}
@@ -36,7 +40,7 @@ spec:
 {{- if .nodeLabelArgs }}
 {{ .nodeLabelArgs.ToYaml | indent 10 }}
 {{- end }}
-{{- if or .registryMirrorMap .kubeletConfiguration }}
+{{- if or .registryMirrorMap .kubeletConfiguration .pauseRepository }}
       files:
 {{- end }}
 {{- if .kubeletConfiguration }}
@@ -54,8 +58,15 @@ spec:
 {{- end }}
 {{- if .registryMirrorMap }}
       - content: |
+{{- if .pauseRepository }}
+          [plugins."io.containerd.grpc.v1.cri"]
+            sandbox_image = "{{.pauseRepository}}:{{.pauseTag}}"
           [plugins."io.containerd.grpc.v1.cri".registry]
             config_path = "/etc/containerd/certs.d"
+{{- else }}
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            config_path = "/etc/containerd/certs.d"
+{{- end }}
         owner: root:root
         path: "/etc/containerd/config_append.toml"
       - content: |
@@ -100,6 +111,17 @@ spec:
         owner: root:root
         path: "/etc/containerd/certs.d/{{ $orig }}/hosts.toml"
       {{- end }}
+      preKubeadmCommands:
+      - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
+      - systemctl daemon-reload
+      - systemctl restart containerd
+{{- end }}
+{{- if and .pauseRepository (not .registryMirrorMap) }}
+      - content: |
+          [plugins."io.containerd.grpc.v1.cri"]
+            sandbox_image = "{{.pauseRepository}}:{{.pauseTag}}"
+        owner: root:root
+        path: "/etc/containerd/config_append.toml"
       preKubeadmCommands:
       - cat /etc/containerd/config_append.toml >> /etc/containerd/config.toml
       - systemctl daemon-reload

--- a/pkg/providers/docker/docker.go
+++ b/pkg/providers/docker/docker.go
@@ -300,6 +300,19 @@ func buildTemplateMapCP(clusterSpec *cluster.Spec) (map[string]interface{}, erro
 		"apiServerCertSANs":             clusterSpec.Cluster.Spec.ControlPlaneConfiguration.CertSANs,
 	}
 
+	clusterKubeVersion, err := v1alpha1.KubeVersionToSemver(clusterSpec.Cluster.Spec.KubernetesVersion)
+	if err != nil {
+		return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", clusterSpec.Cluster.Spec.KubernetesVersion, err)
+	}
+	kube136Semver, err := v1alpha1.KubeVersionToSemver(v1alpha1.Kube136)
+	if err != nil {
+		return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", v1alpha1.Kube136, err)
+	}
+	if clusterKubeVersion.Compare(kube136Semver) >= 0 {
+		values["pauseRepository"] = versionsBundle.KubeDistro.Pause.Image()
+		values["pauseTag"] = versionsBundle.KubeDistro.Pause.Tag()
+	}
+
 	if clusterSpec.Cluster.Spec.ExternalEtcdConfiguration != nil {
 		values["externalEtcd"] = true
 		values["externalEtcdReplicas"] = clusterSpec.Cluster.Spec.ExternalEtcdConfiguration.Count
@@ -424,6 +437,23 @@ func buildTemplateMapMD(clusterSpec *cluster.Spec, workerNodeGroupConfiguration 
 		"workerNodeGroupName":   fmt.Sprintf("%s-%s", clusterSpec.Cluster.Name, workerNodeGroupConfiguration.Name),
 		"workerNodeGroupTaints": workerNodeGroupConfiguration.Taints,
 		"autoscalingConfig":     workerNodeGroupConfiguration.AutoScalingConfiguration,
+	}
+
+	kubeVersion := clusterSpec.Cluster.Spec.KubernetesVersion
+	if workerNodeGroupConfiguration.KubernetesVersion != nil {
+		kubeVersion = *workerNodeGroupConfiguration.KubernetesVersion
+	}
+	workerKubeVersion, err := v1alpha1.KubeVersionToSemver(kubeVersion)
+	if err != nil {
+		return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", kubeVersion, err)
+	}
+	kube136Semver, err := v1alpha1.KubeVersionToSemver(v1alpha1.Kube136)
+	if err != nil {
+		return nil, fmt.Errorf("converting kubeVersion %v to semver: %v", v1alpha1.Kube136, err)
+	}
+	if workerKubeVersion.Compare(kube136Semver) >= 0 {
+		values["pauseRepository"] = versionsBundle.KubeDistro.Pause.Image()
+		values["pauseTag"] = versionsBundle.KubeDistro.Pause.Tag()
 	}
 
 	if clusterSpec.Cluster.Spec.RegistryMirrorConfiguration != nil {


### PR DESCRIPTION
## Issue 1: Kind bootstrap cluster — etcd crash-loops
Kind cluster with EKS Distro etcd 3.5.x fails to start on Kubernetes 1.36

When creating a Kind cluster using kindest/node with Kubernetes 1.36 and overriding the etcd image to EKS Distro's etcd:v3.5.21-eks-1-36-2, the etcd pod crash-loops with:
```
  flag provided but not defined: -feature-gates
  flag provided but not defined: -watch-progress-notify-interval
```

**Root Cause:** kubeadm 1.36 generates the etcd static pod manifest with flags that only etcd 3.6+ supports. These flags cannot be suppressed via extraArgs.

**Solution:** In the Kind config template, use the upstream etcd image (registry.k8s.io/etcd:3.6.8-0) for Kubernetes 1.36+, which is the image kubeadm expects. For older Kubernetes versions, continue using the EKS Distro etcd image.

## Issue 2: Workload cluster — pause image pull failure
After the Kind bootstrap cluster starts successfully, the workload cluster control plane fails during kubeadm init with:
```
[ERROR ImagePull]: failed to pull image public.ecr.aws/eks-distro/kubernetes/pause:3.10.2: not found
```

**Root Cause:** kubeadm 1.36 constructs the pause image reference as `<imageRepository>/pause:<built-in-default-tag>`. With EKS-D imageRepository (`public.ecr.aws/eks-distro/kubernetes`), this resolves to `pause:3.10.2` which does not exist in EKS-D registry. EKS-D publishes the pause image at a different tag.

**Solution:** For K8s >= 1.36, in the Docker provider CAPI templates (both CP and worker):
1. Configure containerd `sandbox_image` to point to the correct EKS-D pause image
2. Add `ignorePreflightErrors: [ImagePull]` to initConfiguration and joinConfiguration so kubeadm skips the failing preflight image pull check
3. Set `pause.imageRepository`/`imageTag` in ClusterConfiguration (used by CAPI Bottlerocket bootstrap path)
4. Add `preKubeadmCommands` to apply the containerd config before kubeadm runs

## Why EKS is unaffected
EKS manages the control plane directly — it starts etcd with only compatible flags and pulls the correct pause image. No kubeadm is involved, so neither issue occurs.

## Testing
- Run `TestDockerKubernetes136SimpleFlow` e2e test on the branch `fix-kind`
  - https://tiny.amazon.com/i2865q4i/IsenLink 