### PR TITLE
feat: Adding platform flag to image download

### DIFF
--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -81,8 +81,10 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 	eksaToolsImageFile := filepath.Join(downloadFolder, eksaToolsImageTarFile)
 
 	var sourceOpts []docker.OriginalRegistrySourceOption
+	var destOpts []docker.DiskDestinationOption
 	if c.platform != "" {
 		sourceOpts = append(sourceOpts, docker.WithOriginalRegistrySourcePlatform(c.platform))
+		destOpts = append(destOpts, docker.WithDiskDestinationPlatform(c.platform))
 	}
 
 	downloadArtifacts := artifacts.Download{
@@ -90,11 +92,11 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 		FileReader: deps.FileReader,
 		BundlesImagesDownloader: docker.NewImageMover(
 			docker.NewOriginalRegistrySource(dockerClient, sourceOpts...),
-			docker.NewDiskDestination(dockerClient, imagesFile),
+			docker.NewDiskDestination(dockerClient, imagesFile, destOpts...),
 		),
 		EksaToolsImageDownloader: docker.NewImageMover(
 			docker.NewOriginalRegistrySource(dockerClient, sourceOpts...),
-			docker.NewDiskDestination(dockerClient, eksaToolsImageFile),
+			docker.NewDiskDestination(dockerClient, eksaToolsImageFile, destOpts...),
 		),
 		ChartDownloader:    helm.NewChartRegistryDownloader(deps.Helm, downloadFolder),
 		Version:            version.Get(),

--- a/cmd/eksctl-anywhere/cmd/downloadimages.go
+++ b/cmd/eksctl-anywhere/cmd/downloadimages.go
@@ -45,6 +45,7 @@ func init() {
 	downloadImagesCmd.Flag("include-packages").Deprecated = "use copy packages command"
 	downloadImagesCmd.Flags().StringVarP(&downloadImagesRunner.bundlesOverride, "bundles-override", "", "", "Override default Bundles manifest (not recommended)")
 	downloadImagesCmd.Flags().BoolVar(&downloadImagesRunner.insecure, "insecure", false, "Flag to indicate skipping TLS verification while downloading helm charts")
+	downloadImagesCmd.Flags().StringVar(&downloadImagesRunner.platform, "platform", "", "Platform (e.g. linux/amd64) of the images to download. Defaults to the platform of the machine running the command. Use this to download images for clusters with a different architecture than the machine running the command, for example downloading amd64 images from an arm64 Mac")
 }
 
 var downloadImagesRunner = downloadImagesCommand{}
@@ -54,6 +55,7 @@ type downloadImagesCommand struct {
 	bundlesOverride string
 	includePackages bool
 	insecure        bool
+	platform        string
 }
 
 func (c downloadImagesCommand) Run(ctx context.Context) error {
@@ -78,15 +80,20 @@ func (c downloadImagesCommand) Run(ctx context.Context) error {
 	imagesFile := filepath.Join(downloadFolder, imagesTarFile)
 	eksaToolsImageFile := filepath.Join(downloadFolder, eksaToolsImageTarFile)
 
+	var sourceOpts []docker.OriginalRegistrySourceOption
+	if c.platform != "" {
+		sourceOpts = append(sourceOpts, docker.WithOriginalRegistrySourcePlatform(c.platform))
+	}
+
 	downloadArtifacts := artifacts.Download{
 		Reader:     deps.ManifestReader,
 		FileReader: deps.FileReader,
 		BundlesImagesDownloader: docker.NewImageMover(
-			docker.NewOriginalRegistrySource(dockerClient),
+			docker.NewOriginalRegistrySource(dockerClient, sourceOpts...),
 			docker.NewDiskDestination(dockerClient, imagesFile),
 		),
 		EksaToolsImageDownloader: docker.NewImageMover(
-			docker.NewOriginalRegistrySource(dockerClient),
+			docker.NewOriginalRegistrySource(dockerClient, sourceOpts...),
 			docker.NewDiskDestination(dockerClient, eksaToolsImageFile),
 		),
 		ChartDownloader:    helm.NewChartRegistryDownloader(deps.Helm, downloadFolder),

--- a/pkg/dependencies/factory_test.go
+++ b/pkg/dependencies/factory_test.go
@@ -775,7 +775,7 @@ func TestFactoryBuildWithProviderTinkerbellWithNoTimeouts(t *testing.T) {
 
 type dummyDockerClient struct{}
 
-func (b dummyDockerClient) PullImage(ctx context.Context, image string) error {
+func (b dummyDockerClient) PullImage(ctx context.Context, image string, platform ...string) error {
 	return nil
 }
 

--- a/pkg/docker/file.go
+++ b/pkg/docker/file.go
@@ -29,19 +29,37 @@ func (s *ImageDiskSource) Load(ctx context.Context, images ...string) error {
 // ImageDiskDestination implements the ImageDestination interface, writing images and tags from
 // from the local docker cache into a tarbal.
 type ImageDiskDestination struct {
-	client ImageDiskWriter
-	file   string
+	client   ImageDiskWriter
+	file     string
+	platform string
 }
 
-func NewDiskDestination(client ImageDiskWriter, file string) *ImageDiskDestination {
-	return &ImageDiskDestination{
+// DiskDestinationOption configures an ImageDiskDestination.
+type DiskDestinationOption func(*ImageDiskDestination)
+
+// WithDiskDestinationPlatform sets the platform (e.g. linux/amd64) exported to the
+// tarball, matching the platform pulled from the origin registry. This is required
+// with the containerd image store, where a plain save would export a multi-arch
+// index whose non-host manifests were never pulled.
+func WithDiskDestinationPlatform(platform string) DiskDestinationOption {
+	return func(d *ImageDiskDestination) {
+		d.platform = platform
+	}
+}
+
+func NewDiskDestination(client ImageDiskWriter, file string, opts ...DiskDestinationOption) *ImageDiskDestination {
+	d := &ImageDiskDestination{
 		client: client,
 		file:   file,
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
 }
 
 // Write creates a tarball including images and tags from the the local docker cache.
 func (s *ImageDiskDestination) Write(ctx context.Context, images ...string) error {
 	logger.Info("Writing images to disk")
-	return s.client.SaveToFile(ctx, s.file, images...)
+	return s.client.SaveToFile(ctx, s.file, s.platform, images...)
 }

--- a/pkg/docker/file_test.go
+++ b/pkg/docker/file_test.go
@@ -34,7 +34,21 @@ func TestNewDiskDestination(t *testing.T) {
 	images := []string{"image1:1", "image2:2"}
 	ctx := context.Background()
 	dstLoader := docker.NewDiskDestination(client, file)
-	client.EXPECT().SaveToFile(ctx, file, images[0], images[1])
+	client.EXPECT().SaveToFile(ctx, file, "", images[0], images[1])
+
+	g.Expect(dstLoader.Write(ctx, images...)).To(Succeed())
+}
+
+func TestNewDiskDestinationWithPlatform(t *testing.T) {
+	g := NewWithT(t)
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockDockerClient(ctrl)
+
+	file := "file"
+	images := []string{"image1:1", "image2:2"}
+	ctx := context.Background()
+	dstLoader := docker.NewDiskDestination(client, file, docker.WithDiskDestinationPlatform("linux/amd64"))
+	client.EXPECT().SaveToFile(ctx, file, "linux/amd64", images[0], images[1])
 
 	g.Expect(dstLoader.Write(ctx, images...)).To(Succeed())
 }

--- a/pkg/docker/mocks/mocks.go
+++ b/pkg/docker/mocks/mocks.go
@@ -165,17 +165,22 @@ func (m *MockImagePuller) EXPECT() *MockImagePullerMockRecorder {
 }
 
 // PullImage mocks base method.
-func (m *MockImagePuller) PullImage(ctx context.Context, image string) error {
+func (m *MockImagePuller) PullImage(ctx context.Context, image string, platform ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullImage", ctx, image)
+	varargs := []interface{}{ctx, image}
+	for _, a := range platform {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PullImage", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PullImage indicates an expected call of PullImage.
-func (mr *MockImagePullerMockRecorder) PullImage(ctx, image interface{}) *gomock.Call {
+func (mr *MockImagePullerMockRecorder) PullImage(ctx, image interface{}, platform ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImagePuller)(nil).PullImage), ctx, image)
+	varargs := append([]interface{}{ctx, image}, platform...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockImagePuller)(nil).PullImage), varargs...)
 }
 
 // MockDockerClient is a mock of DockerClient interface.
@@ -216,17 +221,22 @@ func (mr *MockDockerClientMockRecorder) LoadFromFile(ctx, filepath interface{}) 
 }
 
 // PullImage mocks base method.
-func (m *MockDockerClient) PullImage(ctx context.Context, image string) error {
+func (m *MockDockerClient) PullImage(ctx context.Context, image string, platform ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullImage", ctx, image)
+	varargs := []interface{}{ctx, image}
+	for _, a := range platform {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PullImage", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PullImage indicates an expected call of PullImage.
-func (mr *MockDockerClientMockRecorder) PullImage(ctx, image interface{}) *gomock.Call {
+func (mr *MockDockerClientMockRecorder) PullImage(ctx, image interface{}, platform ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), ctx, image)
+	varargs := append([]interface{}{ctx, image}, platform...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), varargs...)
 }
 
 // SaveToFile mocks base method.

--- a/pkg/docker/mocks/mocks.go
+++ b/pkg/docker/mocks/mocks.go
@@ -72,9 +72,9 @@ func (m *MockImageDiskWriter) EXPECT() *MockImageDiskWriterMockRecorder {
 }
 
 // SaveToFile mocks base method.
-func (m *MockImageDiskWriter) SaveToFile(ctx context.Context, filepath string, images ...string) error {
+func (m *MockImageDiskWriter) SaveToFile(ctx context.Context, filepath, platform string, images ...string) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, filepath}
+	varargs := []interface{}{ctx, filepath, platform}
 	for _, a := range images {
 		varargs = append(varargs, a)
 	}
@@ -84,9 +84,9 @@ func (m *MockImageDiskWriter) SaveToFile(ctx context.Context, filepath string, i
 }
 
 // SaveToFile indicates an expected call of SaveToFile.
-func (mr *MockImageDiskWriterMockRecorder) SaveToFile(ctx, filepath interface{}, images ...interface{}) *gomock.Call {
+func (mr *MockImageDiskWriterMockRecorder) SaveToFile(ctx, filepath, platform interface{}, images ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, filepath}, images...)
+	varargs := append([]interface{}{ctx, filepath, platform}, images...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveToFile", reflect.TypeOf((*MockImageDiskWriter)(nil).SaveToFile), varargs...)
 }
 
@@ -240,9 +240,9 @@ func (mr *MockDockerClientMockRecorder) PullImage(ctx, image interface{}, platfo
 }
 
 // SaveToFile mocks base method.
-func (m *MockDockerClient) SaveToFile(ctx context.Context, filepath string, images ...string) error {
+func (m *MockDockerClient) SaveToFile(ctx context.Context, filepath, platform string, images ...string) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, filepath}
+	varargs := []interface{}{ctx, filepath, platform}
 	for _, a := range images {
 		varargs = append(varargs, a)
 	}
@@ -252,9 +252,9 @@ func (m *MockDockerClient) SaveToFile(ctx context.Context, filepath string, imag
 }
 
 // SaveToFile indicates an expected call of SaveToFile.
-func (mr *MockDockerClientMockRecorder) SaveToFile(ctx, filepath interface{}, images ...interface{}) *gomock.Call {
+func (mr *MockDockerClientMockRecorder) SaveToFile(ctx, filepath, platform interface{}, images ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, filepath}, images...)
+	varargs := append([]interface{}{ctx, filepath, platform}, images...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveToFile", reflect.TypeOf((*MockDockerClient)(nil).SaveToFile), varargs...)
 }
 

--- a/pkg/docker/mover.go
+++ b/pkg/docker/mover.go
@@ -13,7 +13,7 @@ type ImageDiskLoader interface {
 }
 
 type ImageDiskWriter interface {
-	SaveToFile(ctx context.Context, filepath string, images ...string) error
+	SaveToFile(ctx context.Context, filepath string, platform string, images ...string) error
 }
 
 type ImageTaggerPusher interface {

--- a/pkg/docker/mover.go
+++ b/pkg/docker/mover.go
@@ -22,7 +22,7 @@ type ImageTaggerPusher interface {
 }
 
 type ImagePuller interface {
-	PullImage(ctx context.Context, image string) error
+	PullImage(ctx context.Context, image string, platform ...string) error
 }
 
 type DockerClient interface {

--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -66,15 +66,32 @@ func (d *ImageRegistryDestination) Write(ctx context.Context, images ...string) 
 type ImageOriginalRegistrySource struct {
 	client    ImagePuller
 	processor *ConcurrentImageProcessor
+	platform  string
 	Retrier   retrier.Retrier
 }
 
-func NewOriginalRegistrySource(client ImagePuller) *ImageOriginalRegistrySource {
-	return &ImageOriginalRegistrySource{
+// OriginalRegistrySourceOption configures an ImageOriginalRegistrySource.
+type OriginalRegistrySourceOption func(*ImageOriginalRegistrySource)
+
+// WithOriginalRegistrySourcePlatform sets the platform (e.g. linux/amd64) of the
+// images pulled from the origin registry, overriding the default of pulling
+// images matching the platform of the host running the command.
+func WithOriginalRegistrySourcePlatform(platform string) OriginalRegistrySourceOption {
+	return func(s *ImageOriginalRegistrySource) {
+		s.platform = platform
+	}
+}
+
+func NewOriginalRegistrySource(client ImagePuller, opts ...OriginalRegistrySourceOption) *ImageOriginalRegistrySource {
+	s := &ImageOriginalRegistrySource{
 		client:    client,
 		processor: NewConcurrentImageProcessor(runtime.GOMAXPROCS(0)),
 		Retrier:   *retrier.NewWithMaxRetries(5, 200*time.Second),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Load pulls images and tags from their original registry into the local docker cache.
@@ -82,8 +99,13 @@ func (s *ImageOriginalRegistrySource) Load(ctx context.Context, images ...string
 	logger.Info("Pulling images from origin, this might take a while")
 	logger.V(3).Info("Starting pull", "numberOfImages", len(images))
 
+	var platform []string
+	if s.platform != "" {
+		platform = append(platform, s.platform)
+	}
+
 	err := s.processor.Process(ctx, images, func(ctx context.Context, image string) error {
-		err := s.Retrier.Retry(func() error { return s.client.PullImage(ctx, image) })
+		err := s.Retrier.Retry(func() error { return s.client.PullImage(ctx, image, platform...) })
 		if err != nil {
 			return err
 		}

--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -128,6 +128,23 @@ func TestNewOriginalRegistrySource(t *testing.T) {
 	g.Expect(dstLoader.Load(ctx, images...)).To(Succeed())
 }
 
+func TestNewOriginalRegistrySourceWithPlatform(t *testing.T) {
+	g := NewWithT(t)
+	ctrl := gomock.NewController(t)
+	client := mocks.NewMockDockerClient(ctrl)
+
+	platform := "linux/amd64"
+	images := []string{"image1:1", "image2:2"}
+	ctx := context.Background()
+	dstLoader := docker.NewOriginalRegistrySource(client, docker.WithOriginalRegistrySourcePlatform(platform))
+	dstLoader.Retrier = *retrier.NewWithMaxRetries(1, 0)
+	for _, i := range images {
+		client.EXPECT().PullImage(test.AContext(), i, platform)
+	}
+
+	g.Expect(dstLoader.Load(ctx, images...)).To(Succeed())
+}
+
 func TestOriginalRegistrySourceError(t *testing.T) {
 	g := NewWithT(t)
 	ctrl := gomock.NewController(t)

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -35,13 +35,20 @@ func (d *Docker) GetDockerLBPort(ctx context.Context, clusterName string) (port 
 	}
 }
 
-func (d *Docker) PullImage(ctx context.Context, image string) error {
+// PullImage pulls an image from a registry into the local docker cache. An
+// optional platform (e.g. linux/amd64) can be provided to pull the image for
+// a specific platform instead of the platform of the host running the command.
+func (d *Docker) PullImage(ctx context.Context, image string, platform ...string) error {
 	logger.V(2).Info("Pulling docker image", "image", image)
-	if _, err := d.Execute(ctx, "pull", image); err != nil {
-		return err
-	} else {
-		return nil
+	args := []string{"pull"}
+	if len(platform) > 0 && platform[0] != "" {
+		args = append(args, "--platform", platform[0])
 	}
+	args = append(args, image)
+	if _, err := d.Execute(ctx, args...); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (d *Docker) Version(ctx context.Context) (int, error) {

--- a/pkg/executables/docker.go
+++ b/pkg/executables/docker.go
@@ -111,9 +111,16 @@ func (d *Docker) LoadFromFile(ctx context.Context, filepath string) error {
 	return nil
 }
 
-func (d *Docker) SaveToFile(ctx context.Context, filepath string, images ...string) error {
-	params := make([]string, 0, 3+len(images))
+// SaveToFile writes images from the local docker cache into a tarball at filepath.
+// An optional platform (e.g. linux/amd64) selects a single platform to export,
+// which is required when using the containerd image store to avoid exporting a
+// multi-arch index whose non-host manifests were never pulled.
+func (d *Docker) SaveToFile(ctx context.Context, filepath string, platform string, images ...string) error {
+	params := make([]string, 0, 5+len(images))
 	params = append(params, "save", "-o", filepath)
+	if platform != "" {
+		params = append(params, "--platform", platform)
+	}
 	params = append(params, images...)
 
 	if _, err := d.Execute(ctx, params...); err != nil {

--- a/pkg/executables/docker_test.go
+++ b/pkg/executables/docker_test.go
@@ -126,7 +126,22 @@ func TestDockerSaveToFileMultipleImages(t *testing.T) {
 	executable.EXPECT().Execute(ctx, "save", "-o", file, image1, image2, image3).Return(bytes.Buffer{}, nil)
 	d := executables.NewDocker(executable)
 
-	g.Expect(d.SaveToFile(ctx, file, image1, image2, image3)).To(Succeed())
+	g.Expect(d.SaveToFile(ctx, file, "", image1, image2, image3)).To(Succeed())
+}
+
+func TestDockerSaveToFileWithPlatform(t *testing.T) {
+	file := "file"
+	image1 := "image1:tag1"
+
+	g := NewWithT(t)
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+
+	executable := mockexecutables.NewMockExecutable(mockCtrl)
+	executable.EXPECT().Execute(ctx, "save", "-o", file, "--platform", "linux/amd64", image1).Return(bytes.Buffer{}, nil)
+	d := executables.NewDocker(executable)
+
+	g.Expect(d.SaveToFile(ctx, file, "linux/amd64", image1)).To(Succeed())
 }
 
 func TestDockerSaveToFileNoImages(t *testing.T) {
@@ -140,7 +155,7 @@ func TestDockerSaveToFileNoImages(t *testing.T) {
 	executable.EXPECT().Execute(ctx, "save", "-o", file).Return(bytes.Buffer{}, nil)
 	d := executables.NewDocker(executable)
 
-	g.Expect(d.SaveToFile(ctx, file)).To(Succeed())
+	g.Expect(d.SaveToFile(ctx, file, "")).To(Succeed())
 }
 
 func TestDockerRunBasicSucess(t *testing.T) {

--- a/pkg/executables/docker_test.go
+++ b/pkg/executables/docker_test.go
@@ -48,6 +48,22 @@ func TestDockerPullImage(t *testing.T) {
 	}
 }
 
+func TestDockerPullImageWithPlatform(t *testing.T) {
+	image := "test_image"
+	platform := "linux/amd64"
+
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+
+	executable := mockexecutables.NewMockExecutable(mockCtrl)
+	executable.EXPECT().Execute(ctx, "pull", "--platform", platform, image).Return(bytes.Buffer{}, nil)
+	d := executables.NewDocker(executable)
+	err := d.PullImage(ctx, image, platform)
+	if err != nil {
+		t.Fatalf("Docker.PullImage() error = %v, want nil", err)
+	}
+}
+
 func TestDockerVersion(t *testing.T) {
 	version := "1.234"
 	wantVersion := 1

--- a/pkg/executables/dockercontainer.go
+++ b/pkg/executables/dockercontainer.go
@@ -15,7 +15,7 @@ import (
 
 type DockerClient interface {
 	Login(ctx context.Context, endpoint, username, password string) error
-	PullImage(ctx context.Context, image string) error
+	PullImage(ctx context.Context, image string, platform ...string) error
 	Execute(ctx context.Context, args ...string) (stdout bytes.Buffer, err error)
 }
 

--- a/pkg/executables/mocks/executables.go
+++ b/pkg/executables/mocks/executables.go
@@ -188,17 +188,22 @@ func (mr *MockDockerClientMockRecorder) Login(arg0, arg1, arg2, arg3 interface{}
 }
 
 // PullImage mocks base method.
-func (m *MockDockerClient) PullImage(arg0 context.Context, arg1 string) error {
+func (m *MockDockerClient) PullImage(arg0 context.Context, arg1 string, arg2 ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullImage", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PullImage", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PullImage indicates an expected call of PullImage.
-func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDockerClientMockRecorder) PullImage(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerClient)(nil).PullImage), varargs...)
 }
 
 // MockDockerContainer is a mock of DockerContainer interface.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will allow machines such as macs to download images in a different architecture for airgapped environments.

*Testing (if applicable):*

Have built the cli tool and have run the download option with the platform flag. This has produced an images.tar file which contains amd images on an arm machine.

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

