### PR TITLE
Fix control plane taint not set for CAPI v1.13+ readiness gate

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -173,14 +173,14 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 					NodeRegistration: bootstrapv1beta2.NodeRegistrationOptions{
 						KubeletExtraArgs: SecureTlsCipherSuitesExtraArgs().
 							Append(ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration)).ToArgs(),
-						Taints: taintsToPtr(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints),
+						Taints: ControlPlaneTaintsToPtr(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints),
 					},
 				},
 				JoinConfiguration: bootstrapv1beta2.JoinConfiguration{
 					NodeRegistration: bootstrapv1beta2.NodeRegistrationOptions{
 						KubeletExtraArgs: SecureTlsCipherSuitesExtraArgs().
 							Append(ControlPlaneNodeLabelsExtraArgs(clusterSpec.Cluster.Spec.ControlPlaneConfiguration)).ToArgs(),
-						Taints: taintsToPtr(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints),
+						Taints: ControlPlaneTaintsToPtr(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints),
 					},
 				},
 				PreKubeadmCommands:  []string{},

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -558,3 +558,30 @@ func TestEtcdadmCluster(t *testing.T) {
 	want := wantEtcdCluster()
 	tt.Expect(got).To(Equal(want))
 }
+
+func TestKubeadmControlPlaneWithNilTaints(t *testing.T) {
+	tt := newApiBuilerTest(t)
+	// Set taints to nil to test the default taint behavior
+	tt.clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints = nil
+
+	got, err := clusterapi.KubeadmControlPlane(tt.clusterSpec, tt.providerMachineTemplate)
+	tt.Expect(err).To(Succeed())
+
+	// Verify that the default control-plane taint is set when taints are nil
+	expectedTaint := v1.Taint{
+		Key:    "node-role.kubernetes.io/control-plane",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	// Check InitConfiguration NodeRegistration Taints
+	initTaints := got.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.Taints
+	tt.Expect(initTaints).NotTo(BeNil())
+	tt.Expect(*initTaints).To(HaveLen(1))
+	tt.Expect((*initTaints)[0]).To(Equal(expectedTaint))
+
+	// Check JoinConfiguration NodeRegistration Taints
+	joinTaints := got.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.Taints
+	tt.Expect(joinTaints).NotTo(BeNil())
+	tt.Expect(*joinTaints).To(HaveLen(1))
+	tt.Expect((*joinTaints)[0]).To(Equal(expectedTaint))
+}

--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -161,3 +161,26 @@ func taintsToPtr(t []corev1.Taint) *[]corev1.Taint {
 	}
 	return &t
 }
+
+// DefaultControlPlaneTaint returns the default taint for control plane nodes.
+// This taint prevents workloads from being scheduled on control plane nodes unless they
+// explicitly tolerate it.
+func DefaultControlPlaneTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "node-role.kubernetes.io/control-plane",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+// ControlPlaneTaintsToPtr returns a pointer to the taints slice for control plane nodes.
+// If the input slice is nil, it returns a pointer to a slice containing the default
+// control-plane NoSchedule taint. This ensures that control plane nodes always have
+// explicit taints specified, which is required by CAPI v1.13+ for the
+// NodeKubeadmLabelsAndTaintsSet readiness gate to work correctly.
+func ControlPlaneTaintsToPtr(t []corev1.Taint) *[]corev1.Taint {
+	if t == nil {
+		defaultTaints := []corev1.Taint{DefaultControlPlaneTaint()}
+		return &defaultTaints
+	}
+	return &t
+}

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -582,3 +582,59 @@ func contractReference(obj client.Object) clusterv1beta2.ContractVersionedObject
 		Name:     obj.GetName(),
 	}
 }
+
+func TestDefaultControlPlaneTaint(t *testing.T) {
+	g := NewWithT(t)
+	taint := clusterapi.DefaultControlPlaneTaint()
+	g.Expect(taint.Key).To(Equal("node-role.kubernetes.io/control-plane"))
+	g.Expect(taint.Effect).To(Equal(corev1.TaintEffectNoSchedule))
+	g.Expect(taint.Value).To(BeEmpty())
+}
+
+func TestControlPlaneTaintsToPtr(t *testing.T) {
+	tests := []struct {
+		name   string
+		taints []corev1.Taint
+		want   *[]corev1.Taint
+	}{
+		{
+			name:   "nil taints should return default control-plane taint",
+			taints: nil,
+			want: &[]corev1.Taint{
+				{
+					Key:    "node-role.kubernetes.io/control-plane",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name:   "empty taints should return empty taints (not default)",
+			taints: []corev1.Taint{},
+			want:   &[]corev1.Taint{},
+		},
+		{
+			name: "custom taints should be preserved",
+			taints: []corev1.Taint{
+				{
+					Key:    "custom-key",
+					Value:  "custom-value",
+					Effect: corev1.TaintEffectNoExecute,
+				},
+			},
+			want: &[]corev1.Taint{
+				{
+					Key:    "custom-key",
+					Value:  "custom-value",
+					Effect: corev1.TaintEffectNoExecute,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := clusterapi.ControlPlaneTaintsToPtr(tt.taints)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -168,6 +168,7 @@ func wantKubeadmControlPlane(kubeVersion v1alpha1.KubernetesVersion) *controlpla
 								{Name: "provider-id", Value: &pid},
 							}
 						}(),
+						Taints: &[]v1.Taint{{Key: "node-role.kubernetes.io/control-plane", Effect: v1.TaintEffectNoSchedule}},
 					},
 				},
 				JoinConfiguration: bootstrapv1beta2.JoinConfiguration{
@@ -180,6 +181,7 @@ func wantKubeadmControlPlane(kubeVersion v1alpha1.KubernetesVersion) *controlpla
 								{Name: "provider-id", Value: &pid},
 							}
 						}(),
+						Taints: &[]v1.Taint{{Key: "node-role.kubernetes.io/control-plane", Effect: v1.TaintEffectNoSchedule}},
 					},
 				},
 				PreKubeadmCommands: []string{

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -771,6 +771,10 @@ spec:
         - name: tls-cipher-suites
           value: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: ""
+            effect: NoSchedule
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -784,6 +788,10 @@ spec:
         - name: tls-cipher-suites
           value: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: ""
+            effect: NoSchedule
     preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts

--- a/pkg/providers/vsphere/template.go
+++ b/pkg/providers/vsphere/template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	vspherev1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	bootstrapv1beta2 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	"sigs.k8s.io/yaml"
@@ -369,7 +370,9 @@ func buildTemplateMapCP(
 		}
 	}
 
-	if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
+	if clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints == nil {
+		values["controlPlaneTaints"] = []corev1.Taint{clusterapi.DefaultControlPlaneTaint()}
+	} else if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
 		values["controlPlaneTaints"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints
 	}
 

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -355,6 +355,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -368,6 +372,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -648,6 +656,9 @@ data:
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
           volumes:
           - configMap:
               name: vsphere-cloud-config

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -355,6 +355,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -368,6 +372,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -648,6 +656,9 @@ data:
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
           volumes:
           - configMap:
               name: vsphere-cloud-config

--- a/pkg/providers/vsphere/testdata/expected_kcp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp.yaml
@@ -362,6 +362,10 @@ spec:
         - name: cloud-provider
           value: "external"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     joinConfiguration:
       patches: 
         directory: /etc/kubernetes/patches
@@ -371,6 +375,10 @@ spec:
         - name: cloud-provider
           value: "external"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -707,6 +715,9 @@ data:
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
           volumes:
           - configMap:
               name: vsphere-cloud-config

--- a/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
@@ -381,6 +381,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     joinConfiguration:
       pause:
         imageRepository: public.ecr.aws/eks-distro/kubernetes/pause
@@ -405,6 +409,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -735,6 +743,9 @@ data:
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
           volumes:
           - configMap:
               name: vsphere-cloud-config

--- a/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
@@ -381,6 +381,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     joinConfiguration:
       pause:
         imageRepository: public.ecr.aws/eks-distro/kubernetes/pause
@@ -405,6 +409,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     ntp:
       enabled: true
       servers: 
@@ -739,6 +747,9 @@ data:
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
           volumes:
           - configMap:
               name: vsphere-cloud-config

--- a/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
@@ -360,6 +360,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
@@ -373,6 +377,10 @@ spec:
         - name: tls-cipher-suites
           value: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
         name: '{{ ds.meta_data.hostname }}'
+        taints:
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
     preKubeadmCommands:
     - hostname "{{ ds.meta_data.hostname }}"
     - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
@@ -712,6 +720,9 @@ data:
             key: node-role.kubernetes.io/control-plane
           - effect: NoSchedule
             key: node.kubernetes.io/not-ready
+          - key: node-role.kubernetes.io/control-plane
+            value: 
+            effect: NoSchedule
           volumes:
           - configMap:
               name: vsphere-cloud-config


### PR DESCRIPTION
## Issue

The `TestVSphereKubernetes136BottlerocketEtcdScaleDown` and `TestVSphereKubernetes136BottlerocketEtcdScaleUp` tests failed because a new control plane machine remained stuck in `Provisioning` phase for over 44 minutes during etcd scale operations.

**Note:** The Ubuntu test (`TestVSphereKubernetes136UbuntuEtcdScaleDown`) passed because Ubuntu uses cloud-init format where kubeadm automatically applies default taints. This issue is **specific to Bottlerocket** due to how the bootstrap provider handles the `bottlerocket` format differently.

## Root Cause

Starting with CAPI v1.13.x, a new Machine condition called `NodeKubeadmLabelsAndTaintsSet` was introduced as part of the readiness gate mechanism. This condition requires that:
1. The `node-role.kubernetes.io/control-plane` label is present on control plane nodes
2. The `node-role.kubernetes.io/control-plane:NoSchedule` taint is present on control plane nodes

The KubeadmControlPlane (KCP) controller waits for both the label and taint to be set before marking the machine as ready.

### Why Bottlerocket Fails but Ubuntu Passes

| OS | Bootstrap Format | When taints=nil | Result |
|----|------------------|-----------------|--------|
| **Ubuntu/RHEL** | `cloud-init` | kubeadm automatically adds default control-plane taint | ✅ Works |
| **Bottlerocket** | `bottlerocket` | No taint is set (requires explicit configuration) | ❌ Fails |

**Ubuntu (cloud-init format):**
- The CAPI kubeadm bootstrap provider generates a cloud-init script that runs `kubeadm init/join`
- When `nodeRegistration.taints` is `nil`, kubeadm itself applies the default control-plane taint as part of its standard behavior

**Bottlerocket (bottlerocket format):**
- The bootstrap provider generates Bottlerocket-specific TOML configuration instead of cloud-init
- Bottlerocket uses a bootstrap container that interprets this configuration
- Taints must be explicitly specified in Bottlerocket's `settings.kubernetes.node-taints` setting
- When `nodeRegistration.taints` is `nil`, the bootstrap provider does NOT generate any taint configuration, so no taints are applied

### The Bug

1. `pkg/providers/vsphere/template.go`** (used by vSphere provider via YAML templates):
```go
if len(clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints) > 0 {
    values["controlPlaneTaints"] = clusterSpec.Cluster.Spec.ControlPlaneConfiguration.Taints
}
```

Both paths returned nil/skipped setting taints when the input was nil, causing Bottlerocket nodes to never get the default control-plane taint.

### Evidence from Support Bundle

**Machine Condition** (from `machines.cluster.x-k8s.io`):
```
NodeKubeadmLabelsAndTaintsSet: False
```

**KCP Controller Logs**:
```
machines="release-i-01eb7-b001d6d-zhd5c (kubeadm labels and taints not set)"
```

**KubeadmConfig Format**:
```yaml
format: bottlerocket
```

## Testing

### Unit Tests Added
- `TestDefaultControlPlaneTaint`: Verifies the default taint has correct key and effect
- `TestControlPlaneTaintsToPtr`: Verifies behavior for nil, empty, and custom taints
- `TestKubeadmControlPlaneWithNilTaints`: Verifies KubeadmControlPlane uses default taint when none specified
- Updated vSphere golden test files to include the default taint

## Impact

- **Backward Compatible**: Users who had custom taints configured will see no change
- **Default Behavior Change**: Users who had no taints specified will now get the standard control-plane taint (which is the expected Kubernetes behavior)
- **Untainted Control Planes**: Users who explicitly want untainted control planes can set `taints: []` in their cluster configuration
- **Bottlerocket Fix**: This specifically fixes the issue where Bottlerocket clusters were not getting the default taint

## Related Links

- [CAPI v1.12 to v1.13 Migration Guide](https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.12-to-v1.13)
- [CAPI Issue #7149: Create an untainted control plane with KCP](https://github.com/kubernetes-sigs/cluster-api/issues/7149)
- [CAPI Troubleshooting: Labeling nodes with reserved labels](https://cluster-api.sigs.k8s.io/user/troubleshooting#labeling-nodes-with-reserved-labels-such-as-node-rolekubernetesio-fails-with-kubeadm-error-during-bootstrap)
- [Bottlerocket Kubernetes Settings](https://bottlerocket.dev/en/os/1.47.x/api/settings/kubernetes/)

## Checklist

- [x] Code compiles correctly
- [x] Unit tests added and passing
- [x] Existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
