### PR TITLE
Fix control plane label not set for CAPI v1.13+ readiness gate

### DIFF
--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -142,6 +142,9 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 		},
 		Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: DefaultControlPlaneLabels(),
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						APIGroup: infrastructureObject.GetObjectKind().GroupVersionKind().Group,

--- a/pkg/clusterapi/apibuilder.go
+++ b/pkg/clusterapi/apibuilder.go
@@ -142,7 +142,7 @@ func KubeadmControlPlane(clusterSpec *cluster.Spec, infrastructureObject APIObje
 		},
 		Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
-				ObjectMeta: clusterv1.ObjectMeta{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
 					Labels: DefaultControlPlaneLabels(),
 				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -285,6 +285,9 @@ func wantKubeadmControlPlane(opts ...kubeadmControlPlaneOpt) *controlplanev1beta
 		},
 		Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
+					Labels: clusterapi.DefaultControlPlaneLabels(),
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						APIGroup: "infrastructure.cluster.x-k8s.io",

--- a/pkg/clusterapi/apibuilder_test.go
+++ b/pkg/clusterapi/apibuilder_test.go
@@ -585,3 +585,18 @@ func TestKubeadmControlPlaneWithNilTaints(t *testing.T) {
 	tt.Expect(*joinTaints).To(HaveLen(1))
 	tt.Expect((*joinTaints)[0]).To(Equal(expectedTaint))
 }
+
+func TestKubeadmControlPlaneHasControlPlaneLabel(t *testing.T) {
+	tt := newApiBuilerTest(t)
+
+	got, err := clusterapi.KubeadmControlPlane(tt.clusterSpec, tt.providerMachineTemplate)
+	tt.Expect(err).To(Succeed())
+
+	// Verify that the machineTemplate has the control-plane label
+	// This label is required by CAPI v1.13+ for the NodeKubeadmLabelsAndTaintsSet
+	// readiness gate condition to pass. The CAPI Machine controller syncs labels
+	// in the node-role.kubernetes.io/ prefix from Machine to Node.
+	labels := got.Spec.MachineTemplate.ObjectMeta.Labels
+	tt.Expect(labels).NotTo(BeNil())
+	tt.Expect(labels).To(HaveKeyWithValue("node-role.kubernetes.io/control-plane", ""))
+}

--- a/pkg/clusterapi/identity_test.go
+++ b/pkg/clusterapi/identity_test.go
@@ -44,6 +44,9 @@ func TestConfigureAPIServerExtraArgsInKubeadmControlPlane(t *testing.T) {
 				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 					MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+						ObjectMeta: clusterv1beta2.ObjectMeta{
+							Labels: clusterapi.DefaultControlPlaneLabels(),
+						},
 						Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 							InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 								APIGroup: "infrastructure.cluster.x-k8s.io",
@@ -180,6 +183,9 @@ func TestConfigureAWSIAMAuthInKubeadmControlPlane(t *testing.T) {
 				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 					MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+						ObjectMeta: clusterv1beta2.ObjectMeta{
+							Labels: clusterapi.DefaultControlPlaneLabels(),
+						},
 						Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 							InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 								APIGroup: "infrastructure.cluster.x-k8s.io",
@@ -378,6 +384,9 @@ func TestConfigureOIDCInKubeadmControlPlane(t *testing.T) {
 				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 					MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+						ObjectMeta: clusterv1beta2.ObjectMeta{
+							Labels: clusterapi.DefaultControlPlaneLabels(),
+						},
 						Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 							InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 								APIGroup: "infrastructure.cluster.x-k8s.io",
@@ -501,6 +510,9 @@ func TestConfigurePodIamAuthInKubeadmControlPlane(t *testing.T) {
 				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 					MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+						ObjectMeta: clusterv1beta2.ObjectMeta{
+							Labels: clusterapi.DefaultControlPlaneLabels(),
+						},
 						Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 							InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 								APIGroup: "infrastructure.cluster.x-k8s.io",

--- a/pkg/clusterapi/workers.go
+++ b/pkg/clusterapi/workers.go
@@ -184,3 +184,20 @@ func ControlPlaneTaintsToPtr(t []corev1.Taint) *[]corev1.Taint {
 	}
 	return &t
 }
+
+// ControlPlaneNodeRoleLabel is the standard Kubernetes label for identifying control plane nodes.
+// This label is used by kubectl to display the ROLES column and is expected by CAPI v1.13+
+// for the NodeKubeadmLabelsAndTaintsSet readiness gate to be satisfied.
+// The CAPI Machine controller syncs labels in the node-role.kubernetes.io/ prefix from
+// Machine to Node, so this label must be set on the Machine template.
+const ControlPlaneNodeRoleLabel = "node-role.kubernetes.io/control-plane"
+
+// DefaultControlPlaneLabels returns the default labels for control plane machines.
+// These labels are synced from the Machine to the Node by the CAPI Machine controller.
+// The node-role.kubernetes.io/control-plane label is required by CAPI v1.13+ for the
+// NodeKubeadmLabelsAndTaintsSet readiness gate condition to pass.
+func DefaultControlPlaneLabels() map[string]string {
+	return map[string]string{
+		ControlPlaneNodeRoleLabel: "",
+	}
+}

--- a/pkg/clusterapi/workers_test.go
+++ b/pkg/clusterapi/workers_test.go
@@ -638,3 +638,15 @@ func TestControlPlaneTaintsToPtr(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultControlPlaneLabels(t *testing.T) {
+	g := NewWithT(t)
+	labels := clusterapi.DefaultControlPlaneLabels()
+	g.Expect(labels).To(HaveKeyWithValue("node-role.kubernetes.io/control-plane", ""))
+	g.Expect(labels).To(HaveLen(1))
+}
+
+func TestControlPlaneNodeRoleLabelConstant(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(clusterapi.ControlPlaneNodeRoleLabel).To(Equal("node-role.kubernetes.io/control-plane"))
+}

--- a/pkg/providers/cloudstack/config/template-cp.yaml
+++ b/pkg/providers/cloudstack/config/template-cp.yaml
@@ -61,6 +61,9 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/cloudstack/controlplane_test.go
+++ b/pkg/providers/cloudstack/controlplane_test.go
@@ -301,6 +301,9 @@ func kubeadmControlPlane(opts ...func(*controlplanev1beta2.KubeadmControlPlane))
 		},
 		Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
+					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						APIGroup: "infrastructure.cluster.x-k8s.io",

--- a/pkg/providers/cloudstack/reconciler/reconciler_test.go
+++ b/pkg/providers/cloudstack/reconciler/reconciler_test.go
@@ -590,6 +590,9 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		kcp.ObjectMeta.Generation = 2
 		kcp.Spec = controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
+					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						Name: fmt.Sprintf("%s-control-plane-1", cluster.Name),

--- a/pkg/providers/cloudstack/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -53,6 +53,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/cloudstack/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -53,6 +53,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/cloudstack/testdata/expected_kcp.yaml
+++ b/pkg/providers/cloudstack/testdata/expected_kcp.yaml
@@ -53,6 +53,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/docker/config/template-cp.yaml
+++ b/pkg/providers/docker/config/template-cp.yaml
@@ -55,6 +55,9 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/docker/controlplane_test.go
+++ b/pkg/providers/docker/controlplane_test.go
@@ -460,6 +460,9 @@ func kubeadmControlPlane(opts ...func(*controlplanev1beta2.KubeadmControlPlane))
 		},
 		Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
+					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						APIGroup: "infrastructure.cluster.x-k8s.io",

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -49,6 +49,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/docker/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -49,6 +49,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/config/cp-template.yaml
+++ b/pkg/providers/nutanix/config/cp-template.yaml
@@ -98,6 +98,9 @@ spec:
   replicas: {{.controlPlaneReplicas}}
   version: "{{.kubernetesVersion}}"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_additional_trust_bundle.yaml
@@ -81,6 +81,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 1
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 1
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_cluster_ccm_exclude_node_ips.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cluster_ccm_exclude_node_ips.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_cp.yaml
+++ b/pkg/providers/nutanix/testdata/expected_cp.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_additional_categories.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_bootType.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_bootType.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 1
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_etcd_encryption_1_29.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 1
   version: "v1.29.0-eks-1-29-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd.yaml
@@ -52,6 +52,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_external_etcd_with_optional.yaml
@@ -52,6 +52,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_failure_domains.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_failure_domains.yaml
@@ -68,6 +68,9 @@ spec:
   replicas: 1
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_gpus.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_gpus.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_iamauth.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_irsa.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_multi_worker_fds.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_multi_worker_fds.yaml
@@ -64,6 +64,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_node_taints_labels.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_oidc.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_project.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_project.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_proxy.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_registry_mirror.yaml
@@ -48,6 +48,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/nutanix/testdata/expected_results_worker_fds.yaml
+++ b/pkg/providers/nutanix/testdata/expected_results_worker_fds.yaml
@@ -64,6 +64,9 @@ spec:
   replicas: 3
   version: "v1.19.8-eks-1-19-4"
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/snow/apibuilder_test.go
+++ b/pkg/providers/snow/apibuilder_test.go
@@ -120,6 +120,9 @@ func wantKubeadmControlPlane(kubeVersion v1alpha1.KubernetesVersion) *controlpla
 		},
 		Spec: controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
+					Labels: clusterapi.DefaultControlPlaneLabels(),
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						APIGroup: "infrastructure.cluster.x-k8s.io",

--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -499,6 +499,9 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
     format: {{.format}}
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -554,6 +554,9 @@ spec:
       rollingUpdate:
         maxSurge: 1
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
@@ -933,6 +936,9 @@ spec:
       rollingUpdate:
         maxSurge: 1
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -1391,6 +1391,9 @@ func tinkerbellCP(clusterName string, opts ...cpOpt) *tinkerbell.ControlPlane {
 					},
 					Version: "v1.19.8",
 					MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+						ObjectMeta: clusterv1beta2.ObjectMeta{
+							Labels: clusterapi.DefaultControlPlaneLabels(),
+						},
 						Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 							InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 								APIGroup: "infrastructure.cluster.x-k8s.io",

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
@@ -316,6 +316,9 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
     format: cloud-config
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
@@ -316,6 +316,9 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
     format: cloud-config
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
@@ -319,6 +319,9 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
     format: cloud-config
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
@@ -306,6 +306,9 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
     format: cloud-config
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
@@ -306,6 +306,9 @@ spec:
       sudo: ALL=(ALL) NOPASSWD:ALL
     format: cloud-config
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/config/template-cp.yaml
+++ b/pkg/providers/vsphere/config/template-cp.yaml
@@ -82,6 +82,9 @@ metadata:
   namespace: {{.eksaSystemNamespace}}
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/controlplane_test.go
+++ b/pkg/providers/vsphere/controlplane_test.go
@@ -485,6 +485,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/reconciler/reconciler_test.go
+++ b/pkg/providers/vsphere/reconciler/reconciler_test.go
@@ -496,6 +496,9 @@ func newReconcilerTest(t testing.TB) *reconcilerTest {
 		kcp.Name = cluster.Name
 		kcp.Spec = controlplanev1beta2.KubeadmControlPlaneSpec{
 			MachineTemplate: controlplanev1beta2.KubeadmControlPlaneMachineTemplate{
+				ObjectMeta: clusterv1beta2.ObjectMeta{
+					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				},
 				Spec: controlplanev1beta2.KubeadmControlPlaneMachineTemplateSpec{
 					InfrastructureRef: clusterv1beta2.ContractVersionedObjectReference{
 						Name: fmt.Sprintf("%s-control-plane-1", cluster.Name),

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_domain_name.yaml
@@ -66,6 +66,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
+++ b/pkg/providers/vsphere/testdata/expected_cluster_api_server_cert_san_ip.yaml
@@ -66,6 +66,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/testdata/expected_kcp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp.yaml
@@ -71,6 +71,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br.yaml
@@ -71,6 +71,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_br_ntp.yaml
@@ -71,6 +71,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
+++ b/pkg/providers/vsphere/testdata/expected_kcp_vcenter_tags.yaml
@@ -74,6 +74,9 @@ metadata:
   namespace: eksa-system
 spec:
   machineTemplate:
+    metadata:
+      labels:
+        node-role.kubernetes.io/control-plane: ""
     spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
This fix ensures that control plane machines have the node-role.kubernetes.io/control-plane label set on the Machine template, which the CAPI Machine controller then syncs to the Node.

Problem:
- CAPI v1.13.x introduced the NodeKubeadmLabelsAndTaintsSet readiness gate that requires BOTH the control plane label AND taint to be present on nodes before they are considered ready.
- PR #10838 fixed the taint issue but the label was still missing.
- The CAPI Machine controller syncs labels in the node-role.kubernetes.io/ prefix from Machine to Node, but the Machine template wasn't setting this label.
- This caused machines to have the taint but not the label, keeping the NodeKubeadmLabelsAndTaintsSet condition stuck at False.

Solution:
- Add DefaultControlPlaneLabels() function that returns the standard node-role.kubernetes.io/control-plane label.
- Set this label on the MachineTemplate.ObjectMeta.Labels in the KubeadmControlPlane spec.
- Update vSphere template to include the label in machineTemplate.

The fix applies to both the Go code path (used by Snow provider) and the template-based code path (used by vSphere provider).

Related to PR #10838 which fixed the taint portion of this issue.


<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

