### PR TITLE
Fix errCh deadlock and webhook race in cert-manager e2e verification

### DIFF
--- a/test/framework/cluster.go
+++ b/test/framework/cluster.go
@@ -1763,8 +1763,7 @@ func (e *ClusterE2ETest) VerifyCertManagerPackageInstalled(prefix, namespace, pa
 	deployments := []string{"cert-manager", "cert-manager-cainjector", "cert-manager-webhook"}
 
 	var wg sync.WaitGroup
-	errCh := make(chan error, 1)
-	okCh := make(chan string, 1)
+	errCh := make(chan error, len(deployments))
 
 	e.T.Log("Waiting for Package", packageName, "To be installed")
 
@@ -1795,28 +1794,24 @@ func (e *ClusterE2ETest) VerifyCertManagerPackageInstalled(prefix, namespace, pa
 		}(name)
 	}
 
+	// Wait for the cert-manager deployments (including the webhook) to be Available
+	// before applying any Issuer/Certificate. Applying an Issuer triggers the
+	// cert-manager validating webhook; if we apply before the webhook is ready the
+	// apply fails with "failed calling webhook ... connect: connection refused".
+	wg.Wait()
+	close(errCh)
+	if err := <-errCh; err != nil {
+		e.T.Fatalf("cert-manager package deployments did not become healthy: %s", err)
+	}
+
 	e.T.Log("Waiting for Self Signed certificate to be issued")
-	err = e.verifySelfSignedCertificate()
-	if err != nil {
-		errCh <- err
+	if err := e.verifySelfSignedCertificate(); err != nil {
+		e.T.Fatalf("self-signed certificate verification failed: %s", err)
 	}
 
 	e.T.Log("Waiting for Let's Encrypt certificate to be issued")
-	err = e.verifyLetsEncryptCert()
-	if err != nil {
-		errCh <- err
-	}
-
-	go func() {
-		wg.Wait()
-		okCh <- "completed"
-	}()
-
-	select {
-	case err := <-errCh:
-		e.T.Fatal(err)
-	case <-okCh:
-		return
+	if err := e.verifyLetsEncryptCert(); err != nil {
+		e.T.Fatalf("lets-encrypt certificate verification failed: %s", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestVSphereKubernetes1XXUbuntu/BottleRocketWorkloadClusterCuratedPackagesCertManagerSimpleFlow` (all k8s versions, both OS) have been failing by hanging until the 2.5h CodeBuild timeout instead of failing fast.

Two CI junit goroutine dumps (main `d047319`, release-0.26 `af330a4`) show the goroutines parked on `chan send` at `cluster.go:1793` and `cluster.go:1807` for ~130 minutes.

Root cause is in `VerifyCertManagerPackageInstalled`:

1. **errCh deadlock (primary):** `errCh` was created with capacity 1, but up to five goroutines can send to it (three deployment waiters + the self-signed and Let's Encrypt cert verifications). Once one error is sent, the remaining senders block forever, so a single cert-verification failure hangs the whole test until the CodeBuild timeout instead of failing cleanly. This is the direct cause of the red CI runs.

2. **webhook race (secondary):** the cert-manager deployment waiters (including `cert-manager-webhook`) ran as goroutines, but the Issuer/Certificate applies did not wait for them. Applying an Issuer triggers the cert-manager validating webhook, so if it ran before the webhook was ready the apply failed with `connect: connection refused`. This is intermittent (self-heals on retried paths) but was reproduced locally, so waiting for the deployments before applying any Issuer removes the race.

## Fix

- Wait for the cert-manager deployments to be `Available` before applying any Issuer.
- Size `errCh` to the number of deployment waiters.
- Run the certificate verifications sequentially with a direct `Fatalf` so failures are reported immediately instead of hanging.

## Testing

Verified on CodeBuild: `TestVSphereKubernetes136UbuntuWorkloadClusterCuratedPackagesCertManagerSimpleFlow` now **PASSES** (build `aws-eks-anywhere-test-vsphere:100e60a6`, ~30min clean pass — the Let's Encrypt / route53 DNS-01 path completed and `test-cert` was issued).
