### PR TITLE
Add apiVersion to ADOT package update testdata

### DIFF
--- a/test/framework/testdata/adot_package_daemonset.yaml
+++ b/test/framework/testdata/adot_package_daemonset.yaml
@@ -6,6 +6,7 @@ spec:
   packageName: adot
   targetNamespace: observability
   config: |-
+    apiVersion: apps/v1
     mode: daemonset
     clusterRole:
       create: true

--- a/test/framework/testdata/adot_package_deployment.yaml
+++ b/test/framework/testdata/adot_package_deployment.yaml
@@ -6,6 +6,7 @@ spec:
   packageName: adot
   targetNamespace: observability
   config: |-
+    apiVersion: apps/v1
     mode: deployment
     clusterRole:
       create: true


### PR DESCRIPTION
*Issue #, if available:* N/A (follow-up to #10880)

*Description of changes:*
#10880 added `apiVersion=apps/v1` to the ADOT curated-packages e2e **install**
path (`--set apiVersion=apps/v1 --set mode=deployment` in `test/e2e/adot.go`).
However the **update** path (`CuratedPackagesAdotUpdateFlow`) does not go through
that `--set` call — `VerifyAdotPackageDeploymentUpdated` / `VerifyAdotPackageDaemonSetUpdated`
`kubectl apply` the testdata files `test/framework/testdata/adot_package_deployment.yaml`
and `adot_package_daemonset.yaml` directly, and their `spec.config` still only set
`mode`. Since the ADOT 0.48+ chart schema (chart 0.153.0+) requires `apiVersion`
at the config root, the `vpackage.kb.io` webhook rejects the apply with
`apiVersion is required`, so every `CuratedPackagesAdotUpdateFlow` test fails
(16 failures on the vSphere staging run, across all k8s versions 1-30~1-36).

This change adds `apiVersion: apps/v1` to `spec.config` in both testdata files,
matching what #10880 set on the install path.

*Testing (if applicable):*
Validated both files parse and the inner chart-values now contain
`apiVersion: apps/v1` + `mode`. The fix will be verified end-to-end by the next
staging run (release-0.26); the 16 `CuratedPackagesAdotUpdateFlow` failures are
expected to clear.

*Documentation added/planned (if applicable):* N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.