### PR TITLE
Add apiVersion to ADOT curated package e2e install

### DIFF
--- a/test/e2e/adot.go
+++ b/test/e2e/adot.go
@@ -21,7 +21,7 @@ func runCuratedPackagesAdotInstall(test *framework.ClusterE2ETest) {
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),
-		"--set mode=deployment")
+		"--set apiVersion=apps/v1 --set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 }
 
@@ -31,7 +31,7 @@ func runCuratedPackagesAdotInstallWithUpdate(test *framework.ClusterE2ETest) {
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),
-		"--set mode=deployment")
+		"--set apiVersion=apps/v1 --set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 	test.T.Log("Waiting before updating package")
 	time.Sleep(60 * time.Second)


### PR DESCRIPTION
Upstream OpenTelemetry chart added apiVersion to the root required list
([apiVersion,mode]) starting in the v0.48.0 chart. The ADOT SimpleFlow
and UpdateFlow e2e tests only set mode, so the package webhook rejects the
install with "apiVersion is required". Set apiVersion=apps/v1 (the upstream
values.yaml default) to align with upstream instead of patching the schema.

*Issue #, if available:* N/A

*Description of changes:*

Add `--set apiVersion=apps/v1` to both ADOT curated-package install calls in
`test/e2e/adot.go`:

- `runCuratedPackagesAdotInstall` (used by all ADOT `SimpleFlow` variants:
  Tinkerbell / Docker / vSphere / Nutanix / CloudStack)
- `runCuratedPackagesAdotInstallWithUpdate` (used by the ADOT `UpdateFlow`)

Since the v0.48.0 chart (OTel collector chart 0.153.0), upstream added
`apiVersion` to the root `required` array in `values.schema.json`. `make build`
syncs that schema into the package, so the package webhook (`vpackage.kb.io`)
now requires `apiVersion` in the install config. The tests previously passed
only `--set mode=deployment`, so the install was rejected with
`(root): apiVersion is required`.

`apps/v1` is the upstream chart's own default for this field
(`opentelemetry-collector` values.yaml), so setting it keeps the test aligned
with upstream defaults rather than diverging by patching `apiVersion` out of
the schema.

*Testing (if applicable):*

`go vet -tags e2e ./test/e2e/` passes.

Verified via CodeBuild e2e on this branch (`adot-e2e-apiversion`, commit `135938d1`):
`TestTinkerbellKubernetes136UbuntuCuratedPackagesAdotSimpleFlow` — **Succeeded**
(aws-eks-anywhere-test-tinkerbell build #1572, 2026-07-21). The `apiVersion is required`
webhook rejection no longer occurs and the ADOT package installs successfully.



*Documentation added/planned (if applicable):* N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.