### PR TITLE
Remove feature flag for Kubernetes 1.36 support

### DIFF
--- a/pkg/api/v1alpha1/cluster.go
+++ b/pkg/api/v1alpha1/cluster.go
@@ -230,7 +230,7 @@ func GetAndValidateClusterConfig(fileName string) (*Cluster, error) {
 
 // GetClusterDefaultKubernetesVersion returns the default kubernetes version for a Cluster.
 func GetClusterDefaultKubernetesVersion() KubernetesVersion {
-	return Kube135
+	return Kube136
 }
 
 // ValidateClusterConfigContent validates a Cluster object without modifying it

--- a/pkg/api/v1alpha1/cluster_test.go
+++ b/pkg/api/v1alpha1/cluster_test.go
@@ -4037,7 +4037,7 @@ func TestValidateEksaVersion(t *testing.T) {
 
 func TestGetClusterDefaultKubernetesVersion(t *testing.T) {
 	g := NewWithT(t)
-	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube135))
+	g.Expect(GetClusterDefaultKubernetesVersion()).To(Equal(Kube136))
 }
 
 func TestClusterWorkerNodeConfigCount(t *testing.T) {

--- a/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
+++ b/pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml
@@ -17,7 +17,7 @@ spec:
     upgradeRolloutStrategy:
       type: InPlace
   datacenterRef: {}
-  kubernetesVersion: "1.35"
+  kubernetesVersion: "1.36"
   managementCluster:
     name: test-cluster
   workerNodeGroupConfigurations:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -7,7 +7,6 @@ const (
 	UseControllerForCli             = "USE_CONTROLLER_FOR_CLI"
 	VSphereInPlaceEnvVar            = "VSPHERE_IN_PLACE_UPGRADE"
 	APIServerExtraArgsEnabledEnvVar = "API_SERVER_EXTRA_ARGS_ENABLED"
-	K8s136SupportEnvVar             = "K8S_1_36_SUPPORT"
 )
 
 func FeedGates(featureGates []string) {
@@ -58,10 +57,3 @@ func APIServerExtraArgsEnabled() Feature {
 	}
 }
 
-// K8s136Support is the feature flag for Kubernetes 1.36 support.
-func K8s136Support() Feature {
-	return Feature{
-		Name:     "Kubernetes version 1.36 support",
-		IsActive: globalFeatures.isActiveForEnvVar(K8s136SupportEnvVar),
-	}
-}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -86,10 +86,3 @@ func TestAPIServerExtraArgsEnabledFeatureFlag(t *testing.T) {
 	g.Expect(IsActive(APIServerExtraArgsEnabled())).To(BeTrue())
 }
 
-func TestWithK8s136FeatureFlag(t *testing.T) {
-	g := NewWithT(t)
-	setupContext(t)
-
-	g.Expect(os.Setenv(K8s136SupportEnvVar, "true")).To(Succeed())
-	g.Expect(IsActive(K8s136Support())).To(BeTrue())
-}

--- a/pkg/validations/cluster.go
+++ b/pkg/validations/cluster.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/logger"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/bundles"
@@ -384,12 +383,3 @@ func getReleaseManifestFromBundle(clusterSpec v1alpha1.Cluster, bundle *releasev
 	return releaseManifest, nil
 }
 
-// ValidateK8s136Support checks if the 1.36 feature flag is set when using k8s 1.36.
-func ValidateK8s136Support(clusterSpec *cluster.Spec) error {
-	if !features.IsActive(features.K8s136Support()) {
-		if clusterSpec.Cluster.Spec.KubernetesVersion == v1alpha1.Kube136 {
-			return fmt.Errorf("kubernetes version %s is not enabled. Please set the env variable %v", v1alpha1.Kube136, features.K8s136SupportEnvVar)
-		}
-	}
-	return nil
-}

--- a/pkg/validations/cluster_test.go
+++ b/pkg/validations/cluster_test.go
@@ -20,7 +20,6 @@ import (
 	internalmocks "github.com/aws/eks-anywhere/internal/test/mocks"
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/cluster"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/manifests"
 	"github.com/aws/eks-anywhere/pkg/manifests/releases"
 	"github.com/aws/eks-anywhere/pkg/providers"
@@ -1471,17 +1470,3 @@ spec:
 	g.Expect(err.Error()).To(ContainSubstring("unmarshalling eksd release manifest from URL"))
 }
 
-func TestValidateK8s136Support(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube136
-	tt.Expect(validations.ValidateK8s136Support(tt.clusterSpec)).To(
-		MatchError(ContainSubstring("kubernetes version 1.36 is not enabled. Please set the env variable K8S_1_36_SUPPORT")))
-}
-
-func TestValidateK8s136SupportActive(t *testing.T) {
-	tt := newTest(t)
-	tt.clusterSpec.Cluster.Spec.KubernetesVersion = anywherev1.Kube136
-	features.ClearCache()
-	os.Setenv(features.K8s136SupportEnvVar, "true")
-	tt.Expect(validations.ValidateK8s136Support(tt.clusterSpec)).To(Succeed())
-}

--- a/pkg/validations/createvalidations/preflightvalidations.go
+++ b/pkg/validations/createvalidations/preflightvalidations.go
@@ -7,7 +7,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validations"
 )
@@ -55,14 +54,6 @@ func (v *CreateValidations) PreflightValidations(ctx context.Context) []validati
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
 				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *v.Opts.Spec.Cluster, v.Opts.ManifestReader, v.Opts.KubeClient, v.Opts.BundlesOverride),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.36 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s136SupportEnvVar),
-				Err:         validations.ValidateK8s136Support(v.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/pkg/validations/upgradevalidations/preflightvalidations.go
+++ b/pkg/validations/upgradevalidations/preflightvalidations.go
@@ -9,7 +9,6 @@ import (
 	anywherev1 "github.com/aws/eks-anywhere/pkg/api/v1alpha1"
 	"github.com/aws/eks-anywhere/pkg/config"
 	"github.com/aws/eks-anywhere/pkg/constants"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/providers"
 	"github.com/aws/eks-anywhere/pkg/types"
 	"github.com/aws/eks-anywhere/pkg/validation"
@@ -128,14 +127,6 @@ func (u *UpgradeValidations) PreflightValidations(ctx context.Context) []validat
 				Name:        "validate extended kubernetes version support is supported",
 				Remediation: "ensure you have a valid license for extended Kubernetes version support",
 				Err:         validations.ValidateExtendedKubernetesVersionSupport(ctx, *u.Opts.Spec.Cluster, u.Opts.ManifestReader, u.Opts.KubeClient, u.Opts.BundlesOverride),
-			}
-		},
-		func() *validations.ValidationResult {
-			return &validations.ValidationResult{
-				Name:        "validate kubernetes version 1.36 support",
-				Remediation: fmt.Sprintf("ensure %v env variable is set", features.K8s136SupportEnvVar),
-				Err:         validations.ValidateK8s136Support(u.Opts.Spec),
-				Silent:      true,
 			}
 		},
 	}

--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -36,7 +36,6 @@ import (
 	"github.com/aws/eks-anywhere/pkg/cluster"
 	"github.com/aws/eks-anywhere/pkg/constants"
 	"github.com/aws/eks-anywhere/pkg/executables"
-	"github.com/aws/eks-anywhere/pkg/features"
 	"github.com/aws/eks-anywhere/pkg/filewriter"
 	"github.com/aws/eks-anywhere/pkg/git"
 	"github.com/aws/eks-anywhere/pkg/providers/cloudstack/decoder"
@@ -781,7 +780,6 @@ func (e *ClusterE2ETest) ChangeInstanceSecurityGroup(securityGroup string) {
 }
 
 func (e *ClusterE2ETest) CreateCluster(opts ...CommandOpt) {
-	e.setFeatureFlagForUnreleasedKubernetesVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion)
 	e.createCluster(opts...)
 }
 
@@ -917,7 +915,6 @@ func (e *ClusterE2ETest) upgradeCluster(clusterOpts []ClusterE2ETestOpt, command
 		opt(e)
 	}
 	e.buildClusterConfigFile()
-	e.setFeatureFlagForUnreleasedKubernetesVersion(e.ClusterConfig.Cluster.Spec.KubernetesVersion)
 	e.UpgradeCluster(commandOpts...)
 }
 
@@ -2391,14 +2388,3 @@ func (e *ClusterE2ETest) addClusterConfigFillers(fillers ...api.ClusterConfigFil
 	e.clusterConfigFillers = append(e.clusterConfigFillers, fillers...)
 }
 
-func (e *ClusterE2ETest) setFeatureFlagForUnreleasedKubernetesVersion(version v1alpha1.KubernetesVersion) {
-	// Update this variable to equal the feature flagged k8s version when applicable.
-	// For example, if k8s 1.36 is under a feature flag, we would set this to v1alpha1.Kube136
-	unreleasedK8sVersion := v1alpha1.Kube136
-
-	if version == unreleasedK8sVersion {
-		// Set feature flag for the unreleased k8s version when applicable
-		e.T.Logf("Setting k8s version support feature flag...")
-		os.Setenv(features.K8s136SupportEnvVar, "true")
-	}
-}


### PR DESCRIPTION
## Summary
- Remove the `K8S_1_36_SUPPORT` feature flag gating Kubernetes 1.36 usage
- Update default Kubernetes version from 1.35 to 1.36
- Remove associated validation functions, tests, and test framework helpers

## Description
Kubernetes 1.36 is now GA and no longer needs to be behind a feature flag. This follows the same pattern as [PR #6830](https://github.com/aws/eks-anywhere/pull/6830) which removed the k8s 1.35 feature flag.

Changes across 10 files:
- `pkg/features/features.go` — Remove `K8s136SupportEnvVar` constant and `K8s136Support()` function
- `pkg/features/features_test.go` — Remove `TestWithK8s136FeatureFlag` test
- `pkg/validations/cluster.go` — Remove `ValidateK8s136Support()` function
- `pkg/validations/cluster_test.go` — Remove associated tests
- `pkg/validations/createvalidations/preflightvalidations.go` — Remove k8s 1.36 validation entry
- `pkg/validations/upgradevalidations/preflightvalidations.go` — Remove k8s 1.36 validation entry
- `pkg/api/v1alpha1/cluster.go` — Update default version to 1.36
- `pkg/api/v1alpha1/cluster_test.go` — Update test expectation
- `pkg/api/v1alpha1/testdata/cluster_in_place_upgrade.yaml` — Update expected YAML
- `test/framework/cluster.go` — Remove `setFeatureFlagForUnreleasedKubernetesVersion()` helper and its calls

## Test plan
- [x] Unit tests pass for `pkg/features`, `pkg/validations`, `pkg/api/v1alpha1`
- [x] E2E tests for Kubernetes 1.36 run without needing `K8S_1_36_SUPPORT=true`