### PR TITLE
Fix panic in getLatestOCIShaTag when no matching images found

### DIFF
--- a/release/cli/pkg/aws/ecr/ecr.go
+++ b/release/cli/pkg/aws/ecr/ecr.go
@@ -17,7 +17,6 @@ package ecr
 import (
 	"encoding/base64"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -152,10 +151,10 @@ func imageTagFilter(details []*ecr.ImageDetail, substring string) []*ecr.ImageDe
 
 // getLatestOCIShaTag is used to find the tag/sha of the latest pushed OCI image from a list.
 func getLatestOCIShaTag(details []*ecr.ImageDetail, branchName string, isHelmChart bool) (string, string, error) {
-	latest := &ecr.ImageDetail{}
-	latest.ImagePushedAt = &time.Time{}
+	var latest *ecr.ImageDetail
+	var latestPushedAt time.Time
 	for _, detail := range details {
-		if len(details) < 1 || detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 {
+		if detail.ImagePushedAt == nil || detail.ImageDigest == nil || detail.ImageTags == nil || len(detail.ImageTags) == 0 {
 			continue
 		}
 
@@ -174,23 +173,25 @@ func getLatestOCIShaTag(details []*ecr.ImageDetail, branchName string, isHelmCha
 				}
 			} else {
 				// Exclude image if none of the tags contain the branchName
+				found := false
 				for _, tag := range detail.ImageTags {
 					if strings.Contains(*tag, branchName) {
-						skip = true
+						found = true
 						break
 					}
 				}
-				if !skip {
+				if !found {
 					continue
 				}
 			}
 		}
 
-		if detail.ImagePushedAt != nil && latest.ImagePushedAt.Before(*detail.ImagePushedAt) {
+		if detail.ImagePushedAt.After(latestPushedAt) {
 			latest = detail
+			latestPushedAt = *detail.ImagePushedAt
 		}
 	}
-	if reflect.DeepEqual(latest, ecr.ImageDetail{}) {
+	if latest == nil {
 		return "", "", fmt.Errorf("no images found")
 	}
 	return *latest.ImageTags[0], *latest.ImageDigest, nil


### PR DESCRIPTION
## Summary
- Fix `index out of range [0] with length 0` panic in `getLatestOCIShaTag` during dev-release bundle generation
- The `reflect.DeepEqual` check compared a pointer (`*ecr.ImageDetail`) to a value (`ecr.ImageDetail{}`), which never evaluated to true — so the "no images found" error path was unreachable
- When no ECR images match the branch-name filter (e.g. no helm charts tagged with `release-0.26`), the function now returns a proper error instead of panicking

## Root Cause
The `aws-dev-release` CodeBuild on `release-0.26` panics at `ecr.go:196` because:
1. `getLatestOCIShaTag` iterates images looking for tags containing the branch name
2. When no images match, `latest` remains a zero-value struct with nil `ImageTags`
3. The guard `reflect.DeepEqual(latest, ecr.ImageDetail{})` never fires (pointer vs value comparison)
4. `*latest.ImageTags[0]` panics

## Test plan
- [x] `go build ./...` passes for the release CLI
- [ ] Re-run `aws-dev-release` CodeBuild on `release-0.26` after merge — should either succeed or print a graceful error and continue