### PR TITLE
Add apiVersion to ADOT curated package e2e install (#10880)

### DIFF
--- a/test/e2e/adot.go
+++ b/test/e2e/adot.go
@@ -21,7 +21,7 @@ func runCuratedPackagesAdotInstall(test *framework.ClusterE2ETest) {
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),
-		"--set mode=deployment")
+		"--set apiVersion=apps/v1 --set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 }
 
@@ -31,7 +31,7 @@ func runCuratedPackagesAdotInstallWithUpdate(test *framework.ClusterE2ETest) {
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),
-		"--set mode=deployment")
+		"--set apiVersion=apps/v1 --set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 	test.T.Log("Waiting before updating package")
 	time.Sleep(60 * time.Second)


### PR DESCRIPTION
Upstream OpenTelemetry chart added apiVersion to the root required list
  ([apiVersion,mode]) starting in the v0.48.0 chart. The ADOT SimpleFlow
  and UpdateFlow e2e tests only set mode, so the package webhook rejects the
  install with "apiVersion is required". Set apiVersion=apps/v1 (the upstream
  values.yaml default) to align with upstream instead of patching the schema.

(cherry picked from commit 09917c055f7426576c424ae2b25fb7647fa993f7)

*Issue #, if available:*

*Description of changes:*

*Testing (if applicable):*

*Documentation added/planned (if applicable):*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

