### PR TITLE
Add license token to Tinkerbell 1.32 upgrade test

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -617,6 +617,7 @@ func TestTinkerbellKubernetes134RedHat9SimpleFlow(t *testing.T) {
 
 func TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly(t *testing.T) {
 	provider := framework.NewTinkerbell(t)
+	licenseToken := framework.GetLicenseToken()
 	kube132 := v1alpha1.Kube132
 	test := framework.NewClusterE2ETest(
 		t,
@@ -630,6 +631,9 @@ func TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly(t *testing.T) {
 	).WithClusterConfig(
 		provider.WithCPKubeVersionAndOS(kube132, framework.Ubuntu2204),
 		provider.WithWorkerKubeVersionAndOS(kube132, framework.Ubuntu2204),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
 		test,


### PR DESCRIPTION
*Issue #, if available:*
N/A (TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly never passed in release-0.26 nightly runs)

*Description of changes:*
Add license token to TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly.

Kubernetes 1.32 passed endOfStandardSupport on 2026-04-30, so creating a 1.32 cluster now requires a license token. This test uses `.WithClusterConfig()` which bypasses the automatic token injection in `GenerateClusterConfig()`, causing preflight to fail with "licenseToken is required for extended kubernetes support". The fix adds `api.WithLicenseToken(framework.GetLicenseToken())` to the cluster config, matching the pattern used in similar tests (e.g. TestTinkerbellKubernetes131UbuntuTo132UpgradeCPOnly).

*Testing (if applicable):*
- `gofmt` passes
- `go build ./test/e2e/...` passes
- Did not run e2e locally (Tinkerbell hardware environment not set up locally)
- Validated that the change mirrors the working pattern in TestTinkerbellKubernetes131UbuntuTo132UpgradeCPOnly

*Documentation added/planned (if applicable):*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.