### PR TITLE
Fix: propagate feature flags to controller during upgrade with no version diff

### DIFF
--- a/pkg/clustermanager/eksa_installer.go
+++ b/pkg/clustermanager/eksa_installer.go
@@ -121,9 +121,17 @@ func (i *EKSAInstaller) Upgrade(ctx context.Context, log logr.Logger, c *types.C
 		log.V(1).Info("Skipping EKS-A components upgrade, not a self-managed cluster")
 		return nil, nil
 	}
+
 	changeDiff := EksaChangeDiff(currentManagementComponents, newManagementComponents)
 	if changeDiff == nil {
 		log.V(1).Info("Nothing to upgrade for controller and CRDs")
+		// The components are not re-created, so setManagerEnvVars won't run. Reconcile the
+		// feature-flag driven env vars directly so an existing management cluster stays in
+		// sync with the locally enabled feature flags (e.g. API_SERVER_EXTRA_ARGS_ENABLED)
+		// without requiring a version bump.
+		if err := i.reconcileManagerFeatureFlags(ctx, log, c); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 	log.V(1).Info("Starting EKS-A components upgrade")
@@ -134,6 +142,39 @@ func (i *EKSAInstaller) Upgrade(ctx context.Context, log logr.Logger, c *types.C
 	}
 
 	return changeDiff, nil
+}
+
+// managerFeatureFlagEnvVars are the feature-flag driven env vars that
+// gate eksa-controller-manager behavior.
+//
+// TODO: remove APIServerExtraArgsEnabled when we support API server flags, and VSphereInPlaceUpgradeEnabled
+// if we decide to support in-place upgrades for the vSphere provider.
+var managerFeatureFlagEnvVars = []struct {
+	envVar  string
+	feature func() features.Feature
+}{
+	{features.APIServerExtraArgsEnabledEnvVar, features.APIServerExtraArgsEnabled},
+	{features.VSphereInPlaceEnvVar, features.VSphereInPlaceUpgradeEnabled},
+}
+
+// reconcileManagerFeatureFlags sets the feature-flag driven env vars on the eksa-controller-manager
+// deployment. It is used on same-version upgrades, where the components are not re-created and
+// setManagerEnvVars would otherwise not run. When the components version changes, createEKSAComponents
+// (via setManagerEnvVars) already sets these env vars, so this must not be called on that path to
+// avoid a redundant deployment update and controller restart.
+func (i *EKSAInstaller) reconcileManagerFeatureFlags(ctx context.Context, log logr.Logger, c *types.Cluster) error {
+	for _, f := range managerFeatureFlagEnvVars {
+		if !features.IsActive(f.feature()) {
+			continue
+		}
+
+		log.V(1).Info("Ensuring feature flag is set on eksa-controller-manager", "envVar", f.envVar)
+		if err := i.client.SetEksaControllerEnvVar(ctx, f.envVar, "true", c.KubeconfigFile); err != nil {
+			return fmt.Errorf("setting %s on eksa controller: %v", f.envVar, err)
+		}
+	}
+
+	return nil
 }
 
 // createEKSAComponents creates eksa components and applies the objects to the cluster.
@@ -238,14 +279,10 @@ func setManagerEnvVars(d *appsv1.Deployment, spec *cluster.Spec) {
 		}
 	}
 
-	// TODO: remove this feature flag if we decide to support in-place upgrades for vSphere provider.
-	if features.IsActive(features.VSphereInPlaceUpgradeEnabled()) {
-		envVars = append(envVars, v1.EnvVar{Name: features.VSphereInPlaceEnvVar, Value: "true"})
-	}
-
-	// TODO: remove this feature flag when we support API server flags.
-	if features.IsActive(features.APIServerExtraArgsEnabled()) {
-		envVars = append(envVars, v1.EnvVar{Name: features.APIServerExtraArgsEnabledEnvVar, Value: "true"})
+	for _, f := range managerFeatureFlagEnvVars {
+		if features.IsActive(f.feature()) {
+			envVars = append(envVars, v1.EnvVar{Name: f.envVar, Value: "true"})
+		}
 	}
 
 	d.Spec.Template.Spec.Containers[0].Env = envVars

--- a/pkg/clustermanager/eksa_installer_test.go
+++ b/pkg/clustermanager/eksa_installer_test.go
@@ -316,6 +316,70 @@ func TestInstallerUpgradeInstallError(t *testing.T) {
 	tt.Expect(err).NotTo(BeNil())
 }
 
+func TestInstallerUpgradeAPIServerExtraArgsNoVersionChange(t *testing.T) {
+	features.ClearCache()
+	t.Setenv(features.APIServerExtraArgsEnabledEnvVar, "true")
+	tt := newInstallerTest(t)
+
+	// No components version change, so the deployment is not re-created. The feature flag env var
+	// must still be reconciled onto the existing eksa-controller-manager.
+	tt.client.EXPECT().SetEksaControllerEnvVar(tt.ctx, features.APIServerExtraArgsEnabledEnvVar, "true", tt.cluster.KubeconfigFile)
+
+	tt.Expect(tt.installer.Upgrade(tt.ctx, tt.log, tt.cluster, tt.currentManagementComponents, tt.newManagementComponents, tt.newSpec)).To(BeNil())
+}
+
+func TestInstallerUpgradeAPIServerExtraArgsWithVersionChange(t *testing.T) {
+	features.ClearCache()
+	t.Setenv(features.APIServerExtraArgsEnabledEnvVar, "true")
+	tt := newInstallerTest(t)
+
+	tt.newManagementComponents.Eksa.Version = "v0.2.0"
+	tt.newManagementComponents.Eksa.Components = v1alpha1.Manifest{
+		URI: "testdata/eksa_components.yaml",
+	}
+
+	wantDiff := &types.ChangeDiff{
+		ComponentReports: []types.ComponentChangeDiff{
+			{
+				ComponentName: "EKS-A Management",
+				NewVersion:    "v0.2.0",
+				OldVersion:    "v0.1.0",
+			},
+		},
+	}
+
+	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.AssignableToTypeOf(&appsv1.Deployment{}))
+	tt.client.EXPECT().Apply(tt.ctx, tt.cluster.KubeconfigFile, gomock.AssignableToTypeOf(&unstructured.Unstructured{}))
+	tt.client.EXPECT().WaitForDeployment(tt.ctx, tt.cluster, "30m0s", "Available", "eksa-controller-manager", "eksa-system")
+
+	tt.Expect(tt.installer.Upgrade(tt.ctx, tt.log, tt.cluster, tt.currentManagementComponents, tt.newManagementComponents, tt.newSpec)).To(Equal(wantDiff))
+}
+
+func TestInstallerUpgradeAPIServerExtraArgsError(t *testing.T) {
+	features.ClearCache()
+	t.Setenv(features.APIServerExtraArgsEnabledEnvVar, "true")
+	tt := newInstallerTest(t)
+
+	tt.client.EXPECT().
+		SetEksaControllerEnvVar(tt.ctx, features.APIServerExtraArgsEnabledEnvVar, "true", tt.cluster.KubeconfigFile).
+		Return(errors.New("boom"))
+
+	_, err := tt.installer.Upgrade(tt.ctx, tt.log, tt.cluster, tt.currentManagementComponents, tt.newManagementComponents, tt.newSpec)
+	tt.Expect(err).To(MatchError(ContainSubstring("setting API_SERVER_EXTRA_ARGS_ENABLED on eksa controller")))
+}
+
+func TestInstallerUpgradeVSphereInPlaceNoVersionChange(t *testing.T) {
+	features.ClearCache()
+	t.Setenv(features.VSphereInPlaceEnvVar, "true")
+	tt := newInstallerTest(t)
+
+	// Same latent bug class as the API server flag: reconcile the vSphere in-place flag even when
+	// the components version is unchanged.
+	tt.client.EXPECT().SetEksaControllerEnvVar(tt.ctx, features.VSphereInPlaceEnvVar, "true", tt.cluster.KubeconfigFile)
+
+	tt.Expect(tt.installer.Upgrade(tt.ctx, tt.log, tt.cluster, tt.currentManagementComponents, tt.newManagementComponents, tt.newSpec)).To(BeNil())
+}
+
 func TestSetManagerFlags(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -396,10 +460,10 @@ func TestSetManagerEnvVars(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			features.ClearCache()
 			g := NewWithT(t)
 			clustermanager.SetManagerEnvVars(tt.deployment, tt.spec)
 			g.Expect(tt.deployment).To(Equal(tt.want))
-			features.ClearCache()
 		})
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3915

*Description of changes:*
Reconcile the feature-flag-driven env vars on the `eksa-controller-manager`
deployment on every self-managed upgrade, independently of the components version
diff. This mirrors the existing precedent of setting controller env vars out-of-band
(e.g. CloudStack's `SetEksaControllerEnvVar`).

Key changes in `pkg/clustermanager/eksa_installer.go`:

- Introduced a single source of truth for the flag→env-var mapping,
  `managerFeatureFlagEnvVars`, and refactored `setManagerEnvVars` to iterate it
  (removing the previously duplicated inline list).
- Added `reconcileManagerFeatureFlags`, which sets each active flag's env var on the
  controller via `SetEksaControllerEnvVar`.
- Called `reconcileManagerFeatureFlags` in `Upgrade` in the
  `changeDiff == nil` early return, so the flag is propagated even when the
  components version is unchanged.

*Testing (if applicable):*
### Unit tests

Added to `pkg/clustermanager/eksa_installer_test.go`:

- `TestInstallerUpgradeAPIServerExtraArgsNoVersionChange` — flag is set on the
  controller when the components version is unchanged (the bug scenario).
- `TestInstallerUpgradeAPIServerExtraArgsWithVersionChange` — flag is still set when
  the version *does* change (no regression on the existing path).
- `TestInstallerUpgradeAPIServerExtraArgsError` — errors from
  `SetEksaControllerEnvVar` are surfaced.
- `TestInstallerUpgradeVSphereInPlaceNoVersionChange` — the same reconcile logic
  covers the other flag in the table.

Also fixed test isolation in `TestSetManagerEnvVars` by moving `features.ClearCache()`
to the start of the subtest so it passes under a `-run` filter.

```
$ go test ./pkg/clustermanager/ -run 'TestInstallerUpgrade|TestSetManagerEnvVars|TestSetManagerFlags' -count=1
ok  github.com/aws/eks-anywhere/pkg/clustermanager
```

### Manual end-to-end test (docker provider)

Ran a before/after comparison on a Linux host (Amazon Linux 2023, kernel
`6.12.94-amzn2023`) using two CLI binaries built from the same base — one **without**
the fix (`main`) and one **with** the fix — differing only by this commit.

**Setup**

1. Created a self-managed docker-provider management cluster (Kubernetes 1.36) with
   the **fix** binary and **no** `apiServerExtraArgs` / flag set.
2. Confirmed the baseline: the `eksa-controller-manager` deployment had **no**
   `API_SERVER_EXTRA_ARGS_ENABLED` env var — only `POD_NAMESPACE`/`POD_NAME`/`POD_UID`.

**Before the fix — reproduces the bug**

Same-version upgrade adding `apiServerExtraArgs` with the `main` binary and
`API_SERVER_EXTRA_ARGS_ENABLED=true`:

```
Error: failed to upgrade cluster: applying cluster spec: applying object with kubectl:
The Cluster "apiargs-test" is invalid: spec: Invalid value: {...}:
configuring APIServerExtraArgs is not supported. Set env var
API_SERVER_EXTRA_ARGS_ENABLED to enable
```

→ Webhook rejects the config, exactly matching the reported issue.

**After the fix — succeeds**

Same upgrade with the **fix** binary and the same flag:

- Upgrade completed: `🎉 Cluster upgraded!`
- `eksa-controller-manager` deployment now carries
  `{"name":"API_SERVER_EXTRA_ARGS_ENABLED","value":"true"}` (controller pod
  restarted with the new env), set by `reconcileManagerFeatureFlags`.
- The webhook accepted `apiServerExtraArgs`; the value propagated through the eksa
  `Cluster` spec → `KubeadmControlPlane.spec...apiServer.extraArgs` → the running
  control-plane `kube-apiserver` manifest (`--max-requests-inflight=500`).

## Scope

- Only the management (self-managed) cluster upgrade path is changed.
- Behavior when the components version *does* change is unchanged (flag still set via
  the existing `createEKSAComponents` → `setManagerEnvVars` path).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

