### PR TITLE
Remove CloudStack from bundle release pipeline

### DIFF
--- a/release/cli/pkg/assets/config/bundle_release.go
+++ b/release/cli/pkg/assets/config/bundle_release.go
@@ -203,29 +203,7 @@ var bundleReleaseAssetsConfigMap = []assettypes.AssetConfig{
 			},
 		},
 	},
-	// Cluster-api-provider-cloudstack artifacts
-	{
-		ProjectName: "cluster-api-provider-cloudstack",
-		ProjectPath: "projects/kubernetes-sigs/cluster-api-provider-cloudstack",
-		Images: []*assettypes.Image{
-			{
-				RepoName:  "manager",
-				AssetName: "cluster-api-provider-cloudstack",
-			},
-		},
-		ImageRepoPrefix: "kubernetes-sigs/cluster-api-provider-cloudstack/release",
-		ImageTagOptions: []string{
-			"gitTag",
-			"projectPath",
-		},
-		Manifests: []*assettypes.ManifestComponent{
-			{
-				Name:          "infrastructure-cloudstack",
-				ManifestFiles: []string{"infrastructure-components.yaml", "metadata.yaml"},
-			},
-		},
-		UsesKubeRbacProxy: true,
-	},
+	// Cluster-api-provider-cloudstack has been deprecated and removed from the bundle release pipeline.
 	// Cluster-api-provider-docker artifacts
 	{
 		ProjectName: "cluster-api-provider-docker",

--- a/release/cli/pkg/bundles/bundles.go
+++ b/release/cli/pkg/bundles/bundles.go
@@ -126,10 +126,7 @@ func GetVersionsBundles(r *releasetypes.ReleaseConfig, imageDigests releasetypes
 		return nil, errors.Wrapf(err, "Error getting bundle for Tinkerbell infrastructure provider")
 	}
 
-	cloudStackBundle, err := GetCloudStackBundle(r, imageDigests)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error getting bundle for CloudStack infrastructure provider")
-	}
+	cloudStackBundle := GetDeprecatedCloudStackBundle()
 
 	nutanixBundle, err := GetNutanixBundle(r, imageDigests)
 	if err != nil {

--- a/release/cli/pkg/bundles/cloudstack.go
+++ b/release/cli/pkg/bundles/cloudstack.go
@@ -15,94 +15,32 @@
 package bundles
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
-
 	anywherev1alpha1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
-	"github.com/aws/eks-anywhere/release/cli/pkg/constants"
-	releasetypes "github.com/aws/eks-anywhere/release/cli/pkg/types"
-	"github.com/aws/eks-anywhere/release/cli/pkg/version"
 )
 
-func GetCloudStackBundle(r *releasetypes.ReleaseConfig, imageDigests releasetypes.ImageDigestsTable) (anywherev1alpha1.CloudStackBundle, error) {
-	projectsInBundle := []string{"cluster-api-provider-cloudstack", "kube-vip", "kube-rbac-proxy"}
-	cloudstackBundleArtifacts := map[string][]releasetypes.Artifact{}
-	for _, project := range projectsInBundle {
-		projectArtifacts, err := r.BundleArtifactsTable.Load(project)
-		if err != nil {
-			return anywherev1alpha1.CloudStackBundle{}, fmt.Errorf("artifacts for project %s not found in bundle artifacts table", project)
-		}
-		cloudstackBundleArtifacts[project] = projectArtifacts
+// GetDeprecatedCloudStackBundle returns a CloudStackBundle with placeholder values.
+// CloudStack has been deprecated and is no longer built or released.
+// Customers can override these placeholders via bundle override.
+func GetDeprecatedCloudStackBundle() anywherev1alpha1.CloudStackBundle {
+	return anywherev1alpha1.CloudStackBundle{
+		Version: "deprecated",
+		ClusterAPIController: anywherev1alpha1.Image{
+			Name: "cluster-api-provider-cloudstack",
+			URI:  "<placeholder>",
+		},
+		KubeRbacProxy: anywherev1alpha1.Image{
+			Name: "kube-rbac-proxy",
+			URI:  "<placeholder>",
+		},
+		KubeVip: anywherev1alpha1.Image{
+			Name: "kube-vip",
+			URI:  "<placeholder>",
+		},
+		Components: anywherev1alpha1.Manifest{
+			URI: "<placeholder>",
+		},
+		Metadata: anywherev1alpha1.Manifest{
+			URI: "<placeholder>",
+		},
 	}
-
-	var sourceBranch string
-	var componentChecksum string
-	bundleImageArtifacts := map[string]anywherev1alpha1.Image{}
-	bundleManifestArtifacts := map[string]anywherev1alpha1.Manifest{}
-	artifactHashes := []string{}
-	for componentName, artifacts := range cloudstackBundleArtifacts {
-		for _, artifact := range artifacts {
-			if artifact.Image != nil {
-				imageArtifact := artifact.Image
-				if componentName == "cluster-api-provider-cloudstack" {
-					sourceBranch = imageArtifact.SourcedFromBranch
-				}
-				imageDigest, err := imageDigests.Load(imageArtifact.ReleaseImageURI)
-				if err != nil {
-					return anywherev1alpha1.CloudStackBundle{}, fmt.Errorf("loading digest from image digests table: %v", err)
-				}
-				bundleImageArtifact := anywherev1alpha1.Image{
-					Name:        imageArtifact.AssetName,
-					Description: fmt.Sprintf("Container image for %s image", imageArtifact.AssetName),
-					OS:          imageArtifact.OS,
-					Arch:        imageArtifact.Arch,
-					URI:         imageArtifact.ReleaseImageURI,
-					ImageDigest: imageDigest,
-				}
-				bundleImageArtifacts[imageArtifact.AssetName] = bundleImageArtifact
-				artifactHashes = append(artifactHashes, bundleImageArtifact.ImageDigest)
-			}
-
-			if artifact.Manifest != nil {
-				manifestArtifact := artifact.Manifest
-				bundleManifestArtifact := anywherev1alpha1.Manifest{
-					URI: manifestArtifact.ReleaseCdnURI,
-				}
-
-				bundleManifestArtifacts[manifestArtifact.ReleaseName] = bundleManifestArtifact
-
-				manifestHash, err := version.GenerateManifestHash(r, manifestArtifact)
-				if err != nil {
-					return anywherev1alpha1.CloudStackBundle{}, err
-				}
-
-				artifactHashes = append(artifactHashes, manifestHash)
-			}
-		}
-	}
-
-	if r.DryRun {
-		componentChecksum = version.FakeComponentChecksum
-	} else {
-		componentChecksum = version.GenerateComponentHash(artifactHashes, r.DryRun)
-	}
-	version, err := version.BuildComponentVersion(
-		version.NewVersionerWithGITTAG(r.BuildRepoSource, constants.CapcProjectPath, sourceBranch, r),
-		componentChecksum,
-	)
-	if err != nil {
-		return anywherev1alpha1.CloudStackBundle{}, errors.Wrapf(err, "Error getting version for cluster-api-provider-cloudstack")
-	}
-
-	bundle := anywherev1alpha1.CloudStackBundle{
-		Version:              version,
-		ClusterAPIController: bundleImageArtifacts["cluster-api-provider-cloudstack"],
-		KubeVip:              bundleImageArtifacts["kube-vip"],
-		KubeRbacProxy:        bundleImageArtifacts["kube-rbac-proxy"],
-		Components:           bundleManifestArtifacts["infrastructure-components.yaml"],
-		Metadata:             bundleManifestArtifacts["metadata.yaml"],
-	}
-
-	return bundle, nil
 }

--- a/release/cli/pkg/constants/constants.go
+++ b/release/cli/pkg/constants/constants.go
@@ -28,7 +28,6 @@ const (
 
 	// Project paths.
 	CapasProjectPath                    = "projects/aws/cluster-api-provider-aws-snow"
-	CapcProjectPath                     = "projects/kubernetes-sigs/cluster-api-provider-cloudstack"
 	CapiProjectPath                     = "projects/kubernetes-sigs/cluster-api"
 	CaptProjectPath                     = "projects/tinkerbell/cluster-api-provider-tinkerbell"
 	CapvProjectPath                     = "projects/kubernetes-sigs/cluster-api-provider-vsphere"

--- a/release/cli/pkg/operations/testdata/main-bundle-release.yaml
+++ b/release/cli/pkg/operations/testdata/main-bundle-release.yaml
@@ -142,37 +142,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -914,37 +896,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -1686,37 +1650,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -2458,37 +2404,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -3230,37 +3158,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -4002,37 +3912,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -4774,37 +4666,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml
@@ -5546,37 +5420,19 @@ spec:
       version: v1.19.4-1
     cloudStack:
       clusterAPIController:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for cluster-api-provider-cloudstack image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: cluster-api-provider-cloudstack
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:v0.6.1-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       components:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/infrastructure-components.yaml
+        uri: <placeholder>
       kubeRbacProxy:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-rbac-proxy image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-rbac-proxy
-        os: linux
-        uri: public.ecr.aws/release-container-registry/brancz/kube-rbac-proxy:v0.20.2-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       kubeVip:
-        arch:
-        - amd64
-        - arm64
-        description: Container image for kube-vip image
-        imageDigest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
         name: kube-vip
-        os: linux
-        uri: public.ecr.aws/release-container-registry/kube-vip/kube-vip:v1.0.4-eks-a-v0.0.0-dev-build.1
+        uri: <placeholder>
       metadata:
-        uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api-provider-cloudstack/manifests/infrastructure-cloudstack/v0.6.1/metadata.yaml
-      version: v0.6.1+abcdef1
+        uri: <placeholder>
+      version: deprecated
     clusterAPI:
       components:
         uri: https://release-bucket/artifacts/v0.0.0-dev-build.0/cluster-api/manifests/cluster-api/v1.13.2/core-components.yaml


### PR DESCRIPTION
## Summary
- Remove CloudStack project (`cluster-api-provider-cloudstack`) from the bundle release asset config so artifacts are no longer built
- Replace `GetCloudStackBundle()` with `GetDeprecatedCloudStackBundle()` that returns placeholder values (`<placeholder>` URIs) so customers can still use bundle override to supply their own CAPC images/manifests
- Remove unused `CapcProjectPath` constant

## Context
PR #10786 deprecated CloudStack at the CLI consumer layer (skipping placeholder URIs in `Manifests()` and `CloudStackImages()`), but the release pipeline was still building and publishing real CloudStack artifacts into dev bundles. This PR completes the deprecation by stopping the release tooling from producing those artifacts.

## Test
- [x] `go build ./...` passes for `release/cli`
- [x] `go test ./pkg/bundles/` passes
- [x] Use Codebuild to generate the dev bundle: https://tiny.amazon.com/qqs5plnc/IsenLink, and the bundle looks as expected
<img width="1009" height="338" alt="Screenshot 2026-06-19 at 10 52 38" src="https://github.com/user-attachments/assets/a4c4aced-82ea-4705-883d-dbea9bacd4db" />

