### PR TITLE
Fix adot e2e testdata main

### DIFF
--- a/test/framework/testdata/adot_package_daemonset.yaml
+++ b/test/framework/testdata/adot_package_daemonset.yaml
@@ -62,6 +62,3 @@ spec:
             receivers: [prometheus]
             processors: [batch]
             exporters: [debug]
-        telemetry:
-          metrics:
-            address: 0.0.0.0:8888

--- a/test/framework/testdata/adot_package_daemonset.yaml
+++ b/test/framework/testdata/adot_package_daemonset.yaml
@@ -52,7 +52,6 @@ spec:
                   insecure_skip_verify: true
       processors:
         batch: {}
-        memory_limiter: null
       exporters:
         debug:
           verbosity: basic

--- a/test/framework/testdata/adot_package_deployment.yaml
+++ b/test/framework/testdata/adot_package_deployment.yaml
@@ -62,6 +62,3 @@ spec:
             receivers: [prometheus]
             processors: [batch]
             exporters: [debug]
-        telemetry:
-          metrics:
-            address: 0.0.0.0:8888

--- a/test/framework/testdata/adot_package_deployment.yaml
+++ b/test/framework/testdata/adot_package_deployment.yaml
@@ -52,7 +52,6 @@ spec:
                   insecure_skip_verify: true
       processors:
         batch: {}
-        memory_limiter: null
       exporters:
         debug:
           verbosity: basic


### PR DESCRIPTION
## Summary

`CuratedPackagesAdotUpdateFlow` fails on all 14 vSphere variants (1.30–1.36 × Ubuntu/BottleRocket). The two testdata files it applies were written for ADOT 0.45.1 and were never updated for 0.49.0 (chart `opentelemetry-collector-0.165.0`, collector v0.156.0). Two incompatibilities, both making the collector refuse to start:

**1. `service.telemetry.metrics.address` was removed upstream**

Deprecated in favour of `metrics.readers` (open-telemetry/opentelemetry-collector#11205), and now rejected rather than warned about:

```
'migration.MetricsConfigV030' has invalid keys: address
application run finished with error
```

Dropped rather than ported to `readers` — the update-flow assertions only check pod logs and rollout status, they never scrape the `:8888` endpoint (that's the SimpleFlow install path, which passes `--set` and is unaffected).

**2. `memory_limiter: null` deletes a processor the default pipelines still reference**

Helm treats `null` as a deletion, so it removes the `memory_limiter` block that chart 0.165.0 defines by default. The testdata only overrides the `metrics` pipeline, so the default `logs` and `traces` pipelines still reference `[memory_limiter, batch]`:

```
Error: invalid configuration: service::pipelines::traces:
  references processor "memory_limiter" which is not configured
```

Observed directly in the daemonset pod (CrashLoopBackOff, 9 restarts, exit 1), which is why `VerifyAdotPackageDaemonSetUpdated` times out waiting for the rollout.

## Testing

Validated locally by deep-merging `spec.config` onto chart 0.165.0's default `config` with Helm null-coalesce semantics, for **both** modes. Before: `logs` and `traces` each dangle on `memory_limiter` in *both* files. After: no dangling receiver/processor/exporter/extension references in either mode, `metrics` still uses the explicit `[batch]` the test asserts on, and both configs still validate against the chart's values schema.

CodeBuild e2e on this branch (`59c2b27`):
- `TestVSphereKubernetes135CuratedPackagesAdotUpdateFlow` — **pass** (https://tiny.amazon.com/fjmndiri/isenamazfede)
- `TestVSphereKubernetes130BottleRocketCuratedPackagesAdotUpdateFlow` — **pass** (https://tiny.amazon.com/tixtb4it/isenamazfede)

Covers both k8s versions and both OS families, and both of the two failure modes seen in staging (the telemetry crash surfaced in the deployment step, the memory_limiter crash in the daemonset step).

Note: with only the telemetry fix applied, the deployment step passed but the daemonset step still timed out — the deployment step's apparent pass was the rolling update keeping the old healthy pod around while the log assertion ran. Both fixes were needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
