### PR TITLE
Fix missing control-plane toleration for kube-vip DaemonSet

### DIFF
--- a/pkg/providers/tinkerbell/stack/stack.go
+++ b/pkg/providers/tinkerbell/stack/stack.go
@@ -654,6 +654,13 @@ func (s *Installer) createValuesOverride(bundle releasev1alpha1.TinkerbellBundle
 			"kubevip": map[string]any{
 				"enabled": s.loadBalancer,
 				"image":   kubevipImageURI,
+				"tolerations": []map[string]any{
+					{
+						"key":      "node-role.kubernetes.io/control-plane",
+						"operator": "Exists",
+						"effect":   "NoSchedule",
+					},
+				},
 				"additionalEnv": []map[string]string{
 					{
 						"name":  "prometheus_server",

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_upgrade_with_proxy.yaml
@@ -76,6 +76,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_docker.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_boots_on_kubernetes.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_docker_options.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_iso_override.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_hook_override.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_false.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_host_port_enabled_true.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_kubernetes_options.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_false.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_enabled_true.yaml
@@ -73,6 +73,10 @@ optional:
       value: "true"
     enabled: true
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_load_balancer_interface.yaml
@@ -75,6 +75,10 @@ optional:
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
     interface: test-interface
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_proxy_config.yaml
@@ -76,6 +76,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class

--- a/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
+++ b/pkg/providers/tinkerbell/stack/testdata/expected_with_registry_mirror.yaml
@@ -76,6 +76,10 @@ optional:
       value: "true"
     enabled: false
     image: public.ecr.aws/eks-anywhere/kube-vip:latest
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 publicIP: 1.2.3.4
 service:
   lbClass: kube-vip.io/kube-vip-class


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The migration from the legacy tinkerbell-chart (per-component singleNodeClusterConfig) to the mono-repo tinkerbell chart dropped the control-plane NoSchedule toleration from the kube-vip DaemonSet values. This caused kube-vip pods to not schedule on control-plane nodes during upgrades to v0.25.x, blocking the tinkerbellIP VIP creation and stalling cluster upgrades.

Add the toleration to optional.kubevip in the Helm values override so the new chart's kube-vip DaemonSet template renders it correctly.

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

