### PR TITLE
Fix mhc timeout duration overflow in v1beta2 conversion

### DIFF
--- a/cmd/eksctl-anywhere/cmd/options.go
+++ b/cmd/eksctl-anywhere/cmd/options.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -270,9 +269,8 @@ func buildCreateCliConfig(clusterOptions *createClusterOptions) (*config.CreateC
 	createCliConfig := &config.CreateClusterCLIConfig{}
 	createCliConfig.SkipCPIPCheck = clusterOptions.skipIpCheck
 	if clusterOptions.noTimeouts {
-		maxTime := time.Duration(math.MaxInt64)
-		createCliConfig.NodeStartupTimeout = maxTime
-		createCliConfig.UnhealthyMachineTimeout = maxTime
+		createCliConfig.NodeStartupTimeout = constants.MaxMachineHealthCheckTimeout
+		createCliConfig.UnhealthyMachineTimeout = constants.MaxMachineHealthCheckTimeout
 
 		return createCliConfig, nil
 	}
@@ -298,9 +296,8 @@ func buildCreateCliConfig(clusterOptions *createClusterOptions) (*config.CreateC
 func buildUpgradeCliConfig(clusterOptions *upgradeClusterOptions) (*config.UpgradeClusterCLIConfig, error) {
 	upgradeCliConfig := config.UpgradeClusterCLIConfig{}
 	if clusterOptions.noTimeouts {
-		maxTime := time.Duration(math.MaxInt64)
-		upgradeCliConfig.NodeStartupTimeout = maxTime
-		upgradeCliConfig.UnhealthyMachineTimeout = maxTime
+		upgradeCliConfig.NodeStartupTimeout = constants.MaxMachineHealthCheckTimeout
+		upgradeCliConfig.UnhealthyMachineTimeout = constants.MaxMachineHealthCheckTimeout
 
 		return &upgradeCliConfig, nil
 	}

--- a/pkg/clusterapi/machine_health_check.go
+++ b/pkg/clusterapi/machine_health_check.go
@@ -1,6 +1,8 @@
 package clusterapi
 
 import (
+	"math"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1beta2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
@@ -14,11 +16,21 @@ const (
 )
 
 // durationToSeconds converts a *metav1.Duration to *int32 seconds for v1beta2.
+// Durations that exceed MaxInt32 seconds are capped to avoid integer overflow.
 func durationToSeconds(d *metav1.Duration) *int32 {
 	if d == nil {
 		return nil
 	}
-	s := int32(d.Duration.Seconds())
+	seconds := math.Trunc(d.Duration.Seconds())
+	if seconds > math.MaxInt32 {
+		s := int32(math.MaxInt32)
+		return &s
+	}
+	if seconds < 0 {
+		s := int32(0)
+		return &s
+	}
+	s := int32(seconds)
 	return &s
 }
 

--- a/pkg/clusterapi/machine_health_check_test.go
+++ b/pkg/clusterapi/machine_health_check_test.go
@@ -1,6 +1,7 @@
 package clusterapi_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -87,7 +88,16 @@ func TestMachineHealthCheckForControlPlaneWithMaxUnhealthyOverride(t *testing.T)
 }
 
 func durationSecondsInt32(d time.Duration) *int32 {
-	s := int32(d.Seconds())
+	seconds := math.Trunc(d.Seconds())
+	if seconds > math.MaxInt32 {
+		s := int32(math.MaxInt32)
+		return &s
+	}
+	if seconds < 0 {
+		s := int32(0)
+		return &s
+	}
+	s := int32(seconds)
 	return &s
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,6 +113,10 @@ const (
 	DefaultNodeStartupTimeout = 10 * time.Minute
 	// DefaultTinkerbellNodeStartupTimeout is the default node start up timeout for Tinkerbell.
 	DefaultTinkerbellNodeStartupTimeout = 20 * time.Minute
+	// MaxMachineHealthCheckTimeout is the maximum timeout for machine health checks.
+	// Used by --no-timeouts to effectively disable health check timeouts while
+	// staying within the int32 seconds range required by the CAPI v1beta2 API.
+	MaxMachineHealthCheckTimeout = 24 * 365 * time.Hour // 1 year
 	// DefaultMaxUnhealthy is the default maxUnhealthy value for machine health checks.
 	DefaultMaxUnhealthy = "100%"
 	// DefaultWorkerMaxUnhealthy is the default maxUnhealthy value for worker node machine health checks.

--- a/test/e2e/docker_test.go
+++ b/test/e2e/docker_test.go
@@ -50,6 +50,24 @@ func TestDockerKubernetesLabels(t *testing.T) {
 	)
 }
 
+// MachineHealthCheck
+func TestDockerKubernetes135NoTimeoutsCreateCluster(t *testing.T) {
+	provider := framework.NewDocker(t)
+	test := framework.NewClusterE2ETest(
+		t,
+		provider,
+		framework.WithClusterFiller(
+			api.WithKubernetesVersion(v1alpha1.Kube135),
+			api.WithControlPlaneCount(1),
+			api.WithWorkerNodeCount(1),
+		),
+	)
+	test.GenerateClusterConfig()
+	test.CreateCluster(framework.WithNoTimeouts())
+	test.ValidateCluster(v1alpha1.Kube135)
+	test.DeleteCluster()
+}
+
 // Flux
 func TestDockerKubernetes133GithubFlux(t *testing.T) {
 	test := framework.NewClusterE2ETest(t,

--- a/test/framework/commands.go
+++ b/test/framework/commands.go
@@ -36,6 +36,10 @@ func WithPerMachineWaitTimeout(timeout string) CommandOpt {
 	return appendOpt("--per-machine-wait-timeout", timeout)
 }
 
+func WithNoTimeouts() CommandOpt {
+	return appendOpt("--no-timeouts")
+}
+
 func ExecuteWithEksaRelease(release *releasev1alpha1.EksARelease) CommandOpt {
 	return executeWithBinaryCommandOpt(func() (string, error) {
 		return getBinary(release)


### PR DESCRIPTION
*Description of changes:*

- Fix integer overflow in `durationToSeconds()` that produces `-2147483648` (MinInt32) when converting durations exceeding ~68 years to int32 seconds, causing MachineHealthCheck creation to fail permanently on clusters created/upgraded with `--no-timeouts`
```
{"ts":1784215000594.9104,"caller":"controller/controller.go:474","msg":"Reconciler error","controller":"cluster","controllerGroup":"anywhere.eks.amazonaws.com","controllerKind":"Cluster","Cluster":{"name":"xxxxxx","namespace":"default"},"namespace":"default","name":"xxxxxx","reconcileID":"c8b9042e-f675-45e1-b613-951bf5875f88","err":"applying machine health checks: failed to reconcile object cluster.x-k8s.io/v1beta2, Kind=MachineHealthCheck, eksa-system/worker-unhealthy: MachineHealthCheck.cluster.x-k8s.io \"worker-unhealthy\" is invalid: [spec.checks.unhealthyNodeConditions[0].timeoutSeconds: Invalid value: -2147483648: spec.checks.unhealthyNodeConditions[0].timeoutSeconds in body should be greater than or equal to 0, spec.checks.unhealthyNodeConditions[1].timeoutSeconds: Invalid value: -2147483648: spec.checks.unhealthyNodeConditions[1].timeoutSeconds in body should be greater than or equal to 0, spec.checks.nodeStartupTimeoutSeconds: Invalid value: -2147483648: spec.checks.nodeStartupTimeoutSeconds in body should be greater than or equal to 0]"}
```

- Change mhc duration field conversion for v1beta2 matching upstream CAPI implementation @ https://github.com/kubernetes-sigs/cluster-api/blob/main/api/core/v1beta2/conversion.go#L29
- Cap `--no-timeouts` duration to 1 year (previously ~292 years) to stay within int32 range while still effectively disabling health check timeouts

## Root Cause

The v1beta2 migration (PR #10545) introduced `durationToSeconds()` which performs an unsafe `float64 → int32` cast. The `--no-timeouts` flag sets `Duration(math.MaxInt64)` (~292 years), which exceeds MaxInt32 seconds (~68 years). On Go versions without float-to-int saturation, this produces `-2147483648`, which the Kubernetes API rejects (`Minimum=0`), leaving the controller in an infinite retry loop.



## Impact

Any cluster created or upgraded with `--no-timeouts` on v0.25.2 hits this bug. The eksa-controller-manager gets stuck at "Configuring machine health checks" and the cluster never finishes provisioning. Worker nodes remain in "Provisioned" phase indefinitely.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

