### PR TITLE
Increase autoscaler scale-up MachineDeployment ready timeout to 20m

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -2170,7 +2170,7 @@ func (e *ClusterE2ETest) VerifyWorkerNodesScaleUp(mgmtCluster *types.Cluster) {
 		e.T.Fatalf("Failed to get Running phase for machinedeployment: %s", err)
 	}
 
-	err = e.KubectlClient.WaitForMachineDeploymentReady(ctx, mgmtCluster, "5m", machineDeploymentName)
+	err = e.KubectlClient.WaitForMachineDeploymentReady(ctx, mgmtCluster, "20m", machineDeploymentName)
 	if err != nil {
 		e.T.Fatalf("Machine deployment stuck in scaling up: %s", err)
 	}


### PR DESCRIPTION
## Description of changes

`VerifyWorkerNodesScaleUp` (test/framework/cluster.go) waited only **5m** for
`WaitForMachineDeploymentReady` after cluster-autoscaler triggers a scale-up.
On bare-metal Tinkerbell, provisioning a new worker (stream image + reboot +
kubeadm join) routinely takes ~6–8 min — longer than 5m, and inconsistent with
the two preceding waits in the same function (10m for replica count, 20m for
`Running` phase). As a result `TestTinkerbell…ClusterAutoscalerSimpleFlow`
fails with `Machine deployment stuck in scaling up` even when the node does
eventually join.

This bumps the final wait from **5m to 20m** to match the preceding
phase-wait and give bare-metal workers enough time to join.


## Testing

- Local A/B on a CI admin machine:
  - `5m` → FAIL (`cluster.go:2175 Machine deployment stuck in scaling up`)
  - `20m` → PASS (test completed in ~2465s; worker joined within the window)
- CI: `aws-eks-anywhere-test-tinkerbell` build aws-eks-anywhere-test-tinkerbell:0a035d01-d37c-4375-a7df-1bb34151a21a —
  `TestTinkerbellKubernetes136UbuntuCuratedPackagesClusterAutoscalerSimpleFlow`
  **PASSED**.

## Documentation

N/A — test-only change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.