### PR TITLE
Automated cherry pick of #10848: Add license token to Tinkerbell 1.32 upgrade test

### DIFF
--- a/test/e2e/tinkerbell_test.go
+++ b/test/e2e/tinkerbell_test.go
@@ -617,6 +617,7 @@ func TestTinkerbellKubernetes134RedHat9SimpleFlow(t *testing.T) {
 
 func TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly(t *testing.T) {
 	provider := framework.NewTinkerbell(t)
+	licenseToken := framework.GetLicenseToken()
 	kube132 := v1alpha1.Kube132
 	test := framework.NewClusterE2ETest(
 		t,
@@ -630,6 +631,9 @@ func TestTinkerbellKubernetes132UbuntuTo133UpgradeCPOnly(t *testing.T) {
 	).WithClusterConfig(
 		provider.WithCPKubeVersionAndOS(kube132, framework.Ubuntu2204),
 		provider.WithWorkerKubeVersionAndOS(kube132, framework.Ubuntu2204),
+		api.ClusterToConfigFiller(
+			api.WithLicenseToken(licenseToken),
+		),
 	)
 	runSimpleUpgradeFlowWorkerNodeVersionForBareMetal(
 		test,


### PR DESCRIPTION
Cherry pick of #10848 on release-0.26.

#10848: Add license token to Tinkerbell 1.32 upgrade test

For details on the cherry pick process, see the [cherry pick requests](https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md) page.

```release-note

```