### PR TITLE
Automated cherry pick of #10880: Add apiVersion to ADOT curated package e2e install

### DIFF
--- a/test/e2e/adot.go
+++ b/test/e2e/adot.go
@@ -21,7 +21,7 @@ func runCuratedPackagesAdotInstall(test *framework.ClusterE2ETest) {
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),
-		"--set mode=deployment")
+		"--set apiVersion=apps/v1 --set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 }
 
@@ -31,7 +31,7 @@ func runCuratedPackagesAdotInstallWithUpdate(test *framework.ClusterE2ETest) {
 	test.CreateNamespace(adotTargetNamespace)
 	test.InstallCuratedPackage(adotPackageName, adotPackagePrefix+"-"+adotPackageName,
 		kubeconfig.FromClusterName(test.ClusterName),
-		"--set mode=deployment")
+		"--set apiVersion=apps/v1 --set mode=deployment")
 	test.VerifyAdotPackageInstalled(adotPackagePrefix+"-"+adotPackageName, adotTargetNamespace)
 	test.T.Log("Waiting before updating package")
 	time.Sleep(60 * time.Second)


### PR DESCRIPTION
Cherry pick of #10880 on release-0.25.

#10880: Add apiVersion to ADOT curated package e2e install

For details on the cherry pick process, see the [cherry pick requests](https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md) page.

```release-note

```