### PR TITLE
feat(tinkerbell): increase node deletion timeout to 30s

### DIFF
--- a/pkg/providers/tinkerbell/config/template-cp.yaml
+++ b/pkg/providers/tinkerbell/config/template-cp.yaml
@@ -507,6 +507,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: {{.controlPlaneTemplateName}}
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: {{.controlPlaneReplicas}}
 {{- if .upgradeRolloutStrategy }}
   rollout:

--- a/pkg/providers/tinkerbell/config/template-md.yaml
+++ b/pkg/providers/tinkerbell/config/template-md.yaml
@@ -34,6 +34,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: {{.workloadTemplateName}}
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
       version: {{.kubernetesVersion}}
 {{- if .upgradeRolloutStrategy }}
   rollout:

--- a/pkg/providers/tinkerbell/controlplane_test.go
+++ b/pkg/providers/tinkerbell/controlplane_test.go
@@ -562,6 +562,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: test-control-plane-1
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   version: v1.21.2-eks-1-21-4`)
 	if err := yaml.UnmarshalStrict(b, &kcp); err != nil {
@@ -944,6 +946,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: test-control-plane-1
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   version: v1.21.2-eks-1-21-4`)
 	if err := yaml.UnmarshalStrict(b, &kcp); err != nil {

--- a/pkg/providers/tinkerbell/reconciler/reconciler_test.go
+++ b/pkg/providers/tinkerbell/reconciler/reconciler_test.go
@@ -1400,6 +1400,9 @@ func tinkerbellCP(clusterName string, opts ...cpOpt) *tinkerbell.ControlPlane {
 								Kind:     "TinkerbellMachineTemplate",
 								Name:     "workload-cluster-control-plane-1",
 							},
+							Deletion: controlplanev1beta2.KubeadmControlPlaneMachineTemplateDeletionSpec{
+								NodeDeletionTimeoutSeconds: ptr.Int32(30),
+							},
 						},
 					},
 					KubeadmConfigSpec: bootstrapv1beta2.KubeadmConfigSpec{
@@ -1812,6 +1815,9 @@ func tinkWorker(clusterName string, opts ...workerOpt) *tinkerbell.Workers {
 									Kind:     "TinkerbellMachineTemplate",
 									Name:     clusterName + "-md-0-1",
 									APIGroup: "infrastructure.cluster.x-k8s.io",
+								},
+								Deletion: clusterv1beta2.MachineDeletionSpec{
+									NodeDeletionTimeoutSeconds: ptr.Int32(30),
 								},
 								Version: "v1.19.8",
 							},

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_domain_name.yaml
@@ -324,6 +324,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: <no value>
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_cluster_tinkerbell_api_server_cert_san_ip.yaml
@@ -324,6 +324,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: <no value>
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp.yaml
@@ -327,6 +327,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: <no value>
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot.yaml
@@ -314,6 +314,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: <no value>
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kcp_with_hook_iso_boot_bootstrap.yaml
@@ -314,6 +314,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: <no value>
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
   replicas: 1
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/testdata/expected_kct.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_kct.yaml
@@ -27,6 +27,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: test-test-1
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
       version: v1.21.2-eks-1-21-4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot.yaml
@@ -27,6 +27,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: test-md-0-1
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
       version: v1.21.2-eks-1-21-4
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
+++ b/pkg/providers/tinkerbell/testdata/expected_md_with_hook_iso_boot_bootstrap.yaml
@@ -27,6 +27,8 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: TinkerbellMachineTemplate
         name: test-md-0-1
+      deletion:
+        nodeDeletionTimeoutSeconds: 30
       version: v1.21.2-eks-1-21-4
   rollout:
     strategy:

--- a/pkg/providers/tinkerbell/workers_test.go
+++ b/pkg/providers/tinkerbell/workers_test.go
@@ -318,6 +318,9 @@ func machineDeployment(opts ...func(*clusterv1beta2.MachineDeployment)) *cluster
 						Name:     "test-md-0-1",
 						APIGroup: "infrastructure.cluster.x-k8s.io",
 					},
+					Deletion: clusterv1beta2.MachineDeletionSpec{
+						NodeDeletionTimeoutSeconds: ptr.Int32(30),
+					},
 					Version: "v1.21.2-eks-1-21-4",
 				},
 			},


### PR DESCRIPTION
Increase node deletion timeout to 30s for Tinkerbell (v1beta2)

**Description of changes:**

Increase the node deletion timeout for Tinkerbell CP and workers from
the default 10s to 30s. The default 10s is too short to survive a brief
API server blip during control plane scale-down (~45s observed), causing
CAPI to give up on node deletion and leaving orphan nodes, which fails
the ControlPlaneReady condition.

Fresh implementation of the same intent as #10283 using the current
CAPI v1beta2 API (deletion.nodeDeletionTimeoutSeconds: int32) instead
of the old v1beta1 field (nodeDeletionTimeout: duration).

**Issue #, if available:**

Supersedes #10283

**Testing (if applicable):**

- Unit tests updated and passing (`go test ./pkg/providers/tinkerbell/...`)
- Did not run e2e locally 
- This fix directly addresses TestTinkerbellKubernetes136UbuntuControlPlaneScaleDown
  failures observed consistently in release-0.26 nightly runs

**Documentation added/planned (if applicable):**

N/A